### PR TITLE
Fix router and detail page

### DIFF
--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -1,32 +1,87 @@
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { useAuth } from "@/context/AuthContext";
 
 export default function Sidebar() {
   const { access_rights, role, loading } = useAuth();
+  const { pathname } = useLocation();
 
   if (loading) return null;
   const showAll = role === "superadmin";
   const rights = Array.isArray(access_rights) ? access_rights : [];
+  const has = (key) => showAll || rights.includes(key);
 
   return (
     <aside className="w-64 bg-white/5 backdrop-blur-xl text-white p-4 h-screen shadow-md text-shadow">
       <h2 className="text-2xl font-bold mb-6">MamaStock</h2>
-      <nav className="flex flex-col gap-2">
-        {(showAll || rights.includes("dashboard")) && (
-          <Link to="/dashboard">Dashboard</Link>
+      <nav className="flex flex-col gap-2 text-sm">
+        {has("dashboard") && <Link to="/dashboard">Dashboard</Link>}
+
+        {(has("fournisseurs") || has("factures")) && (
+          <details open={pathname.startsWith("/fournisseurs") || pathname.startsWith("/factures")}> 
+            <summary className="cursor-pointer">Achats</summary>
+            <div className="ml-4 flex flex-col gap-1 mt-1">
+              {has("fournisseurs") && <Link to="/fournisseurs">Fournisseurs</Link>}
+              {has("factures") && <Link to="/factures">Factures</Link>}
+            </div>
+          </details>
         )}
-        {(showAll || rights.includes("stock")) && (
-          <Link to="/produits">Produits / Stock</Link>
+
+        {(has("fiches") || has("menus")) && (
+          <details open={pathname.startsWith("/fiches") || pathname.startsWith("/menus")}> 
+            <summary className="cursor-pointer">Cuisine</summary>
+            <div className="ml-4 flex flex-col gap-1 mt-1">
+              {has("fiches") && <Link to="/fiches">Fiches</Link>}
+              {has("menus") && <Link to="/menus">Menus</Link>}
+            </div>
+          </details>
         )}
-        {(showAll || rights.includes("factures")) && (
-          <Link to="/factures">Factures</Link>
+
+        {(has("produits") || has("inventaires") || has("mouvements")) && (
+          <details open={pathname.startsWith("/produits") || pathname.startsWith("/inventaire") || pathname.startsWith("/mouvements")}> 
+            <summary className="cursor-pointer">Stock</summary>
+            <div className="ml-4 flex flex-col gap-1 mt-1">
+              {has("produits") && <Link to="/produits">Produits</Link>}
+              {has("inventaires") && <Link to="/inventaire">Inventaire</Link>}
+              {has("mouvements") && <Link to="/mouvements">Mouvements</Link>}
+            </div>
+          </details>
         )}
-        {(showAll || rights.includes("fiches")) && (
-          <Link to="/fiches">Fiches techniques</Link>
+
+        {(has("alertes") || has("promotions")) && (
+          <details open={pathname.startsWith("/alertes") || pathname.startsWith("/promotions")}> 
+            <summary className="cursor-pointer">Alertes / Promotions</summary>
+            <div className="ml-4 flex flex-col gap-1 mt-1">
+              {has("alertes") && <Link to="/alertes">Alertes</Link>}
+              {has("promotions") && <Link to="/promotions">Promotions</Link>}
+            </div>
+          </details>
         )}
-        {(showAll || rights.includes("parametrage")) && (
-          <Link to="/parametrage">Paramétrage</Link>
+
+        {(has("documents") || has("analyse")) && (
+          <details open={pathname.startsWith("/documents") || pathname.startsWith("/analyse")}> 
+            <summary className="cursor-pointer">Documents / Analyse</summary>
+            <div className="ml-4 flex flex-col gap-1 mt-1">
+              {has("documents") && <Link to="/documents">Documents</Link>}
+              {has("analyse") && <Link to="/analyse">Analyse</Link>}
+            </div>
+          </details>
         )}
+
+        {(has("parametrage") || has("utilisateurs") || has("roles") || has("mamas") || has("permissions") || has("access")) && (
+          <details open={pathname.startsWith("/parametrage")}> 
+            <summary className="cursor-pointer">Paramétrage</summary>
+            <div className="ml-4 flex flex-col gap-1 mt-1">
+              {has("utilisateurs") && <Link to="/parametrage/utilisateurs">Utilisateurs</Link>}
+              {has("roles") && <Link to="/parametrage/roles">Rôles</Link>}
+              {has("mamas") && <Link to="/parametrage/mamas">Mamas</Link>}
+              {has("permissions") && <Link to="/parametrage/permissions">Permissions</Link>}
+              {has("access") && <Link to="/parametrage/access">Accès</Link>}
+            </div>
+          </details>
+        )}
+
+        <Link to="/onboarding">Onboarding</Link>
+        <Link to="/aide">Aide</Link>
       </nav>
     </aside>
   );

--- a/src/pages/AideContextuelle.jsx
+++ b/src/pages/AideContextuelle.jsx
@@ -1,0 +1,2 @@
+import HelpCenter from './HelpCenter';
+export default HelpCenter;

--- a/src/pages/analyse/Analyse.jsx
+++ b/src/pages/analyse/Analyse.jsx
@@ -1,0 +1,3 @@
+export default function Analyse() {
+  return <div>Page Analyse (en construction)</div>;
+}

--- a/src/pages/analyse/AnalyseCostCenter.jsx
+++ b/src/pages/analyse/AnalyseCostCenter.jsx
@@ -1,0 +1,3 @@
+export default function AnalyseCostCenter() {
+  return <div>Page Analyse Cost Center (en construction)</div>;
+}

--- a/src/pages/fiches/FicheDetail.jsx
+++ b/src/pages/fiches/FicheDetail.jsx
@@ -1,10 +1,32 @@
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
 import { saveAs } from "file-saver";
 import * as XLSX from "xlsx";
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/context/AuthContext";
 import { Button } from "@/components/ui/button";
 import jsPDF from "jspdf";
 import "jspdf-autotable";
 
-export default function FicheDetail({ fiche, onClose }) {
+export default function FicheDetail({ fiche: ficheProp, onClose }) {
+  const { id } = useParams();
+  const { mama_id } = useAuth();
+  const [fiche, setFiche] = useState(ficheProp);
+
+  useEffect(() => {
+    const fid = ficheProp?.id || id;
+    if (fid && mama_id && !ficheProp) {
+      supabase
+        .from("fiches")
+        .select("*")
+        .eq("id", fid)
+        .eq("mama_id", mama_id)
+        .single()
+        .then(({ data }) => setFiche(data));
+    }
+  }, [ficheProp, id, mama_id]);
+
+  if (!fiche) return <div className="p-8">Chargement...</div>;
   // Export Excel fiche
   const exportExcel = () => {
     const wb = XLSX.utils.book_new();

--- a/src/pages/parametrage/AccessRights.jsx
+++ b/src/pages/parametrage/AccessRights.jsx
@@ -1,0 +1,3 @@
+export default function AccessRights() {
+  return <div>Page Access Rights (en construction)</div>;
+}

--- a/src/pages/produits/ProduitDetail.jsx
+++ b/src/pages/produits/ProduitDetail.jsx
@@ -1,0 +1,6 @@
+import { useParams } from 'react-router-dom';
+
+export default function ProduitDetail() {
+  const { id } = useParams();
+  return <div>Page Produit Detail {id} (en construction)</div>;
+}

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -1,50 +1,66 @@
-import { Routes, Route, Navigate } from "react-router-dom";
 import { Suspense, lazy } from "react";
+import { Routes, Route, Navigate } from "react-router-dom";
 import Layout from "@/layout/Layout";
 import Login from "@/pages/auth/Login";
 import Unauthorized from "@/pages/auth/Unauthorized";
 import AuthDebug from "@/pages/debug/AuthDebug";
 import { useAuth } from "@/context/AuthContext";
 
-const pageModules = import.meta.glob("./pages/**/*.jsx");
+const Dashboard = lazy(() => import("@/pages/Dashboard.jsx"));
+const Fournisseurs = lazy(() => import("@/pages/fournisseurs/Fournisseurs.jsx"));
+const Factures = lazy(() => import("@/pages/factures/Factures.jsx"));
+const FactureDetail = lazy(() => import("@/pages/factures/FactureDetail.jsx"));
+const Fiches = lazy(() => import("@/pages/fiches/Fiches.jsx"));
+const FicheDetail = lazy(() => import("@/pages/fiches/FicheDetail.jsx"));
+const Menus = lazy(() => import("@/pages/menus/Menus.jsx"));
+const Produits = lazy(() => import("@/pages/produits/Produits.jsx"));
+const ProduitDetail = lazy(() => import("@/pages/produits/ProduitDetail.jsx"));
+const Inventaire = lazy(() => import("@/pages/inventaire/Inventaire.jsx"));
+const Mouvements = lazy(() => import("@/pages/mouvements/Mouvements.jsx"));
+const Alertes = lazy(() => import("@/pages/Alertes.jsx"));
+const Promotions = lazy(() => import("@/pages/promotions/Promotions.jsx"));
+const Documents = lazy(() => import("@/pages/Documents.jsx"));
+const Analyse = lazy(() => import("@/pages/analyse/Analyse.jsx"));
+const AnalyseCostCenter = lazy(() => import("@/pages/analyse/AnalyseCostCenter.jsx"));
+const Utilisateurs = lazy(() => import("@/pages/Utilisateurs.jsx"));
+const Roles = lazy(() => import("@/pages/parametrage/Roles.jsx"));
+const Mamas = lazy(() => import("@/pages/parametrage/Mamas.jsx"));
+const Permissions = lazy(() => import("@/pages/parametrage/Permissions.jsx"));
+const AccessRights = lazy(() => import("@/pages/parametrage/AccessRights.jsx"));
+const Onboarding = lazy(() => import("@/pages/Onboarding.jsx"));
+const AideContextuelle = lazy(() => import("@/pages/AideContextuelle.jsx"));
 
-function toRoutePath(file) {
-  let p = file.replace(/^\.\/pages/, "").replace(/\.jsx$/, "");
-  p = p.replace(/\/index$/i, "");
-  const parts = p
-    .split("/")
-    .map((seg) => seg.replace(/([a-z0-9])([A-Z])/g, "$1-$2").toLowerCase());
-  for (let i = 1; i < parts.length; ) {
-    if (parts[i] === parts[i - 1]) {
-      parts.splice(i, 1);
-    } else {
-      i += 1;
-    }
-  }
-  p = parts.join("/");
-  if (p === "/auth/login") return "/login";
-  if (p === "/debug/auth-debug") return "/debug/auth";
-  return p;
-}
+const accessMap = {
+  "/dashboard": "dashboard",
+  "/fournisseurs": "fournisseurs",
+  "/factures": "factures",
+  "/factures/:id": "factures",
+  "/fiches": "fiches",
+  "/fiches/:id": "fiches",
+  "/menus": "menus",
+  "/produits": "produits",
+  "/produits/:id": "produits",
+  "/inventaire": "inventaires",
+  "/mouvements": "mouvements",
+  "/alertes": "alertes",
+  "/promotions": "promotions",
+  "/documents": "documents",
+  "/analyse": "analyse",
+  "/analyse/cost-centers": "analyse",
+  "/parametrage/utilisateurs": "utilisateurs",
+  "/parametrage/roles": "roles",
+  "/parametrage/mamas": "mamas",
+  "/parametrage/permissions": "permissions",
+  "/parametrage/access": "access",
+  "/onboarding": "onboarding",
+  "/aide": "aide",
+};
 
-const routes = Object.entries(pageModules).map(([file, loader]) => ({
-  path: toRoutePath(file),
-  Component: lazy(loader),
-}));
-
-function getAccess(path) {
-  if (path.startsWith("/produits")) return "stock";
-  if (path.startsWith("/factures")) return "factures";
-  if (path.startsWith("/fiches")) return "fiches";
-  if (path.startsWith("/parametrage")) return "parametrage";
-  if (path.startsWith("/dashboard")) return "dashboard";
-  return null;
-}
-
-function ProtectedRoute({ children, access }) {
+function ProtectedRoute({ children, path }) {
   const { isAuthenticated, loading, role, access_rights } = useAuth();
   if (loading) return null;
   if (!isAuthenticated) return <Navigate to="/login" replace />;
+  const access = accessMap[path] || null;
   if (access && role !== "superadmin" && !access_rights?.includes(access)) {
     return <Navigate to="/unauthorized" replace />;
   }
@@ -53,31 +69,110 @@ function ProtectedRoute({ children, access }) {
 
 export default function Router() {
   return (
-      <Suspense fallback={null}>
-        <Routes>
+    <Suspense fallback={null}>
+      <Routes>
         <Route path="/login" element={<Login />} />
         <Route element={<Layout />}>
-          {routes
-            .filter(r => !["/login", "/debug/auth", "/unauthorized"].includes(r.path))
-            .map(({ path, Component }) => {
-              const Element = Component;
-              return (
-                <Route
-                  key={path}
-                  path={path}
-                  element={
-                    <ProtectedRoute access={getAccess(path)}>
-                      <Element />
-                    </ProtectedRoute>
-                  }
-                />
-              );
-            })}
-          <Route path="/debug/auth" element={<ProtectedRoute><AuthDebug /></ProtectedRoute>} />
+          <Route
+            path="/dashboard"
+            element={<ProtectedRoute path="/dashboard"><Dashboard /></ProtectedRoute>}
+          />
+          <Route
+            path="/fournisseurs"
+            element={<ProtectedRoute path="/fournisseurs"><Fournisseurs /></ProtectedRoute>}
+          />
+          <Route
+            path="/factures"
+            element={<ProtectedRoute path="/factures"><Factures /></ProtectedRoute>}
+          />
+          <Route
+            path="/factures/:id"
+            element={<ProtectedRoute path="/factures/:id"><FactureDetail /></ProtectedRoute>}
+          />
+          <Route
+            path="/fiches"
+            element={<ProtectedRoute path="/fiches"><Fiches /></ProtectedRoute>}
+          />
+          <Route
+            path="/fiches/:id"
+            element={<ProtectedRoute path="/fiches/:id"><FicheDetail /></ProtectedRoute>}
+          />
+          <Route
+            path="/menus"
+            element={<ProtectedRoute path="/menus"><Menus /></ProtectedRoute>}
+          />
+          <Route
+            path="/produits"
+            element={<ProtectedRoute path="/produits"><Produits /></ProtectedRoute>}
+          />
+          <Route
+            path="/produits/:id"
+            element={<ProtectedRoute path="/produits/:id"><ProduitDetail /></ProtectedRoute>}
+          />
+          <Route
+            path="/inventaire"
+            element={<ProtectedRoute path="/inventaire"><Inventaire /></ProtectedRoute>}
+          />
+          <Route
+            path="/mouvements"
+            element={<ProtectedRoute path="/mouvements"><Mouvements /></ProtectedRoute>}
+          />
+          <Route
+            path="/alertes"
+            element={<ProtectedRoute path="/alertes"><Alertes /></ProtectedRoute>}
+          />
+          <Route
+            path="/promotions"
+            element={<ProtectedRoute path="/promotions"><Promotions /></ProtectedRoute>}
+          />
+          <Route
+            path="/documents"
+            element={<ProtectedRoute path="/documents"><Documents /></ProtectedRoute>}
+          />
+          <Route
+            path="/analyse"
+            element={<ProtectedRoute path="/analyse"><Analyse /></ProtectedRoute>}
+          />
+          <Route
+            path="/analyse/cost-centers"
+            element={<ProtectedRoute path="/analyse/cost-centers"><AnalyseCostCenter /></ProtectedRoute>}
+          />
+          <Route
+            path="/parametrage/utilisateurs"
+            element={<ProtectedRoute path="/parametrage/utilisateurs"><Utilisateurs /></ProtectedRoute>}
+          />
+          <Route
+            path="/parametrage/roles"
+            element={<ProtectedRoute path="/parametrage/roles"><Roles /></ProtectedRoute>}
+          />
+          <Route
+            path="/parametrage/mamas"
+            element={<ProtectedRoute path="/parametrage/mamas"><Mamas /></ProtectedRoute>}
+          />
+          <Route
+            path="/parametrage/permissions"
+            element={<ProtectedRoute path="/parametrage/permissions"><Permissions /></ProtectedRoute>}
+          />
+          <Route
+            path="/parametrage/access"
+            element={<ProtectedRoute path="/parametrage/access"><AccessRights /></ProtectedRoute>}
+          />
+          <Route
+            path="/onboarding"
+            element={<ProtectedRoute path="/onboarding"><Onboarding /></ProtectedRoute>}
+          />
+          <Route
+            path="/aide"
+            element={<ProtectedRoute path="/aide"><AideContextuelle /></ProtectedRoute>}
+          />
+          <Route
+            path="/debug/auth"
+            element={<ProtectedRoute path="/debug/auth"><AuthDebug /></ProtectedRoute>}
+          />
           <Route path="/unauthorized" element={<Unauthorized />} />
           <Route path="*" element={<Navigate to="/dashboard" replace />} />
         </Route>
       </Routes>
-      </Suspense>
+    </Suspense>
   );
 }


### PR DESCRIPTION
## Summary
- overhaul router with explicit module routes
- secure each path via access map
- enable `FicheDetail` to fetch data when accessed directly

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685591e943bc832d8bb1ac3d3c7fb2b9