### PR TITLE
Add recommendation engine and supabase views

### DIFF
--- a/"b/supabase/views/v_reco_surco\303\273t.sql"
+++ b/"b/supabase/views/v_reco_surco\303\273t.sql"
@@ -1,0 +1,15 @@
+create or replace view v_reco_surcoût as
+select distinct on (sp.product_id)
+  sp.product_id,
+  p.nom,
+  p.mama_id,
+  sp.prix_achat as dernier_prix,
+  lag(sp.prix_achat) over (partition by sp.product_id order by sp.date_livraison) as prix_precedent,
+  (sp.prix_achat - lag(sp.prix_achat) over (partition by sp.product_id order by sp.date_livraison))
+    / nullif(lag(sp.prix_achat) over (partition by sp.product_id order by sp.date_livraison),0) * 100 as variation_pct
+from supplier_products sp
+join products p on p.id = sp.product_id
+where p.actif = true
+order by sp.product_id, sp.date_livraison desc;
+
+grant select on v_reco_surcoût to authenticated;

--- a/src/components/ia/RecommandationsBox.jsx
+++ b/src/components/ia/RecommandationsBox.jsx
@@ -1,0 +1,38 @@
+import { Loader } from "lucide-react";
+import { useRecommendations } from "@/hooks/useRecommendations";
+
+export default function RecommandationsBox({ filter }) {
+  const { recommendations, loading, refresh } = useRecommendations();
+  const items = filter
+    ? recommendations.filter(r => r.category === filter)
+    : recommendations;
+
+  if (loading) {
+    return (
+      <div className="p-4 text-center text-sm text-gray-500">
+        <Loader className="animate-spin inline-block" />
+      </div>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <div className="p-4 text-sm text-gray-500">Aucune recommandation</div>
+    );
+  }
+
+  return (
+    <div className="space-y-1">
+      {items.map((rec, idx) => (
+        <div
+          key={idx}
+          onClick={() => rec.onClick?.(rec) || refresh()}
+          className="flex items-center gap-2 bg-white rounded-lg p-2 shadow cursor-pointer hover:bg-gray-50 text-sm"
+        >
+          <span>{rec.type === 'alert' ? '🔍' : '🧠'}</span>
+          <span className="flex-1">{rec.message}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/hooks/useRecommendations.js
+++ b/src/hooks/useRecommendations.js
@@ -1,0 +1,95 @@
+import { useState, useEffect } from "react";
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/context/AuthContext";
+
+export async function getRecommendations(user_id, mama_id) {
+  if (!mama_id) return [];
+  const recos = [];
+
+  // 1. Stock mort via view
+  const { data: stockMort } = await supabase
+    .from('v_reco_stockmort')
+    .select('*')
+    .eq('mama_id', mama_id);
+
+  (stockMort || []).forEach(r => {
+    recos.push({
+      type: 'alert',
+      category: 'rotation',
+      product_id: r.product_id,
+      message: `Stock mort: ${r.nom} inactif depuis ${r.jours_inactif} jours`,
+    });
+  });
+
+  // 2. Surcoût
+  const { data: surcout } = await supabase
+    .from('v_reco_surcoût')
+    .select('*')
+    .eq('mama_id', mama_id)
+    .gte('variation_pct', 20);
+
+  (surcout || []).forEach(r => {
+    recos.push({
+      type: 'alert',
+      category: 'coût',
+      product_id: r.product_id,
+      message: `Coût excessif pour ${r.nom} : +${Number(r.variation_pct).toFixed(1)}%`,
+    });
+  });
+
+  // 3. Suggest reorder when stock below minimum
+  const { data: produits } = await supabase
+    .from('products')
+    .select('id, nom, stock_reel, stock_min, actif')
+    .eq('mama_id', mama_id);
+
+  (produits || [])
+    .filter(p => p.actif && p.stock_min !== null && Number(p.stock_reel) < Number(p.stock_min))
+    .forEach(p => {
+      recos.push({
+        type: 'suggestion',
+        category: 'stock',
+        product_id: p.id,
+        message: `Passer commande: ${p.nom} (stock ${p.stock_reel} < ${p.stock_min})`,
+      });
+    });
+
+  // 4. Budget deviation
+  const periode = new Date().toISOString().slice(0,7);
+  const { data: budgets } = await supabase.rpc('fn_calc_budgets', {
+    mama_id_param: mama_id,
+    periode_param: periode,
+  });
+
+  (budgets || [])
+    .filter(b => b.ecart_pct !== null && Math.abs(Number(b.ecart_pct)) > 15)
+    .forEach(b => {
+      recos.push({
+        type: 'alert',
+        category: 'budget',
+        message: `Ecart budget ${b.famille}: ${Number(b.ecart_pct).toFixed(1)}%`,
+      });
+    });
+
+  return recos;
+}
+
+export function useRecommendations() {
+  const { user_id, mama_id } = useAuth();
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  const refresh = async () => {
+    setLoading(true);
+    const recos = await getRecommendations(user_id, mama_id);
+    setItems(recos);
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    if (mama_id) refresh();
+  }, [mama_id]);
+
+  return { recommendations: items, loading, refresh };
+}
+

--- a/supabase/functions/fn_calc_budgets.sql
+++ b/supabase/functions/fn_calc_budgets.sql
@@ -1,0 +1,37 @@
+create or replace function fn_calc_budgets(mama_id_param uuid, periode_param text)
+returns table(famille text, budget_prevu numeric, total_reel numeric, ecart_pct numeric)
+language sql as $$
+  with hist as (
+    select to_char(f.date,'YYYY-MM') as mois,
+           fam.nom as famille,
+           sum(fl.total) as total
+    from factures f
+      join facture_lignes fl on fl.facture_id = f.id
+      left join products p on p.id = fl.product_id
+      left join familles fam on fam.id = p.famille_id
+    where f.mama_id = mama_id_param
+    group by 1,2
+  ),
+  moy as (
+    select famille, avg(total) as avg_mensuel
+    from hist
+    where mois < periode_param
+    group by famille
+  ),
+  courant as (
+    select famille, sum(total) as total_reel
+    from hist
+    where mois = periode_param
+    group by famille
+  )
+  select coalesce(m.famille, c.famille) as famille,
+         coalesce(m.avg_mensuel,0) as budget_prevu,
+         coalesce(c.total_reel,0) as total_reel,
+         case when coalesce(m.avg_mensuel,0) = 0 then null
+              else (coalesce(c.total_reel,0) - m.avg_mensuel)/m.avg_mensuel * 100
+         end as ecart_pct
+  from moy m
+  full join courant c on c.famille = m.famille;
+$$;
+
+grant execute on function fn_calc_budgets to authenticated;

--- a/supabase/views/v_reco_rotation.sql
+++ b/supabase/views/v_reco_rotation.sql
@@ -1,0 +1,12 @@
+create or replace view v_reco_rotation as
+select
+  p.id as product_id,
+  p.nom,
+  p.mama_id,
+  current_date - coalesce(max(m.date), current_date) as jours_inactif
+from products p
+left join mouvements_stock m on m.product_id = p.id
+where p.actif = true
+group by p.id, p.nom, p.mama_id;
+
+grant select on v_reco_rotation to authenticated;

--- a/supabase/views/v_reco_stockmort.sql
+++ b/supabase/views/v_reco_stockmort.sql
@@ -1,0 +1,5 @@
+create or replace view v_reco_stockmort as
+select * from v_reco_rotation
+where jours_inactif > 30;
+
+grant select on v_reco_stockmort to authenticated;


### PR DESCRIPTION
## Summary
- add `getRecommendations` hook to compute suggestions
- create `RecommandationsBox` UI component
- add SQL views for rotation, surcost and dead stock
- add budgeting calculation function

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685805c6cea0832d9ed4e4738c9a9811