### PR TITLE
Implement scheduled tasks module

### DIFF
--- a/src/hooks/useTaches.js
+++ b/src/hooks/useTaches.js
@@ -1,0 +1,67 @@
+import { useState, useCallback } from "react";
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/context/AuthContext";
+
+export function useTaches() {
+  const { mama_id } = useAuth();
+  const [taches, setTaches] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const getTaches = useCallback(async (filters = {}) => {
+    if (!mama_id) return [];
+    setLoading(true);
+    setError(null);
+    let query = supabase
+      .from("taches_recurrentes")
+      .select("*")
+      .eq("mama_id", mama_id)
+      .order("date_debut", { ascending: true });
+    if (filters.type) query = query.eq("frequence", filters.type);
+    const { data, error } = await query;
+    setLoading(false);
+    if (error) {
+      setError(error.message || error);
+      setTaches([]);
+      return [];
+    }
+    setTaches(Array.isArray(data) ? data : []);
+    return data || [];
+  }, [mama_id]);
+
+  const createTache = useCallback(async (values) => {
+    if (!mama_id) return { error: "Aucun mama_id" };
+    setLoading(true);
+    setError(null);
+    const { error } = await supabase
+      .from("taches_recurrentes")
+      .insert([{ ...values, mama_id }]);
+    setLoading(false);
+    if (error) {
+      setError(error.message || error);
+      return { error };
+    }
+    await getTaches();
+    return {};
+  }, [mama_id, getTaches]);
+
+  const validerTache = useCallback(async (id) => {
+    setLoading(true);
+    const { error } = await supabase
+      .from("tache_occurrences")
+      .update({ status: "fait", date_realisation: new Date().toISOString() })
+      .eq("id", id);
+    setLoading(false);
+    if (error) {
+      setError(error.message || error);
+      return;
+    }
+    await getTaches();
+  }, [getTaches]);
+
+  const generateOccurrences = useCallback(async () => {
+    await supabase.rpc("generate_occurrences");
+  }, []);
+
+  return { taches, loading, error, getTaches, createTache, validerTache, generateOccurrences };
+}

--- a/src/pages/taches/Alertes.jsx
+++ b/src/pages/taches/Alertes.jsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from "react";
+import { supabase } from "@/lib/supabase";
+
+export default function Alertes() {
+  const [alertes, setAlertes] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    async function fetchAlertes() {
+      setLoading(true);
+      const { data } = await supabase
+        .from("alertes")
+        .select("*")
+        .order("created_at", { ascending: false });
+      setAlertes(Array.isArray(data) ? data : []);
+      setLoading(false);
+    }
+    fetchAlertes();
+  }, []);
+
+  return (
+    <div className="p-6 text-sm">
+      <h1 className="text-2xl font-bold mb-4">Alertes</h1>
+      {loading && <div>Chargement...</div>}
+      <table className="min-w-full text-white">
+        <thead>
+          <tr>
+            <th className="px-2 py-1">Titre</th>
+            <th className="px-2 py-1">Type</th>
+            <th className="px-2 py-1">Date</th>
+          </tr>
+        </thead>
+        <tbody>
+          {alertes.map(a => (
+            <tr key={a.id} className="border-t">
+              <td className="px-2 py-1">{a.titre}</td>
+              <td className="px-2 py-1">{a.type}</td>
+              <td className="px-2 py-1">{new Date(a.created_at).toLocaleDateString()}</td>
+            </tr>
+          ))}
+          {alertes.length === 0 && !loading && (
+            <tr>
+              <td colSpan="3" className="py-4 text-center text-gray-500">Aucune alerte</td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/pages/taches/TacheForm.jsx
+++ b/src/pages/taches/TacheForm.jsx
@@ -1,0 +1,78 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useTaches } from "@/hooks/useTaches";
+import { Button } from "@/components/ui/button";
+
+export default function TacheForm() {
+  const { createTache } = useTaches();
+  const navigate = useNavigate();
+  const [form, setForm] = useState({
+    nom: "",
+    description: "",
+    frequence: "unique",
+    date_debut: "",
+    date_fin: "",
+    notification: [],
+    module_lie: "",
+  });
+
+  const handleChange = e => setForm(f => ({ ...f, [e.target.name]: e.target.value }));
+  const handleCheck = e => {
+    const value = e.target.value;
+    setForm(f => {
+      const notif = new Set(f.notification);
+      if (notif.has(value)) notif.delete(value); else notif.add(value);
+      return { ...f, notification: Array.from(notif) };
+    });
+  };
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    await createTache(form);
+    navigate("/taches");
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2 max-w-md">
+      <label className="block">
+        <span>Nom</span>
+        <input className="input w-full" name="nom" value={form.nom} onChange={handleChange} required />
+      </label>
+      <label className="block">
+        <span>Description</span>
+        <textarea className="input w-full" name="description" value={form.description} onChange={handleChange} />
+      </label>
+      <label className="block">
+        <span>Fréquence</span>
+        <select className="input w-full" name="frequence" value={form.frequence} onChange={handleChange}>
+          <option value="unique">Unique</option>
+          <option value="hebdo">Hebdomadaire</option>
+          <option value="mensuelle">Mensuelle</option>
+          <option value="quotidien">Quotidien</option>
+        </select>
+      </label>
+      <label className="block">
+        <span>Date début</span>
+        <input type="date" className="input w-full" name="date_debut" value={form.date_debut} onChange={handleChange} required />
+      </label>
+      <label className="block">
+        <span>Date fin</span>
+        <input type="date" className="input w-full" name="date_fin" value={form.date_fin} onChange={handleChange} />
+      </label>
+      <fieldset className="block">
+        <legend>Notification</legend>
+        <label className="mr-4">
+          <input type="checkbox" value="visuel" checked={form.notification.includes("visuel")} onChange={handleCheck} /> Visuelle
+        </label>
+        <label>
+          <input type="checkbox" value="email" checked={form.notification.includes("email")} onChange={handleCheck} /> Email
+        </label>
+      </fieldset>
+      <label className="block">
+        <span>Module lié</span>
+        <input className="input w-full" name="module_lie" value={form.module_lie} onChange={handleChange} />
+      </label>
+      <Button type="submit">Enregistrer</Button>
+    </form>
+  );
+}

--- a/src/pages/taches/Taches.jsx
+++ b/src/pages/taches/Taches.jsx
@@ -1,79 +1,69 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
-import { useTasks } from "@/hooks/useTasks";
-import { useAuth } from "@/context/AuthContext";
-import { Toaster } from "react-hot-toast";
+import { useTaches } from "@/hooks/useTaches";
 import { Button } from "@/components/ui/button";
-import TableContainer from "@/components/ui/TableContainer";
 
 export default function Taches() {
-  const { tasks, loading, error, fetchTasks, deleteTask } = useTasks();
-  const { mama_id, loading: authLoading } = useAuth();
+  const { taches, loading, error, getTaches } = useTaches();
+  const [filters, setFilters] = useState({ type: "", statut: "", start: "", end: "" });
 
   useEffect(() => {
-    if (!authLoading && mama_id) fetchTasks();
-  }, [authLoading, mama_id, fetchTasks]);
+    getTaches(filters);
+  }, [getTaches, filters]);
 
-  const handleDelete = async id => {
-    if (window.confirm("Supprimer cette tâche ?")) {
-      await deleteTask(id);
-    }
-  };
-
-  if (loading) return <div className="p-8">Chargement...</div>;
-  if (error) return <div className="p-8 text-red-600">{error}</div>;
+  const handleChange = e => setFilters(f => ({ ...f, [e.target.name]: e.target.value }));
 
   return (
-    <div className="p-8 text-shadow">
-      <Toaster position="top-right" />
+    <div className="p-6 text-sm">
       <div className="flex justify-between items-center mb-4">
-        <h1 className="text-2xl font-bold">Tâches</h1>
-        <Link to="/taches/nouveau" className="bg-white/10 backdrop-blur-lg text-white font-semibold py-2 px-4 rounded-xl shadow-md hover:shadow-lg">
-          Nouvelle tâche
-        </Link>
+        <h1 className="text-2xl font-bold">Tâches planifiées</h1>
+        <Link to="/taches/new" className="bg-white/10 backdrop-blur-lg text-white font-semibold py-2 px-4 rounded-xl shadow-md hover:shadow-lg">Créer une tâche</Link>
       </div>
-      <TableContainer className="mb-4">
-        <table className="w-full text-sm text-white">
+      <div className="flex gap-2 mb-4">
+        <select name="type" value={filters.type} onChange={handleChange} className="input">
+          <option value="">-- Fréquence --</option>
+          <option value="quotidien">Quotidien</option>
+          <option value="hebdo">Hebdomadaire</option>
+          <option value="mensuelle">Mensuelle</option>
+          <option value="unique">Unique</option>
+        </select>
+        <select name="statut" value={filters.statut} onChange={handleChange} className="input">
+          <option value="">-- Statut --</option>
+          <option value="fait">Réalisée</option>
+          <option value="a faire">En attente</option>
+          <option value="en retard">En retard</option>
+        </select>
+        <input type="date" name="start" value={filters.start} onChange={handleChange} className="input" />
+        <input type="date" name="end" value={filters.end} onChange={handleChange} className="input" />
+        <Button onClick={() => getTaches(filters)}>Filtrer</Button>
+      </div>
+      {loading && <div>Chargement...</div>}
+      {error && <div className="text-red-600">{error}</div>}
+      <table className="min-w-full text-white">
         <thead>
           <tr>
-            <th className="px-2 py-1">Titre</th>
-            <th className="px-2 py-1">Type</th>
-            <th className="px-2 py-1">Prochaine échéance</th>
-            <th className="px-2 py-1">Assignée à</th>
+            <th className="px-2 py-1">Nom</th>
+            <th className="px-2 py-1">Fréquence</th>
+            <th className="px-2 py-1">Prochaine occurrence</th>
             <th className="px-2 py-1">Statut</th>
-            <th className="px-2 py-1"></th>
           </tr>
         </thead>
         <tbody>
-          {tasks.length === 0 ? (
-            <tr>
-              <td colSpan="6" className="px-2 py-4 text-center text-gray-500">
-                Aucune tâche pour le moment
-              </td>
+          {taches.map(t => (
+            <tr key={t.id} className="border-t">
+              <td className="px-2 py-1">{t.nom}</td>
+              <td className="px-2 py-1">{t.frequence}</td>
+              <td className="px-2 py-1">{t.next_occurrence || ""}</td>
+              <td className="px-2 py-1">{t.status || "à faire"}</td>
             </tr>
-          ) : (
-            tasks.map(t => (
-              <tr key={t.id}>
-                <td className="px-2 py-1">
-                  <Link to={`/taches/${t.id}`} className="underline text-white">
-                    {t.titre}
-                  </Link>
-                </td>
-                <td className="px-2 py-1">{t.type}</td>
-                <td className="px-2 py-1">{t.next_echeance || ""}</td>
-                <td className="px-2 py-1">{t.assigned?.email || "-"}</td>
-                <td className="px-2 py-1">{t.statut}</td>
-                <td className="px-2 py-1 text-right">
-                  <button onClick={() => handleDelete(t.id)} className="text-red-600 hover:underline">
-                    Supprimer
-                  </button>
-                </td>
-              </tr>
-            ))
+          ))}
+          {taches.length === 0 && !loading && (
+            <tr>
+              <td colSpan="4" className="py-4 text-center text-gray-500">Aucune tâche</td>
+            </tr>
           )}
         </tbody>
       </table>
-      </TableContainer>
     </div>
   );
 }

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -20,6 +20,9 @@ const InventaireForm = lazy(() => import("@/pages/inventaire/InventaireForm.jsx"
 const InventaireDetail = lazy(() => import("@/pages/inventaire/InventaireDetail.jsx"));
 const Mouvements = lazy(() => import("@/pages/mouvements/Mouvements.jsx"));
 const Alertes = lazy(() => import("@/pages/Alertes.jsx"));
+const Taches = lazy(() => import("@/pages/taches/Taches.jsx"));
+const TacheForm = lazy(() => import("@/pages/taches/TacheForm.jsx"));
+const AlertesTaches = lazy(() => import("@/pages/taches/Alertes.jsx"));
 const Promotions = lazy(() => import("@/pages/promotions/Promotions.jsx"));
 const Documents = lazy(() => import("@/pages/documents/Documents.jsx"));
 const Analyse = lazy(() => import("@/pages/analyse/Analyse.jsx"));
@@ -92,6 +95,18 @@ export default function Router() {
           <Route
             path="/mouvements"
             element={<ProtectedRoute accessKey="mouvements"><Mouvements /></ProtectedRoute>}
+          />
+          <Route
+            path="/taches"
+            element={<ProtectedRoute accessKey="taches"><Taches /></ProtectedRoute>}
+          />
+          <Route
+            path="/taches/new"
+            element={<ProtectedRoute accessKey="taches"><TacheForm /></ProtectedRoute>}
+          />
+          <Route
+            path="/taches/alertes"
+            element={<ProtectedRoute accessKey="alertes"><AlertesTaches /></ProtectedRoute>}
           />
           <Route
             path="/alertes"


### PR DESCRIPTION
## Summary
- add scheduled tasks utilities in `useTaches` hook
- implement pages for task list, creation form and alerts
- wire new pages into router
- minimal UI to create and display recurring tasks

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857d2590230832d825d5f3f4bf62d9b