### PR TITLE
Add planning simulation module

### DIFF
--- a/src/components/simulation/SimulationDetailsModal.jsx
+++ b/src/components/simulation/SimulationDetailsModal.jsx
@@ -1,0 +1,46 @@
+import ModalGlass from "@/components/ui/ModalGlass";
+import Button from "@/components/ui/Button";
+import * as XLSX from "xlsx";
+import { saveAs } from "file-saver";
+
+export default function SimulationDetailsModal({ open, onClose, result }) {
+  const exportExcel = () => {
+    if (!result) return;
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(
+      wb,
+      XLSX.utils.json_to_sheet(result.produits || []),
+      "Besoins"
+    );
+    const buf = XLSX.write(wb, { bookType: "xlsx", type: "array" });
+    saveAs(new Blob([buf]), "besoins_previsionnels.xlsx");
+  };
+
+  return (
+    <ModalGlass open={open} onClose={onClose}>
+      <h2 className="text-lg font-bold mb-2">Détails des besoins</h2>
+      <table className="min-w-full text-sm bg-white text-black rounded mb-4">
+        <thead>
+          <tr>
+            <th className="px-2">Produit</th>
+            <th className="px-2">Quantité</th>
+            <th className="px-2">Valeur</th>
+          </tr>
+        </thead>
+        <tbody>
+          {(result?.produits || []).map((p, idx) => (
+            <tr key={idx}>
+              <td className="px-2">{p.product_nom || p.product_id}</td>
+              <td className="px-2">{p.quantite}</td>
+              <td className="px-2">{p.valeur}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className="flex justify-end gap-2">
+        <Button onClick={exportExcel}>Export Excel</Button>
+        <Button onClick={onClose}>Fermer</Button>
+      </div>
+    </ModalGlass>
+  );
+}

--- a/src/hooks/useSimulation.js
+++ b/src/hooks/useSimulation.js
@@ -1,8 +1,13 @@
 // src/hooks/useSimulation.js
 import { useState } from "react";
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/context/AuthContext";
 
 export const useSimulation = () => {
+  const { mama_id } = useAuth();
   const [selection, setSelection] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
 
   const addRecipe = (recette) => {
     if (!selection.find((r) => r.id === recette.id)) {
@@ -33,11 +38,62 @@ export const useSimulation = () => {
     coutParPortion: r.portions ? (r.cout_total || 0) / r.portions : 0,
   }));
 
+  async function getBesoinsParMenu(menuId, nbPortions = 1) {
+    if (!mama_id || !menuId) return [];
+    setLoading(true);
+    setError(null);
+    const { data, error } = await supabase
+      .from("v_besoins_previsionnels")
+      .select("*")
+      .eq("mama_id", mama_id)
+      .eq("menu_id", menuId);
+    setLoading(false);
+    if (error) {
+      setError(error.message || error);
+      return [];
+    }
+    return (data || []).map((row) => ({
+      ...row,
+      quantite: (Number(row.quantite) || 0) * nbPortions,
+    }));
+  }
+
+  async function simulerBudget(periode = {}, scenario = []) {
+    if (!mama_id) return { produits: [], total: 0 };
+    setLoading(true);
+    setError(null);
+    let produits = [];
+    for (const item of scenario) {
+      const besoins = await getBesoinsParMenu(item.menu_id, item.portions || 1);
+      produits = produits.concat(besoins);
+    }
+    const total = produits.reduce(
+      (sum, p) => sum + (Number(p.valeur) || 0) * (Number(p.quantite) || 0),
+      0
+    );
+    setLoading(false);
+    return { produits, total, periode };
+  }
+
+  async function proposerCommandes(consommationProjetee = []) {
+    if (!mama_id) return [];
+    const commandes = consommationProjetee.map((p) => ({
+      product_id: p.product_id,
+      quantite: p.quantite,
+    }));
+    return commandes;
+  }
+
   return {
     selection,
     addRecipe,
     removeRecipe,
     setPrix,
+    getBesoinsParMenu,
+    simulerBudget,
+    proposerCommandes,
+    loading,
+    error,
     results: {
       totalCout,
       totalPrix,

--- a/src/pages/planning/SimulationPlanner.jsx
+++ b/src/pages/planning/SimulationPlanner.jsx
@@ -1,0 +1,98 @@
+import { useEffect, useState } from "react";
+import { useAuth } from "@/context/AuthContext";
+import { useMenus } from "@/hooks/useMenus";
+import { useSimulation } from "@/hooks/useSimulation";
+import SimulationDetailsModal from "@/components/simulation/SimulationDetailsModal";
+import Button from "@/components/ui/Button";
+
+export default function SimulationPlanner() {
+  const { mama_id, loading: authLoading } = useAuth();
+  const { getMenus } = useMenus();
+  const { simulerBudget, loading } = useSimulation();
+
+  const [periode, setPeriode] = useState({ start: "", end: "" });
+  const [menus, setMenus] = useState([]);
+  const [scenario, setScenario] = useState([]);
+  const [result, setResult] = useState(null);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (!mama_id) return;
+    getMenus({ start: periode.start, end: periode.end }).then(setMenus);
+  }, [mama_id, periode.start, periode.end]);
+
+  const toggleMenu = (id) => {
+    setScenario((prev) => {
+      const existing = prev.find((s) => s.menu_id === id);
+      if (existing) return prev.filter((s) => s.menu_id !== id);
+      return [...prev, { menu_id: id, portions: 1 }];
+    });
+  };
+
+  const handleSimulate = async () => {
+    const res = await simulerBudget(periode, scenario);
+    setResult(res);
+  };
+
+  if (authLoading) return <div className="p-6">Chargement...</div>;
+
+  return (
+    <div className="p-6 text-white">
+      <h1 className="text-2xl font-bold mb-4">Simulation planning</h1>
+      <div className="flex gap-2 items-end mb-4">
+        <input
+          type="date"
+          className="input"
+          value={periode.start}
+          onChange={(e) => setPeriode((p) => ({ ...p, start: e.target.value }))}
+        />
+        <input
+          type="date"
+          className="input"
+          value={periode.end}
+          onChange={(e) => setPeriode((p) => ({ ...p, end: e.target.value }))}
+        />
+        <Button onClick={handleSimulate} disabled={loading}>Simuler</Button>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-2 mb-4">
+        {menus.map((m) => (
+          <label key={m.id} className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={!!scenario.find((s) => s.menu_id === m.id)}
+              onChange={() => toggleMenu(m.id)}
+            />
+            <span>{m.nom} ({m.date})</span>
+          </label>
+        ))}
+      </div>
+      {result && (
+        <div className="mt-4">
+          <table className="min-w-full bg-white text-black text-sm rounded mb-2">
+            <thead>
+              <tr>
+                <th className="px-2">Produit</th>
+                <th className="px-2">Qté</th>
+                <th className="px-2">Valeur</th>
+              </tr>
+            </thead>
+            <tbody>
+              {result.produits.map((p, idx) => (
+                <tr key={idx}>
+                  <td className="px-2">{p.product_nom || p.product_id}</td>
+                  <td className="px-2">{p.quantite}</td>
+                  <td className="px-2">{p.valeur}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <div className="font-semibold">Total : {result.total} €</div>
+          <Button className="mt-2" onClick={() => setOpen(true)}>
+            Détails
+          </Button>
+        </div>
+      )}
+      <SimulationDetailsModal open={open} onClose={() => setOpen(false)} result={result} />
+    </div>
+  );
+}

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -45,6 +45,7 @@ const NotificationSettingsForm = lazy(() => import("@/pages/notifications/Notifi
 const FournisseurApiSettingsForm = lazy(() => import("@/pages/fournisseurs/FournisseurApiSettingsForm.jsx"));
 const CatalogueSyncViewer = lazy(() => import("@/pages/catalogue/CatalogueSyncViewer.jsx"));
 const CommandesEnvoyees = lazy(() => import("@/pages/commandes/CommandesEnvoyees.jsx"));
+const SimulationPlanner = lazy(() => import("@/pages/planning/SimulationPlanner.jsx"));
 
 
 export default function Router() {
@@ -154,6 +155,10 @@ export default function Router() {
           <Route
             path="/commandes/envoyees"
             element={<ProtectedRoute accessKey="fournisseurs"><CommandesEnvoyees /></ProtectedRoute>}
+          />
+          <Route
+            path="/planning/simulation"
+            element={<ProtectedRoute accessKey="planning"><SimulationPlanner /></ProtectedRoute>}
           />
           <Route
             path="/analyse"

--- a/supabase/views/v_besoins_previsionnels.sql
+++ b/supabase/views/v_besoins_previsionnels.sql
@@ -1,0 +1,16 @@
+create or replace view v_besoins_previsionnels as
+select
+  m.mama_id,
+  m.id as menu_id,
+  fl.product_id,
+  sum(fl.quantite * coalesce(f.portions,1)) as quantite,
+  sum(fl.quantite * coalesce(f.portions,1) * coalesce(p.pmp,0)) as valeur,
+  p.nom as product_nom
+from menus m
+join menu_fiches mf on mf.menu_id = m.id
+join fiches f on f.id = mf.fiche_id
+join fiche_lignes fl on fl.fiche_id = f.id
+left join products p on p.id = fl.product_id
+group by m.mama_id, m.id, fl.product_id, p.nom, p.pmp;
+
+grant select on v_besoins_previsionnels to authenticated;

--- a/test/useSimulation.test.js
+++ b/test/useSimulation.test.js
@@ -1,0 +1,52 @@
+import { renderHook, act } from '@testing-library/react';
+import { vi, beforeEach, test, expect } from 'vitest';
+
+const query = {
+  select: vi.fn(() => query),
+  eq: vi.fn(() => query),
+  then: fn => Promise.resolve(fn({ data: [{ product_id: 'p1', quantite: 1, valeur: 2 }], error: null }))
+};
+const fromMock = vi.fn(() => query);
+
+vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
+vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
+
+let useSimulation;
+
+beforeEach(async () => {
+  ({ useSimulation } = await import('@/hooks/useSimulation'));
+  fromMock.mockClear();
+  query.select.mockClear();
+  query.eq.mockClear();
+});
+
+test('getBesoinsParMenu queries view with ids', async () => {
+  const { result } = renderHook(() => useSimulation());
+  let data;
+  await act(async () => {
+    data = await result.current.getBesoinsParMenu('menu1', 2);
+  });
+  expect(fromMock).toHaveBeenCalledWith('v_besoins_previsionnels');
+  expect(query.select).toHaveBeenCalledWith('*');
+  expect(query.eq).toHaveBeenCalledWith('mama_id', 'm1');
+  expect(query.eq).toHaveBeenCalledWith('menu_id', 'menu1');
+  expect(data[0].quantite).toBe(2); // multiplied by nbPortions
+});
+
+test('simulerBudget aggregates scenario', async () => {
+  const { result } = renderHook(() => useSimulation());
+  let res;
+  await act(async () => {
+    res = await result.current.simulerBudget({}, [{ menu_id: 'mA', portions: 2 }]);
+  });
+  expect(fromMock).toHaveBeenCalled();
+  expect(res.total).toBe(4); // valeur(2) * quantite(2)
+});
+
+test('proposerCommandes maps consommation', async () => {
+  const { result } = renderHook(() => useSimulation());
+  const out = await result.current.proposerCommandes([
+    { product_id: 'p1', quantite: 3 },
+  ]);
+  expect(out).toEqual([{ product_id: 'p1', quantite: 3 }]);
+});


### PR DESCRIPTION
## Summary
- add SQL view for projected needs
- implement simulation hook with planning helpers
- provide details modal component
- add simulation planning page
- route to new planning simulation page
- test simulation hook

## Testing
- `npx eslint .`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857f5ebb0ec832da43828cbabee3658