### PR TITLE
Centralize loader styles

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -26,6 +26,17 @@ a:hover {
   height: 40px;
   animation: spin 1s linear infinite;
 }
+/* Smaller loader used in inline buttons */
+.loader-glass {
+  border: 2px solid #fff;
+  border-top: 2px solid #bfa14d;
+  border-radius: 50%;
+  width: 1rem;
+  height: 1rem;
+  margin-right: 8px;
+  animation: spin .9s linear infinite;
+  display: inline-block;
+}
 @keyframes spin {
   0% {
     transform: rotate(0deg);
@@ -67,4 +78,36 @@ a:hover {
 html.dark body {
   background-color: #111827;
   color: #f0f0f5;
+}
+/* Animations LiquidGlass & glass panel */
+.animate-liquid { animation: glassMove 12s ease-in-out infinite alternate; }
+.animate-liquid2 { animation: glassMove2 18s ease-in-out infinite alternate; }
+.animate-liquid3 { animation: glassMove3 20s ease-in-out infinite alternate; }
+@keyframes glassMove {
+  0% { transform: scale(1) translate(0, 0); }
+  100% { transform: scale(1.14) translate(35px, 32px); }
+}
+@keyframes glassMove2 {
+  0% { transform: scale(1) translate(0, 0); }
+  100% { transform: scale(1.08) translate(-48px, 12px); }
+}
+@keyframes glassMove3 {
+  0% { transform: scale(1.06) translate(0, 0); }
+  100% { transform: scale(1) translate(12px, -32px); }
+}
+.glass-panel {
+  background: linear-gradient(125deg, rgba(255,255,255,0.24) 40%, rgba(191,161,77,0.11) 100%);
+}
+
+.animate-fade-in { animation: fadeIn 0.7s; }
+@keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
+
+/* Auth card & logo shadow */
+.auth-card {
+  box-shadow: 0 10px 32px 0 rgba(50,50,80,0.14), 0 1.5px 10px 0 rgba(191,161,77,0.1);
+  backdrop-filter: blur(32px) saturate(1.3);
+  -webkit-backdrop-filter: blur(32px) saturate(1.3);
+}
+.logo-glow {
+  box-shadow: 0 2px 20px 0 #bfa14d50;
 }

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -1,11 +1,26 @@
+import { Link } from "react-router-dom";
+
 export default function NotFound() {
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen text-gray-600">
-      <h1 className="text-5xl font-bold mb-4">404</h1>
-      <p className="text-xl mb-4">Page non trouvée.</p>
-      <a href="/" className="text-mamastock-gold underline">
-        Retour à l’accueil
-      </a>
+    <div className="relative min-h-screen flex items-center justify-center bg-gradient-to-br from-[#0f1c2e] via-[#232a34] to-[#bfa14d] overflow-hidden">
+      {/* Liquid background animations */}
+      <div className="absolute inset-0 -z-10">
+        <div className="absolute -top-10 -left-20 w-[480px] h-[420px] bg-gradient-to-br from-[#bfa14d] via-[#fff8e1]/70 to-transparent blur-[90px] rounded-full opacity-40 animate-liquid" />
+        <div className="absolute bottom-[-20%] right-[-18%] w-[480px] h-[420px] bg-gradient-to-br from-[#fff8e1]/90 via-white/60 to-transparent blur-[80px] rounded-full opacity-20 animate-liquid2" />
+        <div className="absolute top-1/3 left-1/2 -translate-x-1/2 w-[280px] h-[180px] bg-white/20 blur-2xl rounded-[36%_54%_41%_59%/50%_41%_59%_50%] opacity-15 animate-liquid3" />
+      </div>
+
+      <div className="rounded-2xl shadow-2xl bg-white/30 dark:bg-[#202638]/40 border border-white/30 backdrop-blur-xl px-12 py-16 text-center glass-panel">
+        <h1 className="text-6xl font-bold text-mamastockGold mb-4 drop-shadow-md">404</h1>
+        <p className="text-xl text-mamastockText mb-6">Page non trouvée</p>
+        <Link
+          to="/"
+          className="inline-block mt-2 px-6 py-2 rounded-xl bg-mamastockGold text-white font-semibold shadow hover:bg-[#b89730] transition"
+        >
+          Retour à l’accueil
+        </Link>
+      </div>
+
     </div>
   );
 }

--- a/src/pages/auth/Login.jsx
+++ b/src/pages/auth/Login.jsx
@@ -54,18 +54,12 @@ export default function Login() {
       </div>
       <div className="z-10 w-full max-w-md mx-auto">
         <div
-          className="rounded-2xl shadow-2xl bg-white/30 dark:bg-[#202638]/40 border border-white/30 backdrop-blur-xl px-8 py-12 flex flex-col items-center glass-panel"
-          style={{
-            boxShadow: "0 10px 32px 0 rgba(50,50,80,0.14), 0 1.5px 10px 0 rgba(191,161,77,0.10)",
-            backdropFilter: "blur(32px) saturate(1.3)",
-            WebkitBackdropFilter: "blur(32px) saturate(1.3)"
-          }}
+          className="rounded-2xl shadow-2xl bg-white/30 dark:bg-[#202638]/40 border border-white/30 backdrop-blur-xl px-8 py-12 flex flex-col items-center glass-panel auth-card"
         >
           <img
             src={logo}
             alt="MamaStock"
-            className="w-24 h-24 mb-6 rounded-full shadow-md bg-mamastockGold/10 object-contain border-4 border-mamastockGold/30"
-            style={{ boxShadow: "0 2px 20px 0 #bfa14d50" }}
+            className="w-24 h-24 mb-6 rounded-full shadow-md bg-mamastockGold/10 object-contain border-4 border-mamastockGold/30 logo-glow"
           />
           <h2 className="text-3xl font-bold text-mamastockGold drop-shadow mb-1 text-center tracking-wide">
             Connexion
@@ -118,48 +112,6 @@ export default function Login() {
           </form>
         </div>
       </div>
-      <style>{`
-        .loader-glass {
-          border: 2px solid #fff;
-          border-top: 2px solid #bfa14d;
-          border-radius: 50%;
-          width: 1rem;
-          height: 1rem;
-          margin-right: 8px;
-          animation: spin .9s linear infinite;
-          display: inline-block;
-        }
-        @keyframes spin {
-          0% { transform: rotate(0deg);}
-          100% { transform: rotate(360deg);}
-        }
-        .animate-fade-in { animation: fadeIn 0.7s;}
-        @keyframes fadeIn { from { opacity:0; } to { opacity:1; } }
-        .animate-liquid {
-          animation: glassMove 12s ease-in-out infinite alternate;
-        }
-        .animate-liquid2 {
-          animation: glassMove2 18s ease-in-out infinite alternate;
-        }
-        .animate-liquid3 {
-          animation: glassMove3 20s ease-in-out infinite alternate;
-        }
-        @keyframes glassMove {
-          0% { transform: scale(1) translate(0, 0);}
-          100% { transform: scale(1.14) translate(35px, 32px);}
-        }
-        @keyframes glassMove2 {
-          0% { transform: scale(1) translate(0, 0);}
-          100% { transform: scale(1.08) translate(-48px, 12px);}
-        }
-        @keyframes glassMove3 {
-          0% { transform: scale(1.06) translate(0, 0);}
-          100% { transform: scale(1) translate(12px, -32px);}
-        }
-        .glass-panel {
-          background: linear-gradient(125deg, rgba(255,255,255,0.24) 40%, rgba(191,161,77,0.11) 100%);
-        }
-      `}</style>
     </div>
   );
 }

--- a/src/pages/auth/Unauthorized.jsx
+++ b/src/pages/auth/Unauthorized.jsx
@@ -1,21 +1,31 @@
-// src/pages/auth/Unauthorized.jsx
 import { useNavigate } from "react-router-dom";
 
 export default function Unauthorized() {
   const navigate = useNavigate();
 
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-white text-red-600 text-center px-6">
-      <h1 className="text-3xl font-bold mb-4">🚫 Accès refusé</h1>
-      <p className="text-lg mb-6">
-        Vous n'avez pas les droits nécessaires pour accéder à cette page.
-      </p>
-      <button
-        onClick={() => navigate("/")}
-        className="bg-[#bfa14d] hover:bg-[#a98b39] text-white font-semibold py-2 px-4 rounded"
-      >
-        Retour à l'accueil
-      </button>
+    <div className="relative min-h-screen flex items-center justify-center bg-gradient-to-br from-[#0f1c2e] via-[#232a34] to-[#bfa14d] overflow-hidden">
+      {/* Animations LiquidGlass */}
+      <div className="absolute inset-0 -z-10 overflow-hidden">
+        <div className="absolute top-[-10%] left-[-20%] w-[500px] h-[400px] bg-gradient-to-br from-[#bfa14d] via-[#fff8e1]/70 to-[#c4a65d]/0 blur-[90px] rounded-full opacity-40 animate-liquid" />
+        <div className="absolute bottom-[-20%] right-[-18%] w-[480px] h-[420px] bg-gradient-to-br from-[#fff8e1]/90 via-white/60 to-transparent blur-[80px] rounded-full opacity-20 animate-liquid2" />
+        <div className="absolute top-1/3 left-1/2 -translate-x-1/2 w-[280px] h-[180px] bg-white/20 blur-2xl rounded-[36%_54%_41%_59%/50%_41%_59%_50%] opacity-15 animate-liquid3" />
+      </div>
+
+      <div className="z-10 w-full max-w-md mx-auto">
+        <div className="rounded-2xl shadow-2xl bg-white/30 dark:bg-[#202638]/40 border border-white/30 backdrop-blur-xl px-8 py-12 flex flex-col items-center text-center glass-panel auth-card">
+          <h1 className="text-3xl font-bold text-mamastockGold mb-4 drop-shadow">🚫 Accès refusé</h1>
+          <p className="text-mamastockText mb-6">
+            Vous n'avez pas les droits nécessaires pour accéder à cette page.
+          </p>
+          <button
+            onClick={() => navigate("/")}
+            className="mt-2 px-6 py-2 rounded-xl bg-mamastockGold text-white font-semibold shadow hover:bg-[#b89730] transition"
+          >
+            Retour à l'accueil
+          </button>
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- move small loader style from Login page into global CSS
- keep 404 page with LiquidGlass animations
- use shared LiquidGlass card on the Unauthorized page
- remove stray `engines` property from package-lock
- centralize login card styling in CSS
- drop page header comment on Unauthorized screen

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684dcf9fa6d4832dbacf827ac295e664