### PR TITLE
Fix user creation and authentication flow

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,25 +1,19 @@
 import Router from "@/router";
-import { AuthProvider } from "@/context/AuthContext";
 import { HelpProvider } from "@/context/HelpProvider";
 import { MultiMamaProvider } from "@/context/MultiMamaContext";
 import { ThemeProvider } from "@/context/ThemeProvider";
 import { Toaster } from "react-hot-toast";
-import { BrowserRouter } from "react-router-dom";
 
 export default function App() {
   return (
-    <AuthProvider>
-      <HelpProvider>
-        <MultiMamaProvider>
-          <ThemeProvider>
-            <BrowserRouter>
-              <Toaster position="top-right" />
-              <Router />
-            </BrowserRouter>
-          </ThemeProvider>
-        </MultiMamaProvider>
-      </HelpProvider>
-    </AuthProvider>
+    <HelpProvider>
+      <MultiMamaProvider>
+        <ThemeProvider>
+          <Toaster position="top-right" />
+          <Router />
+        </ThemeProvider>
+      </MultiMamaProvider>
+    </HelpProvider>
   );
 }
 

--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -2,14 +2,18 @@ import { Navigate, useLocation } from "react-router-dom";
 import useAuth from "@/hooks/useAuth";
 
 export default function ProtectedRoute({ accessKey, children }) {
-  const { session, loading, access_rights, role, actif, mama_id } = useAuth();
+  const { session, loading, access_rights, role, actif, mama_id, pending } = useAuth();
   const location = useLocation();
 
   if (loading) return null;
 
   if (!session) return <Navigate to="/login" />;
+  if (pending) return <Navigate to="/pending" />;
   if (actif === false) return <Navigate to="/blocked" />;
   if (!role || mama_id === null || access_rights === null) {
+    return <Navigate to="/unauthorized" />;
+  }
+  if (Array.isArray(access_rights) && access_rights.length === 0) {
     return <Navigate to="/unauthorized" />;
   }
   if (!mama_id && location.pathname !== "/create-mama") {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,6 +4,8 @@ import App from "./App";
 import "./globals.css";
 import "@/i18n/i18n";
 import "./registerSW.js";
+import { BrowserRouter } from "react-router-dom";
+import { AuthProvider } from "@/context/AuthContext";
 
 // Option sentry/reporting
 // import * as Sentry from "@sentry/react";
@@ -12,6 +14,10 @@ import "./registerSW.js";
 const root = createRoot(document.getElementById("root"));
 root.render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    </BrowserRouter>
   </React.StrictMode>
 );

--- a/src/pages/auth/Login.jsx
+++ b/src/pages/auth/Login.jsx
@@ -50,11 +50,15 @@ export default function Login() {
     } else {
       const { data: profil } = await supabase
         .from("utilisateurs")
-        .select("id, mama_id")
+        .select("mama_id, access_rights, actif")
         .eq("auth_id", data.user.id)
         .maybeSingle();
       if (!profil) {
-        toast.error("Profil inexistant");
+        toast("Compte en cours de création");
+        navigate("/pending");
+      } else if (profil.actif === false) {
+        navigate("/blocked");
+      } else if (!profil.access_rights || profil.access_rights.length === 0) {
         navigate("/unauthorized");
       } else {
         toast.success("Connecté !");

--- a/src/pages/auth/Pending.jsx
+++ b/src/pages/auth/Pending.jsx
@@ -8,8 +8,8 @@ export default function Pending() {
   return (
     <PageWrapper>
       <GlassCard className="flex flex-col items-center text-center gap-4">
-        <h1 className="text-3xl font-bold text-gold">Compte en cours de validation…</h1>
-        <p>Votre compte est en cours de préparation. Merci de patienter.</p>
+        <h1 className="text-3xl font-bold text-gold">Compte en cours de création…</h1>
+        <p>Votre compte est en cours de création, merci de patienter...</p>
         <PrimaryButton onClick={() => navigate("/logout")}>Se déconnecter</PrimaryButton>
       </GlassCard>
     </PageWrapper>

--- a/src/pages/debug/AuthDebug.jsx
+++ b/src/pages/debug/AuthDebug.jsx
@@ -5,9 +5,16 @@ export default function AuthDebug() {
   const { user_id, role, mama_id, access_rights, session } = useAuth();
 
   return (
-    <div>
-      <h2>Debug Auth</h2>
-      <pre>{JSON.stringify({ user_id, role, mama_id, access_rights, claims: session?.user }, null, 2)}</pre>
+    <div className="p-4 text-sm text-white bg-black space-y-2">
+      <h2 className="text-lg font-bold">Debug Auth</h2>
+      <pre>{JSON.stringify({
+        user_id,
+        email: session?.user?.email,
+        role,
+        mama_id,
+        access_rights,
+        claims: session?.user,
+      }, null, 2)}</pre>
     </div>
   );
 }

--- a/src/pages/public/Signup.jsx
+++ b/src/pages/public/Signup.jsx
@@ -1,17 +1,17 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { supabase } from "@/lib/supabase";
 import MamaLogo from "@/components/ui/MamaLogo";
 import toast from "react-hot-toast";
+import useAuth from "@/hooks/useAuth";
 import PageWrapper from "@/components/ui/PageWrapper";
 import GlassCard from "@/components/ui/GlassCard";
 
 export default function Signup() {
-  const [restaurant, setRestaurant] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
+  const { signup } = useAuth();
 
   const handleSignup = async (e) => {
     e.preventDefault();
@@ -20,40 +20,12 @@ export default function Signup() {
     const sanitizedEmail = email.trim();
 
     try {
-      const { data: authData, error } = await supabase.auth.signUp({
-        email: sanitizedEmail,
-        password,
-      });
-
-      if (error) throw error;
-
-      const { data: mama } = await supabase
-        .from("mamas")
-        .insert({ nom: restaurant })
-        .select()
-        .single();
-
-      const { error: userError } = await supabase
-        .from("utilisateurs")
-        .insert({
-          auth_id: authData.user.id,
-          email: sanitizedEmail,
-          mama_id: mama.id,
-          role: "admin",
-          actif: true,
-        })
-        .select()
-        .single();
-
-      if (userError) {
-        toast.error("Erreur lors de la création du profil utilisateur");
-        return;
-      }
-
-      navigate("/onboarding");
+      const { error } = await signup({ email: sanitizedEmail, password });
+      if (error) throw new Error(error);
+      navigate("/pending");
     } catch (err) {
       if (err?.message) toast.error(err.message);
-      if (err?.status === 500) toast.error("Erreur serveur Supabase (500)");
+      else toast.error("Échec de l'inscription");
     } finally {
       setLoading(false);
     }
@@ -66,15 +38,6 @@ export default function Signup() {
         <div className="text-center">
           <MamaLogo width={80} className="mx-auto mb-4" />
           <h1 className="text-xl font-bold text-white">Créer un compte</h1>
-        </div>
-        <div>
-          <label className="block text-sm text-white mb-1">Nom du restaurant</label>
-          <input
-            className="w-full rounded border border-white/30 bg-white/20 py-2 px-3 text-white placeholder-white/70"
-            value={restaurant}
-            onChange={(e) => setRestaurant(e.target.value)}
-            required
-          />
         </div>
         <div>
           <label className="block text-sm text-white mb-1">Email</label>

--- a/supabase/functions/handle_new_user.sql
+++ b/supabase/functions/handle_new_user.sql
@@ -1,0 +1,16 @@
+create or replace function handle_new_user()
+returns trigger language plpgsql security definer set search_path=public as $$
+begin
+  insert into public.utilisateurs(auth_id, email, mama_id, role, access_rights)
+  values (new.id, new.email,
+          (select id from public.mamas where actif limit 1),
+          'user', '{}'::jsonb)
+  on conflict do nothing;
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_handle_new_user on auth.users;
+create trigger trg_handle_new_user
+after insert on auth.users
+for each row execute function handle_new_user();

--- a/supabase/tables/utilisateurs.sql
+++ b/supabase/tables/utilisateurs.sql
@@ -1,0 +1,14 @@
+create table if not exists public.utilisateurs (
+    id uuid primary key default uuid_generate_v4(),
+    auth_id uuid references auth.users(id) on delete cascade,
+    email text,
+    role text default 'user',
+    mama_id uuid references public.mamas(id),
+    access_rights jsonb default '{}'::jsonb,
+    actif boolean default true,
+    created_at timestamptz default now()
+);
+
+alter table public.utilisateurs enable row level security;
+create policy utilisateurs_select on public.utilisateurs
+  for select using (auth.uid() = auth_id);


### PR DESCRIPTION
## Summary
- wrap router with BrowserRouter and AuthProvider
- simplify App provider tree
- track account creation state in AuthContext
- add signup helper to AuthContext
- improve Login logic and Pending page
- protect routes if account still pending
- add debug info and SQL for new users

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ad5aa31d0832d956c53dd9bbdc075