### PR TITLE
Fix login redirects and add logout menu

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -157,13 +157,14 @@ export function AuthProvider({ children }) {
     setLoading(true);
 
     supabase.auth.getSession().then(async ({ data: { session } }) => {
+      console.log('DEBUG context initial', session);
       setSession(session);
       if (session) await fetchUserData(session);
       setLoading(false);
     });
 
     const { data: listener } = supabase.auth.onAuthStateChange(async (_event, session) => {
-      console.debug('auth state change', session);
+      console.log('DEBUG context change', session);
       setSession(session);
       if (session) {
         setLoading(true);

--- a/src/layout/Sidebar.jsx
+++ b/src/layout/Sidebar.jsx
@@ -1,5 +1,6 @@
-import { Link, useLocation } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import { useAuth } from "@/context/AuthContext";
+import toast from "react-hot-toast";
 import {
   Boxes,
   ClipboardList,
@@ -20,8 +21,9 @@ import {
 } from "lucide-react";
 
 export default function Sidebar() {
-  const { access_rights, loading } = useAuth();
+  const { access_rights, loading, user, logout, session } = useAuth();
   const { pathname } = useLocation();
+  const navigate = useNavigate();
 
   if (loading || !access_rights) {
     return <aside className="w-64 p-4" />;
@@ -125,6 +127,20 @@ export default function Sidebar() {
           </div>
         )}
       </nav>
+      {session && (
+        <div className="mt-6 border-t border-white/20 pt-4 text-sm flex flex-col gap-2">
+          <span>Bienvenue, {user?.email}</span>
+          <button
+            onClick={() => {
+              logout();
+              toast.success('Déconnexion réussie');
+            }}
+            className="text-left text-red-400 hover:underline"
+          >
+            Se déconnecter
+          </button>
+        </div>
+      )}
     </aside>
   );
 }

--- a/src/pages/Accueil.jsx
+++ b/src/pages/Accueil.jsx
@@ -1,0 +1,33 @@
+import { Link, useNavigate } from "react-router-dom";
+import { useEffect } from "react";
+import useAuth from "@/hooks/useAuth";
+
+export default function Accueil() {
+  const { session, user } = useAuth();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (session && user) {
+      navigate("/dashboard");
+    }
+  }, [session, user, navigate]);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 p-4 text-center">
+      <div className="space-y-6 max-w-md">
+        <h1 className="text-2xl font-bold">Simplifiez votre gestion F&amp;B</h1>
+        <p>
+          MamaStock centralise vos fournisseurs, vos produits et vos factures pour un suivi des coûts en toute simplicité.
+        </p>
+        {!session && (
+          <Link
+            to="/login"
+            className="inline-block bg-mamastock-gold hover:bg-mamastock-gold-hover text-black px-6 py-3 rounded-md transition"
+          >
+            Se connecter
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/auth/Login.jsx
+++ b/src/pages/auth/Login.jsx
@@ -29,14 +29,15 @@ export default function Login() {
 
   // Redirection après authentification
   useEffect(() => {
-    console.log("DEBUG auth", session, user);
+    console.log("DEBUG login", session, user);
     if (session && user) {
       navigate("/dashboard");
     }
-  }, [session, user, navigate]); // ✅ Reprendre ici si Codex s'arrête.
+  }, [session, user, navigate]);
 
   const handleLogin = async (e) => {
     e.preventDefault();
+    if (loading) return;
     clearErrors();
     if (!email) setError("email", "Email requis");
     if (!password) setError("password", "Mot de passe requis");

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -36,7 +36,7 @@ const Mamas = lazy(() => import("@/pages/parametrage/Mamas.jsx"));
 const Permissions = lazy(() => import("@/pages/parametrage/Permissions.jsx"));
 const AccessRights = lazy(() => import("@/pages/parametrage/AccessRights.jsx"));
 const Onboarding = lazy(() => import("@/pages/public/Onboarding.jsx"));
-const LandingPage = lazy(() => import("@/pages/public/LandingPage.jsx"));
+const Accueil = lazy(() => import("@/pages/Accueil.jsx"));
 const Signup = lazy(() => import("@/pages/public/Signup.jsx"));
 const PagePrivacy = lazy(() => import("@/pages/public/PagePrivacy.jsx"));
 const PageMentions = lazy(() => import("@/pages/public/PageMentions.jsx"));
@@ -66,7 +66,7 @@ export default function Router() {
   return (
     <Suspense fallback={null}>
       <Routes>
-        <Route path="/" element={<LandingPage />} />
+        <Route path="/" element={<Accueil />} />
         <Route path="/signup" element={<Signup />} />
         <Route path="/login" element={<Login />} />
         <Route path="/logout" element={<Logout />} />


### PR DESCRIPTION
## Summary
- log auth state changes for easier debug
- show login debug info and block double-submit on Login page
- display logged user's email with logout link in sidebar
- add public Accueil page and route `/` to it
- hide login button when session is active

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bcc822600832d8ac3120ecf0302b7