### PR TITLE
Complete forms audit with remaining pages

### DIFF
--- a/audit_formulaires.json
+++ b/audit_formulaires.json
@@ -1,0 +1,178 @@
+[
+  {
+    "form": "src/components/analytics/CostCenterAllocationModal.jsx",
+    "status": "corrected"
+  },
+  {
+    "form": "src/components/inventaires/InventaireForm.jsx",
+    "status": "corrected"
+  },
+  {
+    "form": "src/components/mouvements/MouvementFormModal.jsx",
+    "status": "corrected"
+  },
+  {
+    "form": "src/components/parametrage/ParamCostCenters.jsx",
+    "status": "corrected"
+  },
+  {
+    "form": "src/components/parametrage/ParamFamilles.jsx",
+    "status": "corrected"
+  },
+  {
+    "form": "src/components/parametrage/ParamMama.jsx",
+    "status": "corrected"
+  },
+  {
+    "form": "src/components/parametrage/ParamRoles.jsx",
+    "status": "corrected"
+  },
+  {
+    "form": "src/components/parametrage/ParamUnites.jsx",
+    "status": "corrected"
+  },
+  {
+    "form": "src/components/produits/ProduitForm.jsx",
+    "status": "corrected"
+  },
+  {
+    "form": "src/components/stock/StockMouvementForm.jsx",
+    "status": "corrected"
+  },
+  {
+    "form": "src/components/taches/TacheForm.jsx",
+    "status": "corrected"
+  },
+  {
+    "form": "src/components/utilisateurs/UtilisateurForm.jsx",
+    "status": "corrected"
+  },
+  {
+    "form": "src/pages/Alertes.jsx",
+    "status": "corrected"
+  },
+  {
+    "form": "src/pages/AuditTrail.jsx",
+    "status": "ok"
+  },
+  {
+    "form": "src/pages/Documents.jsx",
+    "status": "corrected"
+  },
+  {
+    "form": "src/pages/Journal.jsx",
+    "status": "ok"
+  },
+  {
+    "form": "src/pages/Pertes.jsx",
+    "status": "corrected"
+  },
+  {
+    "form": "src/pages/Planning.jsx",
+    "status": "corrected"
+  },
+  {
+    "form": "src/pages/Transferts.jsx",
+    "status": "corrected"
+  },
+  {
+    "form": "src/pages/Validations.jsx",
+    "status": "corrected"
+  },
+  {
+    "form": "src/pages/auth/Login.jsx",
+    "status": "corrected"
+  },
+  {
+    "form": "src/pages/auth/ResetPassword.jsx",
+    "status": "corrected"
+  },
+  {
+    "form": "src/pages/auth/UpdatePassword.jsx",
+    "status": "corrected"
+  },
+  {
+    "form": "src/pages/factures/FactureForm.jsx",
+    "status": "corrected"
+  },
+  {
+    "form": "src/pages/factures/ImportFactures.jsx",
+    "status": "corrected"
+  },
+  {
+    "form": "src/pages/fiches/FicheForm.jsx",
+    "status": "corrected"
+  },
+  {
+    "form": "src/pages/fournisseurs/Fournisseurs.jsx",
+    "status": "corrected"
+  },
+  {
+    "form": "src/pages/inventaire/Inventaire.jsx",
+    "status": "corrected"
+  },
+  {
+    "form": "src/pages/menus/MenuDuJourForm.jsx",
+    "status": "corrected"
+  },
+  {
+    "form": "src/pages/menus/MenuForm.jsx",
+    "status": "corrected"
+  },
+  {
+    "form": "src/pages/mouvements/Mouvements.jsx",
+    "status": "corrected"
+  },
+  {
+    "form": "src/pages/parametrage/InviteUser.jsx",
+    "status": "corrected"
+  },
+  {
+    "form": "src/pages/parametrage/MamaForm.jsx",
+    "status": "corrected"
+  },
+  {
+    "form": "src/pages/parametrage/RoleForm.jsx",
+    "status": "corrected"
+  },
+  {
+    "form": "src/pages/parametrage/Roles.jsx",
+    "status": "corrected"
+  },
+  {
+    "form": "src/pages/promotions/Promotions.jsx",
+    "status": "corrected"
+  },
+  {
+    "form": "src/pages/requisitions/RequisitionForm.jsx",
+    "status": "corrected"
+  },
+  {
+    "form": "src/pages/requisitions/Requisitions.jsx",
+    "status": "corrected"
+  },
+  {
+    "form": "src/pages/signalements/SignalementForm.jsx",
+    "status": "corrected"
+  },
+  {
+    "form": "src/components/fournisseurs/SupplierForm.jsx",
+    "status": "corrected"
+  },
+  {
+    "form": "src/pages/parametrage/PermissionsForm.jsx",
+    "status": "corrected"
+  },
+  {
+    "form": "src/pages/simulation/SimulationForm.jsx",
+    "status": "corrected"
+  },
+  {
+    "form": "src/pages/inventaire/InventaireForm.jsx",
+    "status": "corrected"
+  },
+  {
+    "form": "src/components/produits/ProduitFormModal.jsx",
+    "status": "corrected"
+  }
+]

--- a/src/components/inventaires/InventaireForm.jsx
+++ b/src/components/inventaires/InventaireForm.jsx
@@ -88,16 +88,26 @@ export default function InventaireForm({ inventaire, onClose }) {
   const handleCloture = async () => {
     if (!inventaire?.id) return;
     if (window.confirm("Clôturer cet inventaire ? (action irréversible)")) {
-      setLoading(true);
-      await clotureInventaire(inventaire.id);
-      toast.success("Inventaire clôturé !");
-      onClose?.();
+      try {
+        setLoading(true);
+        await clotureInventaire(inventaire.id);
+        toast.success("Inventaire clôturé !");
+        onClose?.();
+      } catch (err) {
+        console.error("Erreur clôture inventaire:", err);
+        toast.error("Erreur lors de la clôture.");
+      } finally {
+        setLoading(false);
+      }
     }
   };
 
   // Submit CRUD
   const handleSubmit = async (e) => {
     e.preventDefault();
+    if (!nom.trim()) return toast.error("Nom requis");
+    if (!date) return toast.error("Date requise");
+    if (lignes.some(l => !l.product_id)) return toast.error("Produit manquant");
     setLoading(true);
     const invData = {
       nom,

--- a/src/components/mouvements/MouvementFormModal.jsx
+++ b/src/components/mouvements/MouvementFormModal.jsx
@@ -49,14 +49,27 @@ export default function MouvementFormModal({
     setForm(f => ({ ...f, [name]: value }));
   }
 
-  function handleSubmit(e) {
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit(e) {
     e.preventDefault();
     const err = validate();
     setErrors(err);
-    if (Object.keys(err).length === 0) {
-      onSubmit(form);
-    } else {
+    if (Object.keys(err).length > 0) {
       toast.error("Veuillez corriger les erreurs.");
+      return;
+    }
+    if (submitting) return;
+    try {
+      setSubmitting(true);
+      await onSubmit(form);
+      toast.success("Mouvement enregistré !");
+      onOpenChange(false);
+    } catch (err) {
+      console.error("Erreur enregistrement mouvement:", err);
+      toast.error("Erreur lors de l'enregistrement.");
+    } finally {
+      setSubmitting(false);
     }
   }
 
@@ -162,11 +175,11 @@ export default function MouvementFormModal({
                 <Button
                   type="submit"
                   className={`w-full mt-3 py-2 rounded-xl bg-mamastockGold hover:bg-[#b89730] text-white font-semibold text-lg shadow transition-all flex items-center justify-center gap-2 disabled:opacity-50 ${
-                    loading ? "opacity-70" : ""
+                    loading || submitting ? "opacity-70" : ""
                   }`}
-                  disabled={loading}
+                  disabled={loading || submitting}
                 >
-                  {loading ? "Enregistrement…" : (editMode ? "Enregistrer" : "Créer")}
+                  {loading || submitting ? "Enregistrement…" : (editMode ? "Enregistrer" : "Créer")}
                 </Button>
               </form>
               {/* Animation */}

--- a/src/components/parametrage/ParamCostCenters.jsx
+++ b/src/components/parametrage/ParamCostCenters.jsx
@@ -31,13 +31,20 @@ export default function ParamCostCenters() {
   const handleEdit = c => { setForm(c); setEditMode(true); };
   const handleDelete = async id => {
     if (window.confirm("Supprimer ce cost center ?")) {
-      await deleteCostCenter(id); await fetchCostCenters();
-      toast.success("Cost center supprimé.");
+      try {
+        await deleteCostCenter(id);
+        await fetchCostCenters();
+        toast.success("Cost center supprimé.");
+      } catch (err) {
+        console.error("Erreur suppression cost center:", err);
+        toast.error("Échec suppression");
+      }
     }
   };
 
   const handleSubmit = async e => {
     e.preventDefault();
+    if (!form.nom.trim()) return toast.error("Nom requis");
     if (editMode) {
       await updateCostCenter(form.id, { nom: form.nom, actif: form.actif });
       toast.success("Cost center modifié !");

--- a/src/components/parametrage/ParamMama.jsx
+++ b/src/components/parametrage/ParamMama.jsx
@@ -15,9 +15,15 @@ export default function ParamMama() {
 
   const handleSubmit = async e => {
     e.preventDefault();
-    await updateMama(form);
-    setEdit(false);
-    toast.success("Établissement mis à jour !");
+    if (!form.nom?.trim()) return toast.error("Nom requis");
+    try {
+      await updateMama(form);
+      toast.success("Établissement mis à jour !");
+      setEdit(false);
+    } catch (err) {
+      console.error("Erreur mise à jour établissement:", err);
+      toast.error("Échec de la mise à jour");
+    }
   };
 
   return (

--- a/src/components/parametrage/ParamRoles.jsx
+++ b/src/components/parametrage/ParamRoles.jsx
@@ -17,21 +17,35 @@ export default function ParamRoles() {
   const handleEdit = r => { setForm(r); setEditMode(true); };
   const handleDelete = async id => {
     if (window.confirm("Supprimer le rôle ?")) {
-      await deleteRole(id); await fetchRoles();
-      toast.success("Rôle supprimé.");
+      try {
+        await deleteRole(id);
+        await fetchRoles();
+        toast.success("Rôle supprimé.");
+      } catch (err) {
+        console.error("Erreur suppression rôle:", err);
+        toast.error("Échec suppression");
+      }
     }
   };
 
   const handleSubmit = async e => {
     e.preventDefault();
-    if (editMode) {
-      await editRole(form.id, { nom: form.nom });
-      toast.success("Rôle modifié !");
-    } else {
-      await addRole({ nom: form.nom });
-      toast.success("Rôle ajouté !");
+    if (!form.nom.trim()) return toast.error("Nom requis");
+    try {
+      if (editMode) {
+        await editRole(form.id, { nom: form.nom });
+        toast.success("Rôle modifié !");
+      } else {
+        await addRole({ nom: form.nom });
+        toast.success("Rôle ajouté !");
+      }
+      setEditMode(false);
+      setForm({ nom: "", id: null });
+      await fetchRoles();
+    } catch (err) {
+      console.error("Erreur enregistrement rôle:", err);
+      toast.error("Échec enregistrement");
     }
-    setEditMode(false); setForm({ nom: "", id: null }); await fetchRoles();
   };
 
   return (

--- a/src/components/parametrage/ParamUnites.jsx
+++ b/src/components/parametrage/ParamUnites.jsx
@@ -19,21 +19,35 @@ export default function ParamUnites() {
   const handleEdit = u => { setForm(u); setEditMode(true); };
   const handleDelete = async id => {
     if (window.confirm("Supprimer l’unité ?")) {
-      await deleteUnite(id); await fetchUnites();
-      toast.success("Unité supprimée.");
+      try {
+        await deleteUnite(id);
+        await fetchUnites();
+        toast.success("Unité supprimée.");
+      } catch (err) {
+        console.error("Erreur suppression unité:", err);
+        toast.error("Échec suppression");
+      }
     }
   };
 
   const handleSubmit = async e => {
     e.preventDefault();
-    if (editMode) {
-      await editUnite(form.id, { nom: form.nom });
-      toast.success("Unité modifiée !");
-    } else {
-      await addUnite({ nom: form.nom });
-      toast.success("Unité ajoutée !");
+    if (!form.nom.trim()) return toast.error("Nom requis");
+    try {
+      if (editMode) {
+        await editUnite(form.id, { nom: form.nom });
+        toast.success("Unité modifiée !");
+      } else {
+        await addUnite({ nom: form.nom });
+        toast.success("Unité ajoutée !");
+      }
+      setEditMode(false);
+      setForm({ nom: "", id: null });
+      await fetchUnites();
+    } catch (err) {
+      console.error("Erreur enregistrement unité:", err);
+      toast.error("Échec enregistrement");
     }
-    setEditMode(false); setForm({ nom: "", id: null }); await fetchUnites();
   };
 
   const exportExcel = () => {

--- a/src/components/stock/StockMouvementForm.jsx
+++ b/src/components/stock/StockMouvementForm.jsx
@@ -13,21 +13,29 @@ export default function StockMouvementForm({ produit, onClose }) {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    if (loading) return;
+    if (!quantite || Number(quantite) <= 0) {
+      toast.error("Quantité invalide");
+      return;
+    }
     setLoading(true);
     try {
-      await addMouvementStock({
+      const res = await addMouvementStock({
         product_id: produit?.id,
         type,
         quantite: Number(quantite),
         zone,
         motif,
       });
+      if (res?.error) throw res.error;
       toast.success("Mouvement enregistré !");
       onClose?.();
-    } catch {
-      toast.error("Erreur lors de l’enregistrement.");
+    } catch (err) {
+      console.error("Erreur mouvement stock:", err);
+      toast.error("Erreur lors de l'enregistrement.");
+    } finally {
+      setLoading(false);
     }
-    setLoading(false);
   };
 
   return (
@@ -66,7 +74,7 @@ export default function StockMouvementForm({ produit, onClose }) {
       />
       <div className="flex gap-2 mt-4">
         <Button type="submit" disabled={loading}>Valider</Button>
-        <Button variant="outline" type="button" onClick={onClose}>Annuler</Button>
+        <Button variant="outline" type="button" onClick={onClose} disabled={loading}>Annuler</Button>
       </div>
     </form>
   );

--- a/src/components/taches/TacheForm.jsx
+++ b/src/components/taches/TacheForm.jsx
@@ -3,6 +3,7 @@ import { useTasks } from "@/hooks/useTasks";
 import { useUsers } from "@/hooks/useUsers";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
+import toast from "react-hot-toast";
 
 export default function TacheForm({ task }) {
   const { addTask, updateTask } = useTasks();
@@ -28,11 +29,26 @@ export default function TacheForm({ task }) {
 
   const handleSubmit = async e => {
     e.preventDefault();
+    if (!form.titre.trim()) {
+      toast.error("Le titre est requis");
+      return;
+    }
     setLoading(true);
-    if (task) await updateTask(task.id, form);
-    else await addTask(form);
-    setLoading(false);
-    navigate("/taches");
+    try {
+      if (task) {
+        await updateTask(task.id, form);
+        toast.success("Tâche mise à jour !");
+      } else {
+        await addTask(form);
+        toast.success("Tâche ajoutée !");
+      }
+      navigate("/taches");
+    } catch (err) {
+      console.error("Erreur enregistrement tâche:", err);
+      toast.error("Erreur lors de l'enregistrement.");
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (

--- a/src/components/utilisateurs/UtilisateurForm.jsx
+++ b/src/components/utilisateurs/UtilisateurForm.jsx
@@ -77,6 +77,7 @@ export default function UtilisateurForm({ utilisateur, onClose }) {
           onChange={e => setPassword(e.target.value)}
           placeholder="Mot de passe"
           required
+          minLength={6}
         />
       )}
       {utilisateur && (
@@ -86,6 +87,7 @@ export default function UtilisateurForm({ utilisateur, onClose }) {
           value={password}
           onChange={e => setPassword(e.target.value)}
           placeholder="Nouveau mot de passe (laisser vide si inchangé)"
+          minLength={6}
         />
       )}
       <div className="flex gap-2 mt-4">

--- a/src/hooks/useRequisitions.js
+++ b/src/hooks/useRequisitions.js
@@ -36,13 +36,13 @@ export const useRequisitions = () => {
     return data || null;
   };
 
-  const createRequisition = async ({ zone, lignes = [], status = "en_attente" }) => {
+  const createRequisition = async ({ zone, type = "", motif = "", lignes = [], status = "en_attente" }) => {
     if (!mama_id) return { success: false, message: "mama_id manquant" };
 
     try {
       const { data: req, error: reqError } = await supabase
         .from("requisitions")
-        .insert([{ zone, mama_id, status }])
+        .insert([{ zone, type, motif, mama_id, status }])
         .select()
         .single();
 

--- a/src/pages/Alertes.jsx
+++ b/src/pages/Alertes.jsx
@@ -23,17 +23,31 @@ export default function Alertes() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    await addRule({ ...form, threshold: Number(form.threshold) });
-    toast.success("Règle ajoutée");
-    await fetchRules({ search });
-    setForm({ product_id: "", threshold: "" });
+    if (!form.product_id) {
+      toast.error("Produit requis");
+      return;
+    }
+    try {
+      await addRule({ ...form, threshold: Number(form.threshold) });
+      toast.success("Règle ajoutée");
+      await fetchRules({ search });
+      setForm({ product_id: "", threshold: "" });
+    } catch (err) {
+      console.error("Erreur ajout règle:", err);
+      toast.error("Erreur lors de l'enregistrement.");
+    }
   };
 
   const handleDelete = async (id) => {
     if (window.confirm("Supprimer cette règle ?")) {
-      await deleteRule(id);
-      toast.success("Règle supprimée");
-      await fetchRules({ search });
+      try {
+        await deleteRule(id);
+        toast.success("Règle supprimée");
+        await fetchRules({ search });
+      } catch (err) {
+        console.error("Erreur suppression règle:", err);
+        toast.error("Erreur lors de la suppression.");
+      }
     }
   };
 
@@ -47,6 +61,7 @@ export default function Alertes() {
           value={form.product_id}
           onChange={(e) => setForm(f => ({ ...f, product_id: e.target.value }))}
           className="w-64"
+          required
         >
           <option value="">-- Produit --</option>
           {products.map(p => (

--- a/src/pages/Documents.jsx
+++ b/src/pages/Documents.jsx
@@ -3,6 +3,7 @@ import { useDocuments } from "@/hooks/useDocuments";
 import { useAuth } from "@/context/AuthContext";
 import { Button } from "@/components/ui/button";
 import { Search } from "lucide-react";
+import toast from "react-hot-toast";
 
 export default function Documents() {
   const { docs, loading, error, fetchDocs, addDoc } = useDocuments();
@@ -19,10 +20,20 @@ export default function Documents() {
 
   const handleAdd = async (e) => {
     e.preventDefault();
-    await addDoc({ title, file_url: url });
-    await fetchDocs({ search });
-    setTitle("");
-    setUrl("");
+    if (!title.trim() || !url.trim()) {
+      toast.error("Titre et URL requis");
+      return;
+    }
+    try {
+      await addDoc({ title, file_url: url });
+      toast.success("Document ajouté");
+      await fetchDocs({ search });
+      setTitle("");
+      setUrl("");
+    } catch (err) {
+      console.error("Erreur ajout document:", err);
+      toast.error("Erreur lors de l'enregistrement.");
+    }
   };
 
 

--- a/src/pages/Planning.jsx
+++ b/src/pages/Planning.jsx
@@ -2,13 +2,14 @@ import { useEffect, useState } from "react";
 import { usePlanning } from "@/hooks/usePlanning";
 import { useAuth } from "@/context/AuthContext";
 import { Button } from "@/components/ui/button";
-import { Toaster } from "react-hot-toast";
+import { Toaster, toast } from "react-hot-toast";
 
 export default function Planning() {
   const { mama_id } = useAuth();
   const { items, loading, error, fetchPlanning, addPlanning } = usePlanning();
   const [date, setDate] = useState("");
   const [notes, setNotes] = useState("");
+  const [saving, setSaving] = useState(false);
 
   useEffect(() => {
     if (mama_id) fetchPlanning();
@@ -16,9 +17,23 @@ export default function Planning() {
 
   const handleAdd = async (e) => {
     e.preventDefault();
-    await addPlanning({ date_prevue: date, notes });
-    setDate("");
-    setNotes("");
+    if (!date) {
+      toast.error("Date requise");
+      return;
+    }
+    try {
+      setSaving(true);
+      await addPlanning({ date_prevue: date, notes });
+      toast.success("Entrée ajoutée !");
+      setDate("");
+      setNotes("");
+      fetchPlanning();
+    } catch (err) {
+      console.error("Erreur ajout planning:", err);
+      toast.error("Erreur lors de l'enregistrement.");
+    } finally {
+      setSaving(false);
+    }
   };
 
   if (loading) return <div className="p-8">Chargement...</div>;
@@ -42,7 +57,7 @@ export default function Planning() {
           value={notes}
           onChange={(e) => setNotes(e.target.value)}
         />
-        <Button type="submit">Ajouter</Button>
+        <Button type="submit" disabled={saving}>Ajouter</Button>
       </form>
       <table className="min-w-full text-sm bg-white rounded-xl shadow-md">
         <thead>

--- a/src/pages/Transferts.jsx
+++ b/src/pages/Transferts.jsx
@@ -32,6 +32,7 @@ export default function Transferts() {
     zone_arrivee: "",
     motif: "",
   });
+  const [savingTf, setSavingTf] = useState(false);
   const [timeline, setTimeline] = useState([]);
   const [loadingTimeline, setLoadingTimeline] = useState(false);
 
@@ -166,6 +167,7 @@ export default function Transferts() {
   // Saisie création transfert
   const handleCreateTf = async (e) => {
     e.preventDefault();
+    if (savingTf) return;
     if (
       !createTf.produit_id ||
       !createTf.quantite ||
@@ -183,6 +185,7 @@ export default function Transferts() {
       toast.error("Authentification requise");
       return;
     }
+    setSavingTf(true);
     const { error } = await supabase.from("transferts").insert([
       {
         ...createTf,
@@ -205,6 +208,7 @@ export default function Transferts() {
     } else {
       toast.error(error.message);
     }
+    setSavingTf(false);
   };
 
   // Timeline produit
@@ -458,7 +462,9 @@ export default function Transferts() {
                 }
               />
             </div>
-            <Button type="submit">Créer</Button>
+            <Button type="submit" disabled={savingTf}>
+              {savingTf ? "Enregistrement…" : "Créer"}
+            </Button>
           </form>
         </DialogContent>
       </Dialog>

--- a/src/pages/Validations.jsx
+++ b/src/pages/Validations.jsx
@@ -8,6 +8,7 @@ export default function Validations() {
   const { isAdmin, mama_id } = useAuth();
   const validations = useValidations();
   const [form, setForm] = useState({ module: "", entity_id: "", action: "" });
+  const [saving, setSaving] = useState(false);
 
   useEffect(() => {
     if (mama_id) validations.fetchRequests();
@@ -15,14 +16,28 @@ export default function Validations() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    if (saving) return;
+    setSaving(true);
     await validations.addRequest(form);
-    toast.success("Demande envoyée");
-    setForm({ module: "", entity_id: "", action: "" });
+    if (validations.error) {
+      toast.error(validations.error);
+    } else {
+      toast.success("Demande envoyée");
+      setForm({ module: "", entity_id: "", action: "" });
+    }
+    setSaving(false);
   };
 
   const handleUpdate = async (id, status) => {
+    if (saving) return;
+    setSaving(true);
     await validations.updateStatus(id, status);
-    toast.success("Statut mis à jour");
+    if (validations.error) {
+      toast.error(validations.error);
+    } else {
+      toast.success("Statut mis à jour");
+    }
+    setSaving(false);
   };
 
   const { items, loading, error } = validations;
@@ -55,7 +70,9 @@ export default function Validations() {
           value={form.entity_id}
           onChange={(e) => setForm(f => ({ ...f, entity_id: e.target.value }))}
         />
-        <Button type="submit">Demander</Button>
+        <Button type="submit" disabled={saving}>
+          {saving ? "Envoi…" : "Demander"}
+        </Button>
       </form>
       <table className="min-w-full bg-white rounded-xl shadow-md">
         <thead>
@@ -74,10 +91,10 @@ export default function Validations() {
               <td className="px-2 py-1">{v.status}</td>
               {isAdmin && (
                 <td className="px-2 py-1 space-x-1 text-right">
-                  <Button size="sm" onClick={() => handleUpdate(v.id, 'approved')}>
+                  <Button size="sm" disabled={saving} onClick={() => handleUpdate(v.id, 'approved')}>
                     OK
                   </Button>
-                  <Button size="sm" variant="destructive" onClick={() => handleUpdate(v.id, 'rejected')}>
+                  <Button size="sm" variant="destructive" disabled={saving} onClick={() => handleUpdate(v.id, 'rejected')}>
                     Refus
                   </Button>
                 </td>

--- a/src/pages/auth/Login.jsx
+++ b/src/pages/auth/Login.jsx
@@ -3,6 +3,7 @@ import { useNavigate, Link } from "react-router-dom";
 import { supabase } from "@/lib/supabase";
 import logo from "@/assets/logo-mamastock.png";
 import { useAuth } from "@/context/AuthContext";
+import toast, { Toaster } from "react-hot-toast";
 
 export default function Login() {
   const [email, setEmail] = useState("");
@@ -32,8 +33,10 @@ export default function Login() {
 
     if (error) {
       setError("Identifiants incorrects ou compte inactif.");
+      toast.error("Échec de la connexion");
       setLoading(false);
     } else {
+      toast.success("Connecté !");
       setTimeout(() => {
         setLoading(false);
         navigate("/");
@@ -53,6 +56,7 @@ export default function Login() {
         <div className="absolute top-1/3 left-1/2 -translate-x-1/2 w-[280px] h-[180px] bg-white/20 blur-2xl rounded-[36%_54%_41%_59%/50%_41%_59%_50%] opacity-15 animate-liquid3" />
       </div>
       <div className="z-10 w-full max-w-md mx-auto">
+        <Toaster position="top-right" />
         <div
           className="rounded-2xl shadow-2xl bg-white/30 dark:bg-[#202638]/40 border border-white/30 backdrop-blur-xl px-8 py-12 flex flex-col items-center glass-panel auth-card"
         >

--- a/src/pages/auth/ResetPassword.jsx
+++ b/src/pages/auth/ResetPassword.jsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
 import logo from "@/assets/logo-mamastock.png";
+import toast, { Toaster } from "react-hot-toast";
 
 export default function ResetPassword() {
   const [email, setEmail] = useState("");
@@ -13,13 +14,19 @@ export default function ResetPassword() {
     const { error } = await supabase.auth.resetPasswordForEmail(email, {
       redirectTo: `${window.location.origin}/update-password`,
     });
-    if (error) setError("Erreur lors de l'envoi du lien.");
-    else setSent(true);
+    if (error) {
+      setError("Erreur lors de l'envoi du lien.");
+      toast.error("Échec de l'envoi");
+    } else {
+      toast.success("Email envoyé !");
+      setSent(true);
+    }
   };
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-[#0f1c2e] via-[#232a34] to-[#bfa14d] relative overflow-hidden">
       <div className="z-10 w-full max-w-md mx-auto">
+        <Toaster position="top-right" />
         <div className="rounded-2xl shadow-2xl bg-white/30 dark:bg-[#202638]/40 border border-white/30 backdrop-blur-xl px-8 py-12 flex flex-col items-center glass-panel auth-card">
           <img src={logo} alt="MamaStock" className="w-24 h-24 mb-6 rounded-full shadow-md bg-mamastockGold/10 object-contain border-4 border-mamastockGold/30 logo-glow" />
           <h2 className="text-3xl font-bold text-mamastockGold drop-shadow mb-1 text-center tracking-wide">Réinitialisation</h2>

--- a/src/pages/auth/UpdatePassword.jsx
+++ b/src/pages/auth/UpdatePassword.jsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { supabase } from "@/lib/supabase";
 import logo from "@/assets/logo-mamastock.png";
+import toast, { Toaster } from "react-hot-toast";
 
 export default function UpdatePassword() {
   const [password, setPassword] = useState("");
@@ -20,7 +21,9 @@ export default function UpdatePassword() {
     const { error } = await supabase.auth.updateUser({ password });
     if (error) {
       setError("Erreur lors de la mise à jour du mot de passe.");
+      toast.error("Échec de la mise à jour");
     } else {
+      toast.success("Mot de passe modifié");
       setMessage("Mot de passe mis à jour, vous pouvez vous connecter.");
       setTimeout(() => navigate("/login"), 1500);
     }
@@ -29,6 +32,7 @@ export default function UpdatePassword() {
   return (
     <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-[#0f1c2e] via-[#232a34] to-[#bfa14d] relative overflow-hidden">
       <div className="z-10 w-full max-w-md mx-auto">
+        <Toaster position="top-right" />
         <div className="rounded-2xl shadow-2xl bg-white/30 dark:bg-[#202638]/40 border border-white/30 backdrop-blur-xl px-8 py-12 flex flex-col items-center glass-panel auth-card">
           <img src={logo} alt="MamaStock" className="w-24 h-24 mb-6 rounded-full shadow-md bg-mamastockGold/10 object-contain border-4 border-mamastockGold/30 logo-glow" />
           <h2 className="text-3xl font-bold text-mamastockGold drop-shadow mb-1 text-center tracking-wide">Nouveau mot de passe</h2>

--- a/src/pages/factures/FactureForm.jsx
+++ b/src/pages/factures/FactureForm.jsx
@@ -34,6 +34,10 @@ export default function FactureForm({ facture, suppliers = [], onClose }) {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    if (!date || !fournisseur_id || !montant) {
+      toast.error("Date, fournisseur et montant requis !");
+      return;
+    }
     setLoading(true);
     const invoice = {
       date,
@@ -51,8 +55,8 @@ export default function FactureForm({ facture, suppliers = [], onClose }) {
         toast.success("Facture ajoutée !");
       }
       onClose?.();
-    } catch {
-      toast.error("Erreur lors de l'enregistrement.");
+    } catch (err) {
+      toast.error(err?.message || "Erreur lors de l'enregistrement.");
     }
     setLoading(false);
   };

--- a/src/pages/factures/ImportFactures.jsx
+++ b/src/pages/factures/ImportFactures.jsx
@@ -9,9 +9,10 @@ export default function ImportFactures() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    if (!file) return;
+    if (!file) return toast.error("Sélectionne un fichier à importer");
     const id = await importFromFile(file);
     if (id) toast.success("Facture importée !");
+    else toast.error("Echec de l'import");
   };
 
   return (

--- a/src/pages/fiches/FicheForm.jsx
+++ b/src/pages/fiches/FicheForm.jsx
@@ -7,7 +7,7 @@ import toast from "react-hot-toast";
 import { uploadFile, deleteFile, pathFromUrl } from "@/hooks/useStorage";
 
 export default function FicheForm({ fiche, onClose }) {
-  const { addFiche, editFiche } = useFiches();
+  const { addFiche, updateFiche } = useFiches();
   const { products, fetchProducts } = useProducts();
   const [nom, setNom] = useState(fiche?.nom || "");
   const [description, setDescription] = useState(fiche?.description || "");
@@ -54,6 +54,10 @@ export default function FicheForm({ fiche, onClose }) {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    if (!nom.trim()) return toast.error("Le nom est obligatoire");
+    if (lignes.some(l => !l.product_id || !l.quantite)) {
+      return toast.error("Chaque ligne doit avoir produit et quantité");
+    }
     setLoading(true);
     const ficheData = {
       nom,
@@ -66,15 +70,15 @@ export default function FicheForm({ fiche, onClose }) {
     };
     try {
       if (fiche?.id) {
-        await editFiche(fiche.id, ficheData);
+        await updateFiche(fiche.id, ficheData);
         toast.success("Fiche modifiée !");
       } else {
         await addFiche(ficheData);
         toast.success("Fiche ajoutée !");
       }
       onClose?.();
-    } catch {
-      toast.error("Erreur lors de l'enregistrement.");
+    } catch (err) {
+      toast.error(err?.message || "Erreur lors de l'enregistrement.");
     }
     setLoading(false);
   };

--- a/src/pages/inventaire/Inventaire.jsx
+++ b/src/pages/inventaire/Inventaire.jsx
@@ -253,6 +253,10 @@ export default function Inventaire() {
       toast.error("Aucun inventaire à corriger !");
       return;
     }
+    if (editRow.stockFinal === "" || isNaN(editRow.stockFinal)) {
+      toast.error("Quantité finale requise");
+      return;
+    }
     const { error } = await supabase
       .from("inventaires")
       .update({

--- a/src/pages/menus/MenuDuJourForm.jsx
+++ b/src/pages/menus/MenuDuJourForm.jsx
@@ -38,6 +38,10 @@ export default function MenuDuJourForm({ menu, fiches = [], onClose }) {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    if (!nom.trim() || !date) {
+      toast.error("Nom et date requis");
+      return;
+    }
     setLoading(true);
     const menuData = {
       nom,
@@ -54,8 +58,8 @@ export default function MenuDuJourForm({ menu, fiches = [], onClose }) {
         toast.success("Menu du jour ajouté !");
       }
       onClose?.();
-    } catch {
-      toast.error("Erreur lors de l'enregistrement.");
+    } catch (err) {
+      toast.error(err?.message || "Erreur lors de l'enregistrement.");
     }
     setLoading(false);
   };

--- a/src/pages/menus/MenuForm.jsx
+++ b/src/pages/menus/MenuForm.jsx
@@ -38,6 +38,10 @@ export default function MenuForm({ menu, fiches = [], onClose }) {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    if (!nom.trim() || !date) {
+      toast.error("Nom et date requis");
+      return;
+    }
     setLoading(true);
     const menuData = {
       nom,
@@ -54,8 +58,8 @@ export default function MenuForm({ menu, fiches = [], onClose }) {
         toast.success("Menu ajouté !");
       }
       onClose?.();
-    } catch {
-      toast.error("Erreur lors de l'enregistrement.");
+    } catch (err) {
+      toast.error(err?.message || "Erreur lors de l'enregistrement.");
     }
     setLoading(false);
   };

--- a/src/pages/mouvements/Mouvements.jsx
+++ b/src/pages/mouvements/Mouvements.jsx
@@ -35,6 +35,7 @@ export default function Mouvements() {
     zone: "",
     motif: "",
   });
+  const [saving, setSaving] = useState(false);
   const [timeline, setTimeline] = useState([]);
   const [loadingTimeline, setLoadingTimeline] = useState(false);
   // selected mouvement for cost center allocation { id, product_id }
@@ -161,6 +162,11 @@ export default function Mouvements() {
       toast.error("Produit, type et quantité requis !");
       return;
     }
+    if (Number(createMv.quantite) <= 0) {
+      toast.error("Quantité invalide");
+      return;
+    }
+    setSaving(true);
     const { error } = await supabase.from("mouvements_stock").insert([
       {
         ...createMv,
@@ -184,6 +190,7 @@ export default function Mouvements() {
     } else {
       toast.error(error.message);
     }
+    setSaving(false);
   };
 
   // Timeline produit
@@ -590,7 +597,7 @@ export default function Mouvements() {
                       }
                     />
                   </div>
-                  <Button type="submit">Créer</Button>
+                  <Button type="submit" disabled={saving}>Créer</Button>
                 </form>
               </Motion.div>
             </DialogContent>

--- a/src/pages/promotions/Promotions.jsx
+++ b/src/pages/promotions/Promotions.jsx
@@ -10,6 +10,7 @@ export default function Promotions() {
   const [showForm, setShowForm] = useState(false);
   const [editRow, setEditRow] = useState(null);
   const [search, setSearch] = useState("");
+  const [saving, setSaving] = useState(false);
 
   useEffect(() => {
     if (!authLoading && mama_id) fetchPromotions();
@@ -73,13 +74,27 @@ export default function Promotions() {
       {showForm && (
         <PromotionForm
           promotion={editRow}
+          saving={saving}
           onClose={() => { setShowForm(false); setEditRow(null); }}
           onSave={async values => {
-            if (editRow) await updatePromotion(editRow.id, values);
-            else await addPromotion(values);
-            setShowForm(false);
-            setEditRow(null);
-            fetchPromotions();
+            try {
+              setSaving(true);
+              if (editRow) {
+                await updatePromotion(editRow.id, values);
+                toast.success("Promotion modifiée !");
+              } else {
+                await addPromotion(values);
+                toast.success("Promotion ajoutée !");
+              }
+              setShowForm(false);
+              setEditRow(null);
+              fetchPromotions();
+            } catch (err) {
+              console.error("Erreur enregistrement promotion:", err);
+              toast.error("Erreur lors de l'enregistrement.");
+            } finally {
+              setSaving(false);
+            }
           }}
         />
       )}
@@ -87,7 +102,7 @@ export default function Promotions() {
   );
 }
 
-function PromotionForm({ promotion = {}, onClose, onSave }) {
+function PromotionForm({ promotion = {}, onClose, onSave, saving }) {
   const [form, setForm] = useState({
     nom: promotion.nom || "",
     description: promotion.description || "",
@@ -126,7 +141,7 @@ function PromotionForm({ promotion = {}, onClose, onSave }) {
             </label>
           </div>
           <div className="flex gap-4 justify-end pt-2">
-            <Button type="submit">Enregistrer</Button>
+            <Button type="submit" disabled={saving}>Enregistrer</Button>
             <Button type="button" variant="secondary" onClick={onClose}>Annuler</Button>
           </div>
         </form>

--- a/src/pages/requisitions/RequisitionForm.jsx
+++ b/src/pages/requisitions/RequisitionForm.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { useRequisitions } from "@/hooks/useRequisitions";
 import { useProducts } from "@/hooks/useProducts";
 import { useAuth } from "@/context/AuthContext";
+import { Toaster, toast } from "react-hot-toast";
 
 function RequisitionFormPage() {
   const navigate = useNavigate();
@@ -27,8 +28,22 @@ function RequisitionFormPage() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    await createRequisition({ type, motif, zone, articles });
-    navigate("/requisitions");
+    if (!type || !zone || articles.some(a => !a.product_id || !a.quantite)) {
+      toast.error("Tous les champs sont obligatoires");
+      return;
+    }
+    const { success, message } = await createRequisition({
+      zone,
+      type,
+      motif,
+      lignes: articles.map(a => ({ product_id: a.product_id, quantite: Number(a.quantite) })),
+    });
+    if (success) {
+      toast.success("Réquisition créée !");
+      navigate("/requisitions");
+    } else {
+      toast.error(message || "Erreur lors de la création");
+    }
   };
 
   if (authLoading) {
@@ -37,6 +52,7 @@ function RequisitionFormPage() {
 
   return (
     <div className="p-6 bg-gray-100 min-h-screen">
+      <Toaster position="top-right" />
       <h1 className="text-3xl font-bold text-mamastock-gold mb-6">Nouvelle réquisition</h1>
       <form onSubmit={handleSubmit} className="bg-white p-6 rounded shadow space-y-4">
 

--- a/src/pages/requisitions/Requisitions.jsx
+++ b/src/pages/requisitions/Requisitions.jsx
@@ -16,6 +16,7 @@ export default function Requisitions() {
   const [periode, setPeriode] = useState({ debut: "", fin: "" });
   const [showCreate, setShowCreate] = useState(false);
   const [createReq, setCreateReq] = useState({ produit_id: "", quantite: 0, zone: "", motif: "" });
+  const [saving, setSaving] = useState(false);
 
   useEffect(() => {
     if (!mama_id || authLoading) return;
@@ -49,6 +50,11 @@ export default function Requisitions() {
       toast.error("Sélectionne un produit et une quantité !");
       return;
     }
+    if (Number(createReq.quantite) <= 0) {
+      toast.error("Quantité invalide");
+      return;
+    }
+    setSaving(true);
     const { error } = await supabase.from("requisitions").insert([
       {
         ...createReq,
@@ -65,6 +71,7 @@ export default function Requisitions() {
     } else {
       toast.error(error.message);
     }
+    setSaving(false);
   };
 
   // Export Excel
@@ -227,7 +234,7 @@ export default function Requisitions() {
                 }
               />
             </div>
-            <Button type="submit">Créer</Button>
+            <Button type="submit" disabled={saving}>Créer</Button>
           </form>
         </DialogContent>
       </Dialog>

--- a/src/pages/simulation/SimulationForm.jsx
+++ b/src/pages/simulation/SimulationForm.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { supabase } from "@/lib/supabase";
 import { useAuth } from "@/context/AuthContext";
+import toast from "react-hot-toast";
 
 export default function SimulationForm({ addRecipe, setPrix }) {
   const { mama_id, loading: authLoading } = useAuth();
@@ -18,10 +19,15 @@ export default function SimulationForm({ addRecipe, setPrix }) {
   }, [mama_id, authLoading]);
 
   const handleAdd = () => {
+    if (!selectedId) {
+      toast.error("Sélectionnez une fiche");
+      return;
+    }
     const recette = recipes.find(r => r.id === selectedId);
     if (recette) {
       addRecipe(recette);
-      setPrix(""); setSelectedId("");
+      setPrix("");
+      setSelectedId("");
     }
   };
 


### PR DESCRIPTION
## Summary
- improve feedback and guard saving in inventory form
- validate recipe selection in simulation form
- track additional forms in `audit_formulaires.json`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68566de63f7c832dbb13de8bf6a76575