### PR TITLE
Add mama branding settings

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import Router from "@/router";
 import { AuthProvider } from "@/context/AuthContext";
 import { HelpProvider } from "@/context/HelpProvider";
 import { MultiMamaProvider } from "@/context/MultiMamaContext";
+import { ThemeProvider } from "@/context/ThemeProvider";
 import { Toaster } from "react-hot-toast";
 import { BrowserRouter } from "react-router-dom";
 
@@ -10,10 +11,12 @@ export default function App() {
     <AuthProvider>
       <HelpProvider>
         <MultiMamaProvider>
-          <BrowserRouter>
-            <Toaster position="top-right" />
-            <Router />
-          </BrowserRouter>
+          <ThemeProvider>
+            <BrowserRouter>
+              <Toaster position="top-right" />
+              <Router />
+            </BrowserRouter>
+          </ThemeProvider>
         </MultiMamaProvider>
       </HelpProvider>
     </AuthProvider>

--- a/src/components/ui/MamaLogo.jsx
+++ b/src/components/ui/MamaLogo.jsx
@@ -1,9 +1,11 @@
-import logo from "@/assets/logo-mamastock.png";
+import defaultLogo from "@/assets/logo-mamastock.png";
+import { useTheme } from "@/context/ThemeProvider";
 
 export default function MamaLogo({ width = 200, className = "animate-fade-in" }) {
+  const { logo } = useTheme();
   return (
     <img
-      src={logo}
+      src={logo || defaultLogo}
       alt="Logo MamaStock"
       width={width}
       className={`drop-shadow-[0_0_20px_rgba(255,210,0,0.8)] ${className}`}

--- a/src/context/ThemeProvider.jsx
+++ b/src/context/ThemeProvider.jsx
@@ -1,0 +1,53 @@
+import { createContext, useContext, useEffect } from "react";
+import useMamaSettings from "@/hooks/useMamaSettings";
+import { useAuth } from "@/context/AuthContext";
+
+const ThemeContext = createContext({});
+
+export function ThemeProvider({ children }) {
+  const { mama_id } = useAuth();
+  const { settings, fetchMamaSettings } = useMamaSettings();
+
+  useEffect(() => {
+    if (mama_id) fetchMamaSettings();
+  }, [mama_id, fetchMamaSettings]);
+
+  useEffect(() => {
+    if (settings.primary_color) {
+      document.documentElement.style.setProperty(
+        "--primary-color",
+        settings.primary_color
+      );
+      document.documentElement.style.setProperty(
+        "--mamastock-gold",
+        settings.primary_color
+      );
+    }
+    if (settings.secondary_color) {
+      document.documentElement.style.setProperty(
+        "--secondary-color",
+        settings.secondary_color
+      );
+    }
+  }, [settings.primary_color, settings.secondary_color]);
+
+  useEffect(() => {
+    if (settings.dark_mode) document.documentElement.classList.add("dark");
+    else document.documentElement.classList.remove("dark");
+  }, [settings.dark_mode]);
+
+  const value = {
+    logo: settings.logo_url,
+    primaryColor: settings.primary_color,
+    secondaryColor: settings.secondary_color,
+    darkMode: settings.dark_mode,
+  };
+
+  return (
+    <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  return useContext(ThemeContext) || {};
+}

--- a/src/globals.css
+++ b/src/globals.css
@@ -6,6 +6,9 @@
   --mamastock-bg: #0f1c2e;
   --mamastock-text: #f0f0f5;
   --mamastock-gold: #bfa14d;
+  /* Theme variables overridable via ThemeProvider */
+  --primary-color: var(--mamastock-gold);
+  --secondary-color: var(--mamastock-bg);
 }
 
 /* Style custom global pour MamaStock */
@@ -126,4 +129,18 @@ html.dark body {
 
 .text-shadow { text-shadow: 1px 1px 2px rgba(0,0,0,0.5); }
 .glow-gold { text-shadow: 0 0 8px var(--mamastock-gold); }
+
+/* Theme color helpers */
+.text-primary,
+.text-mamastockGold {
+  color: var(--primary-color);
+}
+.bg-primary,
+.bg-mamastockGold {
+  background-color: var(--primary-color);
+}
+.border-primary,
+.border-mamastockGold {
+  border-color: var(--primary-color);
+}
 

--- a/src/hooks/useMamaSettings.js
+++ b/src/hooks/useMamaSettings.js
@@ -1,0 +1,57 @@
+import { useState, useCallback } from "react";
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/context/AuthContext";
+
+const defaults = {
+  logo_url: "",
+  primary_color: "#bfa14d",
+  secondary_color: "#0f1c2e",
+  email_envoi: "",
+  email_alertes: "",
+  dark_mode: false,
+  langue: "fr",
+  monnaie: "€",
+  timezone: "Europe/Paris",
+  rgpd_text: "",
+  mentions_legales: "",
+};
+
+export default function useMamaSettings() {
+  const { mama_id } = useAuth();
+  const [settings, setSettings] = useState(defaults);
+  const [loading, setLoading] = useState(false);
+
+  const fetchMamaSettings = useCallback(async () => {
+    if (!mama_id) return null;
+    setLoading(true);
+    const { data, error } = await supabase
+      .from("mamas")
+      .select(
+        "logo_url, primary_color, secondary_color, email_envoi, email_alertes, dark_mode, langue, monnaie, timezone, rgpd_text, mentions_legales"
+      )
+      .eq("id", mama_id)
+      .single();
+    setLoading(false);
+    if (!error && data) setSettings({ ...defaults, ...data });
+    return data;
+  }, [mama_id]);
+
+  const updateMamaSettings = useCallback(
+    async (fields) => {
+      if (!mama_id) return { error: "missing mama_id" };
+      setLoading(true);
+      const { data, error } = await supabase
+        .from("mamas")
+        .update(fields)
+        .eq("id", mama_id)
+        .select()
+        .single();
+      setLoading(false);
+      if (!error && data) setSettings((s) => ({ ...s, ...data }));
+      return { data, error };
+    },
+    [mama_id]
+  );
+
+  return { settings, loading, fetchMamaSettings, updateMamaSettings };
+}

--- a/src/pages/parametrage/MamaSettingsForm.jsx
+++ b/src/pages/parametrage/MamaSettingsForm.jsx
@@ -1,0 +1,131 @@
+import { useEffect, useState } from "react";
+import toast, { Toaster } from "react-hot-toast";
+import { Button } from "@/components/ui/button";
+import useMamaSettings from "@/hooks/useMamaSettings";
+import { uploadFile, deleteFile, pathFromUrl } from "@/hooks/useStorage";
+import { useAuth } from "@/context/AuthContext";
+
+export default function MamaSettingsForm() {
+  const { mama_id } = useAuth();
+  const { settings, fetchMamaSettings, updateMamaSettings } = useMamaSettings();
+  const [form, setForm] = useState(settings);
+  const [logoFile, setLogoFile] = useState(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    fetchMamaSettings();
+  }, [fetchMamaSettings]);
+
+  useEffect(() => {
+    setForm(settings);
+  }, [settings]);
+
+  const handleChange = (e) => {
+    const { name, value, type, checked } = e.target;
+    setForm((f) => ({ ...f, [name]: type === "checkbox" ? checked : value }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setSaving(true);
+    let fields = { ...form };
+    try {
+      if (logoFile) {
+        if (form.logo_url) {
+          await deleteFile(
+            "mamastock-branding",
+            pathFromUrl(form.logo_url)
+          );
+        }
+        const url = await uploadFile(
+          "mamastock-branding",
+          logoFile,
+          `mama_${mama_id}`
+        );
+        fields.logo_url = url;
+      }
+      await updateMamaSettings(fields);
+      toast.success("Paramètres enregistrés");
+    } catch (err) {
+      console.error(err);
+      toast.error("Erreur lors de l'enregistrement");
+    }
+    setSaving(false);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 p-4">
+      <Toaster position="top-right" />
+      <div>
+        <label className="block text-sm mb-1">Logo</label>
+        {form.logo_url && (
+          <img src={form.logo_url} alt="logo" className="h-16 mb-2" />
+        )}
+        <input
+          type="file"
+          accept="image/*"
+          onChange={(e) => setLogoFile(e.target.files[0])}
+        />
+      </div>
+      <div>
+        <label className="block text-sm mb-1">Couleur principale</label>
+        <input
+          type="color"
+          name="primary_color"
+          value={form.primary_color || "#bfa14d"}
+          onChange={handleChange}
+        />
+      </div>
+      <div>
+        <label className="block text-sm mb-1">Email expéditeur</label>
+        <input
+          className="input w-full"
+          name="email_envoi"
+          value={form.email_envoi || ""}
+          onChange={handleChange}
+        />
+      </div>
+      <div>
+        <label className="block text-sm mb-1">Email alertes</label>
+        <input
+          className="input w-full"
+          name="email_alertes"
+          value={form.email_alertes || ""}
+          onChange={handleChange}
+        />
+      </div>
+      <div>
+        <label className="block text-sm mb-1">Mode sombre</label>
+        <input
+          type="checkbox"
+          name="dark_mode"
+          checked={!!form.dark_mode}
+          onChange={handleChange}
+        />
+      </div>
+      <div>
+        <label className="block text-sm mb-1">RGPD</label>
+        <textarea
+          className="input w-full h-32"
+          name="rgpd_text"
+          value={form.rgpd_text || ""}
+          onChange={handleChange}
+        />
+      </div>
+      <div>
+        <label className="block text-sm mb-1">Mentions légales</label>
+        <textarea
+          className="input w-full h-32"
+          name="mentions_legales"
+          value={form.mentions_legales || ""}
+          onChange={handleChange}
+        />
+      </div>
+      <div className="flex gap-4">
+        <Button type="submit" disabled={saving}>
+          {saving ? "Enregistrement…" : "Enregistrer"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/pages/public/PageMentions.jsx
+++ b/src/pages/public/PageMentions.jsx
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import { supabase } from "@/lib/supabase";
+
+export default function PageMentions() {
+  const [params] = useSearchParams();
+  const [text, setText] = useState("");
+  const mamaId = params.get("mama");
+
+  useEffect(() => {
+    async function fetchText() {
+      if (!mamaId) return;
+      const { data } = await supabase
+        .from("mamas")
+        .select("mentions_legales")
+        .eq("id", mamaId)
+        .single();
+      setText(data?.mentions_legales || "");
+    }
+    fetchText();
+  }, [mamaId]);
+
+  return (
+    <div className="p-8 max-w-3xl mx-auto prose">
+      <div dangerouslySetInnerHTML={{ __html: text }} />
+    </div>
+  );
+}

--- a/src/pages/public/PagePrivacy.jsx
+++ b/src/pages/public/PagePrivacy.jsx
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import { supabase } from "@/lib/supabase";
+
+export default function PagePrivacy() {
+  const [params] = useSearchParams();
+  const [text, setText] = useState("");
+  const mamaId = params.get("mama");
+
+  useEffect(() => {
+    async function fetchText() {
+      if (!mamaId) return;
+      const { data } = await supabase
+        .from("mamas")
+        .select("rgpd_text")
+        .eq("id", mamaId)
+        .single();
+      setText(data?.rgpd_text || "");
+    }
+    fetchText();
+  }, [mamaId]);
+
+  return (
+    <div className="p-8 max-w-3xl mx-auto prose">
+      <div dangerouslySetInnerHTML={{ __html: text }} />
+    </div>
+  );
+}

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -35,6 +35,8 @@ const AccessRights = lazy(() => import("@/pages/parametrage/AccessRights.jsx"));
 const Onboarding = lazy(() => import("@/pages/public/Onboarding.jsx"));
 const LandingPage = lazy(() => import("@/pages/public/LandingPage.jsx"));
 const Signup = lazy(() => import("@/pages/public/Signup.jsx"));
+const PagePrivacy = lazy(() => import("@/pages/public/PagePrivacy.jsx"));
+const PageMentions = lazy(() => import("@/pages/public/PageMentions.jsx"));
 const AideContextuelle = lazy(() => import("@/pages/AideContextuelle.jsx"));
 const SupervisionGroupe = lazy(() => import("@/pages/supervision/SupervisionGroupe.jsx"));
 const ComparateurFiches = lazy(() => import("@/pages/supervision/ComparateurFiches.jsx"));
@@ -49,6 +51,8 @@ export default function Router() {
         <Route path="/login" element={<Login />} />
         <Route path="/onboarding" element={<Onboarding />} />
         <Route path="/unauthorized" element={<Unauthorized />} />
+        <Route path="/privacy" element={<PagePrivacy />} />
+        <Route path="/mentions" element={<PageMentions />} />
         <Route element={<Layout />}>
           <Route
             path="/dashboard"

--- a/test/router.test.jsx
+++ b/test/router.test.jsx
@@ -4,6 +4,9 @@ import React from 'react';
 import { vi } from 'vitest';
 import RouterConfig from '../src/router.jsx';
 
+process.env.VITE_SUPABASE_URL = 'https://example.supabase.co';
+process.env.VITE_SUPABASE_ANON_KEY = 'key';
+
 const authState = { isAuthenticated: false, access_rights: ['dashboard'], loading: false };
 vi.mock('@/context/AuthContext', () => ({
   useAuth: () => authState


### PR DESCRIPTION
## Summary
- add ThemeProvider using `useMamaSettings`
- update App to wrap with ThemeProvider
- allow overriding colors via CSS variables
- new hooks/useMamaSettings for settings CRUD
- new MamaSettingsForm to edit branding
- expose public privacy/mentions pages
- use custom logo from theme
- update tests for new env requirement

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857ec45bacc832d841d0ecf7c9593d1