### PR TITLE
Fix router imports to match project pages

### DIFF
--- a/src/pages/parametrage/Roles.jsx
+++ b/src/pages/parametrage/Roles.jsx
@@ -250,9 +250,10 @@ export default function Roles() {
       {editPermsRole && (
         <Dialog open={!!editPermsRole} onOpenChange={v => !v && setEditPermsRole(null)}>
           <DialogContent className="bg-white rounded-xl shadow-lg p-6 max-w-xl">
-            <PermissionsForm
-              role={editPermsRole} {/* Passe bien tout l'objet ici */}
-              onClose={() => setEditPermsRole(null)}
+              {/* Passe bien tout l'objet ici */}
+              <PermissionsForm
+                role={editPermsRole}
+                onClose={() => setEditPermsRole(null)}
               afterSaveLog={async () => {
                 // Log en base le changement de permissions
                 await supabase.from("user_logs").insert([{

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -14,9 +14,9 @@ import FactureDetail from "@/pages/factures/FactureDetail";
 import Produits from "@/pages/produits/Produits";
 import ProduitDetail from "@/pages/produits/ProduitDetail";
 import ProduitForm from "@/pages/produits/ProduitForm";
-import Inventaire from "@/pages/inventaire/Inventaire";
-import Requisitions from "@/pages/requisitions/Requisitions";
-import Mouvements from "@/pages/mouvements/Mouvements";
+import Inventaire from "@/pages/Inventaire";
+import Requisitions from "@/pages/Requisitions";
+import Mouvements from "@/pages/Mouvements";
 
 import Fiches from "@/pages/fiches/Fiches";
 import FicheForm from "@/pages/fiches/FicheForm";


### PR DESCRIPTION
## Summary
- point the router to `Inventaire` and `Requisitions` in the project root
- clean up permissions modal comment to avoid JSX syntax error

## Testing
- `npm run lint` *(fails: 94 problems)*
- `npm run build` *(fails: Could not load components/ui/dialog)*

------
https://chatgpt.com/codex/tasks/task_e_6842eb27133c832dbffffe09e8fa70e9