### PR TITLE
Refactor comparatif and mamas pages to use hooks

### DIFF
--- a/src/hooks/useInventaires.js
+++ b/src/hooks/useInventaires.js
@@ -1,14 +1,22 @@
 // ✅ src/hooks/useInventaires.js
 import { useState, useEffect, useCallback } from "react";
 import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/context/AuthContext";
 
-export const useInventaires = ({ mama_id }) => {
+export const useInventaires = ({ mama_id: mamaIdProp } = {}) => {
+  const { mama_id } = useAuth();
+  const activeMamaId = mamaIdProp || mama_id;
   const [data, setData] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
 
   const fetchInventaires = useCallback(async () => {
-    if (!mama_id) return;
+    if (!activeMamaId) {
+      setData([]);
+      setError(null);
+      setLoading(false);
+      return;
+    }
 
     setLoading(true);
     setError(null);
@@ -16,7 +24,7 @@ export const useInventaires = ({ mama_id }) => {
     const { data, error } = await supabase
       .from("inventaires")
       .select("*")
-      .eq("mama_id", mama_id)
+      .eq("mama_id", activeMamaId)
       .order("date", { ascending: false });
 
     if (error) {
@@ -27,13 +35,11 @@ export const useInventaires = ({ mama_id }) => {
     }
 
     setLoading(false);
-  }, [mama_id]);
+  }, [activeMamaId]);
 
   useEffect(() => {
-    if (mama_id) {
-      fetchInventaires();
-    }
-  }, [mama_id, fetchInventaires]);
+    fetchInventaires();
+  }, [fetchInventaires]);
 
   return { data, loading, error, fetchInventaires };
 };

--- a/src/hooks/useMamas.js
+++ b/src/hooks/useMamas.js
@@ -7,6 +7,7 @@ export function useMamas() {
   const { role, mama_id } = useAuth();
   const [mamas, setMamas] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
 
   const fetchMamas = useCallback(async () => {
     setLoading(true);
@@ -15,9 +16,14 @@ export function useMamas() {
     if (role !== "superadmin") query = query.eq("id", mama_id);
 
     const { data, error } = await query;
-
-    if (!error && data) setMamas(data);
-    else console.error("Erreur chargement mamas :", error);
+    if (error) {
+      console.error("Erreur chargement mamas :", error);
+      setError(error);
+      setMamas([]);
+    } else {
+      setMamas(data || []);
+      setError(null);
+    }
 
     setLoading(false);
   }, [role, mama_id]);
@@ -26,5 +32,5 @@ export function useMamas() {
     fetchMamas();
   }, [role, mama_id, fetchMamas]);
 
-  return { mamas, loading, refetch: fetchMamas };
+  return { mamas, loading, error, refetch: fetchMamas };
 }

--- a/src/hooks/useProducts.js
+++ b/src/hooks/useProducts.js
@@ -1,19 +1,33 @@
 // src/hooks/useProducts.js
-import { useState } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/context/AuthContext";
 
-export function useProducts({ search = "", famille = "", actif = true }) {
+/**
+ * Hook pour récupérer la liste des produits de l'établissement connecté.
+ * Tous les appels sont automatiquement filtrés par mama_id via le contexte Auth.
+ */
+export function useProducts({ search = "", famille = "", actif = true } = {}) {
+  const { mama_id } = useAuth();
   const [produits, setProduits] = useState([]);
   const [familles, setFamilles] = useState([]);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
 
-  const fetchProduits = async (mama_id) => {
+  const fetchProduits = useCallback(async () => {
+    if (!mama_id) {
+      setProduits([]);
+      setFamilles([]);
+      setLoading(false);
+      return;
+    }
     setLoading(true);
+    setError(null);
     try {
       let query = supabase
         .from("products")
         .select(
-          "id, nom, famille, unite, actif, stock_theorique, dernier_prix" // pmp retiré
+          "id, nom, famille, unite, actif, stock_theorique, dernier_prix"
         )
         .eq("mama_id", mama_id);
 
@@ -22,24 +36,37 @@ export function useProducts({ search = "", famille = "", actif = true }) {
       if (search) query = query.ilike("nom", `%${search}%`);
 
       const { data, error } = await query;
-
       if (error) throw error;
-      setProduits(data || []);
 
-      // Extraire les familles uniques
-      const uniqueFamilles = [...new Set(data.map((p) => p.famille).filter(Boolean))];
+      setProduits(data || []);
+      const uniqueFamilles = [
+        ...new Set((data || []).map((p) => p.famille).filter(Boolean)),
+      ];
       setFamilles(uniqueFamilles);
     } catch (err) {
       console.error("❌ Erreur fetchProduits :", err);
+      setError(err);
+      setProduits([]);
     } finally {
       setLoading(false);
     }
-  };
+  }, [mama_id, search, famille, actif]);
+
+  // Chargement initial et rafraîchissement automatique lors d'un changement des paramètres
+  useEffect(() => {
+    fetchProduits();
+  }, [fetchProduits]);
 
   return {
     produits,
+    // compatibilité anciens composants
+    products: produits,
     familles,
     loading,
+    error,
     fetchProduits,
+    refetch: fetchProduits,
   };
 }
+
+export default useProducts;

--- a/src/pages/comparatif/ComparatifPrix.jsx
+++ b/src/pages/comparatif/ComparatifPrix.jsx
@@ -1,33 +1,11 @@
 // src/pages/comparatif/ComparatifPrix.jsx
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import PrixFournisseurs from "./PrixFournisseurs";
-import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import { useProducts } from "@/hooks/useProducts";
 
 export default function ComparatifPrix() {
-  const { mama_id } = useAuth();
-  const [produits, setProduits] = useState([]);
+  const { products } = useProducts();
   const [produitId, setProduitId] = useState("");
-
-  useEffect(() => {
-    const fetchProduits = async () => {
-      try {
-        const { data, error } = await supabase
-          .from("products")
-          .select("id, nom")
-          .eq("mama_id", mama_id)
-          .order("nom", { ascending: true });
-
-        if (error) throw error;
-        setProduits(data || []);
-      } catch (err) {
-        console.error("Erreur chargement produits :", err.message);
-        setProduits([]);
-      }
-    };
-
-    if (mama_id) fetchProduits();
-  }, [mama_id]);
 
   return (
     <div className="p-4">
@@ -44,7 +22,7 @@ export default function ComparatifPrix() {
         aria-label="Sélection produit"
       >
         <option value="">-- Choisir un produit --</option>
-        {produits.map((p) => (
+        {products.map((p) => (
           <option key={p.id} value={p.id}>
             {p.nom}
           </option>

--- a/src/pages/parametrage/Mamas.jsx
+++ b/src/pages/parametrage/Mamas.jsx
@@ -1,36 +1,22 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { supabase } from "@/lib/supabase";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent } from "@radix-ui/react-dialog";
 import MamaForm from "./MamaForm";
+import { useMamas } from "@/hooks/useMamas";
 import toast, { Toaster } from "react-hot-toast";
 
 export default function Mamas() {
-  const [mamas, setMamas] = useState([]);
+  const { mamas, loading, error, refetch } = useMamas();
   const [search, setSearch] = useState("");
   const [editMama, setEditMama] = useState(null);
-  const [loading, setLoading] = useState(true);
   const [confirmDeleteId, setConfirmDeleteId] = useState(null);
-
-  useEffect(() => {
-    fetchMamas();
-  }, []);
-
-  const fetchMamas = async () => {
-    setLoading(true);
-    const { data, error } = await supabase
-      .from("mamas")
-      .select("*")
-      .order("nom", { ascending: true });
-    if (!error) setMamas(data || []);
-    setLoading(false);
-  };
 
   const handleDelete = async id => {
     const { error } = await supabase.from("mamas").delete().eq("id", id);
     if (!error) {
       toast.success("Établissement supprimé.");
-      fetchMamas();
+      refetch();
     } else {
       toast.error("Erreur lors de la suppression.");
     }
@@ -49,6 +35,11 @@ export default function Mamas() {
       <h1 className="text-2xl font-bold text-mamastock-gold mb-4">
         Établissements (MAMA)
       </h1>
+      {error && (
+        <div className="text-center text-red-600 mb-2">
+          Erreur lors du chargement des établissements.
+        </div>
+      )}
       <div className="flex gap-4 mb-4 items-end">
         <input
           className="input input-bordered w-64"
@@ -148,7 +139,7 @@ export default function Mamas() {
           <MamaForm
             mama={editMama}
             onSaved={() => {
-              fetchMamas();
+              refetch();
               setEditMama(null);
             }}
             onClose={() => setEditMama(null)}


### PR DESCRIPTION
## Summary
- simplify `ComparatifPrix` by consuming `useProducts`
- rewrite `Mamas` page to rely on `useMamas` hook and use `refetch` after edits
- reset lists in `useInventaires` and `useProducts` when no tenant is selected
- expose errors from `useProducts`
- added error handling in `useMamas` hook and page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6845f9bfe424832db3237e64d77c0682