### PR TITLE
Fix Supabase user queries

### DIFF
--- a/src/hooks/useLogs.js
+++ b/src/hooks/useLogs.js
@@ -41,7 +41,7 @@ export function useLogs() {
     const rows = (logs || []).map(l => ({
       date: l.created_at,
       action: l.action,
-      utilisateur: l.users?.email || l.done_by,
+      utilisateur: l.utilisateurs?.email || l.done_by,
     }));
     const wb = XLSX.utils.book_new();
     XLSX.utils.book_append_sheet(wb, XLSX.utils.json_to_sheet(rows), "Logs");

--- a/src/hooks/useTasks.js
+++ b/src/hooks/useTasks.js
@@ -15,7 +15,7 @@ export function useTasks() {
     const { data, error } = await supabase
       .from("taches")
       .select(
-        "*, assigned:users!taches_assigned_to_fkey(email)"
+        "*, assigned:utilisateurs!taches_assigned_to_fkey(email)"
       )
       .eq("mama_id", mama_id)
       .order("next_echeance", { ascending: true });
@@ -33,7 +33,7 @@ export function useTasks() {
     const { data, error } = await supabase
       .from("taches")
       .select(
-        "*, assigned:users!taches_assigned_to_fkey(email)"
+        "*, assigned:utilisateurs!taches_assigned_to_fkey(email)"
       )
       .eq("id", id)
       .eq("mama_id", mama_id)
@@ -52,7 +52,7 @@ export function useTasks() {
     let query = supabase
       .from("taches")
       .select(
-        "*, assigned:users!taches_assigned_to_fkey(email)"
+        "*, assigned:utilisateurs!taches_assigned_to_fkey(email)"
       )
       .eq("mama_id", mama_id);
     if (statut) query = query.eq("statut", statut);

--- a/src/pages/AuditTrail.jsx
+++ b/src/pages/AuditTrail.jsx
@@ -72,7 +72,7 @@ export default function AuditTrail() {
               </td>
               <td className="px-2 py-1">{e.table_name}</td>
               <td className="px-2 py-1">{e.operation}</td>
-              <td className="px-2 py-1">{e.users?.email || e.changed_by}</td>
+              <td className="px-2 py-1">{e.utilisateurs?.email || e.changed_by}</td>
               <td className="px-2 py-1 font-mono break-all">
                 {JSON.stringify(e.old_data)}
               </td>

--- a/src/pages/Journal.jsx
+++ b/src/pages/Journal.jsx
@@ -67,7 +67,7 @@ export default function Journal() {
                 {new Date(l.created_at).toLocaleString()}
               </td>
               <td className="px-2 py-1">{l.action}</td>
-              <td className="px-2 py-1">{l.users?.email || l.done_by}</td>
+              <td className="px-2 py-1">{l.utilisateurs?.email || l.done_by}</td>
             </tr>
           ))}
         </tbody>

--- a/src/pages/admin/AuditViewer.jsx
+++ b/src/pages/admin/AuditViewer.jsx
@@ -89,7 +89,7 @@ export default function AuditViewer() {
                 <td className="px-2 py-1 whitespace-nowrap">
                   {new Date(l.created_at).toLocaleString()}
                 </td>
-                <td className="px-2 py-1">{l.users?.email || l.user_id}</td>
+                <td className="px-2 py-1">{l.utilisateurs?.email || l.user_id}</td>
                 <td className="px-2 py-1">
                   {l._source === "security" ? "🛡️" : "✏️"} {l.action || l.type}
                 </td>

--- a/src/pages/stock/Inventaire.jsx
+++ b/src/pages/stock/Inventaire.jsx
@@ -34,7 +34,7 @@ export default function InventairePage() {
             <tr key={inv.id}>
               <td className="p-2">{inv.nom || inv.reference}</td>
               <td className="p-2 text-center">{inv.date}</td>
-              <td className="p-2 text-center">{inv.users?.username || "-"}</td>
+              <td className="p-2 text-center">{inv.utilisateurs?.username || "-"}</td>
               <td className="p-2 text-center">{inv.cloture ? "validé" : "en cours"}</td>
               <td className="p-2 text-center">{inv.ecart_total ?? "-"}</td>
             </tr>

--- a/test/useTasks.test.js
+++ b/test/useTasks.test.js
@@ -27,7 +27,7 @@ test('fetchTasks queries Supabase and stores result', async () => {
     await result.current.fetchTasks();
   });
   expect(fromMock).toHaveBeenCalledWith('taches');
-  expect(selectMock).toHaveBeenCalledWith('*, assigned:users!taches_assigned_to_fkey(email)');
+  expect(selectMock).toHaveBeenCalledWith('*, assigned:utilisateurs!taches_assigned_to_fkey(email)');
   expect(queryChain.eq).toHaveBeenCalledWith('mama_id', 'm1');
   expect(orderMock).toHaveBeenCalledWith('next_echeance', { ascending: true });
   expect(result.current.tasks).toEqual([{ id: 't1' }]);
@@ -39,7 +39,7 @@ test('fetchTaskById queries Supabase with id and mama_id', async () => {
     await result.current.fetchTaskById('t1');
   });
   expect(fromMock).toHaveBeenCalledWith('taches');
-  expect(selectMock).toHaveBeenCalledWith('*, assigned:users!taches_assigned_to_fkey(email)');
+  expect(selectMock).toHaveBeenCalledWith('*, assigned:utilisateurs!taches_assigned_to_fkey(email)');
   expect(queryChain.eq).toHaveBeenNthCalledWith(1, 'id', 't1');
   expect(queryChain.eq).toHaveBeenNthCalledWith(2, 'mama_id', 'm1');
   expect(singleMock).toHaveBeenCalled();
@@ -51,7 +51,7 @@ test('fetchTasksByStatus filters by status', async () => {
     await result.current.fetchTasksByStatus('fait');
   });
   expect(fromMock).toHaveBeenCalledWith('taches');
-  expect(selectMock).toHaveBeenCalledWith('*, assigned:users!taches_assigned_to_fkey(email)');
+  expect(selectMock).toHaveBeenCalledWith('*, assigned:utilisateurs!taches_assigned_to_fkey(email)');
   expect(queryChain.eq).toHaveBeenNthCalledWith(1, 'mama_id', 'm1');
   expect(queryChain.eq).toHaveBeenNthCalledWith(2, 'statut', 'fait');
   expect(orderMock).toHaveBeenCalledWith('next_echeance', { ascending: true });


### PR DESCRIPTION
## Summary
- update user references in logs, audit trails and inventory pages
- use `utilisateurs` table alias in tasks hook
- adjust tests to new alias

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ab9d3bed4832dab6412fb60e14ef7