### PR TITLE
Lot 1 corrections for ProduitForm

### DIFF
--- a/src/components/produits/ProduitForm.jsx
+++ b/src/components/produits/ProduitForm.jsx
@@ -1,14 +1,23 @@
 // src/components/produits/ProduitForm.jsx
 import { useState, useEffect } from "react";
 import { useProducts } from "@/hooks/useProducts";
+import { useFamilles } from "@/hooks/useFamilles";
+import { useUnites } from "@/hooks/useUnites";
+import { useFournisseurs } from "@/hooks/useFournisseurs";
 import { toast } from "react-hot-toast";
 import { uploadFile, deleteFile, pathFromUrl } from "@/hooks/useStorage";
+import AutoCompleteField from "@/components/ui/AutoCompleteField";
 
-export default function ProduitForm({ produit, familles, unites, onSuccess, onClose }) {
+export default function ProduitForm({ produit, familles = [], unites = [], onSuccess, onClose }) {
   const editing = !!produit;
+  const { familles: famillesHook, fetchFamilles, addFamille } = useFamilles();
+  const { unites: unitesHook, fetchUnites, addUnite } = useUnites();
+  const { fournisseurs, fetchFournisseurs } = useFournisseurs();
+
   const [nom, setNom] = useState(produit?.nom || "");
   const [famille, setFamille] = useState(produit?.famille || "");
   const [unite, setUnite] = useState(produit?.unite || "");
+  const [mainSupplierId, setMainSupplierId] = useState(produit?.main_supplier_id || "");
   const [pmp, setPmp] = useState(produit?.pmp || "");
   const [stock_reel, setStockReel] = useState(produit?.stock_reel || 0);
   const [stock_min, setStockMin] = useState(produit?.stock_min || 0);
@@ -17,15 +26,23 @@ export default function ProduitForm({ produit, familles, unites, onSuccess, onCl
   const [allergenes, setAllergenes] = useState(produit?.allergenes || "");
   const [image, setImage] = useState(null);
   const [imageUrl, setImageUrl] = useState(produit?.image || "");
+  const [errors, setErrors] = useState({});
 
   const { addProduct, updateProduct, loading } = useProducts();
   const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    fetchFamilles();
+    fetchUnites();
+    fetchFournisseurs();
+  }, [fetchFamilles, fetchUnites, fetchFournisseurs]);
 
   useEffect(() => {
     if (editing && produit) {
       setNom(produit.nom || "");
       setFamille(produit.famille || "");
       setUnite(produit.unite || "");
+      setMainSupplierId(produit.main_supplier_id || "");
       setPmp(produit.pmp || "");
       setStockReel(produit.stock_reel || 0);
       setStockMin(produit.stock_min || 0);
@@ -39,14 +56,20 @@ export default function ProduitForm({ produit, familles, unites, onSuccess, onCl
   const handleSubmit = async e => {
     e.preventDefault();
     if (saving) return;
-    if (!nom.trim() || !famille.trim() || !unite.trim()) {
-      toast.error("Tous les champs sont obligatoires.");
+    const errs = {};
+    if (!nom.trim()) errs.nom = "Nom requis";
+    if (!famille.trim()) errs.famille = "Famille requise";
+    if (!unite.trim()) errs.unite = "Unité requise";
+    setErrors(errs);
+    if (Object.keys(errs).length) {
+      toast.error("Veuillez remplir les champs obligatoires.");
       return;
     }
     const newProd = {
       nom,
       famille,
       unite,
+      main_supplier_id: mainSupplierId || null,
       pmp: Number(pmp),
       stock_reel: Number(stock_reel),
       stock_min: Number(stock_min),
@@ -103,38 +126,44 @@ export default function ProduitForm({ produit, familles, unites, onSuccess, onCl
           onChange={e => setNom(e.target.value)}
           required
         />
+        {errors.nom && <p className="text-red-500 text-sm">{errors.nom}</p>}
       </div>
+      <AutoCompleteField
+        label="Famille"
+        value={famille}
+        onChange={setFamille}
+        options={[...famillesHook.map(f => f.nom), ...familles]}
+        onAddOption={async val => {
+          const { error } = await addFamille(val);
+          if (error) toast.error(error.message || error);
+        }}
+        required
+      />
+      {errors.famille && <p className="text-red-500 text-sm">{errors.famille}</p>}
+      <AutoCompleteField
+        label="Unité"
+        value={unite}
+        onChange={setUnite}
+        options={[...unitesHook.map(u => u.nom), ...unites]}
+        onAddOption={async val => {
+          const { error } = await addUnite(val);
+          if (error) toast.error(error.message || error);
+        }}
+        required
+      />
+      {errors.unite && <p className="text-red-500 text-sm">{errors.unite}</p>}
       <div>
-        <label className="block text-sm mb-1 font-medium">Famille</label>
-        <input
-          type="text"
+        <label className="block text-sm mb-1 font-medium">Fournisseur principal</label>
+        <select
           className="input input-bordered w-full"
-          value={famille}
-          onChange={e => setFamille(e.target.value)}
-          list="famille-list"
-          required
-        />
-        <datalist id="famille-list">
-          {(familles || []).map(f => (
-            <option key={f} value={f} />
+          value={mainSupplierId}
+          onChange={e => setMainSupplierId(e.target.value)}
+        >
+          <option value="">Aucun</option>
+          {fournisseurs.map(f => (
+            <option key={f.id} value={f.id}>{f.nom}</option>
           ))}
-        </datalist>
-      </div>
-      <div>
-        <label className="block text-sm mb-1 font-medium">Unité</label>
-        <input
-          type="text"
-          className="input input-bordered w-full"
-          value={unite}
-          onChange={e => setUnite(e.target.value)}
-          list="unite-list"
-          required
-        />
-        <datalist id="unite-list">
-          {(unites || []).map(u => (
-            <option key={u} value={u} />
-          ))}
-        </datalist>
+        </select>
       </div>
       <div>
         <label htmlFor="prod-code" className="block text-sm mb-1 font-medium">Code interne</label>

--- a/src/components/ui/AutoCompleteField.jsx
+++ b/src/components/ui/AutoCompleteField.jsx
@@ -14,17 +14,18 @@ export default function AutoCompleteField({
   const [showAdd, setShowAdd] = useState(false);
 
   const optionsSafe = options ?? []; // Évite le crash si options est undefined
+  const isValid = inputValue && optionsSafe.includes(inputValue);
 
-  const handleInputChange = (e) => {
+  const handleInputChange = e => {
     const val = e.target.value;
     setInputValue(val);
     onChange(val);
     setShowAdd(val && !optionsSafe.includes(val));
   };
 
-  const handleAddOption = () => {
+  const handleAddOption = async () => {
     if (inputValue && onAddOption) {
-      onAddOption(inputValue);
+      await onAddOption(inputValue);
       setShowAdd(false);
     }
   };
@@ -38,7 +39,11 @@ export default function AutoCompleteField({
         list={`list-${label}`}
         value={inputValue}
         onChange={handleInputChange}
-        className="bg-white text-black"
+        className={`bg-white text-black ${isValid ? "border-2 border-mamastockGold shadow" : ""}`}
+        aria-label={label}
+        aria-autocomplete="list"
+        role="combobox"
+        aria-expanded={showAdd ? "true" : "false"}
       />
       <datalist id={`list-${label}`}>
         {optionsSafe.map((opt, idx) => (

--- a/src/hooks/useFamilles.js
+++ b/src/hooks/useFamilles.js
@@ -30,27 +30,34 @@ export function useFamilles() {
     setLoading(true);
     setError(null);
     if (!nom) {
-      setError("Le nom est obligatoire.");
+      const err = "Le nom est obligatoire.";
+      setError(err);
       setLoading(false);
-      return;
+      return { error: err };
     }
-    // Vérifie unicité (insensible à la casse)
     const { data: existing } = await supabase
       .from("familles")
       .select("id")
       .eq("mama_id", mama_id)
       .ilike("nom", nom);
     if (existing && existing.length > 0) {
+      const err = "Famille déjà existante.";
       setLoading(false);
-      setError("Famille déjà existante.");
-      return;
+      setError(err);
+      return { error: err };
     }
-    const { error } = await supabase
+    const { data, error } = await supabase
       .from("familles")
-      .insert([{ nom, mama_id }]);
-    if (error) setError(error);
+      .insert([{ nom, mama_id }])
+      .select()
+      .single();
     setLoading(false);
+    if (error) {
+      setError(error);
+      return { error };
+    }
     await fetchFamilles();
+    return { data };
   }
 
   // 3. Modifier une famille

--- a/src/hooks/useUnites.js
+++ b/src/hooks/useUnites.js
@@ -30,27 +30,34 @@ export function useUnites() {
     setLoading(true);
     setError(null);
     if (!nom) {
-      setError("Le nom est obligatoire.");
+      const err = "Le nom est obligatoire.";
+      setError(err);
       setLoading(false);
-      return;
+      return { error: err };
     }
-    // Vérifie que l'unité n'existe pas déjà (case insensitive)
     const { data: existing } = await supabase
       .from("unites")
       .select("id")
       .eq("mama_id", mama_id)
       .ilike("nom", nom);
     if (existing && existing.length > 0) {
+      const err = "Unité déjà existante.";
       setLoading(false);
-      setError("Unité déjà existante.");
-      return;
+      setError(err);
+      return { error: err };
     }
-    const { error } = await supabase
+    const { data, error } = await supabase
       .from("unites")
-      .insert([{ nom, mama_id }]);
-    if (error) setError(error);
+      .insert([{ nom, mama_id }])
+      .select()
+      .single();
     setLoading(false);
+    if (error) {
+      setError(error);
+      return { error };
+    }
     await fetchUnites();
+    return { data };
   }
 
   // 3. Modifier une unité

--- a/test/ProduitForm.test.jsx
+++ b/test/ProduitForm.test.jsx
@@ -11,6 +11,15 @@ vi.mock('@/hooks/useStorage', () => ({
   deleteFile: vi.fn(),
   pathFromUrl: () => '',
 }));
+vi.mock('@/hooks/useFamilles', () => ({
+  useFamilles: () => ({ familles: [], fetchFamilles: vi.fn(), addFamille: vi.fn() })
+}));
+vi.mock('@/hooks/useUnites', () => ({
+  useUnites: () => ({ unites: [], fetchUnites: vi.fn(), addUnite: vi.fn() })
+}));
+vi.mock('@/hooks/useFournisseurs', () => ({
+  useFournisseurs: () => ({ fournisseurs: [], fetchFournisseurs: vi.fn() })
+}));
 
 import ProduitForm from '@/components/produits/ProduitForm.jsx';
 

--- a/test/Produits.test.jsx
+++ b/test/Produits.test.jsx
@@ -12,6 +12,15 @@ vi.mock('@/hooks/useStorage', () => ({
   deleteFile: vi.fn(),
   pathFromUrl: () => '',
 }));
+vi.mock('@/hooks/useFamilles', () => ({
+  useFamilles: () => ({ familles: [], fetchFamilles: vi.fn(), addFamille: vi.fn() })
+}));
+vi.mock('@/hooks/useUnites', () => ({
+  useUnites: () => ({ unites: [], fetchUnites: vi.fn(), addUnite: vi.fn() })
+}));
+vi.mock('@/hooks/useFournisseurs', () => ({
+  useFournisseurs: () => ({ fournisseurs: [], fetchFournisseurs: vi.fn() })
+}));
 
 import Produits from '@/pages/produits/Produits.jsx';
 


### PR DESCRIPTION
## Summary
- improve AutoCompleteField styling and accessibility
- update product form to use dynamic families and units
- allow optional main supplier field and inline errors
- return inserted rows in `useFamilles` and `useUnites`
- adjust tests to mock new hooks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856e9047a80832db65d210138eccf52