### PR TITLE
Fix sidebar access rights loading

### DIFF
--- a/src/layout/Sidebar.jsx
+++ b/src/layout/Sidebar.jsx
@@ -151,7 +151,7 @@ const MENUS = [
 ];
 
 export default function Sidebar() {
-  const { access_rights, role } = useAuth();
+  const { access_rights, role, loading } = useAuth();
   const location = useLocation();
   const containerRef = useRef(null);
 
@@ -188,7 +188,7 @@ export default function Sidebar() {
     setOpen(newOpen);
   }, [location.pathname]);
 
-  if (access_rights === undefined) return <div>Chargement des droits...</div>;
+  if (loading) return null;
 
   const hasAccess = (accessKey) =>
     role === "superadmin" ||


### PR DESCRIPTION
## Summary
- fetch role, mama_id and access_rights from Supabase when a session is found
- expose the fetched values directly from the `AuthContext` provider
- halt sidebar rendering while authentication data is loading

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853c6edc168832db723f41166032a4f