### PR TITLE
Add OCR dependency and clarify testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ npm run preview
 ```
 
 If linting or tests fail because required packages are missing, simply run
-`npm install` again. This ensures `vitest`, `@eslint/js` and `playwright` are
-available before running the commands above.
+`npm install` again. This ensures `tesseract.js`, `vitest`, `@eslint/js` and
+`playwright` are available before running the commands above.
 
 ### Branding & PWA
 
@@ -57,6 +57,9 @@ The `.env` file is not tracked by Git, so you can safely replace these
 defaults with your own credentials for local development.
 
 ## Tests
+
+Invoice OCR features rely on `tesseract.js`, so ensure dependencies are
+installed with `npm install` before running tests.
 
 Unit tests run with `vitest`:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "react-to-print": "^3.1.0",
         "react-toastify": "^11.0.5",
         "recharts": "^2.15.3",
-        "tesseract.js": "^6.0.1",
+        "tesseract.js": "6.0.1",
         "xlsx": "^0.18.5"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "react-to-print": "^3.1.0",
     "react-toastify": "^11.0.5",
     "recharts": "^2.15.3",
-    "tesseract.js": "^6.0.1",
+    "tesseract.js": "6.0.1",
     "xlsx": "^0.18.5"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- pin `tesseract.js` in dependencies
- mention `tesseract.js` in dependency instructions
- add note about OCR dependency in tests section

## Testing
- `npm test`
- `npm run test:e2e` *(skipped: browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6857f1585748832d87b703c278a93df5