### PR TITLE
Implement export manager

### DIFF
--- a/src/components/export/ExportManager.jsx
+++ b/src/components/export/ExportManager.jsx
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+import ModalGlass from '@/components/ui/ModalGlass';
+import Button from '@/components/ui/Button';
+
+export default function ExportManager({ open, onClose, onExport }) {
+  const [format, setFormat] = useState('pdf');
+  const [type, setType] = useState('fiches');
+  const [start, setStart] = useState('');
+  const [end, setEnd] = useState('');
+
+  const handleExport = () => {
+    onExport?.({ format, type, options: { start, end } });
+    onClose?.();
+  };
+
+  return (
+    <ModalGlass open={open} onClose={onClose}>
+      <h2 className="text-lg font-bold mb-4">Exporter les données</h2>
+      <div className="mb-2">
+        <label className="block text-sm mb-1">Format</label>
+        <select
+          className="input input-bordered w-full"
+          value={format}
+          onChange={(e) => setFormat(e.target.value)}
+        >
+          <option value="pdf">PDF</option>
+          <option value="excel">Excel</option>
+          <option value="csv">CSV</option>
+          <option value="print">Impression</option>
+        </select>
+      </div>
+      <div className="mb-2">
+        <label className="block text-sm mb-1">Données</label>
+        <select
+          className="input input-bordered w-full"
+          value={type}
+          onChange={(e) => setType(e.target.value)}
+        >
+          <option value="fiches">Fiches techniques</option>
+          <option value="inventaire">Inventaire</option>
+          <option value="produits">Produits</option>
+          <option value="factures">Factures</option>
+        </select>
+      </div>
+      {type === 'factures' && (
+        <div className="flex gap-2 mb-2">
+          <input
+            type="date"
+            className="input input-bordered w-full"
+            value={start}
+            onChange={(e) => setStart(e.target.value)}
+          />
+          <input
+            type="date"
+            className="input input-bordered w-full"
+            value={end}
+            onChange={(e) => setEnd(e.target.value)}
+          />
+        </div>
+      )}
+      <div className="text-right mt-4">
+        <Button onClick={handleExport}>Exporter</Button>
+      </div>
+    </ModalGlass>
+  );
+}

--- a/src/components/export/FicheExportView.jsx
+++ b/src/components/export/FicheExportView.jsx
@@ -1,0 +1,37 @@
+export default function FicheExportView({ fiches = [] }) {
+  return (
+    <div className="p-6 text-black">
+      {fiches.map((fiche, i) => (
+        <div key={fiche.id} className={i > 0 ? 'page-break mt-6' : ''}>
+          <h1 className="text-2xl font-bold mb-2">{fiche.nom}</h1>
+          {fiche.image && (
+            <img src={fiche.image} alt={fiche.nom} className="max-w-xs mb-2" />
+          )}
+          <table className="w-full text-sm border mb-4">
+            <thead>
+              <tr className="bg-gray-100">
+                <th className="border px-2 py-1">Ingrédient</th>
+                <th className="border px-2 py-1">Qté</th>
+                <th className="border px-2 py-1">Unité</th>
+                <th className="border px-2 py-1">Prix</th>
+              </tr>
+            </thead>
+            <tbody>
+              {fiche.lignes?.map((l) => (
+                <tr key={l.id}>
+                  <td className="border px-2 py-1">{l.nom}</td>
+                  <td className="border px-2 py-1 text-right">{l.quantite}</td>
+                  <td className="border px-2 py-1">{l.unite}</td>
+                  <td className="border px-2 py-1 text-right">{l.prix}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <div className="text-right font-semibold">
+            Coût portion : {fiche.cout_portion} €
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/hooks/useExport.js
+++ b/src/hooks/useExport.js
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import { supabase } from '@/lib/supabase';
+import { useAuth } from '@/context/AuthContext';
+import {
+  exportToPDF,
+  exportToExcel,
+  exportToCSV,
+  printView,
+} from '@/lib/export/exportHelpers';
+import toast from 'react-hot-toast';
+
+export default function useExport() {
+  const { mama_id } = useAuth();
+  const [loading, setLoading] = useState(false);
+
+  async function exportData({ type, format, options = {} }) {
+    if (!mama_id) return null;
+    setLoading(true);
+    try {
+      let data = [];
+      if (type === 'fiches') {
+        const res = await supabase
+          .from('fiches_techniques')
+          .select('*, lignes:fiche_lignes(*)')
+          .eq('mama_id', mama_id);
+        data = res.data || [];
+      } else if (type === 'inventaire') {
+        const res = await supabase
+          .from('inventaires')
+          .select('*, lignes:inventaire_lignes(*)')
+          .eq('mama_id', mama_id);
+        data = res.data || [];
+      } else if (type === 'produits') {
+        const res = await supabase
+          .from('products')
+          .select('*, supplier_products(*, fournisseur:fournisseurs(nom))')
+          .eq('mama_id', mama_id);
+        data = res.data || [];
+      } else if (type === 'factures') {
+        let query = supabase
+          .from('factures')
+          .select('*, lignes:facture_lignes(*)')
+          .eq('mama_id', mama_id);
+        if (options.start) query = query.gte('date', options.start);
+        if (options.end) query = query.lte('date', options.end);
+        const res = await query;
+        data = res.data || [];
+      }
+
+      if (format === 'pdf') exportToPDF(data, options);
+      else if (format === 'excel') exportToExcel(data, options);
+      else if (format === 'csv') exportToCSV(data, options);
+      else if (format === 'print') printView(options.content);
+
+      toast.success('Export effectué');
+      return data;
+    } catch (err) {
+      console.error(err);
+      toast.error('Erreur lors de l\'export');
+      return null;
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return { exportData, loading };
+}

--- a/src/lib/export/exportHelpers.js
+++ b/src/lib/export/exportHelpers.js
@@ -1,0 +1,69 @@
+import jsPDF from 'jspdf';
+import 'jspdf-autotable';
+import * as XLSX from 'xlsx';
+import { saveAs } from 'file-saver';
+
+export function exportToPDF(data = [], config = {}) {
+  const { filename = 'export.pdf', columns = [] } = config;
+  const doc = new jsPDF();
+  if (!Array.isArray(data)) data = [data];
+  const headers = columns.length
+    ? [columns.map((c) => c.label)]
+    : [Object.keys(data[0] || {})];
+  const rows = data.map((item) =>
+    columns.length
+      ? columns.map((c) => item[c.key])
+      : Object.values(item)
+  );
+  doc.autoTable({ head: headers, body: rows, styles: { fontSize: 9 } });
+  doc.save(filename);
+}
+
+export function exportToExcel(data = [], config = {}) {
+  const {
+    filename = 'export.xlsx',
+    sheet = 'Sheet1',
+    columns = [],
+  } = config;
+  if (!Array.isArray(data)) data = [data];
+  const arr = data.map((item) => {
+    if (columns.length) {
+      const obj = {};
+      columns.forEach((c) => {
+        obj[c.label] = item[c.key];
+      });
+      return obj;
+    }
+    return item;
+  });
+  const wb = XLSX.utils.book_new();
+  const ws = XLSX.utils.json_to_sheet(arr);
+  XLSX.utils.book_append_sheet(wb, ws, sheet);
+  const buf = XLSX.write(wb, { bookType: 'xlsx', type: 'array' });
+  saveAs(new Blob([buf]), filename);
+}
+
+export function exportToCSV(data = [], config = {}) {
+  const { filename = 'export.csv', columns = [] } = config;
+  if (!Array.isArray(data)) data = [data];
+  const header = columns.length
+    ? columns.map((c) => c.label).join(',')
+    : Object.keys(data[0] || {}).join(',');
+  const rows = data.map((item) =>
+    columns.length
+      ? columns.map((c) => item[c.key]).join(',')
+      : Object.values(item).join(',')
+  );
+  const csv = [header, ...rows].join('\n');
+  saveAs(new Blob([csv], { type: 'text/csv;charset=utf-8;' }), filename);
+}
+
+export function printView(content) {
+  const w = window.open('', '_blank');
+  if (!w) return;
+  w.document.write(typeof content === 'string' ? content : content.outerHTML);
+  w.document.close();
+  w.focus();
+  w.print();
+  w.close();
+}

--- a/test/useExport.test.js
+++ b/test/useExport.test.js
@@ -1,0 +1,57 @@
+import { renderHook, act } from '@testing-library/react';
+import { vi, beforeEach, test, expect } from 'vitest';
+
+const queryObj = {
+  select: vi.fn(() => queryObj),
+  eq: vi.fn(() => queryObj),
+  gte: vi.fn(() => queryObj),
+  lte: vi.fn(() => queryObj),
+  then: (fn) => Promise.resolve(fn({ data: [{ id: 1 }], error: null })),
+};
+const fromMock = vi.fn(() => queryObj);
+vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
+vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
+
+const pdfMock = vi.fn();
+const excelMock = vi.fn();
+const csvMock = vi.fn();
+const printMock = vi.fn();
+
+vi.mock('@/lib/export/exportHelpers', () => ({
+  exportToPDF: pdfMock,
+  exportToExcel: excelMock,
+  exportToCSV: csvMock,
+  printView: printMock,
+}));
+
+let useExport;
+
+beforeEach(async () => {
+  ({ default: useExport } = await import('@/hooks/useExport'));
+  fromMock.mockClear();
+  queryObj.select.mockClear();
+  queryObj.eq.mockClear();
+  queryObj.gte.mockClear();
+  queryObj.lte.mockClear();
+  pdfMock.mockClear();
+  excelMock.mockClear();
+  csvMock.mockClear();
+  printMock.mockClear();
+});
+
+test('exportData queries factures with dates and calls Excel export', async () => {
+  const { result } = renderHook(() => useExport());
+  await act(async () => {
+    await result.current.exportData({
+      type: 'factures',
+      format: 'excel',
+      options: { start: '2024-01-01', end: '2024-12-31' },
+    });
+  });
+  expect(fromMock).toHaveBeenCalledWith('factures');
+  expect(queryObj.select).toHaveBeenCalled();
+  expect(queryObj.eq).toHaveBeenCalledWith('mama_id', 'm1');
+  expect(queryObj.gte).toHaveBeenCalledWith('date', '2024-01-01');
+  expect(queryObj.lte).toHaveBeenCalledWith('date', '2024-12-31');
+  expect(excelMock).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- add generic export hook
- add modal component to handle export options
- add print-friendly fiche view
- provide PDF, Excel and CSV helpers
- test export logic

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857f281ba74832d916993dd1abbbe7f