### PR TITLE
Public landing & signup with onboarding

### DIFF
--- a/sql/full_setup.sql
+++ b/sql/full_setup.sql
@@ -1574,6 +1574,30 @@ create policy onboarding_progress_update on onboarding_progress
   with check (user_id = auth.uid());
 grant select, insert, update on onboarding_progress to authenticated;
 
+-- Historique détaillé des étapes d'onboarding
+create table if not exists etapes_onboarding (
+    id uuid primary key default uuid_generate_v4(),
+    user_id uuid references users(id) on delete cascade,
+    etape text,
+    statut text check (statut in ('en cours','terminé','sauté')),
+    mama_id uuid not null references mamas(id) on delete cascade,
+    created_at timestamptz default now()
+);
+create index if not exists idx_etapes_onboarding_mama on etapes_onboarding(mama_id);
+alter table etapes_onboarding enable row level security;
+alter table etapes_onboarding force row level security;
+create policy etapes_onboarding_select on etapes_onboarding
+  for select to authenticated
+  using (mama_id = current_user_mama_id());
+create policy etapes_onboarding_insert on etapes_onboarding
+  for insert to authenticated
+  with check (mama_id = current_user_mama_id() and user_id = auth.uid());
+create policy etapes_onboarding_update on etapes_onboarding
+  for update to authenticated
+  using (user_id = auth.uid() and mama_id = current_user_mama_id())
+  with check (user_id = auth.uid() and mama_id = current_user_mama_id());
+grant select, insert, update on etapes_onboarding to authenticated;
+
 -- Articles d'aide et FAQ
 create table if not exists help_articles (
     id uuid primary key default uuid_generate_v4(),

--- a/sql/mama_stock_patch.sql
+++ b/sql/mama_stock_patch.sql
@@ -975,6 +975,33 @@ create policy onboarding_progress_update on onboarding_progress
   with check (user_id = auth.uid());
 grant select, insert, update on onboarding_progress to authenticated;
 
+-- Historique détaillé des étapes d'onboarding
+create table if not exists etapes_onboarding (
+    id uuid primary key default uuid_generate_v4(),
+    user_id uuid references users(id) on delete cascade,
+    etape text,
+    statut text check (statut in ('en cours','terminé','sauté')),
+    mama_id uuid not null references mamas(id) on delete cascade,
+    created_at timestamptz default now()
+);
+create index if not exists idx_etapes_onboarding_mama on etapes_onboarding(mama_id);
+alter table etapes_onboarding enable row level security;
+alter table etapes_onboarding force row level security;
+drop policy if exists etapes_onboarding_select on etapes_onboarding;
+create policy etapes_onboarding_select on etapes_onboarding
+  for select to authenticated
+  using (mama_id = current_user_mama_id());
+drop policy if exists etapes_onboarding_insert on etapes_onboarding;
+create policy etapes_onboarding_insert on etapes_onboarding
+  for insert to authenticated
+  with check (mama_id = current_user_mama_id() and user_id = auth.uid());
+drop policy if exists etapes_onboarding_update on etapes_onboarding;
+create policy etapes_onboarding_update on etapes_onboarding
+  for update to authenticated
+  using (user_id = auth.uid() and mama_id = current_user_mama_id())
+  with check (user_id = auth.uid() and mama_id = current_user_mama_id());
+grant select, insert, update on etapes_onboarding to authenticated;
+
 -- Articles d'aide et FAQ
 create table if not exists help_articles (
     id uuid primary key default uuid_generate_v4(),

--- a/src/pages/public/LandingPage.jsx
+++ b/src/pages/public/LandingPage.jsx
@@ -1,0 +1,44 @@
+import { Link } from "react-router-dom";
+import MamaLogo from "@/components/ui/MamaLogo";
+
+export default function LandingPage() {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-[#0f1c2e] via-[#232a34] to-[#bfa14d] text-white text-center p-8">
+      <MamaLogo width={120} className="mb-8" />
+      <h1 className="text-4xl font-bold mb-4">Simplifiez votre gestion F&B</h1>
+      <p className="max-w-xl mb-8 text-lg opacity-90">
+        MamaStock centralise vos fournisseurs, vos produits et vos factures pour
+        un suivi des coûts en toute simplicité.
+      </p>
+      <div className="flex gap-4 mb-16">
+        <Link
+          to="/login"
+          className="px-6 py-3 rounded-xl bg-white/20 hover:bg-white/30 transition"
+        >
+          Se connecter
+        </Link>
+        <Link
+          to="/signup"
+          className="px-6 py-3 rounded-xl bg-mamastockGold hover:bg-mamastockGoldHover text-mamastockBg transition"
+        >
+          Créer un compte
+        </Link>
+      </div>
+      <section className="max-w-2xl">
+        <h2 className="text-2xl font-semibold mb-2">Pourquoi MamaStock ?</h2>
+        <p className="mb-6">
+          Réduisez les pertes, maîtrisez vos marges et gagnez du temps grâce à un
+          outil tout-en-un pensé pour la restauration.
+        </p>
+        <h2 className="text-2xl font-semibold mb-2">Fonctionnalités clés</h2>
+        <ul className="mb-6 list-disc list-inside text-left">
+          <li>Gestion des produits et des fournisseurs</li>
+          <li>Suivi des coûts et reporting détaillé</li>
+          <li>Processus d'inventaire simplifié</li>
+        </ul>
+        <h2 className="text-2xl font-semibold mb-2">Ils nous font confiance</h2>
+        <p className="opacity-80">Plusieurs groupes de restaurants utilisent déjà MamaStock au quotidien.</p>
+      </section>
+    </div>
+  );
+}

--- a/src/pages/public/Onboarding.jsx
+++ b/src/pages/public/Onboarding.jsx
@@ -1,0 +1,69 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { motion as Motion } from "framer-motion";
+import { useOnboarding } from "@/hooks/useOnboarding";
+
+const steps = [
+  "Choisissez votre type d'établissement",
+  "Ajoutez vos premiers produits ou fournisseurs",
+  "Découvrez la documentation pour aller plus loin",
+];
+
+export default function Onboarding() {
+  const { step, startOnboarding, nextStep, skip, complete } = useOnboarding();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    startOnboarding();
+  }, []);
+
+  const handleNext = async () => {
+    if (step < steps.length - 1) {
+      await nextStep();
+    } else {
+      await complete();
+      navigate("/dashboard");
+    }
+  };
+
+  const handleSkip = async () => {
+    await skip();
+    navigate("/dashboard");
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center p-8 bg-gradient-to-br from-[#0f1c2e] via-[#232a34] to-[#bfa14d] text-white">
+      <div className="max-w-lg w-full text-center space-y-8">
+        <Motion.div
+          key={step}
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.3 }}
+          className="text-xl"
+        >
+          {steps[step]}
+        </Motion.div>
+        <div className="flex justify-center gap-4">
+          <button
+            className="px-5 py-2 rounded bg-mamastockGold text-mamastockBg hover:bg-mamastockGoldHover transition"
+            onClick={handleNext}
+          >
+            {step < steps.length - 1 ? 'Suivant' : 'Terminer'}
+          </button>
+          <button
+            className="px-5 py-2 rounded bg-white/20 hover:bg-white/30 transition"
+            onClick={handleSkip}
+          >
+            Passer
+          </button>
+        </div>
+        <div className="h-2 bg-white/30 rounded-full overflow-hidden">
+          <div
+            className="h-full bg-mamastockGold"
+            style={{ width: `${((step + 1) / steps.length) * 100}%` }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/public/Signup.jsx
+++ b/src/pages/public/Signup.jsx
@@ -1,0 +1,85 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { supabase } from "@/lib/supabase";
+import MamaLogo from "@/components/ui/MamaLogo";
+
+export default function Signup() {
+  const [restaurant, setRestaurant] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+  const navigate = useNavigate();
+
+  const handleSignup = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+    const { data: authData, error } = await supabase.auth.signUp({
+      email,
+      password,
+    });
+    if (error) {
+      setLoading(false);
+      return;
+    }
+    const { data: mama } = await supabase
+      .from("mamas")
+      .insert({ nom: restaurant })
+      .select()
+      .single();
+    await supabase
+      .from("users")
+      .update({ role: "admin", mama_id: mama.id })
+      .eq("id", authData.user.id);
+    setLoading(false);
+    navigate("/onboarding");
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-[#0f1c2e] via-[#232a34] to-[#bfa14d] p-8">
+      <form
+        onSubmit={handleSignup}
+        className="w-full max-w-md bg-white/30 backdrop-blur-xl rounded-xl p-8 space-y-4"
+      >
+        <div className="text-center">
+          <MamaLogo width={80} className="mx-auto mb-4" />
+          <h1 className="text-xl font-bold text-white">Créer un compte</h1>
+        </div>
+        <div>
+          <label className="block text-sm text-white mb-1">Nom du restaurant</label>
+          <input
+            className="w-full rounded border border-white/30 bg-white/20 py-2 px-3 text-white placeholder-white/70"
+            value={restaurant}
+            onChange={(e) => setRestaurant(e.target.value)}
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-sm text-white mb-1">Email</label>
+          <input
+            className="w-full rounded border border-white/30 bg-white/20 py-2 px-3 text-white placeholder-white/70"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-sm text-white mb-1">Mot de passe</label>
+          <input
+            className="w-full rounded border border-white/30 bg-white/20 py-2 px-3 text-white placeholder-white/70"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+        </div>
+        <button
+          className="w-full py-2 rounded bg-mamastockGold text-mamastockBg font-semibold hover:bg-mamastockGoldHover transition"
+          disabled={loading}
+        >
+          {loading ? "Création..." : "S'inscrire"}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -32,7 +32,9 @@ const Roles = lazy(() => import("@/pages/parametrage/Roles.jsx"));
 const Mamas = lazy(() => import("@/pages/parametrage/Mamas.jsx"));
 const Permissions = lazy(() => import("@/pages/parametrage/Permissions.jsx"));
 const AccessRights = lazy(() => import("@/pages/parametrage/AccessRights.jsx"));
-const Onboarding = lazy(() => import("@/pages/Onboarding.jsx"));
+const Onboarding = lazy(() => import("@/pages/public/Onboarding.jsx"));
+const LandingPage = lazy(() => import("@/pages/public/LandingPage.jsx"));
+const Signup = lazy(() => import("@/pages/public/Signup.jsx"));
 const AideContextuelle = lazy(() => import("@/pages/AideContextuelle.jsx"));
 
 
@@ -40,8 +42,10 @@ export default function Router() {
   return (
     <Suspense fallback={null}>
       <Routes>
-        <Route path="/" element={<Navigate to="/login" replace />} />
+        <Route path="/" element={<LandingPage />} />
+        <Route path="/signup" element={<Signup />} />
         <Route path="/login" element={<Login />} />
+        <Route path="/onboarding" element={<Onboarding />} />
         <Route path="/unauthorized" element={<Unauthorized />} />
         <Route element={<Layout />}>
           <Route
@@ -147,10 +151,6 @@ export default function Router() {
           <Route
             path="/parametrage/access"
             element={<ProtectedRoute accessKey="access"><AccessRights /></ProtectedRoute>}
-          />
-          <Route
-            path="/onboarding"
-            element={<ProtectedRoute accessKey="onboarding"><Onboarding /></ProtectedRoute>}
           />
           <Route
             path="/aide"

--- a/test/router.test.jsx
+++ b/test/router.test.jsx
@@ -38,23 +38,22 @@ vi.mock('@/pages/auth/Login.jsx', () => ({
 }));
 
 // We test that navigating to '/' shows the login component when not authenticated
-test('root path redirects to login when unauthenticated', async () => {
+test('root path shows landing when unauthenticated', async () => {
   render(
     <MemoryRouter initialEntries={["/"]}>
       <RouterConfig />
     </MemoryRouter>
   );
-  // Login component should be displayed
-  expect(await screen.findByText('Login')).toBeInTheDocument();
+  expect(await screen.findByText(/Simplifiez votre gestion/)).toBeInTheDocument();
 });
 
-test('root path redirects to login even when authenticated', async () => {
+test('root path shows landing even when authenticated', async () => {
   authState.isAuthenticated = true;
   render(
     <MemoryRouter initialEntries={["/"]}>
       <RouterConfig />
     </MemoryRouter>
   );
-  expect(await screen.findByText('Login')).toBeInTheDocument();
+  expect(await screen.findByText(/Simplifiez votre gestion/)).toBeInTheDocument();
   authState.isAuthenticated = false;
 });


### PR DESCRIPTION
## Summary
- add marketing landing page with links to login and signup
- create public signup form with automatic `mamas` and admin user creation
- implement simple onboarding flow with step tracking
- expose landing, signup and onboarding routes in the router
- extend `useOnboarding` hook to manage steps in `etapes_onboarding`
- include new SQL table for onboarding steps
- update unit tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857d41dcd38832d9b55098057504e87