### PR TITLE
Add accounting export feature

### DIFF
--- a/src/hooks/useExportCompta.js
+++ b/src/hooks/useExportCompta.js
@@ -1,0 +1,87 @@
+import { useState } from 'react';
+import { supabase } from '@/lib/supabase';
+import { useAuth } from '@/context/AuthContext';
+import { exportToCSV } from '@/lib/export/exportHelpers';
+import toast from 'react-hot-toast';
+
+export default function useExportCompta() {
+  const { mama_id } = useAuth();
+  const [loading, setLoading] = useState(false);
+
+  async function fetchJournalLines(month) {
+    if (!mama_id) return [];
+    const start = `${month}-01`;
+    const end = new Date(start);
+    end.setMonth(end.getMonth() + 1);
+    const endStr = end.toISOString().slice(0, 10);
+    const { data, error } = await supabase
+      .from('facture_lignes')
+      .select(
+        'quantite, prix_unitaire, tva, factures(date, fournisseur:fournisseurs(nom))'
+      )
+      .eq('mama_id', mama_id)
+      .gte('factures.date', start)
+      .lt('factures.date', endStr);
+    if (error) {
+      console.error(error);
+      return [];
+    }
+    return data || [];
+  }
+
+  async function generateJournalCsv(month, download = true) {
+    setLoading(true);
+    const lignes = await fetchJournalLines(month);
+    const rows = lignes.map((l) => {
+      const ht = l.quantite * l.prix_unitaire;
+      const tva = ht * ((l.tva || 0) / 100);
+      return {
+        date: l.factures?.date,
+        fournisseur: l.factures?.fournisseur?.nom || '',
+        ht,
+        tva,
+        ttc: ht + tva,
+      };
+    });
+    if (download) {
+      exportToCSV(rows, { filename: `journal-achat-${month}.csv` });
+      toast.success('Export généré');
+    }
+    setLoading(false);
+    return rows;
+  }
+
+  async function mapFournisseursToTiers() {
+    if (!mama_id) return {};
+    const { data, error } = await supabase
+      .from('compta_mapping')
+      .select('cle, compte')
+      .eq('mama_id', mama_id)
+      .eq('type', 'fournisseur');
+    if (error) return {};
+    const map = {};
+    for (const row of data) map[row.cle] = row.compte;
+    return map;
+  }
+
+  async function exportToERP(month, endpoint, token) {
+    try {
+      const rows = await generateJournalCsv(month, false);
+      const res = await fetch(endpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify({ journal: rows }),
+      });
+      if (!res.ok) throw new Error('API error');
+      toast.success('Export envoyé');
+    } catch (err) {
+      console.error(err);
+      toast.error("Erreur lors de l'envoi à l'ERP");
+    }
+  }
+
+  return { generateJournalCsv, mapFournisseursToTiers, exportToERP, loading };
+}

--- a/src/pages/parametrage/ExportComptaPage.jsx
+++ b/src/pages/parametrage/ExportComptaPage.jsx
@@ -1,0 +1,102 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Toaster } from 'react-hot-toast';
+import useExportCompta from '@/hooks/useExportCompta';
+
+export default function ExportComptaPage() {
+  const { generateJournalCsv, exportToERP, loading } = useExportCompta();
+  const [mois, setMois] = useState(new Date().toISOString().slice(0,7));
+  const [format, setFormat] = useState('csv');
+  const [preview, setPreview] = useState([]);
+  const [endpoint, setEndpoint] = useState('');
+  const [token, setToken] = useState('');
+
+  const handlePreview = async () => {
+    const rows = await generateJournalCsv(mois, false);
+    setPreview(rows);
+  };
+
+  const handleDownload = () => generateJournalCsv(mois, true);
+
+  const handleSend = () => exportToERP(mois, endpoint, token);
+
+  return (
+    <div className="p-6 space-y-4">
+      <Toaster position="top-right" />
+      <h1 className="text-xl font-bold mb-2">Export comptable</h1>
+      <div className="flex gap-4 items-end">
+        <div>
+          <label className="block text-sm">Mois</label>
+          <input
+            type="month"
+            value={mois}
+            onChange={(e) => setMois(e.target.value)}
+            className="input input-bordered"
+          />
+        </div>
+        <div>
+          <label className="block text-sm">Format</label>
+          <select
+            value={format}
+            onChange={(e) => setFormat(e.target.value)}
+            className="select select-bordered"
+          >
+            <option value="csv">📄 CSV</option>
+            <option value="xml">🧾 XML</option>
+            <option value="json">JSON</option>
+            <option value="txt">TXT</option>
+          </select>
+        </div>
+        <Button onClick={handlePreview} disabled={loading}>
+          Aperçu
+        </Button>
+        <Button onClick={handleDownload} disabled={loading}>
+          Télécharger
+        </Button>
+      </div>
+      <div className="flex gap-4 items-end">
+        <input
+          className="input input-bordered flex-1"
+          placeholder="Endpoint ERP"
+          value={endpoint}
+          onChange={(e) => setEndpoint(e.target.value)}
+        />
+        <input
+          className="input input-bordered"
+          placeholder="Token"
+          value={token}
+          onChange={(e) => setToken(e.target.value)}
+        />
+        <Button onClick={handleSend} disabled={!endpoint || loading}>
+          🧮 Envoyer à ERP
+        </Button>
+      </div>
+      {preview.length > 0 && (
+        <div className="bg-white shadow rounded-xl overflow-x-auto">
+          <table className="min-w-full table-auto text-sm">
+            <thead>
+              <tr>
+                <th className="px-2 py-1">Date</th>
+                <th className="px-2 py-1">Fournisseur</th>
+                <th className="px-2 py-1">HT</th>
+                <th className="px-2 py-1">TVA</th>
+                <th className="px-2 py-1">TTC</th>
+              </tr>
+            </thead>
+            <tbody>
+              {preview.map((row, i) => (
+                <tr key={i} className="odd:bg-gray-50">
+                  <td className="px-2 py-1">{row.date}</td>
+                  <td className="px-2 py-1">{row.fournisseur}</td>
+                  <td className="px-2 py-1 text-right">{row.ht.toFixed(2)}</td>
+                  <td className="px-2 py-1 text-right">{row.tva.toFixed(2)}</td>
+                  <td className="px-2 py-1 text-right">{row.ttc.toFixed(2)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/supabase/tables/compta_mapping.sql
+++ b/supabase/tables/compta_mapping.sql
@@ -1,0 +1,30 @@
+create table if not exists compta_mapping (
+    id uuid primary key default uuid_generate_v4(),
+    mama_id uuid not null references mamas(id) on delete cascade,
+    type text not null,
+    cle text not null,
+    compte text not null,
+    created_at timestamptz default now(),
+    unique(mama_id, type, cle)
+);
+
+alter table compta_mapping enable row level security;
+alter table compta_mapping force row level security;
+create policy compta_mapping_admin on compta_mapping
+  for all using (
+    mama_id = current_user_mama_id() and
+    exists(
+      select 1 from users u
+      join roles r on u.role_id = r.id
+      where u.id = auth.uid() and r.nom in ('admin','superadmin','compta')
+    )
+  )
+  with check (
+    mama_id = current_user_mama_id() and
+    exists(
+      select 1 from users u
+      join roles r on u.role_id = r.id
+      where u.id = auth.uid() and r.nom in ('admin','superadmin','compta')
+    )
+  );
+grant select, insert, update, delete on compta_mapping to authenticated;


### PR DESCRIPTION
## Summary
- add `useExportCompta` hook to generate journals and push them to ERP
- create `ExportComptaPage` UI for admins
- define `compta_mapping` table with RLS policies

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685800666dfc832d9a9a3a78f0f13acb