### PR TITLE
Add fournisseur API module

### DIFF
--- a/src/hooks/useFournisseurAPI.js
+++ b/src/hooks/useFournisseurAPI.js
@@ -1,0 +1,151 @@
+import { useState } from "react";
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/context/AuthContext";
+import toast from "react-hot-toast";
+
+export function useFournisseurAPI() {
+  const { mama_id } = useAuth();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  async function getConfig(fournisseur_id) {
+    if (!mama_id || !fournisseur_id) return null;
+    const { data, error } = await supabase
+      .from("fournisseurs_api_config")
+      .select("*")
+      .eq("mama_id", mama_id)
+      .eq("fournisseur_id", fournisseur_id)
+      .single();
+    if (error) {
+      setError(error);
+      toast.error(error.message || "Erreur configuration API");
+      return null;
+    }
+    if (!data?.token && data?.type_api !== "ftp") {
+      setError("missing_token");
+      toast.error("Token API manquant");
+      return null;
+    }
+    return data;
+  }
+
+  async function importFacturesFournisseur(fournisseur_id) {
+    const config = await getConfig(fournisseur_id);
+    if (!config) return [];
+    setLoading(true);
+    try {
+      const res = await fetch(`${config.url}/factures`, {
+        headers: { Authorization: `Bearer ${config.token}` },
+      });
+      const factures = await res.json();
+      for (const ft of factures) {
+        await supabase
+          .from("factures")
+          .upsert({ ...ft, fournisseur_id, mama_id }, { onConflict: "reference" });
+      }
+      toast.success("Factures importées");
+      return factures;
+    } catch (err) {
+      setError(err);
+      toast.error("Erreur import factures");
+      return [];
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function syncCatalogue(fournisseur_id) {
+    const config = await getConfig(fournisseur_id);
+    if (!config) return [];
+    setLoading(true);
+    try {
+      const res = await fetch(`${config.url}/catalogue`, {
+        headers: { Authorization: `Bearer ${config.token}` },
+      });
+      const produits = await res.json();
+      const updates = [];
+      for (const p of produits) {
+        const { data: existing } = await supabase
+          .from("supplier_products")
+          .select("price")
+          .eq("product_id", p.product_id)
+          .eq("fournisseur_id", fournisseur_id)
+          .eq("mama_id", mama_id)
+          .maybeSingle();
+        await supabase.from("supplier_products").upsert({
+          product_id: p.product_id,
+          fournisseur_id,
+          price: p.price,
+          mama_id,
+        });
+        if (existing && existing.price !== p.price) {
+          await supabase.from("catalogue_updates").insert({
+            fournisseur_id,
+            produit_id: p.product_id,
+            ancienne_valeur: existing.price,
+            nouvelle_valeur: p.price,
+            modification: p,
+            mama_id,
+          });
+          updates.push(p);
+        }
+      }
+      toast.success("Catalogue synchronisé");
+      return updates;
+    } catch (err) {
+      setError(err);
+      toast.error("Erreur sync catalogue");
+      return [];
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function envoyerCommande(commande_id) {
+    if (!mama_id || !commande_id) return { error: "missing data" };
+    setLoading(true);
+    setError(null);
+    const { data: commande, error } = await supabase
+      .from("commandes")
+      .select("*")
+      .eq("id", commande_id)
+      .eq("mama_id", mama_id)
+      .single();
+    if (error) {
+      setLoading(false);
+      setError(error);
+      toast.error(error.message || "Erreur récupération commande");
+      return { error };
+    }
+    const config = await getConfig(commande.fournisseur_id);
+    if (!config) {
+      setLoading(false);
+      return { error: "config" };
+    }
+    try {
+      const res = await fetch(`${config.url}/commandes`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${config.token}`,
+        },
+        body: JSON.stringify(commande),
+      });
+      const body = await res.json();
+      await supabase
+        .from("commandes")
+        .update({ statut: body.statut || "envoyee" })
+        .eq("id", commande_id);
+      toast.success("Commande envoyée");
+      return { data: body };
+    } catch (err) {
+      setError(err);
+      toast.error("Erreur envoi commande");
+      return { error: err };
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return { loading, error, importFacturesFournisseur, syncCatalogue, envoyerCommande };
+}

--- a/src/pages/catalogue/CatalogueSyncViewer.jsx
+++ b/src/pages/catalogue/CatalogueSyncViewer.jsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from "react";
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/context/AuthContext";
+import { Button } from "@/components/ui/button";
+import toast from "react-hot-toast";
+
+export default function CatalogueSyncViewer({ fournisseur_id }) {
+  const { mama_id } = useAuth();
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!mama_id) return;
+    setLoading(true);
+    let query = supabase
+      .from("catalogue_updates")
+      .select("*, produit:products(nom)")
+      .eq("mama_id", mama_id)
+      .order("created_at", { ascending: false });
+    if (fournisseur_id) query = query.eq("fournisseur_id", fournisseur_id);
+    query.then(({ data }) => {
+      setItems(data || []);
+      setLoading(false);
+    });
+  }, [mama_id, fournisseur_id]);
+
+  const acceptUpdate = async (row) => {
+    await supabase
+      .from("supplier_products")
+      .update({ price: row.nouvelle_valeur })
+      .eq("product_id", row.produit_id)
+      .eq("fournisseur_id", row.fournisseur_id)
+      .eq("mama_id", mama_id);
+    await supabase.from("catalogue_updates").delete().eq("id", row.id);
+    setItems((it) => it.filter((i) => i.id !== row.id));
+    toast.success("Modification appliquée");
+  };
+
+  const rejectUpdate = async (id) => {
+    await supabase.from("catalogue_updates").delete().eq("id", id);
+    setItems((it) => it.filter((i) => i.id !== id));
+  };
+
+  if (loading) return <div className="p-6">Chargement...</div>;
+
+  return (
+    <div className="p-6">
+      <h2 className="text-lg font-bold mb-4">Mises à jour catalogue</h2>
+      <table className="w-full table-auto text-sm">
+        <thead>
+          <tr>
+            <th className="px-2 py-1 text-left">Produit</th>
+            <th className="px-2 py-1">Ancien prix</th>
+            <th className="px-2 py-1">Nouveau prix</th>
+            <th className="px-2 py-1" />
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((u) => (
+            <tr key={u.id}>
+              <td className="px-2 py-1">{u.produit?.nom || u.produit_id}</td>
+              <td className="px-2 py-1">{u.ancienne_valeur}</td>
+              <td className="px-2 py-1">{u.nouvelle_valeur}</td>
+              <td className="px-2 py-1 space-x-1">
+                <Button size="sm" onClick={() => acceptUpdate(u)}>
+                  Accepter
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => rejectUpdate(u.id)}
+                >
+                  Rejeter
+                </Button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/pages/commandes/CommandesEnvoyees.jsx
+++ b/src/pages/commandes/CommandesEnvoyees.jsx
@@ -1,0 +1,62 @@
+import { useEffect, useState } from "react";
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/context/AuthContext";
+import { Button } from "@/components/ui/button";
+import { useFournisseurAPI } from "@/hooks/useFournisseurAPI";
+
+export default function CommandesEnvoyees() {
+  const { mama_id } = useAuth();
+  const { envoyerCommande } = useFournisseurAPI();
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!mama_id) return;
+    setLoading(true);
+    supabase
+      .from("commandes")
+      .select("*, fournisseur:fournisseurs(nom)")
+      .eq("mama_id", mama_id)
+      .order("created_at", { ascending: false })
+      .then(({ data }) => {
+        setItems(data || []);
+        setLoading(false);
+      });
+  }, [mama_id]);
+
+  const relancer = async (id) => {
+    await envoyerCommande(id);
+  };
+
+  if (loading) return <div className="p-6">Chargement...</div>;
+
+  return (
+    <div className="p-6">
+      <h2 className="text-lg font-bold mb-4">Commandes envoyées</h2>
+      <table className="w-full table-auto text-sm">
+        <thead>
+          <tr>
+            <th className="px-2 py-1">Date</th>
+            <th className="px-2 py-1">Fournisseur</th>
+            <th className="px-2 py-1">Statut</th>
+            <th className="px-2 py-1" />
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((c) => (
+            <tr key={c.id}>
+              <td className="px-2 py-1">{c.created_at?.slice(0, 10)}</td>
+              <td className="px-2 py-1">{c.fournisseur?.nom || "-"}</td>
+              <td className="px-2 py-1">{c.statut}</td>
+              <td className="px-2 py-1">
+                <Button size="sm" onClick={() => relancer(c.id)}>
+                  Relancer
+                </Button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/pages/fournisseurs/FournisseurApiSettingsForm.jsx
+++ b/src/pages/fournisseurs/FournisseurApiSettingsForm.jsx
@@ -1,0 +1,120 @@
+import { useEffect, useState } from "react";
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/context/AuthContext";
+import { Button } from "@/components/ui/button";
+import toast from "react-hot-toast";
+
+export default function FournisseurApiSettingsForm({ fournisseur_id }) {
+  const { mama_id } = useAuth();
+  const [config, setConfig] = useState({
+    url: "",
+    type_api: "rest",
+    token: "",
+    format_facture: "json",
+    actif: true,
+  });
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!mama_id || !fournisseur_id) return;
+    supabase
+      .from("fournisseurs_api_config")
+      .select("*")
+      .eq("mama_id", mama_id)
+      .eq("fournisseur_id", fournisseur_id)
+      .maybeSingle()
+      .then(({ data }) => {
+        if (data) setConfig(c => ({ ...c, ...data }));
+        setLoading(false);
+      });
+  }, [mama_id, fournisseur_id]);
+
+  const handleChange = e => {
+    const { name, value, type, checked } = e.target;
+    setConfig(c => ({ ...c, [name]: type === "checkbox" ? checked : value }));
+  };
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    if (!mama_id || !fournisseur_id) return;
+    setSaving(true);
+    const { data, error } = await supabase
+      .from("fournisseurs_api_config")
+      .upsert([{ ...config, fournisseur_id, mama_id }], { onConflict: "fournisseur_id" })
+      .select()
+      .single();
+    setSaving(false);
+    if (error) toast.error(error.message || error);
+    else {
+      toast.success("Configuration sauvegardée");
+      setConfig(data);
+    }
+  };
+
+  if (loading) return <div className="p-4">Chargement...</div>;
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 p-4 text-sm">
+      <div>
+        <label className="block font-medium mb-1">URL API</label>
+        <input
+          className="input input-bordered w-full"
+          name="url"
+          value={config.url || ""}
+          onChange={handleChange}
+          required
+        />
+      </div>
+      <div>
+        <label className="block font-medium mb-1">Type</label>
+        <select
+          className="input input-bordered w-full"
+          name="type_api"
+          value={config.type_api || "rest"}
+          onChange={handleChange}
+        >
+          <option value="rest">REST</option>
+          <option value="edi">EDI</option>
+          <option value="ftp">FTP</option>
+        </select>
+      </div>
+      <div>
+        <label className="block font-medium mb-1">Token / Credentials</label>
+        <input
+          className="input input-bordered w-full"
+          name="token"
+          value={config.token || ""}
+          onChange={handleChange}
+        />
+      </div>
+      <div>
+        <label className="block font-medium mb-1">Format factures</label>
+        <select
+          className="input input-bordered w-full"
+          name="format_facture"
+          value={config.format_facture || "json"}
+          onChange={handleChange}
+        >
+          <option value="pdf">PDF</option>
+          <option value="xml">XML</option>
+          <option value="json">JSON</option>
+          <option value="csv">CSV</option>
+        </select>
+      </div>
+      <label className="block">
+        <input
+          type="checkbox"
+          name="actif"
+          checked={!!config.actif}
+          onChange={handleChange}
+          className="mr-2"
+        />
+        Actif
+      </label>
+      <Button type="submit" disabled={saving} className="mt-2">
+        {saving ? "Enregistrement…" : "Enregistrer"}
+      </Button>
+    </form>
+  );
+}

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -42,6 +42,9 @@ const SupervisionGroupe = lazy(() => import("@/pages/supervision/SupervisionGrou
 const ComparateurFiches = lazy(() => import("@/pages/supervision/ComparateurFiches.jsx"));
 const NotificationsInbox = lazy(() => import("@/pages/notifications/NotificationsInbox.jsx"));
 const NotificationSettingsForm = lazy(() => import("@/pages/notifications/NotificationSettingsForm.jsx"));
+const FournisseurApiSettingsForm = lazy(() => import("@/pages/fournisseurs/FournisseurApiSettingsForm.jsx"));
+const CatalogueSyncViewer = lazy(() => import("@/pages/catalogue/CatalogueSyncViewer.jsx"));
+const CommandesEnvoyees = lazy(() => import("@/pages/commandes/CommandesEnvoyees.jsx"));
 
 
 export default function Router() {
@@ -63,6 +66,10 @@ export default function Router() {
           <Route
             path="/fournisseurs"
             element={<ProtectedRoute accessKey="fournisseurs"><Fournisseurs /></ProtectedRoute>}
+          />
+          <Route
+            path="/fournisseurs/:id/api"
+            element={<ProtectedRoute accessKey="fournisseurs"><FournisseurApiSettingsForm /></ProtectedRoute>}
           />
           <Route
             path="/factures"
@@ -139,6 +146,14 @@ export default function Router() {
           <Route
             path="/documents"
             element={<ProtectedRoute accessKey="documents"><Documents /></ProtectedRoute>}
+          />
+          <Route
+            path="/catalogue/sync"
+            element={<ProtectedRoute accessKey="produits"><CatalogueSyncViewer /></ProtectedRoute>}
+          />
+          <Route
+            path="/commandes/envoyees"
+            element={<ProtectedRoute accessKey="fournisseurs"><CommandesEnvoyees /></ProtectedRoute>}
           />
           <Route
             path="/analyse"


### PR DESCRIPTION
## Summary
- add hook to manage supplier API integration
- new forms for supplier API configuration
- viewer for catalogue updates
- list view for sent orders
- wire new routes

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857f4273384832d857cf1234ee9122f