### PR TITLE
Add analytic dashboard module

### DIFF
--- a/src/hooks/useAnalytique.js
+++ b/src/hooks/useAnalytique.js
@@ -1,0 +1,68 @@
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/context/AuthContext";
+
+export function useAnalytique() {
+  const { mama_id } = useAuth();
+
+  const applyPeriode = (query, periode = {}) => {
+    if (periode.debut) query = query.gte("date", periode.debut);
+    if (periode.fin) query = query.lte("date", periode.fin);
+    return query;
+  };
+
+  async function getVentilationProduits(periode = {}, centre_id = null) {
+    if (!mama_id) return [];
+    let query = supabase
+      .from("v_analytique_stock")
+      .select(
+        "famille, activite, cost_center_id, cost_center_nom, sum:quantite, sumv:valeur"
+      )
+      .eq("mama_id", mama_id)
+      .group("famille, activite, cost_center_id, cost_center_nom");
+    if (centre_id) query = query.eq("cost_center_id", centre_id);
+    query = applyPeriode(query, periode);
+    const { data, error } = await query;
+    if (error) {
+      console.error("getVentilationProduits", error);
+      return [];
+    }
+    return data || [];
+  }
+
+  async function getEcartsParFamille(periode = {}) {
+    if (!mama_id) return [];
+    let query = supabase
+      .from("v_analytique_stock")
+      .select("famille, sumv:valeur")
+      .eq("mama_id", mama_id)
+      .group("famille");
+    query = applyPeriode(query, periode);
+    const { data, error } = await query;
+    if (error) {
+      console.error("getEcartsParFamille", error);
+      return [];
+    }
+    return data || [];
+  }
+
+  async function getConsommationParActivite(periode = {}, centre_id = null) {
+    if (!mama_id) return [];
+    let query = supabase
+      .from("v_analytique_stock")
+      .select("activite, sumv:valeur")
+      .eq("mama_id", mama_id)
+      .group("activite");
+    if (centre_id) query = query.eq("cost_center_id", centre_id);
+    query = applyPeriode(query, periode);
+    const { data, error } = await query;
+    if (error) {
+      console.error("getConsommationParActivite", error);
+      return [];
+    }
+    return data || [];
+  }
+
+  return { getVentilationProduits, getEcartsParFamille, getConsommationParActivite };
+}
+
+export default useAnalytique;

--- a/src/pages/analytique/AnalytiqueDashboard.jsx
+++ b/src/pages/analytique/AnalytiqueDashboard.jsx
@@ -1,0 +1,91 @@
+import { useEffect, useState } from "react";
+import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip, PieChart, Pie, Cell } from "recharts";
+import { Toaster } from "react-hot-toast";
+import * as XLSX from "xlsx";
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/context/AuthContext";
+import { useCostCenters } from "@/hooks/useCostCenters";
+import { useFamilles } from "@/hooks/useFamilles";
+import { useAnalytique } from "@/hooks/useAnalytique";
+
+export default function AnalytiqueDashboard() {
+  const { isAuthenticated, loading: authLoading } = useAuth();
+  const { costCenters, fetchCostCenters } = useCostCenters();
+  const { familles, fetchFamilles } = useFamilles();
+  const { getConsommationParActivite, getVentilationProduits } = useAnalytique();
+
+  const [filters, setFilters] = useState({ famille: "", centre: "", debut: "" });
+  const [dataActivite, setDataActivite] = useState([]);
+  const [dataProduits, setDataProduits] = useState([]);
+
+  useEffect(() => {
+    if (!isAuthenticated || authLoading) return;
+    fetchCostCenters();
+    fetchFamilles();
+  }, [isAuthenticated, authLoading, fetchCostCenters, fetchFamilles]);
+
+  useEffect(() => {
+    if (!isAuthenticated || authLoading) return;
+    const periode = filters.debut ? { debut: filters.debut + "-01", fin: filters.debut + "-31" } : {};
+    getConsommationParActivite(periode, filters.centre || null).then(setDataActivite);
+    getVentilationProduits(periode, filters.centre || null).then(data => {
+      const filtered = filters.famille ? data.filter(d => d.famille === filters.famille) : data;
+      setDataProduits(filtered);
+    });
+  }, [isAuthenticated, authLoading, filters, getConsommationParActivite, getVentilationProduits]);
+
+  const exportExcel = () => {
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, XLSX.utils.json_to_sheet(dataProduits), "Ventilation");
+    XLSX.writeFile(wb, "analytique.xlsx");
+  };
+
+  return (
+    <div className="p-8 container mx-auto">
+      <Toaster position="top-right" />
+      <h1 className="text-2xl font-bold mb-4">Dashboard analytique</h1>
+      <div className="flex flex-wrap gap-2 mb-4">
+        <select className="input" value={filters.centre} onChange={e => setFilters(f => ({ ...f, centre: e.target.value }))}>
+          <option value="">Tous centres</option>
+          {costCenters.map(c => (
+            <option key={c.id} value={c.id}>{c.nom}</option>
+          ))}
+        </select>
+        <select className="input" value={filters.famille} onChange={e => setFilters(f => ({ ...f, famille: e.target.value }))}>
+          <option value="">Toutes familles</option>
+          {familles.map(f => (
+            <option key={f.id} value={f.nom}>{f.nom}</option>
+          ))}
+        </select>
+        <input type="month" className="input" value={filters.debut} onChange={e => setFilters(f => ({ ...f, debut: e.target.value }))} />
+      </div>
+      <Button variant="outline" className="mb-4" onClick={exportExcel}>Export Excel</Button>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="bg-white p-4 rounded-xl shadow">
+          <h3 className="font-semibold mb-2">Consommation par activité</h3>
+          <ResponsiveContainer width="100%" height={300}>
+            <BarChart data={dataActivite}>
+              <XAxis dataKey="activite" />
+              <YAxis />
+              <Tooltip />
+              <Bar dataKey="sumv" fill="#8884d8" />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+        <div className="bg-white p-4 rounded-xl shadow">
+          <h3 className="font-semibold mb-2">Ventilation produits</h3>
+          <ResponsiveContainer width="100%" height={300}>
+            <PieChart>
+              <Pie data={dataProduits} dataKey="sumv" nameKey="famille" label>
+                {dataProduits.map((_, i) => (
+                  <Cell key={i} fill={["#0088FE", "#00C49F", "#FFBB28", "#FF8042"][i % 4]} />
+                ))}
+              </Pie>
+              <Tooltip />
+            </PieChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/parametrage/CentreCoutForm.jsx
+++ b/src/pages/parametrage/CentreCoutForm.jsx
@@ -1,0 +1,104 @@
+import { useState } from "react";
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/context/AuthContext";
+import { Button } from "@/components/ui/button";
+import toast, { Toaster } from "react-hot-toast";
+
+export default function CentreCoutForm({ centre, onClose, onSaved }) {
+  const { mama_id } = useAuth();
+  const [values, setValues] = useState({
+    nom: centre?.nom || "",
+    activite: centre?.activite || "",
+    type: centre?.type || "",
+    actif: centre?.actif ?? true,
+  });
+  const [saving, setSaving] = useState(false);
+
+  const handleChange = e =>
+    setValues(v => ({ ...v, [e.target.name]: e.target.value }));
+
+  const handleCheck = e =>
+    setValues(v => ({ ...v, [e.target.name]: e.target.checked }));
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    setSaving(true);
+    let res;
+    if (centre?.id) {
+      res = await supabase
+        .from("cost_centers")
+        .update(values)
+        .eq("id", centre.id)
+        .select()
+        .single();
+    } else {
+      res = await supabase
+        .from("cost_centers")
+        .insert([{ ...values, mama_id }])
+        .select()
+        .single();
+    }
+    setSaving(false);
+    if (res.error) {
+      toast.error(res.error.message || "Erreur");
+    } else {
+      toast.success("Enregistré !");
+      if (onSaved) onSaved(res.data);
+      if (onClose) onClose();
+    }
+  };
+
+  return (
+    <form className="space-y-3 p-4" onSubmit={handleSubmit}>
+      <Toaster />
+      <div>
+        <label>Nom</label>
+        <input
+          className="input input-bordered w-full"
+          name="nom"
+          value={values.nom}
+          onChange={handleChange}
+          required
+          autoFocus
+        />
+      </div>
+      <div>
+        <label>Activité</label>
+        <input
+          className="input input-bordered w-full"
+          name="activite"
+          value={values.activite}
+          onChange={handleChange}
+        />
+      </div>
+      <div>
+        <label>Type</label>
+        <input
+          className="input input-bordered w-full"
+          name="type"
+          value={values.type}
+          onChange={handleChange}
+        />
+      </div>
+      <div>
+        <label>
+          <input
+            type="checkbox"
+            name="actif"
+            checked={!!values.actif}
+            onChange={handleCheck}
+          />{" "}
+          Actif
+        </label>
+      </div>
+      <div className="flex gap-4 mt-4">
+        <Button type="submit" disabled={saving}>
+          {saving ? "Enregistrement…" : "Enregistrer"}
+        </Button>
+        <Button type="button" variant="secondary" onClick={onClose} disabled={saving}>
+          Annuler
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -27,6 +27,7 @@ const Promotions = lazy(() => import("@/pages/promotions/Promotions.jsx"));
 const Documents = lazy(() => import("@/pages/documents/Documents.jsx"));
 const Analyse = lazy(() => import("@/pages/analyse/Analyse.jsx"));
 const AnalyseCostCenter = lazy(() => import("@/pages/analyse/AnalyseCostCenter.jsx"));
+const AnalytiqueDashboard = lazy(() => import("@/pages/analytique/AnalytiqueDashboard.jsx"));
 const Utilisateurs = lazy(() => import("@/pages/parametrage/Utilisateurs.jsx"));
 const Roles = lazy(() => import("@/pages/parametrage/Roles.jsx"));
 const Mamas = lazy(() => import("@/pages/parametrage/Mamas.jsx"));
@@ -167,6 +168,10 @@ export default function Router() {
           <Route
             path="/analyse/cost-centers"
             element={<ProtectedRoute accessKey="analyse"><AnalyseCostCenter /></ProtectedRoute>}
+          />
+          <Route
+            path="/analyse/analytique"
+            element={<ProtectedRoute accessKey="analyse"><AnalytiqueDashboard /></ProtectedRoute>}
           />
           <Route
             path="/parametrage/utilisateurs"

--- a/supabase/views/v_analytique_stock.sql
+++ b/supabase/views/v_analytique_stock.sql
@@ -1,0 +1,17 @@
+create or replace view v_analytique_stock as
+select
+  m.date,
+  m.product_id,
+  p.famille,
+  mc.cost_center_id,
+  c.nom as cost_center_nom,
+  c.activite,
+  m.quantite,
+  m.valeur,
+  m.mama_id
+from mouvements_stock m
+left join mouvement_cost_centers mc on mc.mouvement_id = m.id
+left join cost_centers c on c.id = mc.cost_center_id
+left join products p on p.id = m.product_id;
+
+grant select on v_analytique_stock to authenticated;


### PR DESCRIPTION
## Summary
- add SQL view `v_analytique_stock`
- implement `useAnalytique` hook for analytics queries
- create `CentreCoutForm` for managing cost centers
- build `AnalytiqueDashboard` page with Recharts graphs and filters
- register new dashboard route

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857fdb83444832da53dc8a4406868d4