### PR TITLE
Add dashboard builder module

### DIFF
--- a/src/components/dashboard/WidgetRenderer.jsx
+++ b/src/components/dashboard/WidgetRenderer.jsx
@@ -1,0 +1,54 @@
+import { ResponsiveContainer, LineChart, Line, BarChart, Bar, PieChart, Pie, Cell, Tooltip } from "recharts";
+import DashboardCard from "./DashboardCard";
+
+export default function WidgetRenderer({ config }) {
+  if (!config) return null;
+  const type = config.type || "indicator";
+
+  switch (type) {
+    case "line":
+      return (
+        <ResponsiveContainer width="100%" height={220}>
+          <LineChart data={config.data || []}>
+            <Line type="monotone" dataKey={config.dataKey} stroke={config.color || "#bfa14d"} />
+            <Tooltip />
+          </LineChart>
+        </ResponsiveContainer>
+      );
+    case "bar":
+      return (
+        <ResponsiveContainer width="100%" height={220}>
+          <BarChart data={config.data || []}>
+            <Bar dataKey={config.dataKey} fill={config.color || "#bfa14d"} />
+            <Tooltip />
+          </BarChart>
+        </ResponsiveContainer>
+      );
+    case "pie":
+      return (
+        <ResponsiveContainer width="100%" height={220}>
+          <PieChart>
+            <Pie data={config.data || []} dataKey={config.dataKey} nameKey={config.nameKey} outerRadius={80} fill={config.color || "#bfa14d"}>
+              {(config.data || []).map((_, idx) => (
+                <Cell key={idx} fill={config.colors?.[idx % config.colors.length] || "#bfa14d"} />
+              ))}
+            </Pie>
+            <Tooltip />
+          </PieChart>
+        </ResponsiveContainer>
+      );
+    case "list":
+      return (
+        <ul className="list-disc pl-4 text-sm">
+          {(config.items || []).map((it, idx) => (
+            <li key={idx}>{it}</li>
+          ))}
+        </ul>
+      );
+    case "indicator":
+    default:
+      return (
+        <DashboardCard title={config.label} value={config.value} type={config.indicatorType} />
+      );
+  }
+}

--- a/src/hooks/useDashboards.js
+++ b/src/hooks/useDashboards.js
@@ -1,0 +1,133 @@
+import { useState, useCallback } from "react";
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/context/AuthContext";
+
+export function useDashboards() {
+  const { user_id, mama_id } = useAuth();
+  const [dashboards, setDashboards] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const getDashboards = useCallback(async () => {
+    if (!user_id || !mama_id) return [];
+    setLoading(true);
+    setError(null);
+    const { data, error } = await supabase
+      .from("dashboards")
+      .select("*, widgets:widgets(*)")
+      .eq("user_id", user_id)
+      .eq("mama_id", mama_id)
+      .order("created_at", { ascending: true });
+    setLoading(false);
+    if (error) {
+      setError(error.message || error);
+      setDashboards([]);
+      return [];
+    }
+    setDashboards(Array.isArray(data) ? data : []);
+    return data || [];
+  }, [user_id, mama_id]);
+
+  async function createDashboard(nom) {
+    if (!user_id || !mama_id) return null;
+    setLoading(true);
+    setError(null);
+    const { data, error } = await supabase
+      .from("dashboards")
+      .insert([{ nom, user_id, mama_id }])
+      .select()
+      .single();
+    setLoading(false);
+    if (error) {
+      setError(error.message || error);
+      return null;
+    }
+    setDashboards((d) => [...d, { ...data, widgets: [] }]);
+    return data;
+  }
+
+  async function addWidget(dashboardId, config) {
+    if (!dashboardId) return null;
+    setLoading(true);
+    setError(null);
+    const { data: ordreData } = await supabase
+      .from("widgets")
+      .select("ordre")
+      .eq("dashboard_id", dashboardId)
+      .order("ordre", { ascending: false })
+      .limit(1)
+      .single();
+    const ordre = ordreData ? (ordreData.ordre || 0) + 1 : 0;
+    const { data, error } = await supabase
+      .from("widgets")
+      .insert([{ dashboard_id: dashboardId, config, ordre }])
+      .select()
+      .single();
+    setLoading(false);
+    if (error) {
+      setError(error.message || error);
+      return null;
+    }
+    setDashboards((ds) =>
+      ds.map((db) =>
+        db.id === dashboardId
+          ? { ...db, widgets: [...(db.widgets || []), data] }
+          : db
+      )
+    );
+    return data;
+  }
+
+  async function updateWidget(id, values) {
+    if (!id) return null;
+    setLoading(true);
+    setError(null);
+    const { data, error } = await supabase
+      .from("widgets")
+      .update(values)
+      .eq("id", id)
+      .select()
+      .single();
+    setLoading(false);
+    if (error) {
+      setError(error.message || error);
+      return null;
+    }
+    setDashboards((ds) =>
+      ds.map((db) => ({
+        ...db,
+        widgets: db.widgets?.map((w) => (w.id === id ? data : w)) || [],
+      }))
+    );
+    return data;
+  }
+
+  async function deleteWidget(id) {
+    if (!id) return;
+    setLoading(true);
+    setError(null);
+    const { error } = await supabase.from("widgets").delete().eq("id", id);
+    setLoading(false);
+    if (error) {
+      setError(error.message || error);
+      return;
+    }
+    setDashboards((ds) =>
+      ds.map((db) => ({
+        ...db,
+        widgets: db.widgets?.filter((w) => w.id !== id) || [],
+      }))
+    );
+  }
+
+  return {
+    dashboards,
+    loading,
+    error,
+    getDashboards,
+    createDashboard,
+    addWidget,
+    updateWidget,
+    deleteWidget,
+  };
+}

--- a/src/pages/dashboard/DashboardBuilder.jsx
+++ b/src/pages/dashboard/DashboardBuilder.jsx
@@ -1,0 +1,114 @@
+import { useEffect, useState } from "react";
+import { Reorder } from "framer-motion";
+import { useDashboards } from "@/hooks/useDashboards";
+import WidgetRenderer from "@/components/dashboard/WidgetRenderer";
+import { Button } from "@/components/ui/button";
+
+export default function DashboardBuilder() {
+  const {
+    dashboards,
+    getDashboards,
+    createDashboard,
+    addWidget,
+    updateWidget,
+    deleteWidget,
+  } = useDashboards();
+  const [current, setCurrent] = useState(null);
+  const [newName, setNewName] = useState("");
+  const [ordered, setOrdered] = useState([]);
+
+  useEffect(() => {
+    getDashboards();
+  }, [getDashboards]);
+
+  useEffect(() => {
+    if (current) setOrdered(current.widgets || []);
+  }, [current]);
+
+  if (!current) {
+    return (
+      <div className="p-6 max-w-3xl mx-auto">
+        <h1 className="text-2xl font-bold mb-4">Mes tableaux de bord</h1>
+        <ul className="mb-6 list-disc pl-6">
+          {dashboards.map((d) => (
+            <li key={d.id}>
+              <button className="underline" onClick={() => setCurrent(d)}>{d.nom}</button>
+            </li>
+          ))}
+        </ul>
+        <div className="flex gap-2">
+          <input
+            className="input flex-1"
+            placeholder="Nom du dashboard"
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+          />
+          <Button
+            onClick={async () => {
+              const db = await createDashboard(newName);
+              if (db) {
+                setNewName("");
+                setCurrent(db);
+              }
+            }}
+          >
+            Créer
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  const saveOrder = async () => {
+    for (let i = 0; i < ordered.length; i++) {
+      if (ordered[i].ordre !== i) {
+        await updateWidget(ordered[i].id, { ordre: i });
+      }
+    }
+    const list = await getDashboards();
+    const match = list.find((d) => d.id === current.id);
+    setCurrent(match || null);
+  };
+
+  return (
+    <div className="p-6">
+      <Button className="mb-4" onClick={() => setCurrent(null)}>
+        Retour
+      </Button>
+      <h2 className="text-xl font-bold mb-4">{current.nom}</h2>
+      <Reorder.Group
+        axis="y"
+        values={ordered}
+        onReorder={setOrdered}
+        className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6"
+      >
+        {ordered.map((w) => (
+          <Reorder.Item key={w.id} value={w} className="bg-white rounded-xl p-4 relative">
+            <button
+              className="absolute top-2 right-2 text-red-600"
+              onClick={() => deleteWidget(w.id)}
+            >
+              ✕
+            </button>
+            <WidgetRenderer config={w.config} />
+          </Reorder.Item>
+        ))}
+      </Reorder.Group>
+      <div className="flex gap-2">
+        <Button
+          onClick={() =>
+            addWidget(current.id, {
+              type: "indicator",
+              label: "Nouvel indicateur",
+              value: 0,
+              indicatorType: "default",
+            })
+          }
+        >
+          Ajouter un widget
+        </Button>
+        <Button onClick={saveOrder}>Publier le dashboard</Button>
+      </div>
+    </div>
+  );
+}

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -47,6 +47,7 @@ const FournisseurApiSettingsForm = lazy(() => import("@/pages/fournisseurs/Fourn
 const CatalogueSyncViewer = lazy(() => import("@/pages/catalogue/CatalogueSyncViewer.jsx"));
 const CommandesEnvoyees = lazy(() => import("@/pages/commandes/CommandesEnvoyees.jsx"));
 const SimulationPlanner = lazy(() => import("@/pages/planning/SimulationPlanner.jsx"));
+const DashboardBuilder = lazy(() => import("@/pages/dashboard/DashboardBuilder.jsx"));
 
 
 export default function Router() {
@@ -61,9 +62,13 @@ export default function Router() {
         <Route path="/privacy" element={<PagePrivacy />} />
         <Route path="/mentions" element={<PageMentions />} />
         <Route element={<Layout />}>
-          <Route
+        <Route
             path="/dashboard"
             element={<ProtectedRoute accessKey="dashboard"><Dashboard /></ProtectedRoute>}
+          />
+          <Route
+            path="/dashboard/builder"
+            element={<ProtectedRoute accessKey="dashboard"><DashboardBuilder /></ProtectedRoute>}
           />
           <Route
             path="/fournisseurs"

--- a/supabase/tables/dashboards.sql
+++ b/supabase/tables/dashboards.sql
@@ -1,0 +1,18 @@
+create table if not exists dashboards (
+    id uuid primary key default uuid_generate_v4(),
+    user_id uuid references users(id) on delete cascade,
+    mama_id uuid references mamas(id) on delete cascade,
+    nom text,
+    created_at timestamptz default now()
+);
+
+alter table dashboards enable row level security;
+alter table dashboards force row level security;
+create policy dashboards_owner on dashboards
+  for all using (
+    user_id = auth.uid() and mama_id = current_user_mama_id()
+  ) with check (
+    user_id = auth.uid() and mama_id = current_user_mama_id()
+  );
+
+grant select, insert, update, delete on dashboards to authenticated;

--- a/supabase/tables/widgets.sql
+++ b/supabase/tables/widgets.sql
@@ -1,0 +1,27 @@
+create table if not exists widgets (
+    id uuid primary key default uuid_generate_v4(),
+    dashboard_id uuid references dashboards(id) on delete cascade,
+    config jsonb,
+    ordre int default 0
+);
+
+alter table widgets enable row level security;
+alter table widgets force row level security;
+create policy widgets_owner on widgets
+  for all using (
+    exists (
+      select 1 from dashboards d
+      where d.id = widgets.dashboard_id
+        and d.user_id = auth.uid()
+        and d.mama_id = current_user_mama_id()
+    )
+  ) with check (
+    exists (
+      select 1 from dashboards d
+      where d.id = widgets.dashboard_id
+        and d.user_id = auth.uid()
+        and d.mama_id = current_user_mama_id()
+    )
+  );
+
+grant select, insert, update, delete on widgets to authenticated;


### PR DESCRIPTION
## Summary
- add Supabase tables for dashboards and widgets with RLS policies
- implement hooks/useDashboards for CRUD operations
- render widgets generically with new WidgetRenderer component
- create DashboardBuilder page with drag & drop ordering
- expose builder page via router

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68580420a228832d85647c11dc37c578