### PR TITLE
Add MamaLogo branding and PWA assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ If linting or tests fail because required packages are missing, simply run
 `npm install` again. This ensures `vitest`, `@eslint/js` and `playwright` are
 available before running the commands above.
 
+### Branding & PWA
+
+The interface uses a reusable `MamaLogo` component for consistent branding.
+The default router redirects unauthenticated visitors from `/` to `/login` and
+shows the dashboard when logged in. `index.html` contains PWA metadata with the
+favicon, manifest and splash screen so you can install the app on mobile.
+
 ### Database
 
 SQL scripts are stored in [`sql/`](./sql). To initialise a local Supabase instance:

--- a/index.html
+++ b/index.html
@@ -8,18 +8,18 @@
     
     <title>MamaStock</title>
 
-    <!-- Icône navigateur -->
-    <link rel="icon" type="image/png" href="/icons/icon-192x192.png" />
-
-    <!-- Manifest PWA -->
+    <!-- PWA -->
+    <link rel="icon" href="/favicon.ico" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/manifest.json" />
-    <meta name="theme-color" content="#bfa14d" />
-
-    <!-- Meta PWA Apple -->
-    <link rel="apple-touch-icon" href="/icons/icon-192x192.png" />
+    <meta name="theme-color" content="#181818" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-    <meta name="apple-mobile-web-app-title" content="MamaStock" />
+    <link
+      rel="apple-touch-startup-image"
+      href="/apple-splash-2732x2732.png"
+      media="(device-width: 1024px) and (device-height: 1366px)"
+    />
 
     <!-- Typo optionnelle (Inter ou autre) -->
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,52 +1,26 @@
 {
   "name": "MamaStock",
   "short_name": "MamaStock",
-  "description": "Application de gestion de stock pour Mama Shelter",
   "start_url": "/",
   "display": "standalone",
-  "background_color": "#f0f0f5",
-  "theme_color": "#bfa14d",
-  "orientation": "portrait",
+  "background_color": "#000000",
+  "theme_color": "#181818",
   "icons": [
     {
-      "src": "/icons/icon-72x72.png",
-      "sizes": "72x72",
-      "type": "image/png"
-    },
-    {
-      "src": "/icons/icon-96x96.png",
-      "sizes": "96x96",
-      "type": "image/png"
-    },
-    {
-      "src": "/icons/icon-128x128.png",
-      "sizes": "128x128",
-      "type": "image/png"
-    },
-    {
-      "src": "/icons/icon-144x144.png",
-      "sizes": "144x144",
-      "type": "image/png"
-    },
-    {
-      "src": "/icons/icon-152x152.png",
-      "sizes": "152x152",
-      "type": "image/png"
-    },
-    {
-      "src": "/icons/icon-192x192.png",
+      "src": "/android-chrome-192x192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "/icons/icon-384x384.png",
-      "sizes": "384x384",
+      "src": "/android-chrome-512x512.png",
+      "sizes": "512x512",
       "type": "image/png"
     },
     {
-      "src": "/icons/icon-512x512.png",
+      "src": "/maskable-icon-512x512.png",
       "sizes": "512x512",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "maskable"
     }
   ]
 }

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -1,5 +1,6 @@
 import { Link, useLocation } from "react-router-dom";
 import { useAuth } from "@/context/AuthContext";
+import MamaLogo from "@/components/ui/MamaLogo";
 
 export default function Sidebar() {
   const { access_rights, role, loading } = useAuth();
@@ -12,7 +13,9 @@ export default function Sidebar() {
 
   return (
     <aside className="w-64 bg-white/5 backdrop-blur-xl text-white p-4 h-screen shadow-md text-shadow">
-      <h2 className="text-2xl font-bold mb-6">MamaStock</h2>
+      <div className="mb-6">
+        <MamaLogo width={140} />
+      </div>
       <nav className="flex flex-col gap-2 text-sm">
         {has("dashboard") && <Link to="/dashboard">Dashboard</Link>}
 

--- a/src/components/ui/MamaLogo.jsx
+++ b/src/components/ui/MamaLogo.jsx
@@ -1,0 +1,12 @@
+import logo from "@/assets/logo-mamastock.png";
+
+export default function MamaLogo({ width = 200 }) {
+  return (
+    <img
+      src={logo}
+      alt="Logo MamaStock"
+      width={width}
+      className="drop-shadow-[0_0_20px_rgba(255,210,0,0.8)] animate-fade-in"
+    />
+  );
+}

--- a/src/globals.css
+++ b/src/globals.css
@@ -97,8 +97,16 @@ html.dark body {
   background: linear-gradient(125deg, rgba(255,255,255,0.24) 40%, rgba(191,161,77,0.11) 100%);
 }
 
-.animate-fade-in { animation: fadeIn 0.7s; }
-@keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
+.animate-fade-in { animation: fade-in 0.8s ease-out forwards; }
+.animate-fade-in-down { animation: fade-in-down 0.8s ease-out forwards; }
+@keyframes fade-in {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@keyframes fade-in-down {
+  from { opacity: 0; transform: translateY(-20px); }
+  to { opacity: 1; transform: translateY(0); }
+}
 
 /* Auth card & logo shadow */
 .auth-card {

--- a/src/index.css
+++ b/src/index.css
@@ -97,8 +97,16 @@ html.dark body {
   background: linear-gradient(125deg, rgba(255,255,255,0.24) 40%, rgba(191,161,77,0.11) 100%);
 }
 
-.animate-fade-in { animation: fadeIn 0.7s; }
-@keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
+.animate-fade-in { animation: fade-in 0.8s ease-out forwards; }
+.animate-fade-in-down { animation: fade-in-down 0.8s ease-out forwards; }
+@keyframes fade-in {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@keyframes fade-in-down {
+  from { opacity: 0; transform: translateY(-20px); }
+  to { opacity: 1; transform: translateY(0); }
+}
 
 /* Auth card & logo shadow */
 .auth-card {

--- a/src/pages/auth/Login.jsx
+++ b/src/pages/auth/Login.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import { supabase } from "@/lib/supabase";
-import logo from "@/assets/logo-mamastock.png";
+import MamaLogo from "@/components/ui/MamaLogo";
 import { useAuth } from "@/context/AuthContext";
 import toast, { Toaster } from "react-hot-toast";
 
@@ -60,11 +60,9 @@ export default function Login() {
         <div
           className="rounded-2xl shadow-2xl bg-white/30 dark:bg-[#202638]/40 border border-white/30 backdrop-blur-xl px-8 py-12 flex flex-col items-center glass-panel auth-card"
         >
-          <img
-            src={logo}
-            alt="MamaStock"
-            className="w-24 h-24 mb-6 rounded-full shadow-md bg-mamastockGold/10 object-contain border-4 border-mamastockGold/30 logo-glow"
-          />
+          <div className="mb-6">
+            <MamaLogo width={96} />
+          </div>
           <h2 className="text-3xl font-bold text-mamastockGold drop-shadow mb-1 text-center tracking-wide">
             Connexion
           </h2>

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -67,10 +67,17 @@ function ProtectedRoute({ children, path }) {
   return children;
 }
 
+function RootRedirect() {
+  const { isAuthenticated, loading } = useAuth();
+  if (loading) return null;
+  return <Navigate to={isAuthenticated ? "/dashboard" : "/login"} replace />;
+}
+
 export default function Router() {
   return (
     <Suspense fallback={null}>
       <Routes>
+        <Route path="/" element={<RootRedirect />} />
         <Route path="/login" element={<Login />} />
         <Route element={<Layout />}>
           <Route

--- a/test/router.test.jsx
+++ b/test/router.test.jsx
@@ -4,8 +4,9 @@ import React from 'react';
 import { vi } from 'vitest';
 import RouterConfig from '../src/router.jsx';
 
+const authState = { isAuthenticated: false, access_rights: ['dashboard'], loading: false };
 vi.mock('@/context/AuthContext', () => ({
-  useAuth: () => ({ isAuthenticated: true, access_rights: ['dashboard'], loading: false })
+  useAuth: () => authState
 }));
 
 vi.mock('@/hooks/useDashboard', () => ({
@@ -36,14 +37,24 @@ vi.mock('@/pages/auth/Login.jsx', () => ({
   default: () => <div>Login</div>,
 }));
 
-// We only test that navigating to '/' renders the dashboard component
-// which implies the redirect is configured.
-test('root path redirects to dashboard', async () => {
+// We test that navigating to '/' shows the login component when not authenticated
+test('root path redirects to login when unauthenticated', async () => {
   render(
     <MemoryRouter initialEntries={["/"]}>
       <RouterConfig />
     </MemoryRouter>
   );
-  // Check dashboard component is displayed
+  // Login component should be displayed
+  expect(await screen.findByText('Login')).toBeInTheDocument();
+});
+
+test('root path redirects to dashboard when authenticated', async () => {
+  authState.isAuthenticated = true;
+  render(
+    <MemoryRouter initialEntries={["/"]}>
+      <RouterConfig />
+    </MemoryRouter>
+  );
   expect(await screen.findByText('Dashboard Stock & Achats')).toBeInTheDocument();
+  authState.isAuthenticated = false;
 });


### PR DESCRIPTION
## Summary
- use MamaLogo in login and sidebar
- dark animated login page keeps existing auth flow
- fix router default route to dashboard
- update PWA metadata and manifest icons
- add docs about branding and PWA

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68568f82d240832d9b38fc143bfc5adf