### PR TITLE
Add multi mama supervision module

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import Router from "@/router";
 import { AuthProvider } from "@/context/AuthContext";
 import { HelpProvider } from "@/context/HelpProvider";
+import { MultiMamaProvider } from "@/context/MultiMamaContext";
 import { Toaster } from "react-hot-toast";
 import { BrowserRouter } from "react-router-dom";
 
@@ -8,10 +9,12 @@ export default function App() {
   return (
     <AuthProvider>
       <HelpProvider>
-        <BrowserRouter>
-          <Toaster position="top-right" />
-          <Router />
-        </BrowserRouter>
+        <MultiMamaProvider>
+          <BrowserRouter>
+            <Toaster position="top-right" />
+            <Router />
+          </BrowserRouter>
+        </MultiMamaProvider>
       </HelpProvider>
     </AuthProvider>
   );

--- a/src/context/MultiMamaContext.jsx
+++ b/src/context/MultiMamaContext.jsx
@@ -1,0 +1,58 @@
+import { createContext, useContext, useEffect, useState } from "react";
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/context/AuthContext";
+
+const MultiMamaContext = createContext();
+
+export function MultiMamaProvider({ children }) {
+  const { user_id, role, mama_id: authMamaId } = useAuth();
+  const [mamas, setMamas] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [mamaActif, setMamaActifState] = useState(
+    localStorage.getItem("mamaActif") || authMamaId
+  );
+
+  useEffect(() => {
+    if (authMamaId && !mamaActif) {
+      setMamaActifState(authMamaId);
+    }
+  }, [authMamaId]);
+
+  useEffect(() => {
+    if (user_id) fetchMamas();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user_id, role]);
+
+  async function fetchMamas() {
+    setLoading(true);
+    let data = [];
+    if (role === "superadmin") {
+      const res = await supabase.from("mamas").select("id, nom").order("nom");
+      if (!res.error) data = res.data;
+    } else {
+      const res = await supabase
+        .from("users_mamas")
+        .select("mamas(id, nom)")
+        .eq("user_id", user_id)
+        .eq("actif", true);
+      if (!res.error) data = (res.data || []).map((r) => r.mamas);
+    }
+    setMamas(Array.isArray(data) ? data : []);
+    setLoading(false);
+  }
+
+  const changeMama = (id) => {
+    setMamaActifState(id);
+    localStorage.setItem("mamaActif", id);
+  };
+
+  const value = { mamas, mamaActif, setMamaActif: changeMama, loading };
+
+  return (
+    <MultiMamaContext.Provider value={value}>{children}</MultiMamaContext.Provider>
+  );
+}
+
+export function useMultiMama() {
+  return useContext(MultiMamaContext) || {};
+}

--- a/src/hooks/useMamaSwitcher.js
+++ b/src/hooks/useMamaSwitcher.js
@@ -1,0 +1,17 @@
+import { useEffect } from "react";
+import { useMultiMama } from "@/context/MultiMamaContext";
+
+export function useMamaSwitcher() {
+  const { mamas, mamaActif, setMamaActif, loading } = useMultiMama();
+
+  useEffect(() => {
+    const stored = localStorage.getItem("mamaActif");
+    if (!mamaActif && stored) setMamaActif(stored);
+  }, [mamaActif, setMamaActif]);
+
+  function switchMama(id) {
+    setMamaActif(id);
+  }
+
+  return { mamas, mamaActif, switchMama, loading };
+}

--- a/src/pages/supervision/ComparateurFiches.jsx
+++ b/src/pages/supervision/ComparateurFiches.jsx
@@ -1,0 +1,63 @@
+import { useState } from "react";
+import { supabase } from "@/lib/supabase";
+import { useMultiMama } from "@/context/MultiMamaContext";
+import TableContainer from "@/components/ui/TableContainer";
+import { Button } from "@/components/ui/button";
+
+export default function ComparateurFiches() {
+  const { mamas } = useMultiMama();
+  const [ficheId, setFicheId] = useState("");
+  const [results, setResults] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  const handleCompare = async () => {
+    if (!ficheId || mamas.length === 0) return;
+    setLoading(true);
+    const { data } = await supabase.rpc("compare_fiche", {
+      fiche_id: ficheId,
+      mama_ids: mamas.map((m) => m.id),
+    });
+    setResults(Array.isArray(data) ? data : []);
+    setLoading(false);
+  };
+
+  return (
+    <div className="p-6 container mx-auto text-shadow">
+      <h1 className="text-2xl font-bold mb-4">Comparateur de fiches</h1>
+      <div className="flex gap-2 mb-4">
+        <input
+          className="input input-bordered"
+          placeholder="ID fiche"
+          value={ficheId}
+          onChange={(e) => setFicheId(e.target.value)}
+        />
+        <Button onClick={handleCompare} disabled={loading || !ficheId}>
+          Comparer
+        </Button>
+      </div>
+      {loading && <div className="mb-2">Chargement...</div>}
+      {results.length > 0 && (
+        <TableContainer>
+          <table className="min-w-full text-center">
+            <thead>
+              <tr>
+                <th className="px-2 py-1">Mama</th>
+                <th className="px-2 py-1">Coût</th>
+                <th className="px-2 py-1">Rendement</th>
+              </tr>
+            </thead>
+            <tbody>
+              {results.map((r) => (
+                <tr key={r.mama_id}>
+                  <td className="px-2 py-1">{r.nom}</td>
+                  <td className="px-2 py-1">{r.cout || '-'}</td>
+                  <td className="px-2 py-1">{r.rendement || '-'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </TableContainer>
+      )}
+    </div>
+  );
+}

--- a/src/pages/supervision/GroupeParamForm.jsx
+++ b/src/pages/supervision/GroupeParamForm.jsx
@@ -1,0 +1,117 @@
+import { useEffect, useState } from "react";
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/context/AuthContext";
+import { Button } from "@/components/ui/button";
+import toast from "react-hot-toast";
+
+export default function GroupeParamForm({ groupe, onClose, onSaved }) {
+  const { role } = useAuth();
+  const [values, setValues] = useState({
+    nom: groupe?.nom || "",
+    description: groupe?.description || "",
+  });
+  const [mamas, setMamas] = useState([]);
+  const [selected, setSelected] = useState(groupe?.mamas_ids || []);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    fetchMamas();
+  }, []);
+
+  async function fetchMamas() {
+    const { data } = await supabase.from("mamas").select("id, nom").order("nom");
+    setMamas(data || []);
+  }
+
+  const toggleMama = (id) => {
+    setSelected((s) =>
+      s.includes(id) ? s.filter((m) => m !== id) : [...s, id]
+    );
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (role !== "superadmin") return;
+    setSaving(true);
+    let saved = null;
+    let error = null;
+    if (groupe?.id) {
+      const res = await supabase
+        .from("groupes")
+        .update({ nom: values.nom, description: values.description })
+        .eq("id", groupe.id)
+        .select()
+        .single();
+      error = res.error;
+      saved = res.data;
+      await supabase.from("mamas").update({ groupe_id: null }).eq("groupe_id", groupe.id);
+      if (selected.length > 0) {
+        await supabase.from("mamas").update({ groupe_id: groupe.id }).in("id", selected);
+      }
+    } else {
+      const res = await supabase
+        .from("groupes")
+        .insert({ nom: values.nom, description: values.description })
+        .select()
+        .single();
+      error = res.error;
+      saved = res.data;
+      if (saved && selected.length > 0) {
+        await supabase.from("mamas").update({ groupe_id: saved.id }).in("id", selected);
+      }
+    }
+    setSaving(false);
+    if (!error) {
+      toast.success("Groupe enregistré");
+      if (onSaved) onSaved(saved);
+      if (onClose) onClose();
+    } else {
+      toast.error("Erreur enregistrement");
+    }
+  };
+
+  return (
+    <form className="space-y-3 p-4" onSubmit={handleSubmit}>
+      <div>
+        <label>Nom du groupe</label>
+        <input
+          className="input input-bordered w-full"
+          value={values.nom}
+          onChange={(e) => setValues({ ...values, nom: e.target.value })}
+          required
+        />
+      </div>
+      <div>
+        <label>Description</label>
+        <textarea
+          className="textarea textarea-bordered w-full"
+          value={values.description}
+          onChange={(e) => setValues({ ...values, description: e.target.value })}
+        />
+      </div>
+      <div>
+        <label className="block mb-1">Établissements</label>
+        <div className="flex flex-col gap-1 max-h-40 overflow-y-auto border p-2 rounded">
+          {mamas.map((m) => (
+            <label key={m.id} className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={selected.includes(m.id)}
+                onChange={() => toggleMama(m.id)}
+              />
+              {m.nom}
+            </label>
+          ))}
+        </div>
+      </div>
+      <div className="flex gap-4 mt-4">
+        <Button type="submit" disabled={saving}>
+          {saving ? "Enregistrement…" : "Enregistrer"}
+        </Button>
+        <Button type="button" variant="secondary" onClick={onClose} disabled={saving}>
+          Annuler
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/pages/supervision/SupervisionGroupe.jsx
+++ b/src/pages/supervision/SupervisionGroupe.jsx
@@ -1,0 +1,56 @@
+import { useEffect, useState } from "react";
+import { supabase } from "@/lib/supabase";
+import { useMultiMama } from "@/context/MultiMamaContext";
+import TableContainer from "@/components/ui/TableContainer";
+
+export default function SupervisionGroupe() {
+  const { mamas } = useMultiMama();
+  const [stats, setStats] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (mamas.length > 0) fetchStats();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mamas]);
+
+  async function fetchStats() {
+    setLoading(true);
+    const ids = mamas.map((m) => m.id);
+    const { data } = await supabase.rpc("stats_multi_mamas", { mama_ids: ids });
+    setStats(Array.isArray(data) ? data : []);
+    setLoading(false);
+  }
+
+  const display = stats.length ? stats : mamas.map((m) => ({ ...m, mama_id: m.id }));
+
+  return (
+    <div className="p-6 container mx-auto text-shadow">
+      <h1 className="text-2xl font-bold mb-4">Supervision Groupe</h1>
+      {loading && <div className="mb-2">Chargement...</div>}
+      <TableContainer>
+        <table className="min-w-full text-center">
+          <thead>
+            <tr>
+              <th className="px-2 py-1">Établissement</th>
+              <th className="px-2 py-1">Coût matière</th>
+              <th className="px-2 py-1">Factures</th>
+              <th className="px-2 py-1">Validation</th>
+              <th className="px-2 py-1">Inventaire</th>
+            </tr>
+          </thead>
+          <tbody>
+            {display.map((d) => (
+              <tr key={d.mama_id}>
+                <td className="px-2 py-1">{d.nom}</td>
+                <td className="px-2 py-1">{d.cout_matiere || '-'}</td>
+                <td className="px-2 py-1">{d.nb_factures || '-'}</td>
+                <td className="px-2 py-1">{d.taux_validation || '-'}</td>
+                <td className="px-2 py-1">{d.ecart_inventaire || '-'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </TableContainer>
+    </div>
+  );
+}

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -36,6 +36,8 @@ const Onboarding = lazy(() => import("@/pages/public/Onboarding.jsx"));
 const LandingPage = lazy(() => import("@/pages/public/LandingPage.jsx"));
 const Signup = lazy(() => import("@/pages/public/Signup.jsx"));
 const AideContextuelle = lazy(() => import("@/pages/AideContextuelle.jsx"));
+const SupervisionGroupe = lazy(() => import("@/pages/supervision/SupervisionGroupe.jsx"));
+const ComparateurFiches = lazy(() => import("@/pages/supervision/ComparateurFiches.jsx"));
 
 
 export default function Router() {
@@ -155,6 +157,14 @@ export default function Router() {
           <Route
             path="/aide"
             element={<ProtectedRoute accessKey="aide"><AideContextuelle /></ProtectedRoute>}
+          />
+          <Route
+            path="/supervision"
+            element={<ProtectedRoute accessKey="dashboard"><SupervisionGroupe /></ProtectedRoute>}
+          />
+          <Route
+            path="/supervision/comparateur"
+            element={<ProtectedRoute accessKey="fiches"><ComparateurFiches /></ProtectedRoute>}
           />
           <Route
             path="/debug/auth"


### PR DESCRIPTION
## Summary
- implement `MultiMamaContext` for multi-establishment handling
- add `useMamaSwitcher` hook
- add supervision pages for group comparison and fiche comparison
- include a form component for group parameters
- register context provider and new routes

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857dfbface4832db5406826e064b206