### PR TITLE
Refactor suppliers module

### DIFF
--- a/src/pages/fournisseurs/FournisseurForm.jsx
+++ b/src/pages/fournisseurs/FournisseurForm.jsx
@@ -1,0 +1,81 @@
+import { useState, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import toast from "react-hot-toast";
+
+export default function FournisseurForm({ fournisseur = {}, onSubmit, onCancel, saving }) {
+  const [nom, setNom] = useState(fournisseur.nom || "");
+  const [ville, setVille] = useState(fournisseur.ville || "");
+  const [telephone, setTelephone] = useState(fournisseur.telephone || "");
+  const [email, setEmail] = useState(fournisseur.email || "");
+  const [actif, setActif] = useState(fournisseur.actif ?? true);
+  const [errors, setErrors] = useState({});
+
+  useEffect(() => {
+    setNom(fournisseur.nom || "");
+    setVille(fournisseur.ville || "");
+    setTelephone(fournisseur.telephone || "");
+    setEmail(fournisseur.email || "");
+    setActif(fournisseur.actif ?? true);
+    setErrors({});
+  }, [fournisseur]);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const errs = {};
+    if (!nom.trim()) errs.nom = "Nom requis";
+    if (email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) errs.email = "Email invalide";
+    setErrors(errs);
+    if (Object.keys(errs).length) {
+      toast.error("Veuillez corriger les erreurs");
+      return;
+    }
+    onSubmit?.({ nom, ville, telephone, email, actif });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label className="block font-semibold mb-1">Nom *</label>
+        <input
+          className="input input-bordered w-full"
+          value={nom}
+          onChange={(e) => setNom(e.target.value)}
+        />
+        {errors.nom && <p className="text-red-600 text-sm mt-1">{errors.nom}</p>}
+      </div>
+      <div>
+        <label className="block font-semibold mb-1">Ville</label>
+        <input
+          className="input input-bordered w-full"
+          value={ville}
+          onChange={(e) => setVille(e.target.value)}
+        />
+      </div>
+      <div>
+        <label className="block font-semibold mb-1">Téléphone</label>
+        <input
+          className="input input-bordered w-full"
+          value={telephone}
+          onChange={(e) => setTelephone(e.target.value)}
+        />
+      </div>
+      <div>
+        <label className="block font-semibold mb-1">Email</label>
+        <input
+          className="input input-bordered w-full"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        {errors.email && <p className="text-red-600 text-sm mt-1">{errors.email}</p>}
+      </div>
+      <label className="flex items-center gap-2">
+        <input type="checkbox" checked={actif} onChange={(e) => setActif(e.target.checked)} />
+        Actif
+      </label>
+      <div className="flex gap-2">
+        <Button type="submit" disabled={saving}>Enregistrer</Button>
+        <Button type="button" variant="outline" disabled={saving} onClick={onCancel}>Annuler</Button>
+      </div>
+    </form>
+  );
+}

--- a/test/Fournisseurs.test.jsx
+++ b/test/Fournisseurs.test.jsx
@@ -41,10 +41,11 @@ test('export excel button triggers hook', async () => {
   const excel = vi.fn();
   mockHook = () => ({
     fournisseurs: [],
-    fetchFournisseurs: vi.fn(),
-    addFournisseur: vi.fn(),
+    total: 0,
+    getFournisseurs: vi.fn(),
+    createFournisseur: vi.fn(),
     updateFournisseur: vi.fn(),
-    deleteFournisseur: vi.fn(),
+    disableFournisseur: vi.fn(),
     exportFournisseursToExcel: excel,
   });
   render(<Fournisseurs />);


### PR DESCRIPTION
## Summary
- implement reusable `FournisseurForm`
- update `useFournisseurs` hook API with pagination & filters
- rework supplier listing with search, filter and pagination
- enhance supplier detail with purchase history and toggle active button
- adjust tests for new hook interface

## Testing
- `npm run lint`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6857b6b92450832da05c96a8f54043be