### PR TITLE
Add security tab with 2FA setup

### DIFF
--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -10,7 +10,7 @@ export default function Sidebar() {
   const rights = Array.isArray(access_rights) ? access_rights : [];
 
   return (
-    <aside className="w-64 bg-mamastockBg text-white p-4 h-screen shadow-md">
+    <aside className="w-64 bg-white/5 backdrop-blur-xl text-white p-4 h-screen shadow-md">
       <h2 className="text-2xl font-bold mb-6">MamaStock</h2>
       <nav className="flex flex-col gap-2">
         {(showAll || rights.includes("dashboard")) && (

--- a/src/components/parametrage/ParamSecurity.jsx
+++ b/src/components/parametrage/ParamSecurity.jsx
@@ -1,0 +1,10 @@
+import TwoFactorSetup from "@/components/security/TwoFactorSetup";
+
+export default function ParamSecurity() {
+  return (
+    <div>
+      <h2 className="font-bold text-xl mb-4">Sécurité</h2>
+      <TwoFactorSetup />
+    </div>
+  );
+}

--- a/src/components/ui/button.jsx
+++ b/src/components/ui/button.jsx
@@ -14,7 +14,7 @@ export function Button({
       type={type}
       onClick={onClick}
       disabled={disabled}
-      className={`bg-mamastock-gold hover:bg-mamastock-gold-hover text-white font-semibold py-2 px-4 rounded-xl shadow-md transition-all duration-150 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-mamastock-gold ${className}`}
+      className={`bg-white/10 backdrop-blur-lg text-white font-semibold py-2 px-4 rounded-xl shadow-md hover:shadow-lg transition-all duration-150 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none ${className}`}
       aria-label={ariaLabel || undefined}
       aria-disabled={disabled}
       {...props}

--- a/src/components/ui/card.jsx
+++ b/src/components/ui/card.jsx
@@ -5,7 +5,7 @@ export function Card({ className = "", children, ...props }) {
   return (
     <div
       className={
-        "rounded-2xl shadow-xl bg-white/60 dark:bg-[#222a38]/60 border border-white/30 backdrop-blur-md p-6 " +
+        "rounded-xl shadow-md bg-glass backdrop-blur-lg p-4 text-white " +
         className
       }
       {...props}
@@ -17,7 +17,7 @@ export function Card({ className = "", children, ...props }) {
 
 export function CardContent({ className = "", children, ...props }) {
   return (
-    <div className={"p-2 " + className} {...props}>
+    <div className={"p-2 text-white " + className} {...props}>
       {children}
     </div>
   );

--- a/src/components/ui/input.jsx
+++ b/src/components/ui/input.jsx
@@ -18,7 +18,7 @@ export function Input({
       placeholder={placeholder}
       disabled={disabled}
       aria-label={ariaLabel || placeholder || "Champ de saisie"}
-      className={`w-full p-2 border border-mamastock-gold rounded-md bg-white text-mamastock-text placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-mamastock-gold disabled:opacity-50 disabled:cursor-not-allowed ${className}`}
+      className={`w-full p-2 rounded-lg border border-white/20 bg-white/10 text-white placeholder-white/70 focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed ${className}`}
       {...props}
     />
   );

--- a/src/index.css
+++ b/src/index.css
@@ -5,7 +5,7 @@
 /* Style custom global pour MamaStock */
 body {
   font-family: "Inter", sans-serif;
-  @apply bg-white text-black dark:bg-mamastock-bg dark:text-mamastock-text;
+  @apply bg-gradient-to-br from-[#2b4b61] to-[#6c92a9] text-white;
 }
 
 a {
@@ -48,7 +48,7 @@ a:hover {
 /* Buttons pro */
 .btn,
 .btn-primary {
-  @apply px-4 py-2 rounded-xl font-bold bg-mamastockGold text-mamastockBg shadow hover:bg-mamastockGoldHover transition;
+  @apply px-4 py-2 rounded-xl font-bold bg-white/10 text-white shadow hover:shadow-md transition backdrop-blur-lg;
 }
 .btn-sm {
   @apply px-2 py-1 text-sm;
@@ -70,13 +70,12 @@ a:hover {
 
 /* Input custom */
 .input {
-  @apply px-3 py-2 rounded-lg border border-mamastockGold bg-transparent text-mamastockText focus:outline-none;
+  @apply px-3 py-2 rounded-lg border border-white/20 bg-white/10 text-white placeholder-white/70 focus:outline-none;
 }
 
 /* Dark mode auto */
 html.dark body {
-  background-color: #111827;
-  color: #f0f0f5;
+  @apply bg-gradient-to-br from-[#2b4b61] to-[#6c92a9] text-white;
 }
 /* Animations LiquidGlass & glass panel */
 .animate-liquid { animation: glassMove 12s ease-in-out infinite alternate; }

--- a/src/layout/AdminLayout.jsx
+++ b/src/layout/AdminLayout.jsx
@@ -7,7 +7,10 @@ import Navbar from "@/layout/Navbar";
  */
 export default function AdminLayout({ children }) {
   return (
-    <div className="flex min-h-screen bg-mamastock-bg text-white">
+    <div
+      className="flex min-h-screen text-white"
+      style={{ textShadow: '0 1px 2px rgba(0,0,0,0.2)' }}
+    >
       <Sidebar />
       <div className="flex flex-col flex-1">
         <Navbar />

--- a/src/layout/Layout.jsx
+++ b/src/layout/Layout.jsx
@@ -7,7 +7,7 @@ export default function Layout() {
   if (pathname === "/login") return <Outlet />;
 
   return (
-    <div className="flex h-screen overflow-auto">
+    <div className="flex h-screen overflow-auto" style={{ textShadow: '0 1px 2px rgba(0,0,0,0.2)' }}>
       <Sidebar />
       <main className="flex-1 p-4">
         <Outlet />

--- a/src/layout/Navbar.jsx
+++ b/src/layout/Navbar.jsx
@@ -35,7 +35,7 @@ export default function Navbar() {
   };
 
   return (
-    <nav className="bg-mamastock-bg border-b border-mamastock-gold text-white px-6 py-4 flex items-center justify-between shadow-md">
+    <nav className="bg-white/5 backdrop-blur-xl text-white px-6 py-4 flex items-center justify-between shadow-md">
       {/* Logo / Titre */}
       <div className="flex items-center gap-4">
         <button onClick={toggleSidebar} className="md:hidden text-mamastock-gold text-2xl" aria-label="Ouvrir le menu">

--- a/src/layout/ViewerLayout.jsx
+++ b/src/layout/ViewerLayout.jsx
@@ -6,10 +6,13 @@ import Navbar from "@/layout/Navbar";
  */
 export default function ViewerLayout({ children }) {
   return (
-    <div className="flex flex-col min-h-screen bg-mamastockBg text-mamastockText">
+    <div
+      className="flex flex-col min-h-screen text-white"
+      style={{ textShadow: '0 1px 2px rgba(0,0,0,0.2)' }}
+    >
       <Navbar />
       <main className="flex-1 px-4 py-6 flex justify-center items-start overflow-y-auto">
-        <div className="w-full max-w-5xl bg-white text-black rounded-2xl shadow-lg p-6">
+        <div className="w-full max-w-5xl bg-glass backdrop-blur-lg rounded-xl shadow-md p-6">
           {children}
         </div>
       </main>

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -50,7 +50,7 @@ export default function Dashboard() {
   if (error) return <div className="p-6 text-red-600">{error}</div>;
 
   return (
-    <div className="p-6 container mx-auto">
+    <div className="p-6 container mx-auto" style={{ textShadow: '0 1px 2px rgba(0,0,0,0.2)' }}>
       <Toaster position="top-right" />
       <h1 className="text-3xl font-bold mb-6">Dashboard Stock & Achats</h1>
 

--- a/src/pages/Utilisateurs.jsx
+++ b/src/pages/Utilisateurs.jsx
@@ -55,7 +55,7 @@ export default function Utilisateurs() {
   };
 
   return (
-    <div className="p-6 container mx-auto">
+    <div className="p-6 container mx-auto" style={{ textShadow: '0 1px 2px rgba(0,0,0,0.2)' }}>
       <Toaster position="top-right" />
       <div className="flex flex-wrap gap-4 items-center mb-4">
         <input
@@ -78,7 +78,7 @@ export default function Utilisateurs() {
       <Motion.table
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
-        className="min-w-full bg-white rounded-xl shadow-md"
+        className="min-w-full bg-white/5 backdrop-blur-lg rounded-xl shadow-md text-white"
       >
         <thead>
           <tr>
@@ -94,7 +94,7 @@ export default function Utilisateurs() {
               <td className="border px-4 py-2">
                 <Button
                   variant="link"
-                  className="font-semibold text-mamastockGold"
+                  className="font-semibold text-white"
                   onClick={() => { setSelected(u); setShowDetail(true); }}
                 >
                   {u.email}

--- a/src/pages/factures/Factures.jsx
+++ b/src/pages/factures/Factures.jsx
@@ -61,7 +61,7 @@ export default function Factures() {
   };
 
   return (
-    <div className="p-6 container mx-auto">
+    <div className="p-6 container mx-auto" style={{ textShadow: '0 1px 2px rgba(0,0,0,0.2)' }}>
       <Toaster position="top-right" />
       <div className="flex flex-wrap gap-4 items-center mb-4">
         <input
@@ -89,7 +89,7 @@ export default function Factures() {
       <Motion.table
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
-        className="min-w-full bg-white rounded-xl shadow-md"
+        className="min-w-full bg-white/5 backdrop-blur-lg rounded-xl shadow-md text-white"
       >
         <thead>
           <tr>

--- a/src/pages/fiches/FicheDetail.jsx
+++ b/src/pages/fiches/FicheDetail.jsx
@@ -37,8 +37,8 @@ export default function FicheDetail({ fiche, onClose }) {
   ];
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
-      <div className="bg-white rounded-xl shadow-lg p-8 min-w-[400px] max-w-[95vw] flex flex-col gap-2 relative">
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-glass backdrop-blur-lg text-white rounded-xl shadow-lg p-8 min-w-[400px] max-w-[95vw] flex flex-col gap-2 relative" style={{ textShadow: '0 1px 2px rgba(0,0,0,0.2)' }}>
         <Button variant="outline" className="absolute top-2 right-2" onClick={onClose}>Fermer</Button>
         <h2 className="font-bold text-xl mb-4">{fiche.nom}</h2>
         <div><b>Portions :</b> {fiche.portions}</div>

--- a/src/pages/fiches/FicheForm.jsx
+++ b/src/pages/fiches/FicheForm.jsx
@@ -79,7 +79,7 @@ export default function FicheForm({ fiche, onClose }) {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="bg-white p-6 rounded-lg shadow-md max-w-2xl mx-auto">
+    <form onSubmit={handleSubmit} className="bg-glass backdrop-blur-lg text-white p-6 rounded-lg shadow-md max-w-2xl mx-auto" style={{ textShadow: '0 1px 2px rgba(0,0,0,0.2)' }}>
       <h2 className="text-lg font-bold mb-4">
         {fiche ? "Modifier la fiche technique" : "Ajouter une fiche technique"}
       </h2>
@@ -108,7 +108,7 @@ export default function FicheForm({ fiche, onClose }) {
       {/* Gestion dynamique des lignes produits */}
       <div className="mb-4">
         <label className="block font-semibold mb-2">Ingrédients :</label>
-        <table className="min-w-full mb-2">
+        <table className="min-w-full mb-2 bg-white/5 backdrop-blur-lg rounded-md text-white">
           <thead>
             <tr>
               <th>Produit</th>

--- a/src/pages/fiches/Fiches.jsx
+++ b/src/pages/fiches/Fiches.jsx
@@ -47,7 +47,7 @@ export default function Fiches() {
   };
 
   return (
-    <div className="p-6 container mx-auto">
+    <div className="p-6 container mx-auto" style={{ textShadow: '0 1px 2px rgba(0,0,0,0.2)' }}>
       <Toaster position="top-right" />
       <div className="flex flex-wrap gap-4 items-center mb-4">
         <input
@@ -66,7 +66,7 @@ export default function Fiches() {
       <Motion.table
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
-        className="min-w-full bg-white rounded-xl shadow-md"
+        className="min-w-full bg-white/5 backdrop-blur-lg rounded-xl shadow-md text-white"
       >
         <thead>
           <tr>
@@ -83,7 +83,7 @@ export default function Fiches() {
               <td className="border px-4 py-2">
                 <Button
                   variant="link"
-                  className="font-semibold text-mamastockGold"
+                  className="font-semibold text-white"
                   onClick={() => { setSelected(fiche); setShowDetail(true); }}
                 >
                   {fiche.nom}

--- a/src/pages/fournisseurs/Fournisseurs.jsx
+++ b/src/pages/fournisseurs/Fournisseurs.jsx
@@ -73,9 +73,9 @@ export default function Fournisseurs() {
   }, [fournisseurs, products]);
 
   return (
-    <div className="max-w-7xl mx-auto p-8">
+    <div className="max-w-7xl mx-auto p-8" style={{ textShadow: '0 1px 2px rgba(0,0,0,0.2)' }}>
       <Toaster />
-      <h1 className="text-2xl font-bold text-mamastockGold mb-6">Gestion des fournisseurs</h1>
+      <h1 className="text-2xl font-bold mb-6">Gestion des fournisseurs</h1>
       <div className="flex flex-wrap gap-4 mb-6 items-end">
         <div className="relative flex-1">
           <input
@@ -84,7 +84,7 @@ export default function Fournisseurs() {
             value={search}
             onChange={e => setSearch(e.target.value)}
           />
-          <Search className="absolute left-2 top-2.5 text-mamastockGold" size={18} />
+          <Search className="absolute left-2 top-2.5 text-white" size={18} />
         </div>
         <Button onClick={() => setShowCreate(true)}><PlusCircle className="mr-2" /> Ajouter fournisseur</Button>
         <Button variant="outline" onClick={exportFournisseursToExcel}>Export Excel</Button>
@@ -102,7 +102,7 @@ export default function Fournisseurs() {
       )}
       {/* Statistiques générales */}
       <div className="grid md:grid-cols-2 gap-8 mb-10">
-        <div className="glass-card p-4">
+        <div className="bg-glass backdrop-blur-lg p-4 rounded-xl shadow-md">
           <h2 className="font-semibold mb-2">Évolution des achats (tous fournisseurs)</h2>
           <ResponsiveContainer width="100%" height={180}>
             <LineChart data={stats}>
@@ -114,7 +114,7 @@ export default function Fournisseurs() {
             </LineChart>
           </ResponsiveContainer>
         </div>
-        <div className="glass-card p-4">
+        <div className="bg-glass backdrop-blur-lg p-4 rounded-xl shadow-md">
           <h2 className="font-semibold mb-2">Top produits achetés</h2>
           <ResponsiveContainer width="100%" height={180}>
             <BarChart data={topProducts}>
@@ -128,7 +128,7 @@ export default function Fournisseurs() {
         </div>
       </div>
       {/* Tableau fournisseurs */}
-      <div className="glass-table overflow-x-auto shadow-xl rounded-2xl mb-6">
+      <div className="bg-white/5 backdrop-blur-lg overflow-x-auto shadow-xl rounded-2xl mb-6">
         <table className="min-w-full text-center">
           <thead>
             <tr>
@@ -144,7 +144,7 @@ export default function Fournisseurs() {
           <tbody>
             {fournisseursFiltrés.map(f => (
               <tr key={f.id} className={f.actif ? '' : 'opacity-50'}>
-                <td className="py-1 px-3 font-semibold text-mamastockGold">{f.nom}</td>
+                <td className="py-1 px-3 font-semibold text-white">{f.nom}</td>
                 <td>{f.ville}</td>
                 <td>{f.tel}</td>
                 <td>{f.contact}</td>
@@ -167,7 +167,7 @@ export default function Fournisseurs() {
 
       {/* Modal création/édition */}
       <Dialog open={showCreate || !!editRow} onOpenChange={v => { if (!v) { setShowCreate(false); setEditRow(null); } }}>
-        <DialogContent className="glass-modal max-w-lg w-full p-8">
+        <DialogContent className="bg-glass backdrop-blur-lg rounded-2xl shadow-xl max-w-lg w-full p-8">
           <FournisseurForm
             fournisseur={editRow}
             onCancel={() => { setShowCreate(false); setEditRow(null); }}
@@ -184,31 +184,11 @@ export default function Fournisseurs() {
 
       {/* Modal détail */}
       <Dialog open={!!selected} onOpenChange={v => !v && setSelected(null)}>
-        <DialogContent className="glass-modal max-w-2xl w-full p-10">
+        <DialogContent className="bg-glass backdrop-blur-lg rounded-2xl shadow-xl max-w-2xl w-full p-10">
           {selected && <FournisseurDetail id={selected} />}
         </DialogContent>
       </Dialog>
 
-      <style>{`
-        .glass-card {
-          background: rgba(255,255,255,0.35);
-          backdrop-filter: blur(16px);
-          border-radius: 20px;
-          box-shadow: 0 8px 32px 0 rgba(191,161,77,0.13), 0 1.5px 10px 0 rgba(15,28,46,0.09);
-        }
-        .glass-table {
-          background: rgba(255,255,255,0.32);
-          backdrop-filter: blur(12px);
-          border-radius: 18px;
-        }
-        .glass-modal {
-          background: rgba(255,255,255,0.40);
-          box-shadow: 0 12px 40px 0 #bfa14d1a, 0 2px 20px 0 #0f1c2e21;
-          border-radius: 2rem;
-          backdrop-filter: blur(18px);
-          border: 1.5px solid #e5c98455;
-        }
-      `}</style>
     </div>
   );
 }

--- a/src/pages/inventaire/Inventaire.jsx
+++ b/src/pages/inventaire/Inventaire.jsx
@@ -308,13 +308,13 @@ export default function Inventaire() {
   if (!mama_id) return null;
 
   return (
-    <div className="p-8 max-w-7xl mx-auto">
+    <div className="p-8 max-w-7xl mx-auto" style={{ textShadow: '0 1px 2px rgba(0,0,0,0.2)' }}>
       <Toaster />
-      <h1 className="text-2xl font-bold text-mamastock-gold mb-4">
+      <h1 className="text-2xl font-bold mb-4">
         Suivi des écarts théoriques (Inventaire)
       </h1>
       {/* Graphe top écarts */}
-      <div className="mb-8 bg-white shadow rounded-xl p-4">
+      <div className="mb-8 bg-white/5 backdrop-blur-lg shadow rounded-xl p-4 text-white">
         <h2 className="font-bold mb-2">Top écarts valeur (€)</h2>
         <ResponsiveContainer width="100%" height={220}>
           <BarChart data={topEcarts}>
@@ -367,8 +367,8 @@ export default function Inventaire() {
         <Button onClick={handleExportAuditPDF}>Export Audit PDF</Button>
       </div>
       {/* Tableau principal, par zone */}
-      <div className="bg-white shadow rounded-xl overflow-x-auto">
-        <table className="min-w-full table-auto text-center">
+      <div className="bg-white/5 backdrop-blur-lg shadow rounded-xl overflow-x-auto">
+        <table className="min-w-full table-auto text-center text-white">
           <thead>
             <tr>
               <th className="px-2 py-1">Produit</th>
@@ -425,7 +425,7 @@ export default function Inventaire() {
                             Timeline
                           </Button>
                         </DialogTrigger>
-                        <DialogContent className="bg-white rounded-xl shadow-lg p-6 max-w-lg">
+                        <DialogContent className="bg-glass backdrop-blur-lg text-white rounded-xl shadow-lg p-6 max-w-lg">
                           <h3 className="font-bold mb-2">
                             Historique inventaire {p.nom} ({zone})
                           </h3>
@@ -465,7 +465,7 @@ export default function Inventaire() {
       </div>
       {/* Modal édition ligne */}
       <Dialog open={!!editRow} onOpenChange={v => !v && setEditRow(null)}>
-        <DialogContent className="bg-white rounded-xl shadow-lg p-6 max-w-md">
+        <DialogContent className="bg-glass backdrop-blur-lg text-white rounded-xl shadow-lg p-6 max-w-md">
           <h2 className="font-bold mb-2">
             Correction stock physique / commentaire
           </h2>
@@ -531,7 +531,7 @@ export default function Inventaire() {
           Justificatifs transferts inter-zones (période)
         </h2>
         <div className="bg-white shadow rounded-xl p-4 mb-4">
-          <table className="min-w-full table-auto text-center">
+          <table className="min-w-full table-auto text-center text-white">
             <thead>
               <tr>
                 <th className="px-2 py-1">Produit</th>

--- a/src/pages/parametrage/Mamas.jsx
+++ b/src/pages/parametrage/Mamas.jsx
@@ -45,9 +45,9 @@ export default function Mamas() {
   );
 
   return (
-    <div className="p-8 max-w-4xl mx-auto">
+    <div className="p-8 max-w-4xl mx-auto" style={{ textShadow: '0 1px 2px rgba(0,0,0,0.2)' }}>
       <Toaster />
-      <h1 className="text-2xl font-bold text-mamastock-gold mb-4">
+      <h1 className="text-2xl font-bold mb-4">
         Établissements (MAMA)
       </h1>
       <div className="flex gap-4 mb-4 items-end">
@@ -61,7 +61,7 @@ export default function Mamas() {
           + Nouvel établissement
         </Button>
       </div>
-      <div className="bg-white shadow rounded-xl overflow-x-auto mb-6">
+      <div className="bg-white/5 backdrop-blur-lg shadow rounded-xl overflow-x-auto mb-6">
         {loading ? (
           <div className="text-center py-8 text-gray-500">
             <span className="animate-spin mr-2">⏳</span>Chargement…
@@ -145,7 +145,7 @@ export default function Mamas() {
         )}
       </div>
       <Dialog open={!!editMama} onOpenChange={v => !v && setEditMama(null)}>
-        <DialogContent className="bg-white rounded-xl shadow-lg p-6 max-w-md">
+        <DialogContent className="bg-glass backdrop-blur-lg text-white rounded-xl shadow-lg p-6 max-w-md">
           <MamaForm
             mama={editMama}
             onSaved={() => {

--- a/src/pages/parametrage/Parametrage.jsx
+++ b/src/pages/parametrage/Parametrage.jsx
@@ -5,6 +5,7 @@ import ParamRoles from "@/components/parametrage/ParamRoles";
 import ParamAccess from "@/components/parametrage/ParamAccess";
 import ParamMama from "@/components/parametrage/ParamMama";
 import ParamCostCenters from "@/components/parametrage/ParamCostCenters";
+import ParamSecurity from "@/components/parametrage/ParamSecurity";
 import { useAuth } from "@/context/AuthContext";
 
 export default function Parametrage() {
@@ -20,6 +21,7 @@ export default function Parametrage() {
           { name: "Accès", content: <ParamAccess /> },
           { name: "Cost centers", content: <ParamCostCenters /> },
           { name: "Établissement", content: <ParamMama /> },
+          { name: "Sécurité", content: <ParamSecurity /> },
         ]}
       />
     </div>

--- a/src/pages/parametrage/Roles.jsx
+++ b/src/pages/parametrage/Roles.jsx
@@ -109,9 +109,9 @@ export default function Roles() {
   if (!mama_id) return null;
 
   return (
-    <div className="p-8 max-w-4xl mx-auto">
+    <div className="p-8 max-w-4xl mx-auto" style={{ textShadow: '0 1px 2px rgba(0,0,0,0.2)' }}>
       <Toaster />
-      <h1 className="text-2xl font-bold text-mamastock-gold mb-4">
+      <h1 className="text-2xl font-bold mb-4">
         Gestion des rôles
       </h1>
       <div className="flex gap-4 mb-4 items-end">
@@ -125,7 +125,7 @@ export default function Roles() {
           + Nouveau rôle
         </Button>
       </div>
-      <div className="bg-white shadow rounded-xl overflow-x-auto mb-6">
+      <div className="bg-white/5 backdrop-blur-lg shadow rounded-xl overflow-x-auto mb-6">
         <table className="min-w-full table-auto text-center">
           <thead>
             <tr>
@@ -202,7 +202,7 @@ export default function Roles() {
       </div>
       {/* Modale création/édition */}
       <Dialog open={!!editRole} onOpenChange={v => !v && setEditRole(null)}>
-        <DialogContent className="bg-white rounded-xl shadow-lg p-6 max-w-md">
+        <DialogContent className="bg-glass backdrop-blur-lg text-white rounded-xl shadow-lg p-6 max-w-md">
           <h2 className="font-bold mb-2">
             {editRole?.id ? "Modifier le rôle" : "Nouveau rôle"}
           </h2>
@@ -250,7 +250,7 @@ export default function Roles() {
       {/* Modale permissions */}
       {editPermsRole && (
         <Dialog open={!!editPermsRole} onOpenChange={v => !v && setEditPermsRole(null)}>
-          <DialogContent className="bg-white rounded-xl shadow-lg p-6 max-w-xl">
+          <DialogContent className="bg-glass backdrop-blur-lg text-white rounded-xl shadow-lg p-6 max-w-xl">
               {/* Passe bien tout l'objet ici */}
               <PermissionsForm
                 role={editPermsRole}

--- a/src/pages/produits/Produits.jsx
+++ b/src/pages/produits/Produits.jsx
@@ -83,9 +83,9 @@ export default function Produits() {
   }, [fetchProducts, search, familleFilter, actifFilter, page, sortField, sortOrder]);
 
   return (
-    <div className="p-8 max-w-7xl mx-auto">
+    <div className="p-8 max-w-7xl mx-auto" style={{ textShadow: '0 1px 2px rgba(0,0,0,0.2)' }}>
       <Toaster />
-      <h1 className="text-2xl font-bold text-mamastockGold mb-4">Produits stock</h1>
+      <h1 className="text-2xl font-bold mb-4">Produits stock</h1>
       <div className="flex flex-wrap gap-2 mb-6 items-end">
         <input
           type="search"
@@ -123,8 +123,8 @@ export default function Produits() {
           className="hidden"
         />
       </div>
-      <div className="bg-white/70 shadow rounded-xl overflow-x-auto">
-        <table className="min-w-full table-auto text-center">
+      <div className="bg-white/5 backdrop-blur-lg shadow rounded-xl overflow-x-auto">
+        <table className="min-w-full table-auto text-center text-white">
           <thead>
             <tr>
               <th className="cursor-pointer" onClick={() => toggleSort("nom")}>Nom{renderArrow("nom")}</th>

--- a/src/pages/taches/Taches.jsx
+++ b/src/pages/taches/Taches.jsx
@@ -23,15 +23,15 @@ export default function Taches() {
   if (error) return <div className="p-8 text-red-600">{error}</div>;
 
   return (
-    <div className="p-8">
+    <div className="p-8" style={{ textShadow: '0 1px 2px rgba(0,0,0,0.2)' }}>
       <Toaster position="top-right" />
       <div className="flex justify-between items-center mb-4">
         <h1 className="text-2xl font-bold">Tâches</h1>
-        <Link to="/taches/nouveau" className="bg-mamastock-gold hover:bg-mamastock-gold-hover text-white font-semibold py-2 px-4 rounded-xl shadow-md">
+        <Link to="/taches/nouveau" className="bg-white/10 backdrop-blur-lg text-white font-semibold py-2 px-4 rounded-xl shadow-md hover:shadow-lg">
           Nouvelle tâche
         </Link>
       </div>
-      <table className="w-full text-sm bg-white shadow rounded">
+      <table className="w-full text-sm bg-white/5 backdrop-blur-lg shadow rounded text-white">
         <thead>
           <tr>
             <th className="px-2 py-1">Titre</th>
@@ -53,7 +53,7 @@ export default function Taches() {
             tasks.map(t => (
               <tr key={t.id}>
                 <td className="px-2 py-1">
-                  <Link to={`/taches/${t.id}`} className="text-mamastockGold underline">
+                  <Link to={`/taches/${t.id}`} className="underline text-white">
                     {t.titre}
                   </Link>
                 </td>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -20,6 +20,10 @@ module.exports = {
         'mamastock-gold': '#bfa14d',
         'mamastock-goldHover': '#a98b39',
         'mamastock-gold-hover': '#a98b39',
+        glass: 'rgba(255, 255, 255, 0.05)',
+      },
+      backdropBlur: {
+        lg: '20px',
       },
     },
   },


### PR DESCRIPTION
## Summary
- integrate two-factor authentication management into Settings
- add new `ParamSecurity` component with `TwoFactorSetup`
- expose a new "Sécurité" tab on `/parametrage`
- overhaul UI with Liquid Glass design

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68553c2cc104832dbfe7a85ac8b7307c