### PR TITLE
Add basic stock management pages

### DIFF
--- a/src/hooks/useStock.js
+++ b/src/hooks/useStock.js
@@ -67,6 +67,61 @@ export function useStock() {
     return data || [];
   }
 
+  // ----- New helpers for stock module -----
+  const getStockTheorique = useCallback(
+    async (product_id) => {
+      if (!user?.mama_id || !product_id) return 0;
+      const { data, error } = await supabase
+        .from("products")
+        .select("stock_theorique")
+        .eq("mama_id", user.mama_id)
+        .eq("id", product_id)
+        .single();
+      if (error) return 0;
+      return data?.stock_theorique ?? 0;
+    },
+    [user?.mama_id]
+  );
+
+  const getInventaires = useCallback(async () => {
+    if (!user?.mama_id) return [];
+    const { data, error } = await supabase
+      .from("inventaires")
+      .select("*, users:created_by(username)")
+      .eq("mama_id", user.mama_id)
+      .order("date", { ascending: false });
+    if (error) return [];
+    return data || [];
+  }, [user?.mama_id]);
+
+  const createInventaire = useCallback(
+    async (payload) => {
+      if (!user?.mama_id) return null;
+      const { data, error } = await supabase
+        .from("inventaires")
+        .insert([{ ...payload, mama_id: user.mama_id, created_by: user?.user_id }])
+        .select()
+        .single();
+      if (error) return null;
+      return data;
+    },
+    [user?.mama_id, user?.user_id]
+  );
+
+  const createMouvement = useCallback(
+    async (payload) => {
+      if (!user?.mama_id) return null;
+      const { data, error } = await supabase
+        .from("mouvements_stock")
+        .insert([{ ...payload, mama_id: user.mama_id, created_by: user?.user_id }])
+        .select()
+        .single();
+      if (error) return null;
+      return data;
+    },
+    [user?.mama_id, user?.user_id]
+  );
+
   return {
     stocks,
     mouvements,
@@ -76,5 +131,9 @@ export function useStock() {
     fetchMouvements,
     addMouvementStock,
     fetchRotationStats,
+    getStockTheorique,
+    getInventaires,
+    createInventaire,
+    createMouvement,
   };
 }

--- a/src/pages/stock/Inventaire.jsx
+++ b/src/pages/stock/Inventaire.jsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { useStock } from "@/hooks/useStock";
+import { Button } from "@/components/ui/button";
+
+export default function InventairePage() {
+  const { getInventaires } = useStock();
+  const [inventaires, setInventaires] = useState([]);
+
+  useEffect(() => {
+    getInventaires().then(setInventaires);
+  }, [getInventaires]);
+
+  return (
+    <div className="p-6 max-w-4xl mx-auto">
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="text-xl font-bold">Inventaires</h1>
+        <Button asChild>
+          <Link to="/stock/inventaires/new">Créer un nouvel inventaire</Link>
+        </Button>
+      </div>
+      <table className="min-w-full text-sm bg-white rounded shadow">
+        <thead>
+          <tr>
+            <th className="p-2 text-left">Nom</th>
+            <th className="p-2">Date</th>
+            <th className="p-2">Utilisateur</th>
+            <th className="p-2">État</th>
+            <th className="p-2">Écart total</th>
+          </tr>
+        </thead>
+        <tbody>
+          {inventaires.map((inv) => (
+            <tr key={inv.id}>
+              <td className="p-2">{inv.nom || inv.reference}</td>
+              <td className="p-2 text-center">{inv.date}</td>
+              <td className="p-2 text-center">{inv.users?.username || "-"}</td>
+              <td className="p-2 text-center">{inv.cloture ? "validé" : "en cours"}</td>
+              <td className="p-2 text-center">{inv.ecart_total ?? "-"}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/pages/stock/InventaireForm.jsx
+++ b/src/pages/stock/InventaireForm.jsx
@@ -1,0 +1,16 @@
+import { useNavigate, useParams } from "react-router-dom";
+import InventaireForm from "@/components/inventaires/InventaireForm";
+
+export default function InventaireFormPage() {
+  const navigate = useNavigate();
+  const { id } = useParams();
+
+  return (
+    <div className="p-4">
+      <InventaireForm
+        inventaireId={id}
+        onClose={() => navigate(-1)}
+      />
+    </div>
+  );
+}

--- a/src/pages/stock/MouvementForm.jsx
+++ b/src/pages/stock/MouvementForm.jsx
@@ -1,0 +1,59 @@
+import { useState } from "react";
+import { useStock } from "@/hooks/useStock";
+import { Button } from "@/components/ui/button";
+
+export default function MouvementForm({ onClose }) {
+  const { createMouvement } = useStock();
+  const [form, setForm] = useState({ product_id: "", quantite: 0, type: "entree", commentaire: "" });
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+    await createMouvement(form);
+    setLoading(false);
+    onClose?.();
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/20 flex items-center justify-center">
+      <form onSubmit={handleSubmit} className="bg-white p-6 rounded shadow w-80">
+        <h2 className="font-bold mb-2">Nouveau mouvement</h2>
+        <input
+          className="input mb-2 w-full"
+          placeholder="Produit ID"
+          value={form.product_id}
+          onChange={(e) => setForm({ ...form, product_id: e.target.value })}
+        />
+        <input
+          className="input mb-2 w-full"
+          type="number"
+          step="0.01"
+          placeholder="Quantité"
+          value={form.quantite}
+          onChange={(e) => setForm({ ...form, quantite: parseFloat(e.target.value) })}
+        />
+        <select
+          className="input mb-2 w-full"
+          value={form.type}
+          onChange={(e) => setForm({ ...form, type: e.target.value })}
+        >
+          <option value="entree">Entrée</option>
+          <option value="sortie">Sortie</option>
+          <option value="transfert">Transfert</option>
+        </select>
+        <textarea
+          className="input mb-2 w-full"
+          rows={2}
+          placeholder="Commentaire"
+          value={form.commentaire}
+          onChange={(e) => setForm({ ...form, commentaire: e.target.value })}
+        />
+        <div className="flex gap-2 justify-end mt-4">
+          <Button type="submit" disabled={loading}>Valider</Button>
+          <Button type="button" variant="outline" onClick={onClose} disabled={loading}>Annuler</Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/pages/stock/Mouvements.jsx
+++ b/src/pages/stock/Mouvements.jsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from "react";
+import { useStock } from "@/hooks/useStock";
+import { Button } from "@/components/ui/button";
+import MouvementForm from "./MouvementForm";
+
+export default function MouvementsPage() {
+  const { fetchMouvements, mouvements } = useStock();
+  const [showForm, setShowForm] = useState(false);
+
+  useEffect(() => {
+    fetchMouvements();
+  }, [fetchMouvements]);
+
+  return (
+    <div className="p-6 max-w-5xl mx-auto">
+      <div className="flex justify-between mb-4">
+        <h1 className="text-xl font-bold">Mouvements de stock</h1>
+        <Button onClick={() => setShowForm(true)}>Nouveau mouvement</Button>
+      </div>
+      <table className="min-w-full text-sm bg-white rounded shadow">
+        <thead>
+          <tr>
+            <th className="p-2">Date</th>
+            <th className="p-2">Produit</th>
+            <th className="p-2">Quantité</th>
+            <th className="p-2">Type</th>
+            <th className="p-2">Utilisateur</th>
+          </tr>
+        </thead>
+        <tbody>
+          {mouvements.map((m) => (
+            <tr key={m.id}>
+              <td className="p-2 text-center">{m.date}</td>
+              <td className="p-2 text-center">{m.product_id}</td>
+              <td className="p-2 text-center">{m.quantite}</td>
+              <td className="p-2 text-center">{m.type}</td>
+              <td className="p-2 text-center">{m.created_by || "-"}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {showForm && <MouvementForm onClose={() => setShowForm(false)} />}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- extend `useStock` with helpers for inventaires and mouvements
- add simple inventory list page
- add inventory form wrapper page
- add movement list page and form modal

## Testing
- `npx vitest run` *(fails: cannot find package 'vite')*

------
https://chatgpt.com/codex/tasks/task_e_6857b98f7058832d97977bcd1165a1e0