### PR TITLE
Améliorer fournisseurs produits

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ End-to-end tests use Playwright and require your `.env` Supabase credentials:
 npm run test:e2e
 ```
 
+First-time runs require downloading Playwright browsers:
+
+```bash
+npx playwright install
+```
+
 The Playwright configuration automatically starts the dev server.
 
 ## Features
@@ -65,6 +71,15 @@ The Playwright configuration automatically starts the dev server.
 - Daily menu handling provided by `useMenuDuJour`
 - PDF export for invoices and fiches techniques using jsPDF
 - Forms display links to preview uploaded documents immediately
+- Product management supports codes, allergens and photo upload
+- Products track a minimum stock level for dashboard alerts
+- Product list features pagination, sortable columns, filters, quick
+  duplication of existing entries and Excel import/export (the importer reads
+  the first sheet if no "Produits" sheet is found)
+- Each product records supplier prices and automatically updates its PMP
+- Stock and movement history available from the product detail modal
+- Supplier list supports Excel/PDF export and highlights inactive suppliers
+- Stock detail charts show monthly product rotation
 
 ## Continuous Integration
 

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -3,6 +3,9 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   testDir: 'e2e',
+  use: {
+    baseURL: 'http://localhost:5173',
+  },
   webServer: {
     command: 'npm run dev',
     url: 'http://localhost:5173',

--- a/src/components/produits/ProduitDetail.jsx
+++ b/src/components/produits/ProduitDetail.jsx
@@ -3,6 +3,10 @@ import { useEffect, useState } from "react";
 import { useProducts } from "@/hooks/useProducts";
 import { Dialog, DialogContent } from "@radix-ui/react-dialog";
 import { Loader } from "lucide-react";
+import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend } from "recharts";
+import * as XLSX from "xlsx";
+import { saveAs } from "file-saver";
+import { buildPriceData } from "./priceHelpers";
 
 export default function ProduitDetail({ produitId, open, onClose }) {
   const { fetchProductPrices } = useProducts();
@@ -19,9 +23,18 @@ export default function ProduitDetail({ produitId, open, onClose }) {
     }
   }, [open, produitId, fetchProductPrices]);
 
+  const chartData = buildPriceData(historique);
+
+  const exportExcel = () => {
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, XLSX.utils.json_to_sheet(historique), "Prix");
+    const buf = XLSX.write(wb, { bookType: "xlsx", type: "array" });
+    saveAs(new Blob([buf]), `prix_produit_${produitId}.xlsx`);
+  };
+
   return (
     <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent className="bg-white/80 backdrop-blur-2xl border border-mamastockGold/20 rounded-xl shadow-2xl p-8 max-w-2xl w-full">
+      <DialogContent className="bg-white/80 backdrop-blur-2xl border border-mamastockGold/20 rounded-2xl shadow-2xl p-8 max-w-2xl w-full">
         <h2 className="text-lg font-bold text-mamastockGold mb-3">Historique des prix d’achat</h2>
         {loading ? (
           <div className="flex justify-center py-6"><Loader className="animate-spin" /></div>
@@ -49,7 +62,23 @@ export default function ProduitDetail({ produitId, open, onClose }) {
             </tbody>
           </table>
         )}
-        <div className="flex justify-end mt-4">
+        {chartData.length > 0 && (
+          <div className="mt-6">
+            <ResponsiveContainer width="100%" height={200}>
+              <LineChart data={chartData} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
+                <XAxis dataKey="date" fontSize={11} />
+                <YAxis fontSize={11} />
+                <Tooltip />
+                <Legend />
+                {Object.keys(chartData[0]).filter(k => k !== 'date').map(key => (
+                  <Line key={key} type="monotone" dataKey={key} stroke="#bfa14d" />
+                ))}
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+        <div className="flex justify-end gap-2 mt-4">
+          <button onClick={exportExcel} className="btn btn-secondary">Export Excel</button>
           <button onClick={onClose} className="btn">Fermer</button>
         </div>
       </DialogContent>

--- a/src/components/produits/priceHelpers.js
+++ b/src/components/produits/priceHelpers.js
@@ -1,0 +1,18 @@
+export function buildPriceData(historique = []) {
+  const suppliers = {};
+  const dates = new Set();
+  historique.forEach(h => {
+    const date = h.updated_at?.slice(0, 10);
+    if (!date) return;
+    const key = h.supplier?.nom || '';
+    if (!suppliers[key]) suppliers[key] = {};
+    suppliers[key][date] = h.prix_achat;
+    dates.add(date);
+  });
+  const sorted = Array.from(dates).sort();
+  return sorted.map(d => {
+    const row = { date: d };
+    Object.keys(suppliers).forEach(s => { row[s] = suppliers[s][d] ?? null; });
+    return row;
+  });
+}

--- a/src/components/stock/StockDetail.jsx
+++ b/src/components/stock/StockDetail.jsx
@@ -1,8 +1,21 @@
 import { Button } from "@/components/ui/button";
 import { saveAs } from "file-saver";
 import * as XLSX from "xlsx";
+import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip, Legend } from "recharts";
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function buildRotationData(mouvements) {
+  const map = {};
+  mouvements.forEach(m => {
+    if (m.type !== 'sortie' || !m.date) return;
+    const mois = m.date.slice(0, 7);
+    map[mois] = (map[mois] || 0) + Number(m.quantite || 0);
+  });
+  return Object.entries(map).map(([mois, q]) => ({ mois, q }));
+}
 
 export default function StockDetail({ produit, mouvements, onClose }) {
+  const rotationData = buildRotationData(mouvements);
   const exportExcel = () => {
     const wb = XLSX.utils.book_new();
     const ws = XLSX.utils.json_to_sheet(mouvements);
@@ -45,6 +58,20 @@ export default function StockDetail({ produit, mouvements, onClose }) {
             </tbody>
           </table>
         </div>
+        {rotationData.length > 0 && (
+          <div className="mt-4">
+            <h3 className="font-semibold mb-1">Rotation mensuelle</h3>
+            <ResponsiveContainer width="100%" height={180}>
+              <LineChart data={rotationData}>
+                <XAxis dataKey="mois" fontSize={11} />
+                <YAxis fontSize={11} />
+                <Tooltip />
+                <Legend />
+                <Line type="monotone" dataKey="q" name="Sorties" stroke="#bfa14d" />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        )}
         <div className="flex gap-2 mt-4">
           <Button variant="outline" onClick={exportExcel}>Export Excel</Button>
         </div>

--- a/src/hooks/useStock.js
+++ b/src/hooks/useStock.js
@@ -60,6 +60,15 @@ export function useStock() {
     // On ne met pas à jour ici, c’est fait au fetchStocks/fetchMouvements
   }
 
+  async function fetchRotationStats(product_id) {
+    const { data, error } = await supabase.rpc('stats_rotation_produit', {
+      mama_id_param: user?.mama_id,
+      product_id_param: product_id,
+    });
+    if (error) return [];
+    return data || [];
+  }
+
   return {
     stocks,
     mouvements,
@@ -68,5 +77,6 @@ export function useStock() {
     fetchStocks,
     fetchMouvements,
     addMouvementStock,
+    fetchRotationStats,
   };
 }

--- a/src/hooks/useSupplierProducts.js
+++ b/src/hooks/useSupplierProducts.js
@@ -6,6 +6,7 @@ import { useAuth } from "@/context/AuthContext";
 // Permet de récupérer tous les produits liés à un fournisseur (+ historique achats, PMP, etc.)
 export function useSupplierProducts() {
   const { mama_id } = useAuth();
+  const [cache, setCache] = useState({});
 
   // Tous les produits fournis par ce fournisseur (avec totaux achats/prix moyens)
   function useProductsBySupplier(fournisseur_id) {
@@ -21,7 +22,9 @@ export function useSupplierProducts() {
       setError(null);
       const { data, error } = await supabase
         .from("supplier_products")
-        .select("*, product:products(nom, famille, unite), achats:invoices(date_facture, montant_total)")
+        .select(
+          "*, product:products(nom, famille, unite), achats:invoices(date_facture, montant_total)"
+        )
         .eq("fournisseur_id", fournisseur_id)
         .eq("mama_id", mama_id);
       setProducts(data || []);
@@ -33,5 +36,18 @@ export function useSupplierProducts() {
     return { products, loading, error, fetch };
   }
 
-  return { useProductsBySupplier };
+  async function getProductsBySupplier(fournisseur_id) {
+    if (cache[fournisseur_id]) return cache[fournisseur_id];
+    const { data } = await supabase
+      .from("supplier_products")
+      .select(
+        "*, product:products(nom, famille, unite), achats:invoices(date_facture, montant_total)"
+      )
+      .eq("fournisseur_id", fournisseur_id)
+      .eq("mama_id", mama_id);
+    setCache(c => ({ ...c, [fournisseur_id]: data || [] }));
+    return data || [];
+  }
+
+  return { useProductsBySupplier, getProductsBySupplier };
 }

--- a/src/pages/produits/Produits.jsx
+++ b/src/pages/produits/Produits.jsx
@@ -1,59 +1,151 @@
 // src/pages/Produits.jsx
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import { useProducts } from "@/hooks/useProducts";
 import ProduitFormModal from "@/components/produits/ProduitFormModal";
 import ProduitDetail from "@/components/produits/ProduitDetail";
 import { Button } from "@/components/ui/button";
 import { Toaster } from "react-hot-toast";
 
+const PAGE_SIZE = 20;
+
 export default function Produits() {
   const {
     products,
+    total,
     fetchProducts,
     exportProductsToExcel,
+    importProductsFromExcel,
+    addProduct,
+    duplicateProduct,
   } = useProducts();
 
   const [showForm, setShowForm] = useState(false);
   const [selectedProduct, setSelectedProduct] = useState(null);
   const [showDetail, setShowDetail] = useState(false);
+  const [search, setSearch] = useState("");
+  const [familleFilter, setFamilleFilter] = useState("");
+  const [actifFilter, setActifFilter] = useState("all");
+  const [page, setPage] = useState(1);
+  const [sortField, setSortField] = useState("famille");
+  const [sortOrder, setSortOrder] = useState("asc");
+  const fileRef = useRef();
+
+  async function handleImport(e) {
+    const file = e.target.files[0];
+    if (!file) return;
+    const rows = await importProductsFromExcel(file);
+    for (const row of rows) {
+      await addProduct({
+        nom: row.nom,
+        famille: row.famille,
+        unite: row.unite,
+        pmp: Number(row.pmp) || 0,
+        stock_reel: Number(row.stock_reel) || 0,
+        stock_min: Number(row.stock_min) || 0,
+        actif: row.actif !== false,
+        code: row.code || "",
+        allergenes: row.allergenes || "",
+        image: row.image || "",
+      });
+    }
+    fetchProducts();
+    e.target.value = null;
+  }
+
+  function toggleSort(field) {
+    if (sortField === field) {
+      setSortOrder(sortOrder === "asc" ? "desc" : "asc");
+    } else {
+      setSortField(field);
+      setSortOrder("asc");
+    }
+  }
+
+  function renderArrow(field) {
+    if (sortField !== field) return null;
+    return sortOrder === "asc" ? " ↑" : " ↓";
+  }
 
   // Filtre et familles/unites dynamiques
   const familles = [...new Set(products.map(p => p.famille).filter(Boolean))];
   const unites = [...new Set(products.map(p => p.unite).filter(Boolean))];
 
   useEffect(() => {
-    fetchProducts();
-  }, [fetchProducts]);
+    fetchProducts({
+      search,
+      famille: familleFilter,
+      actif: actifFilter === "all" ? null : actifFilter === "true",
+      page,
+      limit: PAGE_SIZE,
+      sortBy: sortField,
+      order: sortOrder,
+    });
+  }, [fetchProducts, search, familleFilter, actifFilter, page, sortField, sortOrder]);
 
   return (
     <div className="p-8 max-w-7xl mx-auto">
       <Toaster />
       <h1 className="text-2xl font-bold text-mamastockGold mb-4">Produits stock</h1>
-      <div className="flex gap-2 mb-6">
+      <div className="flex flex-wrap gap-2 mb-6 items-end">
+        <input
+          type="search"
+          value={search}
+          onChange={e => { setPage(1); setSearch(e.target.value); }}
+          className="input"
+          placeholder="Recherche nom"
+        />
+        <select
+          className="input"
+          value={familleFilter}
+          onChange={e => { setPage(1); setFamilleFilter(e.target.value); }}
+        >
+          <option value="">Toutes familles</option>
+          {familles.map(f => <option key={f} value={f}>{f}</option>)}
+        </select>
+        <select
+          className="input"
+          value={actifFilter}
+          onChange={e => { setPage(1); setActifFilter(e.target.value); }}
+        >
+          <option value="all">Actif ou non</option>
+          <option value="true">Actif</option>
+          <option value="false">Inactif</option>
+        </select>
         <Button onClick={() => { setShowForm(true); setSelectedProduct(null); }}>+ Nouveau produit</Button>
         <Button onClick={exportProductsToExcel}>Export Excel</Button>
+        <Button onClick={() => fileRef.current.click()}>Import Excel</Button>
+        <input
+          type="file"
+          accept=".xlsx"
+          ref={fileRef}
+          onChange={handleImport}
+          data-testid="import-input"
+          className="hidden"
+        />
       </div>
       <div className="bg-white/70 shadow rounded-xl overflow-x-auto">
         <table className="min-w-full table-auto text-center">
           <thead>
             <tr>
-              <th>Nom</th>
-              <th>Famille</th>
+              <th className="cursor-pointer" onClick={() => toggleSort("nom")}>Nom{renderArrow("nom")}</th>
+              <th className="cursor-pointer" onClick={() => toggleSort("famille")}>Famille{renderArrow("famille")}</th>
               <th>Unité</th>
-              <th>PMP (€)</th>
-              <th>Stock</th>
+              <th className="cursor-pointer" onClick={() => toggleSort("pmp")}>PMP (€){renderArrow("pmp")}</th>
+              <th className="cursor-pointer" onClick={() => toggleSort("stock_reel")}>Stock{renderArrow("stock_reel")}</th>
+              <th className="cursor-pointer" onClick={() => toggleSort("stock_min")}>Min{renderArrow("stock_min")}</th>
               <th>Actif</th>
               <th>Actions</th>
             </tr>
           </thead>
           <tbody>
-            {products.map(p => (
-              <tr key={p.id}>
+          {products.map(p => (
+            <tr key={p.id}>
                 <td>{p.nom}</td>
                 <td>{p.famille}</td>
                 <td>{p.unite}</td>
                 <td>{p.pmp}</td>
                 <td>{p.stock_reel}</td>
+                <td>{p.stock_min}</td>
                 <td>{p.actif ? "✅" : "❌"}</td>
                 <td>
                   <Button size="sm" variant="outline" onClick={() => { setSelectedProduct(p); setShowForm(true); }}>
@@ -62,12 +154,27 @@ export default function Produits() {
                   <Button size="sm" variant="secondary" onClick={() => { setSelectedProduct(p); setShowDetail(true); }}>
                     Historique prix
                   </Button>
+                  <Button size="sm" variant="ghost" onClick={() => duplicateProduct(p.id)}>
+                    Dupliquer
+                  </Button>
                 </td>
               </tr>
-            ))}
-          </tbody>
-        </table>
+          ))}
+        </tbody>
+      </table>
+      <div className="mt-4 flex gap-2 justify-center">
+        {Array.from({ length: Math.max(1, Math.ceil(total / PAGE_SIZE)) }, (_, i) => (
+          <Button
+            key={i + 1}
+            size="sm"
+            variant={page === i + 1 ? "default" : "outline"}
+            onClick={() => setPage(i + 1)}
+          >
+            {i + 1}
+          </Button>
+        ))}
       </div>
+    </div>
       {/* Modale création/édition */}
       <ProduitFormModal
         open={showForm}

--- a/test/Fournisseurs.test.jsx
+++ b/test/Fournisseurs.test.jsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+import { fireEvent } from '@testing-library/react';
+import React from 'react';
+import { vi } from 'vitest';
+
+let mockHook;
+vi.mock('@/hooks/useFournisseurs', () => ({
+  useFournisseurs: () => mockHook(),
+}));
+vi.mock('@/hooks/useFournisseurStats', () => ({
+  useFournisseurStats: () => ({ fetchStatsAll: vi.fn(() => Promise.resolve([])) }),
+}));
+vi.mock('@/hooks/useSupplierProducts', () => ({
+  useSupplierProducts: () => ({ getProductsBySupplier: () => [] }),
+}));
+vi.mock('@/hooks/useProducts', () => ({
+  useProducts: () => ({ products: [] }),
+}));
+vi.mock('@/hooks/useInvoices', () => ({
+  useInvoices: () => ({ fetchInvoicesBySupplier: vi.fn() }),
+}));
+vi.mock('@/lib/supabase', () => ({ supabase: { from: vi.fn() } }));
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }) => <div>{children}</div>,
+  LineChart: ({ children }) => <div>{children}</div>,
+  BarChart: ({ children }) => <div>{children}</div>,
+  Line: () => null,
+  Bar: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  Tooltip: () => null,
+  Legend: () => null,
+}));
+
+import Fournisseurs from '@/pages/fournisseurs/Fournisseurs.jsx';
+
+test('export excel button triggers hook', async () => {
+  const excel = vi.fn();
+  mockHook = () => ({
+    fournisseurs: [],
+    fetchFournisseurs: vi.fn(),
+    addFournisseur: vi.fn(),
+    updateFournisseur: vi.fn(),
+    deleteFournisseur: vi.fn(),
+    exportFournisseursToExcel: excel,
+  });
+  render(<Fournisseurs />);
+  const button = await screen.findByText('Export Excel');
+  fireEvent.click(button);
+  expect(excel).toHaveBeenCalled();
+});

--- a/test/ProduitDetail.test.jsx
+++ b/test/ProduitDetail.test.jsx
@@ -1,0 +1,14 @@
+import { buildPriceData } from '@/components/produits/priceHelpers.js';
+import { expect, test } from 'vitest';
+
+test('buildPriceData groups price by supplier and date', () => {
+  const hist = [
+    { updated_at: '2024-01-05', prix_achat: 2, supplier: { nom: 'A' } },
+    { updated_at: '2024-01-05', prix_achat: 3, supplier: { nom: 'B' } },
+    { updated_at: '2024-02-01', prix_achat: 4, supplier: { nom: 'A' } },
+  ];
+  expect(buildPriceData(hist)).toEqual([
+    { date: '2024-01-05', A: 2, B: 3 },
+    { date: '2024-02-01', A: 4, B: null },
+  ]);
+});

--- a/test/ProduitForm.test.jsx
+++ b/test/ProduitForm.test.jsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { vi } from 'vitest';
+
+let mockHook;
+vi.mock('@/hooks/useProducts', () => ({
+  useProducts: () => mockHook(),
+}));
+vi.mock('@/hooks/useStorage', () => ({
+  uploadFile: vi.fn(),
+  deleteFile: vi.fn(),
+  pathFromUrl: () => '',
+}));
+
+import ProduitForm from '@/components/produits/ProduitForm.jsx';
+
+// ensure new fields render
+
+test('renders additional product inputs', () => {
+  mockHook = () => ({ addProduct: vi.fn(), updateProduct: vi.fn(), loading: false });
+  render(
+    <ProduitForm familles={[]} unites={[]} onSuccess={vi.fn()} onClose={vi.fn()} />
+  );
+  expect(screen.getByLabelText(/Code interne/)).toBeInTheDocument();
+  expect(screen.getByLabelText(/Allergènes/)).toBeInTheDocument();
+  expect(screen.getByLabelText(/Stock minimum/)).toBeInTheDocument();
+});

--- a/test/Produits.test.jsx
+++ b/test/Produits.test.jsx
@@ -1,0 +1,53 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent } from '@testing-library/react';
+import React from 'react';
+import { vi } from 'vitest';
+
+let mockHook;
+vi.mock('@/hooks/useProducts', () => ({
+  useProducts: () => mockHook(),
+}));
+vi.mock('@/hooks/useStorage', () => ({
+  uploadFile: vi.fn(),
+  deleteFile: vi.fn(),
+  pathFromUrl: () => '',
+}));
+
+import Produits from '@/pages/produits/Produits.jsx';
+
+test('duplicate button calls hook', async () => {
+  const duplicate = vi.fn();
+  mockHook = () => ({
+    products: [{ id: '1', nom: 'Test', famille: 'F', unite: 'kg', pmp: 1, stock_reel: 10, actif: true }],
+    total: 1,
+    fetchProducts: vi.fn(),
+    exportProductsToExcel: vi.fn(),
+    importProductsFromExcel: vi.fn(() => Promise.resolve([])),
+    addProduct: vi.fn(),
+    duplicateProduct: duplicate,
+  });
+  render(<Produits />);
+  const button = await screen.findByText('Dupliquer');
+  fireEvent.click(button);
+  expect(duplicate).toHaveBeenCalledWith('1');
+});
+
+test('import input calls hook and adds products', async () => {
+  const importFn = vi.fn(() => Promise.resolve([{ nom: 'N', famille: 'F', unite: 'kg' }]));
+  const add = vi.fn();
+  mockHook = () => ({
+    products: [],
+    total: 0,
+    fetchProducts: vi.fn(),
+    exportProductsToExcel: vi.fn(),
+    importProductsFromExcel: importFn,
+    addProduct: add,
+    duplicateProduct: vi.fn(),
+  });
+  render(<Produits />);
+  const input = screen.getByTestId('import-input');
+  const file = new File([''], 'p.xlsx');
+  await fireEvent.change(input, { target: { files: [file] } });
+  expect(importFn).toHaveBeenCalledWith(file);
+  await waitFor(() => expect(add).toHaveBeenCalled());
+});

--- a/test/StockDetail.test.jsx
+++ b/test/StockDetail.test.jsx
@@ -1,0 +1,11 @@
+import { buildRotationData } from '@/components/stock/StockDetail.jsx';
+import { expect, test } from 'vitest';
+
+test('buildRotationData aggregates sorties by month', () => {
+  const mvts = [
+    { date: '2024-01-05', type: 'sortie', quantite: 2 },
+    { date: '2024-01-10', type: 'sortie', quantite: 3 },
+    { date: '2024-02-02', type: 'entree', quantite: 1 },
+  ];
+  expect(buildRotationData(mvts)).toEqual([{ mois: '2024-01', q: 5 }]);
+});

--- a/test/useSupplierProducts.test.js
+++ b/test/useSupplierProducts.test.js
@@ -1,0 +1,39 @@
+import { renderHook, act } from '@testing-library/react';
+import { vi, beforeEach, test, expect } from 'vitest';
+
+const final = { data: [{ id: '1' }], error: null };
+const eq2Mock = vi.fn(() => Promise.resolve(final));
+const eq1Mock = vi.fn(() => ({ eq: eq2Mock }));
+const selectMock = vi.fn(() => ({ eq: eq1Mock }));
+const fromMock = vi.fn(() => ({ select: selectMock }));
+
+vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
+vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
+
+let useSupplierProducts;
+beforeEach(async () => {
+  ({ useSupplierProducts } = await import('@/hooks/useSupplierProducts'));
+  fromMock.mockClear();
+  selectMock.mockClear();
+  eq1Mock.mockClear();
+  eq2Mock.mockClear();
+});
+
+test('getProductsBySupplier fetches and caches results', async () => {
+  const { result } = renderHook(() => useSupplierProducts());
+  let res1;
+  await act(async () => {
+    res1 = await result.current.getProductsBySupplier('f1');
+  });
+  expect(fromMock).toHaveBeenCalledWith('supplier_products');
+  expect(selectMock).toHaveBeenCalled();
+  expect(eq1Mock).toHaveBeenCalledWith('fournisseur_id', 'f1');
+  expect(eq2Mock).toHaveBeenCalledWith('mama_id', 'm1');
+  expect(res1).toEqual(final.data);
+  let res2;
+  await act(async () => {
+    res2 = await result.current.getProductsBySupplier('f1');
+  });
+  expect(fromMock).toHaveBeenCalledTimes(1);
+  expect(res2).toEqual(final.data);
+});


### PR DESCRIPTION
## Summary
- add Excel import for products list page
- update README to mention Excel import/export
- add tests for new import functionality
- improve Excel import fall back to first sheet

## Testing
- `npm run lint`
- `npm test --silent`
- `npm run test:e2e --silent` *(fails: browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_684e03ce370c832d81717aa6e44d5e1c