### PR TITLE
Fix sidebar access rights loading

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -48,10 +48,10 @@ export function AuthProvider({ children }) {
     setLoading(true);
 
     // Check session à l'ouverture
-    supabase.auth.getSession().then(({ data: { session } }) => {
+    supabase.auth.getSession().then(async ({ data: { session } }) => {
       setSession(session);
       setUser(session?.user || null);
-      if (session?.user) fetchClaims(session.user.id);
+      if (session?.user) await fetchClaims(session.user.id);
       setLoading(false);
     });
 
@@ -96,10 +96,11 @@ export function AuthProvider({ children }) {
     claimsError,
     logout,
     refreshClaims,
+    user_id: user?.id || null,
     isAuthenticated: !!user && !!claims,
     isAdmin: claims?.role === "admin" || claims?.role === "superadmin",
     mama_id: claims?.mama_id || null,
-    access_rights: claims?.access_rights || [],
+    access_rights: claims?.access_rights,
     role: claims?.role || null,
   };
 

--- a/src/layout/Sidebar.jsx
+++ b/src/layout/Sidebar.jsx
@@ -151,22 +151,15 @@ const MENUS = [
 ];
 
 export default function Sidebar() {
-  const { access_rights } = useAuth();
+  const { access_rights, role } = useAuth();
   const location = useLocation();
   const containerRef = useRef(null);
-
-  useEffect(() => {
-    if (Array.isArray(access_rights) && access_rights.length === 0) {
-      console.warn("Aucun droit d'accès défini pour l'utilisateur", access_rights);
-    }
-  }, [access_rights]);
-
-  if (!access_rights) return <div>Chargement des droits...</div>;
 
   // Permet de voir quels menus sont ouverts selon la route active
   const [open, setOpen] = useState({});
   const [mobileOpen, setMobileOpen] = useState(false);
   const isMobile = typeof window !== 'undefined' && window.innerWidth < 768;
+
   useSwipe(containerRef, {
     onSwipeLeft: () => setMobileOpen(false),
     onSwipeRight: () => setMobileOpen(true),
@@ -176,6 +169,12 @@ export default function Sidebar() {
     document.addEventListener('toggle-sidebar', toggle);
     return () => document.removeEventListener('toggle-sidebar', toggle);
   }, []);
+
+  useEffect(() => {
+    if (Array.isArray(access_rights) && access_rights.length === 0) {
+      console.warn("Aucun droit d'accès défini pour l'utilisateur", access_rights);
+    }
+  }, [access_rights]);
 
   useEffect(() => {
     const path = location.pathname;
@@ -189,8 +188,11 @@ export default function Sidebar() {
     setOpen(newOpen);
   }, [location.pathname]);
 
+  if (access_rights === undefined) return <div>Chargement des droits...</div>;
+
   const hasAccess = (accessKey) =>
-    access_rights?.includes?.(accessKey) ||
+    role === "superadmin" ||
+    (Array.isArray(access_rights) && access_rights.includes(accessKey)) ||
     (typeof access_rights === "object" && access_rights?.[accessKey]);
 
   return (

--- a/src/pages/debug/AuthDebug.jsx
+++ b/src/pages/debug/AuthDebug.jsx
@@ -2,24 +2,12 @@
 import { useAuth } from "@/context/AuthContext";
 
 export default function AuthDebug() {
-  const { session, role, mama_id, access_rights } = useAuth();
+  const { user_id, role, mama_id, access_rights } = useAuth();
 
   return (
-    <div className="p-6 text-white bg-black min-h-screen">
-      <h1 className="text-3xl text-mamastock-gold font-bold mb-4">🔍 Debug Auth</h1>
-      <pre className="bg-white text-black p-4 rounded shadow overflow-auto">
-        {JSON.stringify(
-          {
-            user_id: session?.user?.id,
-            email: session?.user?.email,
-            role,
-            mama_id,
-            access_rights,
-          },
-          null,
-          2
-        )}
-      </pre>
+    <div>
+      <h2>Debug Auth</h2>
+      <pre>{JSON.stringify({ user_id, role, mama_id, access_rights }, null, 2)}</pre>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- wait for user claims when initializing auth state
- expose `user_id` and use undefined when rights not loaded
- update sidebar loading logic and superadmin access
- add simple `/debug/auth` component

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6853c222ef00832d9e1eeb0fa498e534