### PR TITLE
Add document management module

### DIFF
--- a/src/components/documents/DocumentPreview.jsx
+++ b/src/components/documents/DocumentPreview.jsx
@@ -1,0 +1,14 @@
+import SmartDialog from "@/components/ui/SmartDialog";
+
+export default function DocumentPreview({ url, type = "", open, onClose }) {
+  const isPdf = type.includes("pdf") || url?.toLowerCase().endsWith(".pdf");
+  return (
+    <SmartDialog open={open} onClose={onClose} title="Aperçu document">
+      {isPdf ? (
+        <iframe src={url} className="w-full h-[80vh] rounded-lg" />
+      ) : (
+        <img src={url} alt="Aperçu" className="max-h-[80vh] mx-auto" />
+      )}
+    </SmartDialog>
+  );
+}

--- a/src/components/documents/DocumentUpload.jsx
+++ b/src/components/documents/DocumentUpload.jsx
@@ -1,0 +1,74 @@
+import { useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+
+export default function DocumentUpload({
+  onUploaded,
+  entiteType = "",
+  entiteId = null,
+  categories = [],
+}) {
+  const inputRef = useRef(null);
+  const [files, setFiles] = useState([]);
+  const [categorie, setCategorie] = useState("");
+
+  const handleFiles = (list) => {
+    setFiles(Array.from(list || []));
+  };
+
+  const openDialog = () => {
+    inputRef.current?.click();
+  };
+
+  const handleDrop = (e) => {
+    e.preventDefault();
+    handleFiles(e.dataTransfer.files);
+  };
+
+  const upload = async () => {
+    for (const file of files) {
+      await onUploaded?.(file, {
+        categorie,
+        entite_liee_type: entiteType,
+        entite_liee_id: entiteId,
+      });
+    }
+    setFiles([]);
+    setCategorie("");
+  };
+
+  return (
+    <div>
+      <div
+        className="border-2 border-dashed rounded-xl p-6 text-center cursor-pointer mb-2"
+        onClick={openDialog}
+        onDrop={handleDrop}
+        onDragOver={(e) => e.preventDefault()}
+      >
+        <p className="mb-2">Glissez-déposez vos fichiers ou cliquez pour sélectionner</p>
+        <input
+          ref={inputRef}
+          type="file"
+          multiple
+          className="hidden"
+          onChange={(e) => handleFiles(e.target.files)}
+        />
+        {files.length > 0 && (
+          <p className="text-sm text-gray-300">{files.length} fichier(s) sélectionné(s)</p>
+        )}
+      </div>
+      <select
+        className="input w-full mb-2"
+        value={categorie}
+        onChange={(e) => setCategorie(e.target.value)}
+      >
+        <option value="">Catégorie</option>
+        {categories.map((c) => (
+          <option key={c} value={c}>{c}</option>
+        ))}
+      </select>
+      {files.length > 0 && (
+        <Button onClick={upload}>Uploader</Button>
+      )}
+    </div>
+  );
+}

--- a/src/pages/documents/Documents.jsx
+++ b/src/pages/documents/Documents.jsx
@@ -1,0 +1,95 @@
+import { useEffect, useState } from "react";
+import { useAuth } from "@/context/AuthContext";
+import { useDocuments } from "@/hooks/useDocuments";
+import DocumentUpload from "@/components/documents/DocumentUpload";
+import DocumentPreview from "@/components/documents/DocumentPreview";
+import TableContainer from "@/components/ui/TableContainer";
+import { Button } from "@/components/ui/button";
+
+export default function Documents() {
+  const { mama_id, loading: authLoading } = useAuth();
+  const { documents, listDocuments, uploadDocument, deleteDocument } = useDocuments();
+  const [showUpload, setShowUpload] = useState(false);
+  const [preview, setPreview] = useState(null);
+
+  useEffect(() => {
+    if (!authLoading && mama_id) {
+      listDocuments();
+    }
+  }, [authLoading, mama_id, listDocuments]);
+
+  const handleUploaded = async (file, meta) => {
+    await uploadDocument(file, meta);
+    await listDocuments();
+    setShowUpload(false);
+  };
+
+  const handleDelete = async (id) => {
+    await deleteDocument(id);
+    await listDocuments();
+  };
+
+  return (
+    <div className="p-6 container mx-auto">
+      <div className="flex justify-between items-center mb-4">
+        <h1 className="text-2xl font-bold">Documents</h1>
+        <Button onClick={() => setShowUpload(!showUpload)}>Ajouter un document</Button>
+      </div>
+      {showUpload && (
+        <div className="mb-4">
+          <DocumentUpload
+            onUploaded={handleUploaded}
+            categories={["Contrat fournisseur", "Spécification produit"]}
+          />
+        </div>
+      )}
+      <TableContainer>
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr>
+              <th className="p-2">Nom</th>
+              <th className="p-2">Catégorie</th>
+              <th className="p-2">Type</th>
+              <th className="p-2">Taille</th>
+              <th className="p-2">Date</th>
+              <th className="p-2">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {documents.map((doc) => (
+              <tr key={doc.id}>
+                <td className="p-2">{doc.nom}</td>
+                <td className="p-2">
+                  {doc.categorie && (
+                    <span className="bg-blue-800/50 text-white px-2 py-0.5 rounded-full text-xs">
+                      {doc.categorie}
+                    </span>
+                  )}
+                </td>
+                <td className="p-2">{doc.type}</td>
+                <td className="p-2">{(doc.taille / 1024).toFixed(1)} Ko</td>
+                <td className="p-2">{doc.created_at?.split("T")[0]}</td>
+                <td className="p-2 space-x-2">
+                  <Button size="sm" variant="outline" onClick={() => setPreview(doc)}>
+                    Prévisualiser
+                  </Button>
+                  <Button size="sm" variant="destructive" onClick={() => handleDelete(doc.id)}>
+                    Supprimer
+                  </Button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </TableContainer>
+      {preview && (
+        <DocumentPreview
+          open={!!preview}
+          url={preview.url}
+          type={preview.type}
+          onClose={() => setPreview(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -21,7 +21,7 @@ const InventaireDetail = lazy(() => import("@/pages/inventaire/InventaireDetail.
 const Mouvements = lazy(() => import("@/pages/mouvements/Mouvements.jsx"));
 const Alertes = lazy(() => import("@/pages/Alertes.jsx"));
 const Promotions = lazy(() => import("@/pages/promotions/Promotions.jsx"));
-const Documents = lazy(() => import("@/pages/Documents.jsx"));
+const Documents = lazy(() => import("@/pages/documents/Documents.jsx"));
 const Analyse = lazy(() => import("@/pages/analyse/Analyse.jsx"));
 const AnalyseCostCenter = lazy(() => import("@/pages/analyse/AnalyseCostCenter.jsx"));
 const Utilisateurs = lazy(() => import("@/pages/parametrage/Utilisateurs.jsx"));

--- a/test/useDocuments.test.js
+++ b/test/useDocuments.test.js
@@ -7,38 +7,41 @@ const queryObj = {
   eq: vi.fn(() => queryObj),
   ilike: vi.fn(() => queryObj),
   insert: vi.fn(() => queryObj),
-  update: vi.fn(() => queryObj),
   delete: vi.fn(() => queryObj),
-  then: (fn) => Promise.resolve(fn({ data: [], error: null })),
+  single: vi.fn(() => Promise.resolve({ data: { url: '/f' }, error: null })),
 };
 const fromMock = vi.fn(() => queryObj);
 vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
 vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
+vi.mock('@/hooks/useStorage', () => ({
+  uploadFile: vi.fn(() => '/f'),
+  deleteFile: vi.fn(),
+  pathFromUrl: vi.fn(() => 'p'),
+}));
 
 let useDocuments;
 
 beforeEach(async () => {
   ({ useDocuments } = await import('@/hooks/useDocuments'));
   fromMock.mockClear();
-  queryObj.select.mockClear();
-  queryObj.order.mockClear();
-  queryObj.eq.mockClear();
-  queryObj.ilike.mockClear();
-  queryObj.insert.mockClear();
+  Object.values(queryObj).forEach(fn => fn.mockClear && fn.mockClear());
 });
 
-test('fetchDocs queries documents with search', async () => {
+test('listDocuments queries documents with search', async () => {
+  queryObj.then = (fn) => Promise.resolve(fn({ data: [], error: null }));
   const { result } = renderHook(() => useDocuments());
-  await act(async () => { await result.current.fetchDocs({ search: 'foo' }); });
+  await act(async () => { await result.current.listDocuments({ search: 'foo' }); });
   expect(fromMock).toHaveBeenCalledWith('documents');
   expect(queryObj.select).toHaveBeenCalledWith('*');
   expect(queryObj.eq).toHaveBeenCalledWith('mama_id', 'm1');
-  expect(queryObj.ilike).toHaveBeenCalledWith('title', '%foo%');
-  expect(queryObj.order).toHaveBeenCalledWith('created_at', { ascending: false });
+  expect(queryObj.ilike).toHaveBeenCalledWith('nom', '%foo%');
 });
 
-test('addDoc inserts row with mama_id', async () => {
+test('uploadDocument inserts row with metadata', async () => {
+  queryObj.select.mockReturnValue(queryObj);
+  queryObj.single.mockReturnValue(Promise.resolve({ data: { id: '1' }, error: null }));
   const { result } = renderHook(() => useDocuments());
-  await act(async () => { await result.current.addDoc({ title: 't', file_url: '/f' }); });
-  expect(queryObj.insert).toHaveBeenCalledWith([{ title: 't', file_url: '/f', mama_id: 'm1' }]);
+  const file = new File(['a'], 'file.txt', { type: 'text/plain' });
+  await act(async () => { await result.current.uploadDocument(file, { categorie: 'c' }); });
+  expect(queryObj.insert).toHaveBeenCalled();
 });


### PR DESCRIPTION
## Summary
- implement new GED page under `pages/documents`
- add reusable `DocumentUpload` and `DocumentPreview` components
- rewrite document hook with upload/list/delete helpers
- adjust router and tests for the new API

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857cea47190832d8afdad346a2ffa8f