### PR TITLE
Fix login redirect

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -205,6 +205,7 @@ export function AuthProvider({ children }) {
   const value = {
     ...userData,
     session,
+    user: session?.user || null,
     loading,
     pending,
     login,

--- a/src/pages/auth/Login.jsx
+++ b/src/pages/auth/Login.jsx
@@ -16,8 +16,8 @@ export default function Login() {
   const navigate = useNavigate();
 
   const {
-    isAuthenticated,
-    loading: authLoading,
+    session,
+    user,
     login,
     pending,
     mama_id,
@@ -27,12 +27,13 @@ export default function Login() {
   const [totp, setTotp] = useState("");
   const [twoFA, setTwoFA] = useState(false);
 
-  // Redirection propre (évite navigate dans le rendu)
+  // Redirection après authentification
   useEffect(() => {
-    if (isAuthenticated && !authLoading) {
+    console.log("DEBUG auth", session, user);
+    if (session && user) {
       navigate("/dashboard");
     }
-  }, [isAuthenticated, authLoading, navigate]);
+  }, [session, user, navigate]); // ✅ Reprendre ici si Codex s'arrête.
 
   const handleLogin = async (e) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- use `session` and `user` from `AuthContext` in Login page
- redirect to dashboard once authenticated
- expose `user` from auth context

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bc95c9c38832da143ce31c7a8f3d7