### PR TITLE
Implement audit and usage stats hooks

### DIFF
--- a/sql/full_setup.sql
+++ b/sql/full_setup.sql
@@ -1618,3 +1618,72 @@ create policy help_articles_mutation on help_articles
   using (mama_id = current_user_mama_id())
   with check (mama_id = current_user_mama_id());
 grant select, insert, update, delete on help_articles to authenticated;
+
+-- Audit et statistiques d'usage
+create table if not exists logs_audit (
+    id uuid primary key default uuid_generate_v4(),
+    user_id uuid references users(id) on delete set null,
+    mama_id uuid not null references mamas(id) on delete cascade,
+    module text not null,
+    action text not null,
+    cible_id uuid,
+    details jsonb,
+    created_at timestamptz default now()
+);
+create index if not exists idx_logs_audit_mama on logs_audit(mama_id);
+create index if not exists idx_logs_audit_module on logs_audit(module);
+create index if not exists idx_logs_audit_date on logs_audit(created_at);
+alter table logs_audit enable row level security;
+alter table logs_audit force row level security;
+create policy logs_audit_all on logs_audit
+  for all using (mama_id = current_user_mama_id())
+  with check (mama_id = current_user_mama_id());
+grant select, insert on logs_audit to authenticated;
+
+create table if not exists logs_securite (
+    id uuid primary key default uuid_generate_v4(),
+    type text not null,
+    user_id uuid references users(id) on delete set null,
+    mama_id uuid not null references mamas(id) on delete cascade,
+    ip text,
+    navigateur text,
+    description text,
+    created_at timestamptz default now()
+);
+create index if not exists idx_logs_securite_mama on logs_securite(mama_id);
+create index if not exists idx_logs_securite_type on logs_securite(type);
+create index if not exists idx_logs_securite_date on logs_securite(created_at);
+alter table logs_securite enable row level security;
+alter table logs_securite force row level security;
+create policy logs_securite_all on logs_securite
+  for all using (mama_id = current_user_mama_id())
+  with check (mama_id = current_user_mama_id());
+grant select, insert on logs_securite to authenticated;
+
+create table if not exists usage_stats (
+    id uuid primary key default uuid_generate_v4(),
+    user_id uuid references users(id) on delete set null,
+    mama_id uuid not null references mamas(id) on delete cascade,
+    module text,
+    action text,
+    timestamp timestamptz default now()
+);
+create index if not exists idx_usage_stats_mama on usage_stats(mama_id);
+create index if not exists idx_usage_stats_user on usage_stats(user_id);
+create index if not exists idx_usage_stats_module on usage_stats(module);
+alter table usage_stats enable row level security;
+alter table usage_stats force row level security;
+create policy usage_stats_all on usage_stats
+  for all using (mama_id = current_user_mama_id())
+  with check (mama_id = current_user_mama_id());
+grant select, insert on usage_stats to authenticated;
+
+create or replace function log_audit_event(p_mama uuid, p_user uuid, p_module text, p_action text, p_cible uuid, p_details jsonb)
+returns void language plpgsql security definer as $$
+begin
+  insert into logs_audit(mama_id, user_id, module, action, cible_id, details)
+  values(p_mama, p_user, p_module, p_action, p_cible, p_details);
+end;
+$$;
+grant execute on function log_audit_event(uuid, uuid, text, text, uuid, jsonb) to authenticated;
+

--- a/sql/mama_stock_patch.sql
+++ b/sql/mama_stock_patch.sql
@@ -1052,3 +1052,73 @@ alter table requisitions add column if not exists quantite numeric;
 alter table requisitions add column if not exists motif text;
 alter table requisitions add column if not exists date_requisition date default current_date;
 alter table requisitions add column if not exists created_by uuid references users(id) on delete set null;
+
+-- Audit et statistiques d'usage
+create table if not exists logs_audit (
+    id uuid primary key default uuid_generate_v4(),
+    user_id uuid references users(id) on delete set null,
+    mama_id uuid not null references mamas(id) on delete cascade,
+    module text not null,
+    action text not null,
+    cible_id uuid,
+    details jsonb,
+    created_at timestamptz default now()
+);
+create index if not exists idx_logs_audit_mama on logs_audit(mama_id);
+create index if not exists idx_logs_audit_module on logs_audit(module);
+create index if not exists idx_logs_audit_date on logs_audit(created_at);
+alter table logs_audit enable row level security;
+alter table logs_audit force row level security;
+create policy logs_audit_all on logs_audit
+  for all using (mama_id = current_user_mama_id())
+  with check (mama_id = current_user_mama_id());
+grant select, insert on logs_audit to authenticated;
+
+create table if not exists logs_securite (
+    id uuid primary key default uuid_generate_v4(),
+    type text not null,
+    user_id uuid references users(id) on delete set null,
+    mama_id uuid not null references mamas(id) on delete cascade,
+    ip text,
+    navigateur text,
+    description text,
+    created_at timestamptz default now()
+);
+create index if not exists idx_logs_securite_mama on logs_securite(mama_id);
+create index if not exists idx_logs_securite_type on logs_securite(type);
+create index if not exists idx_logs_securite_date on logs_securite(created_at);
+alter table logs_securite enable row level security;
+alter table logs_securite force row level security;
+create policy logs_securite_all on logs_securite
+  for all using (mama_id = current_user_mama_id())
+  with check (mama_id = current_user_mama_id());
+grant select, insert on logs_securite to authenticated;
+
+create table if not exists usage_stats (
+    id uuid primary key default uuid_generate_v4(),
+    user_id uuid references users(id) on delete set null,
+    mama_id uuid not null references mamas(id) on delete cascade,
+    module text,
+    action text,
+    timestamp timestamptz default now()
+);
+create index if not exists idx_usage_stats_mama on usage_stats(mama_id);
+create index if not exists idx_usage_stats_user on usage_stats(user_id);
+create index if not exists idx_usage_stats_module on usage_stats(module);
+alter table usage_stats enable row level security;
+alter table usage_stats force row level security;
+create policy usage_stats_all on usage_stats
+  for all using (mama_id = current_user_mama_id())
+  with check (mama_id = current_user_mama_id());
+grant select, insert on usage_stats to authenticated;
+
+-- Helper function for manual logging
+create or replace function log_audit_event(p_mama uuid, p_user uuid, p_module text, p_action text, p_cible uuid, p_details jsonb)
+returns void language plpgsql security definer as $$
+begin
+  insert into logs_audit(mama_id, user_id, module, action, cible_id, details)
+  values(p_mama, p_user, p_module, p_action, p_cible, p_details);
+end;
+$$;
+grant execute on function log_audit_event(uuid, uuid, text, text, uuid, jsonb) to authenticated;
+

--- a/src/hooks/useAuditLog.js
+++ b/src/hooks/useAuditLog.js
@@ -17,5 +17,35 @@ export function useAuditLog() {
     ]);
   }
 
-  return { log };
+  async function logAction({ module, action, cible_id = null, details = null }) {
+    if (!mama_id) return;
+    await supabase.from("logs_audit").insert([
+      {
+        mama_id,
+        user_id: user?.id || null,
+        module,
+        action,
+        cible_id,
+        details,
+      },
+    ]);
+  }
+
+  async function logSecurityEvent({ type, user_id = null, description = "" }) {
+    if (!mama_id) return;
+    const ip = window?.location?.hostname || null;
+    const navigateur = navigator.userAgent;
+    await supabase.from("logs_securite").insert([
+      {
+        mama_id,
+        type,
+        user_id: user_id || user?.id || null,
+        ip,
+        navigateur,
+        description,
+      },
+    ]);
+  }
+
+  return { log, logAction, logSecurityEvent };
 }

--- a/src/hooks/useUsageStats.js
+++ b/src/hooks/useUsageStats.js
@@ -1,0 +1,45 @@
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/context/AuthContext";
+
+export function useUsageStats() {
+  const { mama_id } = useAuth();
+
+  async function getModuleUsageCount() {
+    if (!mama_id) return [];
+    const { data, error } = await supabase
+      .from("usage_stats")
+      .select("module, count:id")
+      .eq("mama_id", mama_id)
+      .group("module");
+    if (error) return [];
+    return data || [];
+  }
+
+  async function getLastSeen(user_id) {
+    if (!mama_id || !user_id) return null;
+    const { data } = await supabase
+      .from("usage_stats")
+      .select("timestamp")
+      .eq("mama_id", mama_id)
+      .eq("user_id", user_id)
+      .order("timestamp", { ascending: false })
+      .limit(1)
+      .single();
+    return data?.timestamp || null;
+  }
+
+  async function getFrequentErrors() {
+    if (!mama_id) return [];
+    const { data } = await supabase
+      .from("logs_securite")
+      .select("description, count:id")
+      .eq("mama_id", mama_id)
+      .ilike("type", "%erreur%")
+      .group("description")
+      .order("count", { ascending: false })
+      .limit(5);
+    return data || [];
+  }
+
+  return { getModuleUsageCount, getLastSeen, getFrequentErrors };
+}

--- a/src/pages/admin/AuditViewer.jsx
+++ b/src/pages/admin/AuditViewer.jsx
@@ -1,0 +1,106 @@
+import { useState, useEffect } from "react";
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/context/AuthContext";
+import { Button } from "@/components/ui/button";
+
+export default function AuditViewer() {
+  const { mama_id } = useAuth();
+  const [logs, setLogs] = useState([]);
+  const [user, setUser] = useState("");
+  const [type, setType] = useState("");
+  const [date, setDate] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const fetchLogs = async () => {
+    if (!mama_id) return;
+    setLoading(true);
+    const { data: audit } = await supabase
+      .from("logs_audit")
+      .select("*, users:user_id(email)")
+      .eq("mama_id", mama_id)
+      .order("created_at", { ascending: false })
+      .limit(200);
+    const { data: security } = await supabase
+      .from("logs_securite")
+      .select("*, users:user_id(email)")
+      .eq("mama_id", mama_id)
+      .order("created_at", { ascending: false })
+      .limit(200);
+    const combined = [];
+    (audit || []).forEach((l) => combined.push({ ...l, _source: "audit" }));
+    (security || []).forEach((l) => combined.push({ ...l, _source: "security" }));
+    let rows = combined;
+    if (user) rows = rows.filter((l) => l.user_id === user);
+    if (type) rows = rows.filter((l) => l.action === type || l.type === type);
+    if (date) rows = rows.filter((l) => l.created_at.startsWith(date));
+    rows.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+    setLogs(rows);
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    fetchLogs();
+  }, [mama_id]);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    fetchLogs();
+  };
+
+  return (
+    <div className="p-8 container mx-auto text-sm">
+      <h1 className="text-2xl font-bold mb-4">Journal d'audit</h1>
+      <form onSubmit={handleSubmit} className="flex gap-2 mb-4 items-end">
+        <input
+          className="input"
+          placeholder="Utilisateur id"
+          value={user}
+          onChange={(e) => setUser(e.target.value)}
+        />
+        <input
+          className="input"
+          placeholder="Type"
+          value={type}
+          onChange={(e) => setType(e.target.value)}
+        />
+        <input
+          type="date"
+          className="input"
+          value={date}
+          onChange={(e) => setDate(e.target.value)}
+        />
+        <Button type="submit">Filtrer</Button>
+      </form>
+      {loading ? (
+        <div>Chargement...</div>
+      ) : (
+        <table className="min-w-full bg-white rounded-xl shadow-md">
+          <thead>
+            <tr>
+              <th className="px-2 py-1">Date</th>
+              <th className="px-2 py-1">Utilisateur</th>
+              <th className="px-2 py-1">Action</th>
+              <th className="px-2 py-1">Détails</th>
+            </tr>
+          </thead>
+          <tbody>
+            {logs.map((l) => (
+              <tr key={`${l.id}-${l._source}`} className="align-top">
+                <td className="px-2 py-1 whitespace-nowrap">
+                  {new Date(l.created_at).toLocaleString()}
+                </td>
+                <td className="px-2 py-1">{l.users?.email || l.user_id}</td>
+                <td className="px-2 py-1">
+                  {l._source === "security" ? "🛡️" : "✏️"} {l.action || l.type}
+                </td>
+                <td className="px-2 py-1 font-mono break-all">
+                  {JSON.stringify(l.details || l.description || {})}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/src/pages/admin/StatsDashboard.jsx
+++ b/src/pages/admin/StatsDashboard.jsx
@@ -1,0 +1,56 @@
+import { useEffect, useState } from "react";
+import { useUsageStats } from "@/hooks/useUsageStats";
+import { useAuth } from "@/context/AuthContext";
+import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip } from "recharts";
+
+export default function StatsDashboard() {
+  const { mama_id } = useAuth();
+  const { getModuleUsageCount, getFrequentErrors } = useUsageStats();
+  const [modules, setModules] = useState([]);
+  const [errors, setErrors] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!mama_id) return;
+    const load = async () => {
+      setLoading(true);
+      const m = await getModuleUsageCount();
+      const e = await getFrequentErrors();
+      setModules(m);
+      setErrors(e);
+      setLoading(false);
+    };
+    load();
+  }, [mama_id]);
+
+  return (
+    <div className="p-8 container mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Statistiques d'usage</h1>
+      {loading ? (
+        <div>Chargement...</div>
+      ) : (
+        <div className="grid gap-6">
+          <div className="bg-white rounded-xl shadow p-4">
+            <h2 className="font-semibold mb-2">Modules les plus utilisés</h2>
+            <ResponsiveContainer width="100%" height={300}>
+              <BarChart data={modules}>
+                <XAxis dataKey="module" />
+                <YAxis />
+                <Tooltip />
+                <Bar dataKey="count" fill="#bfa14d" />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+          <div className="bg-white rounded-xl shadow p-4">
+            <h2 className="font-semibold mb-2">Erreurs fréquentes</h2>
+            <ul className="list-disc pl-4">
+              {errors.map((e) => (
+                <li key={e.description}>{e.description} ({e.count})</li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- extend `useAuditLog` with logAction and logSecurityEvent helpers
- add `useUsageStats` hook
- create admin pages AuditViewer and StatsDashboard
- support audit/usage tables in schema

## Testing
- `npm run lint`
- `npm test`
- `npm run test:e2e` *(skipped: Playwright browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6857dacf85c8832d964ef7245617af19