### PR TITLE
Add 2FA login support

### DIFF
--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -1,0 +1,6 @@
+import { useContext } from "react";
+import { AuthContext } from "@/context/AuthContext";
+
+export default function useAuth() {
+  return useContext(AuthContext);
+}

--- a/src/pages/debug/AuthDebug.jsx
+++ b/src/pages/debug/AuthDebug.jsx
@@ -1,13 +1,13 @@
 // src/pages/debug/AuthDebug.jsx
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export default function AuthDebug() {
-  const { user_id, role, mama_id, access_rights } = useAuth();
+  const { user_id, role, mama_id, access_rights, session } = useAuth();
 
   return (
     <div>
       <h2>Debug Auth</h2>
-      <pre>{JSON.stringify({ user_id, role, mama_id, access_rights }, null, 2)}</pre>
+      <pre>{JSON.stringify({ user_id, role, mama_id, access_rights, claims: session?.user }, null, 2)}</pre>
     </div>
   );
 }

--- a/test/useTwoFactorAuth.test.js
+++ b/test/useTwoFactorAuth.test.js
@@ -2,9 +2,9 @@ import { describe, it, expect, vi } from "vitest";
 import { useTwoFactorAuth } from "../src/hooks/useTwoFactorAuth";
 import { renderHook, act } from "@testing-library/react";
 
-var rpcMock;
+var upsertMock;
 vi.mock("@/lib/supabase", () => {
-  rpcMock = vi.fn().mockResolvedValue({ error: null });
+  upsertMock = vi.fn().mockResolvedValue({ error: null });
   const data = { user: { id: "u1" } };
   return {
     supabase: {
@@ -14,9 +14,10 @@ vi.mock("@/lib/supabase", () => {
       from: vi.fn(() => ({
         select: vi.fn().mockReturnThis(),
         eq: vi.fn().mockReturnThis(),
-        single: vi.fn().mockResolvedValue({ data: { two_fa_enabled: false, two_fa_secret: null } }),
+        single: vi.fn().mockResolvedValue({ data: { enabled: false, secret: null } }),
+        upsert: upsertMock,
+        update: vi.fn().mockReturnThis(),
       })),
-      rpc: rpcMock,
     },
   };
 });
@@ -27,11 +28,10 @@ describe("useTwoFactorAuth", () => {
     act(() => {
       result.current.startSetup();
     });
-    const secret = result.current.secret;
     await act(async () => {
       await result.current.finalizeSetup();
     });
-    expect(rpcMock).toHaveBeenCalledWith("enable_two_fa", { p_secret: secret });
+    expect(upsertMock).toHaveBeenCalled();
     expect(result.current.enabled).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- integrate 2FA checks in `AuthContext`
- create `useAuth` hook wrapper
- update login page to handle TOTP
- adjust `useTwoFactorAuth` to use `two_factor_auth` table
- expand `AuthDebug` output and update hook usage
- fix unit test for new 2FA API

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857d0457a64832da79192589f2751ba