### PR TITLE
Add notifications system

### DIFF
--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -61,7 +61,7 @@ export default function Sidebar() {
         )}
 
         {(has("documents") || has("analyse")) && (
-          <details open={pathname.startsWith("/documents") || pathname.startsWith("/analyse")}> 
+          <details open={pathname.startsWith("/documents") || pathname.startsWith("/analyse")}>
             <summary className="cursor-pointer">Documents / Analyse</summary>
             <div className="ml-4 flex flex-col gap-1 mt-1">
               {has("documents") && <Link to="/documents">Documents</Link>}
@@ -69,6 +69,8 @@ export default function Sidebar() {
             </div>
           </details>
         )}
+
+        {has("notifications") && <Link to="/notifications">Notifications</Link>}
 
         {(has("parametrage") || has("utilisateurs") || has("roles") || has("mamas") || has("permissions") || has("access")) && (
           <details open={pathname.startsWith("/parametrage")}> 

--- a/src/hooks/useNotifications.js
+++ b/src/hooks/useNotifications.js
@@ -1,0 +1,128 @@
+import { useState, useCallback } from "react";
+import toast from "react-hot-toast";
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/context/AuthContext";
+
+export default function useNotifications() {
+  const { mama_id, user_id } = useAuth();
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const sendToast = useCallback((message, type = "info") => {
+    if (type === "success") toast.success(message);
+    else if (type === "error") toast.error(message);
+    else toast(message);
+  }, []);
+
+  const createNotification = useCallback(
+    async ({ titre, texte, lien, user_id: targetUser, type = "info" }) => {
+      if (!mama_id) return { error: "missing mama_id" };
+      const { error } = await supabase.from("notifications").insert([
+        {
+          mama_id,
+          user_id: targetUser || user_id,
+          titre,
+          texte,
+          lien,
+          type,
+        },
+      ]);
+      if (error) return { error };
+      return { data: true };
+    },
+    [mama_id, user_id]
+  );
+
+  const sendEmailNotification = useCallback(async (template, params) => {
+    const { data, error } = await supabase.rpc("send_email_notification", {
+      template,
+      params,
+    });
+    return { data, error };
+  }, []);
+
+  const sendWebhook = useCallback(async (payload) => {
+    const { data, error } = await supabase.rpc("send_notification_webhook", {
+      payload,
+    });
+    return { data, error };
+  }, []);
+
+  const fetchNotifications = useCallback(
+    async ({ type = "" } = {}) => {
+      if (!mama_id || !user_id) return [];
+      setLoading(true);
+      setError(null);
+      let query = supabase
+        .from("notifications")
+        .select("*")
+        .eq("mama_id", mama_id)
+        .eq("user_id", user_id)
+        .order("created_at", { ascending: false });
+      if (type) query = query.eq("type", type);
+      const { data, error } = await query;
+      setLoading(false);
+      if (error) {
+        setError(error.message || error);
+        setItems([]);
+        return [];
+      }
+      setItems(Array.isArray(data) ? data : []);
+      return data || [];
+    },
+    [mama_id, user_id]
+  );
+
+  const markAsRead = useCallback(
+    async (id) => {
+      if (!mama_id || !user_id || !id) return;
+      await supabase
+        .from("notifications")
+        .update({ lu: true })
+        .eq("id", id)
+        .eq("mama_id", mama_id)
+        .eq("user_id", user_id);
+      setItems((ns) => ns.map((n) => (n.id === id ? { ...n, lu: true } : n)));
+    },
+    [mama_id, user_id]
+  );
+
+  const fetchPreferences = useCallback(async () => {
+    if (!mama_id || !user_id) return null;
+    const { data } = await supabase
+      .from("notification_preferences")
+      .select("*")
+      .eq("mama_id", mama_id)
+      .eq("user_id", user_id)
+      .maybeSingle();
+    return data;
+  }, [mama_id, user_id]);
+
+  const updatePreferences = useCallback(
+    async (fields) => {
+      if (!mama_id || !user_id) return { error: "missing ids" };
+      const { data, error } = await supabase
+        .from("notification_preferences")
+        .upsert([{ ...fields, mama_id, user_id }], { onConflict: "user_id" })
+        .select()
+        .single();
+      return { data, error };
+    },
+    [mama_id, user_id]
+  );
+
+  return {
+    items,
+    loading,
+    error,
+    fetchNotifications,
+    markAsRead,
+    fetchPreferences,
+    updatePreferences,
+    sendToast,
+    createNotification,
+    sendEmailNotification,
+    sendWebhook,
+  };
+}

--- a/src/pages/notifications/NotificationSettingsForm.jsx
+++ b/src/pages/notifications/NotificationSettingsForm.jsx
@@ -1,0 +1,88 @@
+import { useEffect, useState } from "react";
+import useNotifications from "@/hooks/useNotifications";
+import { Toaster, toast } from "react-hot-toast";
+import { Button } from "@/components/ui/button";
+
+export default function NotificationSettingsForm() {
+  const { fetchPreferences, updatePreferences } = useNotifications();
+  const [prefs, setPrefs] = useState({
+    email_enabled: true,
+    webhook_enabled: false,
+    webhook_url: "",
+    webhook_token: "",
+  });
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    fetchPreferences().then((data) => {
+      if (data) setPrefs((p) => ({ ...p, ...data }));
+      setLoading(false);
+    });
+  }, [fetchPreferences]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setSaving(true);
+    const { error } = await updatePreferences(prefs);
+    setSaving(false);
+    if (error) toast.error(error.message || error);
+    else toast.success("Préférences mises à jour");
+  };
+
+  if (loading) return <div className="p-6">Chargement...</div>;
+
+  return (
+    <div className="p-6 text-sm">
+      <Toaster position="top-right" />
+      <h1 className="text-2xl font-bold mb-4">Paramètres notifications</h1>
+      <form onSubmit={handleSubmit} className="space-y-4 max-w-md">
+        <label className="block">
+          <input
+            type="checkbox"
+            checked={prefs.email_enabled}
+            onChange={(e) =>
+              setPrefs((p) => ({ ...p, email_enabled: e.target.checked }))
+            }
+            className="mr-2"
+          />
+          Recevoir des e-mails
+        </label>
+        <label className="block">
+          <input
+            type="checkbox"
+            checked={prefs.webhook_enabled}
+            onChange={(e) =>
+              setPrefs((p) => ({ ...p, webhook_enabled: e.target.checked }))
+            }
+            className="mr-2"
+          />
+          Activer les webhooks
+        </label>
+        {prefs.webhook_enabled && (
+          <>
+            <input
+              className="input w-full"
+              placeholder="Webhook URL"
+              value={prefs.webhook_url || ""}
+              onChange={(e) =>
+                setPrefs((p) => ({ ...p, webhook_url: e.target.value }))
+              }
+            />
+            <input
+              className="input w-full"
+              placeholder="Webhook token"
+              value={prefs.webhook_token || ""}
+              onChange={(e) =>
+                setPrefs((p) => ({ ...p, webhook_token: e.target.value }))
+              }
+            />
+          </>
+        )}
+        <Button type="submit" disabled={saving}>
+          {saving ? "Enregistrement…" : "Enregistrer"}
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/src/pages/notifications/NotificationsInbox.jsx
+++ b/src/pages/notifications/NotificationsInbox.jsx
@@ -1,0 +1,80 @@
+import { useEffect, useState } from "react";
+import useNotifications from "@/hooks/useNotifications";
+import { Toaster } from "react-hot-toast";
+import { Button } from "@/components/ui/button";
+
+export default function NotificationsInbox() {
+  const {
+    items,
+    loading,
+    error,
+    fetchNotifications,
+    markAsRead,
+  } = useNotifications();
+  const [filters, setFilters] = useState({ type: "" });
+
+  useEffect(() => {
+    fetchNotifications(filters);
+  }, [fetchNotifications, filters]);
+
+  const handleChange = (e) =>
+    setFilters((f) => ({ ...f, [e.target.name]: e.target.value }));
+
+  return (
+    <div className="p-6 text-sm">
+      <Toaster position="top-right" />
+      <h1 className="text-2xl font-bold mb-4">Notifications</h1>
+      <div className="flex gap-2 mb-4">
+        <select
+          name="type"
+          value={filters.type}
+          onChange={handleChange}
+          className="input"
+        >
+          <option value="">-- Type --</option>
+          <option value="info">Info</option>
+          <option value="alerte">Alerte</option>
+          <option value="erreur">Erreur</option>
+        </select>
+        <Button onClick={() => fetchNotifications(filters)}>Filtrer</Button>
+      </div>
+      {loading && <div>Chargement...</div>}
+      {error && <div className="text-red-600">{error}</div>}
+      <table className="min-w-full">
+        <thead>
+          <tr>
+            <th className="px-2 py-1 text-left">Titre</th>
+            <th className="px-2 py-1 text-left">Texte</th>
+            <th className="px-2 py-1">Date</th>
+            <th className="px-2 py-1"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((n) => (
+            <tr key={n.id} className={n.lu ? "" : "font-bold"}>
+              <td className="px-2 py-1">{n.titre}</td>
+              <td className="px-2 py-1">{n.texte}</td>
+              <td className="px-2 py-1">
+                {new Date(n.created_at).toLocaleString()}
+              </td>
+              <td className="px-2 py-1 text-right">
+                {!n.lu && (
+                  <Button size="sm" onClick={() => markAsRead(n.id)}>
+                    Marquer comme lu
+                  </Button>
+                )}
+              </td>
+            </tr>
+          ))}
+          {items.length === 0 && !loading && (
+            <tr>
+              <td colSpan="4" className="py-4 text-center text-gray-500">
+                Aucune notification
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -40,6 +40,8 @@ const PageMentions = lazy(() => import("@/pages/public/PageMentions.jsx"));
 const AideContextuelle = lazy(() => import("@/pages/AideContextuelle.jsx"));
 const SupervisionGroupe = lazy(() => import("@/pages/supervision/SupervisionGroupe.jsx"));
 const ComparateurFiches = lazy(() => import("@/pages/supervision/ComparateurFiches.jsx"));
+const NotificationsInbox = lazy(() => import("@/pages/notifications/NotificationsInbox.jsx"));
+const NotificationSettingsForm = lazy(() => import("@/pages/notifications/NotificationSettingsForm.jsx"));
 
 
 export default function Router() {
@@ -125,6 +127,14 @@ export default function Router() {
           <Route
             path="/promotions"
             element={<ProtectedRoute accessKey="promotions"><Promotions /></ProtectedRoute>}
+          />
+          <Route
+            path="/notifications"
+            element={<ProtectedRoute accessKey="notifications"><NotificationsInbox /></ProtectedRoute>}
+          />
+          <Route
+            path="/notifications/settings"
+            element={<ProtectedRoute accessKey="notifications"><NotificationSettingsForm /></ProtectedRoute>}
           />
           <Route
             path="/documents"

--- a/src/workers/NotificationServiceWorker.js
+++ b/src/workers/NotificationServiceWorker.js
@@ -1,0 +1,23 @@
+self.addEventListener('push', (event) => {
+  const data = event.data?.json() || {};
+  const title = data.title || 'MamaStock';
+  const options = {
+    body: data.body,
+    icon: '/icons/icon-192x192.png',
+    data: { url: data.url },
+  };
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  const url = event.notification.data?.url;
+  event.waitUntil(
+    self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((wins) => {
+      for (const client of wins) {
+        if (client.url === url && 'focus' in client) return client.focus();
+      }
+      if (self.clients.openWindow && url) return self.clients.openWindow(url);
+    })
+  );
+});

--- a/test/useNotifications.test.js
+++ b/test/useNotifications.test.js
@@ -1,0 +1,47 @@
+import { renderHook, act } from '@testing-library/react';
+import { vi, beforeEach, test, expect } from 'vitest';
+
+const queryObj = {
+  select: vi.fn(() => queryObj),
+  eq: vi.fn(() => queryObj),
+  order: vi.fn(() => queryObj),
+  insert: vi.fn(() => queryObj),
+  update: vi.fn(() => queryObj),
+  maybeSingle: vi.fn(() => queryObj),
+  upsert: vi.fn(() => queryObj),
+  then: (fn) => Promise.resolve(fn({ data: [], error: null })),
+};
+const fromMock = vi.fn(() => queryObj);
+const rpcMock = vi.fn(() => ({ data: null, error: null }));
+vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock, rpc: rpcMock } }));
+vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1', user_id: 'u1' }) }));
+
+let useNotifications;
+
+beforeEach(async () => {
+  ({ default: useNotifications } = await import('@/hooks/useNotifications'));
+  fromMock.mockClear();
+  queryObj.select.mockClear();
+  queryObj.eq.mockClear();
+  queryObj.order.mockClear();
+  queryObj.insert.mockClear();
+});
+
+test('fetchNotifications queries table with filters', async () => {
+  const { result } = renderHook(() => useNotifications());
+  await act(async () => { await result.current.fetchNotifications({ type: 'info' }); });
+  expect(fromMock).toHaveBeenCalledWith('notifications');
+  expect(queryObj.select).toHaveBeenCalled();
+  expect(queryObj.eq).toHaveBeenCalledWith('mama_id', 'm1');
+  expect(queryObj.eq).toHaveBeenCalledWith('user_id', 'u1');
+  expect(queryObj.eq).toHaveBeenCalledWith('type', 'info');
+  expect(queryObj.order).toHaveBeenCalledWith('created_at', { ascending: false });
+});
+
+test('createNotification inserts row with mama_id', async () => {
+  const { result } = renderHook(() => useNotifications());
+  await act(async () => { await result.current.createNotification({ titre: 't', texte: 'x', lien: '' }); });
+  expect(queryObj.insert).toHaveBeenCalledWith([
+    { mama_id: 'm1', user_id: 'u1', titre: 't', texte: 'x', lien: '', type: 'info' }
+  ]);
+});


### PR DESCRIPTION
## Summary
- implement notification utilities and preferences in `useNotifications`
- display user notifications inbox
- add notification settings form
- handle push events in new service worker
- expose notifications routes and sidebar links
- test notification hook

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6857efd1496c832db378366ddf95fa8c