### PR TITLE
Implement RGPD compliance module

### DIFF
--- a/src/pages/parametrage/ExportUserData.jsx
+++ b/src/pages/parametrage/ExportUserData.jsx
@@ -1,0 +1,40 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import toast, { Toaster } from "react-hot-toast";
+import { useAuth } from "@/context/AuthContext";
+import { useRGPD } from "@/hooks/useRGPD";
+
+export default function ExportUserData({ userId = null }) {
+  const { user_id, role } = useAuth();
+  const { getUserDataExport } = useRGPD();
+  const [loading, setLoading] = useState(false);
+
+  const targetId = userId || user_id;
+  if (!targetId) return null;
+  if (userId && role !== "superadmin") return null;
+
+  const handleExport = async () => {
+    setLoading(true);
+    const data = await getUserDataExport(targetId);
+    const blob = new Blob([JSON.stringify(data, null, 2)], {
+      type: "application/json",
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `export_${targetId}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+    toast.success("Export généré");
+    setLoading(false);
+  };
+
+  return (
+    <div className="p-6">
+      <Toaster />
+      <Button onClick={handleExport} disabled={loading}>
+        {loading ? "Export..." : "Exporter mes données"}
+      </Button>
+    </div>
+  );
+}

--- a/src/pages/parametrage/RGPDConsentForm.jsx
+++ b/src/pages/parametrage/RGPDConsentForm.jsx
@@ -1,0 +1,51 @@
+import { useState } from "react";
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/context/AuthContext";
+import { Button } from "@/components/ui/button";
+import toast, { Toaster } from "react-hot-toast";
+
+export default function RGPDConsentForm() {
+  const { user_id, mama_id } = useAuth();
+  const [values, setValues] = useState({ cookies: false, interne: false, tiers: false });
+  const [loading, setLoading] = useState(false);
+
+  const handleChange = e =>
+    setValues(v => ({ ...v, [e.target.name]: e.target.checked }));
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    setLoading(true);
+    await supabase.from("consentements_utilisateur").insert([
+      {
+        user_id,
+        mama_id,
+        consentement: values.cookies && values.interne && values.tiers,
+        date_consentement: new Date().toISOString(),
+      },
+    ]);
+    toast.success("Consentement enregistré");
+    setLoading(false);
+  };
+
+  return (
+    <form className="p-6 space-y-4" onSubmit={handleSubmit}>
+      <Toaster />
+      <h1 className="text-xl font-bold">Consentement RGPD</h1>
+      <label className="flex items-center gap-2">
+        <input type="checkbox" name="cookies" checked={values.cookies} onChange={handleChange} />
+        J'accepte l'utilisation des cookies
+      </label>
+      <label className="flex items-center gap-2">
+        <input type="checkbox" name="interne" checked={values.interne} onChange={handleChange} />
+        J'accepte l'usage interne de mes données
+      </label>
+      <label className="flex items-center gap-2">
+        <input type="checkbox" name="tiers" checked={values.tiers} onChange={handleChange} />
+        J'accepte le partage avec des tiers
+      </label>
+      <Button type="submit" disabled={loading || !(values.cookies && values.interne && values.tiers)}>
+        {loading ? "Enregistrement..." : "Valider"}
+      </Button>
+    </form>
+  );
+}

--- a/supabase/functions/cron_purge_inactive_users.sql
+++ b/supabase/functions/cron_purge_inactive_users.sql
@@ -1,0 +1,15 @@
+create or replace function cron_purge_inactive_users()
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  delete from users
+  where actif = false
+    and created_at < now() - interval '2 years';
+end;
+$$;
+
+-- schedule daily at 03:00 via pg_cron
+select cron.schedule('purge_inactive_users', '0 3 * * *', $$call cron_purge_inactive_users();$$);

--- a/supabase/tables/audit_logs.sql
+++ b/supabase/tables/audit_logs.sql
@@ -1,0 +1,19 @@
+create table if not exists audit_logs (
+    id uuid primary key default uuid_generate_v4(),
+    user_id uuid,
+    mama_id uuid,
+    action text,
+    table_name text,
+    created_at timestamptz default now()
+);
+
+alter table audit_logs enable row level security;
+create policy select_own_or_admin on audit_logs
+  for select using (
+    user_id = auth.uid() or
+    exists(
+      select 1 from users u
+      join roles r on u.role_id = r.id
+      where u.id = auth.uid() and r.nom in ('admin','superadmin')
+    )
+  );

--- a/supabase/tables/consentements_utilisateur.sql
+++ b/supabase/tables/consentements_utilisateur.sql
@@ -1,0 +1,11 @@
+create table if not exists consentements_utilisateur (
+    id uuid primary key default uuid_generate_v4(),
+    user_id uuid references users(id) on delete cascade,
+    mama_id uuid,
+    consentement boolean,
+    date_consentement timestamptz default now()
+);
+
+alter table consentements_utilisateur enable row level security;
+create policy user_own_consent on consentements_utilisateur
+  for all using (user_id = auth.uid()) with check (user_id = auth.uid());


### PR DESCRIPTION
## Summary
- add hooks to handle RGPD actions (`useRGPD`)
- create consent form and export page
- add SQL definitions for audit logs and consents
- schedule cron function for inactive users purge

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857f98a13a8832d9c8c94cc39262ec8