### PR TITLE
Fix useProducts for missing mama_id

### DIFF
--- a/src/hooks/useProducts.js
+++ b/src/hooks/useProducts.js
@@ -1,19 +1,33 @@
 // src/hooks/useProducts.js
-import { useState } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/context/AuthContext";
 
-export function useProducts({ search = "", famille = "", actif = true }) {
+/**
+ * Hook pour récupérer la liste des produits de l'établissement connecté.
+ * Tous les appels sont automatiquement filtrés par mama_id via le contexte Auth.
+ */
+export function useProducts({ search = "", famille = "", actif = true } = {}) {
+  const { mama_id } = useAuth();
   const [produits, setProduits] = useState([]);
   const [familles, setFamilles] = useState([]);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
 
-  const fetchProduits = async (mama_id) => {
+  const fetchProduits = useCallback(async () => {
+    if (!mama_id) {
+      setProduits([]);
+      setFamilles([]);
+      setLoading(false);
+      return;
+    }
     setLoading(true);
+    setError(null);
     try {
       let query = supabase
         .from("products")
         .select(
-          "id, nom, famille, unite, actif, stock_theorique, dernier_prix" // pmp retiré
+          "id, nom, famille, unite, actif, stock_theorique, dernier_prix"
         )
         .eq("mama_id", mama_id);
 
@@ -22,24 +36,37 @@ export function useProducts({ search = "", famille = "", actif = true }) {
       if (search) query = query.ilike("nom", `%${search}%`);
 
       const { data, error } = await query;
-
       if (error) throw error;
-      setProduits(data || []);
 
-      // Extraire les familles uniques
-      const uniqueFamilles = [...new Set(data.map((p) => p.famille).filter(Boolean))];
+      setProduits(data || []);
+      const uniqueFamilles = [
+        ...new Set((data || []).map((p) => p.famille).filter(Boolean)),
+      ];
       setFamilles(uniqueFamilles);
     } catch (err) {
       console.error("❌ Erreur fetchProduits :", err);
+      setError(err);
+      setProduits([]);
     } finally {
       setLoading(false);
     }
-  };
+  }, [mama_id, search, famille, actif]);
+
+  // Chargement initial et rafraîchissement automatique lors d'un changement des paramètres
+  useEffect(() => {
+    fetchProduits();
+  }, [fetchProduits]);
 
   return {
     produits,
+    // compatibilité anciens composants
+    products: produits,
     familles,
     loading,
+    error,
     fetchProduits,
+    refetch: fetchProduits,
   };
 }
+
+export default useProducts;


### PR DESCRIPTION
## Summary
- clean product state when no `mama_id` is available
- expose legacy `fetchProduits` alongside `refetch`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6845f9bfe424832db3237e64d77c0682