### PR TITLE
Fix forms validations and add debug logs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "tailwindcss": "^3.4.17",
         "vite": "^6.3.5",
         "vite-plugin-pwa": "^1.0.0",
-        "vitest": "^1.5.3"
+        "vitest": "^1.6.1"
       },
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -67,6 +67,6 @@
     "tailwindcss": "^3.4.17",
     "vite": "^6.3.5",
     "vite-plugin-pwa": "^1.0.0",
-    "vitest": "^1.5.3"
+    "vitest": "^1.6.1"
   }
 }

--- a/src/components/fournisseurs/SupplierForm.jsx
+++ b/src/components/fournisseurs/SupplierForm.jsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+// ✅ Vérifié
 import { useFournisseurs } from "@/hooks/useFournisseurs";
 import { Button } from "@/components/ui/button";
 import toast from "react-hot-toast";
@@ -21,23 +22,29 @@ export default function SupplierForm({ supplier, onClose, glass }) {
 
   const handleSubmit = async e => {
     e.preventDefault();
+    if (loading) return;
     setLoading(true);
+    console.log("DEBUG form", form);
     if (!form.nom) {
       toast.error("Le nom est obligatoire");
       setLoading(false);
       return;
     }
-    let res;
-    if (supplier) {
-      res = await updateFournisseur(supplier.id, form);
-    } else {
-      res = await addFournisseur(form);
-    }
-    setLoading(false);
-    if (res?.error) toast.error(res.error);
-    else {
+    try {
+      let res;
+      if (supplier) {
+        res = await updateFournisseur(supplier.id, form);
+      } else {
+        res = await addFournisseur(form);
+      }
+      if (res?.error) throw res.error;
       toast.success("Fournisseur sauvegardé");
       onClose?.();
+    } catch (err) {
+      console.log("DEBUG error", err);
+      toast.error(err?.message || "Erreur enregistrement");
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -77,8 +84,8 @@ export default function SupplierForm({ supplier, onClose, glass }) {
         </label>
       </div>
       <div className="flex gap-2 justify-end">
-        <Button type="button" variant="outline" onClick={onClose}>Annuler</Button>
-        <Button type="submit" loading={loading}>{supplier ? "Enregistrer" : "Ajouter"}</Button>
+        <Button type="button" variant="outline" onClick={onClose} disabled={loading}>Annuler</Button>
+        <Button type="submit" loading={loading} disabled={loading}>{supplier ? "Enregistrer" : "Ajouter"}</Button>
       </div>
     </Motion.form>
   );

--- a/src/components/help/FeedbackForm.jsx
+++ b/src/components/help/FeedbackForm.jsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
+// ✅ Vérifié
 import { Dialog, DialogContent, DialogOverlay } from "@/components/ui/dialog";
 import { supabase } from "@/lib/supabase";
 import { Button } from "@/components/ui/button";
 import { useAuth } from "@/context/AuthContext";
+import { toast } from "react-hot-toast";
 
 export default function FeedbackForm({ open, onOpenChange }) {
   const { user_id, mama_id } = useAuth();
@@ -15,12 +17,20 @@ export default function FeedbackForm({ open, onOpenChange }) {
     e.preventDefault();
     if (sending) return;
     setSending(true);
-    await supabase.from("feedback").insert([
-      { user_id, mama_id, module, message, urgence } ,
-    ]);
-    setSending(false);
-    setMessage("");
-    onOpenChange(false);
+    const payload = { user_id, mama_id, module, message, urgence };
+    console.log("DEBUG form", payload);
+    try {
+      const { error } = await supabase.from("feedback").insert([payload]);
+      if (error) throw error;
+      toast.success("Message envoyé !");
+      setMessage("");
+      onOpenChange(false);
+    } catch (err) {
+      console.log("DEBUG error", err);
+      toast.error(err.message || "Erreur lors de l'envoi");
+    } finally {
+      setSending(false);
+    }
   }
 
   return (

--- a/src/components/inventaires/InventaireForm.jsx
+++ b/src/components/inventaires/InventaireForm.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+// ✅ Vérifié
 import { useInventaires } from "@/hooks/useInventaires";
 import { useProducts } from "@/hooks/useProducts";
 import { Button } from "@/components/ui/button";
@@ -116,6 +117,7 @@ export default function InventaireForm({ inventaire, onClose }) {
       document: fileUrl || inventaire?.document,
       date_debut: dateDebut,
     };
+    console.log("DEBUG form", invData);
     try {
       if (inventaire?.id) {
         await editInventaire(inventaire.id, invData);
@@ -125,10 +127,12 @@ export default function InventaireForm({ inventaire, onClose }) {
         toast.success("Inventaire ajouté !");
       }
       onClose?.();
-    } catch {
+    } catch (err) {
+      console.log("DEBUG error", err);
       toast.error("Erreur lors de l'enregistrement.");
+    } finally {
+      setLoading(false);
     }
-    setLoading(false);
   };
 
   return (

--- a/src/components/mouvements/MouvementFormModal.jsx
+++ b/src/components/mouvements/MouvementFormModal.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+// ✅ Vérifié
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent } from "@radix-ui/react-dialog";
 import { AnimatePresence, motion as Motion } from "framer-motion";
@@ -60,12 +61,14 @@ export default function MouvementFormModal({
       return;
     }
     if (submitting) return;
+    console.log("DEBUG form", form);
     try {
       setSubmitting(true);
       await onSubmit(form);
       toast.success("Mouvement enregistré !");
       onOpenChange(false);
     } catch (err) {
+      console.log("DEBUG error", err);
       console.error("Erreur enregistrement mouvement:", err);
       toast.error("Erreur lors de l'enregistrement.");
     } finally {

--- a/src/components/produits/ProduitForm.jsx
+++ b/src/components/produits/ProduitForm.jsx
@@ -1,4 +1,5 @@
 // src/components/produits/ProduitForm.jsx
+// ✅ Vérifié
 import { useState, useEffect } from "react";
 import { useProducts } from "@/hooks/useProducts";
 import { useFamilles } from "@/hooks/useFamilles";
@@ -78,6 +79,7 @@ export default function ProduitForm({ produit, familles = [], unites = [], onSuc
       allergenes,
       image: imageUrl || produit?.image,
     };
+    console.log("DEBUG form", newProd);
     try {
       setSaving(true);
       if (editing) {
@@ -92,6 +94,7 @@ export default function ProduitForm({ produit, familles = [], unites = [], onSuc
       onSuccess?.();
       onClose?.();
     } catch (err) {
+      console.log("DEBUG error", err);
       console.error("Erreur enregistrement produit:", err);
       toast.error("Erreur lors de l'enregistrement.");
     } finally {

--- a/src/components/stock/StockMouvementForm.jsx
+++ b/src/components/stock/StockMouvementForm.jsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+// ✅ Vérifié
 import { useStock } from "@/hooks/useStock";
 import { Button } from "@/components/ui/button";
 import toast from "react-hot-toast";
@@ -19,18 +20,21 @@ export default function StockMouvementForm({ produit, onClose }) {
       return;
     }
     setLoading(true);
+    const payload = {
+      product_id: produit?.id,
+      type,
+      quantite: Number(quantite),
+      zone,
+      motif,
+    };
+    console.log("DEBUG form", payload);
     try {
-      const res = await addMouvementStock({
-        product_id: produit?.id,
-        type,
-        quantite: Number(quantite),
-        zone,
-        motif,
-      });
+      const res = await addMouvementStock(payload);
       if (res?.error) throw res.error;
       toast.success("Mouvement enregistré !");
       onClose?.();
     } catch (err) {
+      console.log("DEBUG error", err);
       console.error("Erreur mouvement stock:", err);
       toast.error("Erreur lors de l'enregistrement.");
     } finally {

--- a/src/components/taches/TacheForm.jsx
+++ b/src/components/taches/TacheForm.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+// ✅ Vérifié
 import { useTasks } from "@/hooks/useTasks";
 import { useUsers } from "@/hooks/useUsers";
 import { useNavigate } from "react-router-dom";
@@ -29,11 +30,13 @@ export default function TacheForm({ task }) {
 
   const handleSubmit = async e => {
     e.preventDefault();
+    if (loading) return;
     if (!form.titre.trim()) {
       toast.error("Le titre est requis");
       return;
     }
     setLoading(true);
+    console.log("DEBUG form", form);
     try {
       if (task) {
         await updateTask(task.id, form);
@@ -44,6 +47,7 @@ export default function TacheForm({ task }) {
       }
       navigate("/taches");
     } catch (err) {
+      console.log("DEBUG error", err);
       console.error("Erreur enregistrement tâche:", err);
       toast.error("Erreur lors de l'enregistrement.");
     } finally {

--- a/src/components/utilisateurs/UtilisateurForm.jsx
+++ b/src/components/utilisateurs/UtilisateurForm.jsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+// ✅ Vérifié
 import { useUsers } from "@/hooks/useUsers";
 import { Button } from "@/components/ui/button";
 import toast from "react-hot-toast";
@@ -19,6 +20,7 @@ export default function UtilisateurForm({ utilisateur, onClose }) {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    if (loading) return;
     setLoading(true);
     const data = {
       email,
@@ -26,6 +28,7 @@ export default function UtilisateurForm({ utilisateur, onClose }) {
       actif,
       ...(password && { password }),
     };
+    console.log("DEBUG form", data);
     try {
       if (utilisateur?.id) {
         await updateUser(utilisateur.id, data);
@@ -35,10 +38,12 @@ export default function UtilisateurForm({ utilisateur, onClose }) {
         toast.success("Utilisateur ajouté !");
       }
       onClose?.();
-    } catch {
+    } catch (err) {
+      console.log("DEBUG error", err);
       toast.error("Erreur lors de l'enregistrement.");
+    } finally {
+      setLoading(false);
     }
-    setLoading(false);
   };
 
   return (

--- a/src/pages/factures/FactureForm.jsx
+++ b/src/pages/factures/FactureForm.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+// ✅ Vérifié
 import { useFactures } from "@/hooks/useFactures";
 import { useProducts } from "@/hooks/useProducts";
 import { Button } from "@/components/ui/button";
@@ -46,6 +47,7 @@ export default function FactureForm({ facture, suppliers = [], onClose }) {
       toast.error("Date et fournisseur requis !");
       return;
     }
+    if (loading) return;
     setLoading(true);
     const total_ht = lignes.reduce((s,l) => s + l.quantite * l.prix_unitaire, 0);
     const total_tva = lignes.reduce((s,l) => s + l.quantite * l.prix_unitaire * (l.tva || 0) / 100, 0);
@@ -60,6 +62,7 @@ export default function FactureForm({ facture, suppliers = [], onClose }) {
       total_ttc: total_ht + total_tva,
       justificatif: fileUrl || facture?.justificatif,
     };
+    console.log("DEBUG form", invoice, lignes);
     try {
       let fid = facture?.id;
       if (fid) {
@@ -79,9 +82,11 @@ export default function FactureForm({ facture, suppliers = [], onClose }) {
       toast.success(facture ? "Facture modifiée !" : "Facture ajoutée !");
       onClose?.();
     } catch (err) {
+      console.log("DEBUG error", err);
       toast.error(err?.message || "Erreur lors de l'enregistrement.");
+    } finally {
+      setLoading(false);
     }
-    setLoading(false);
   };
 
   return (

--- a/src/pages/fiches/FicheForm.jsx
+++ b/src/pages/fiches/FicheForm.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+// ✅ Vérifié
 import { useFiches } from "@/hooks/useFiches";
 import { useProducts } from "@/hooks/useProducts";
 import { useFamilles } from "@/hooks/useFamilles";
@@ -38,6 +39,7 @@ export default function FicheForm({ fiche, onClose }) {
     if (lignes.some(l => !l.product_id || !l.quantite)) {
       return toast.error("Ligne incomplète");
     }
+    if (loading) return;
     setLoading(true);
     const payload = {
       nom,
@@ -46,6 +48,7 @@ export default function FicheForm({ fiche, onClose }) {
       rendement,
       lignes,
     };
+    console.log("DEBUG form", payload);
     try {
       if (fiche?.id) {
         await updateFiche(fiche.id, payload);
@@ -56,9 +59,11 @@ export default function FicheForm({ fiche, onClose }) {
       }
       onClose?.();
     } catch (err) {
+      console.log("DEBUG error", err);
       toast.error(err.message);
+    } finally {
+      setLoading(false);
     }
-    setLoading(false);
   }
 
   return (

--- a/src/pages/fournisseurs/FournisseurForm.jsx
+++ b/src/pages/fournisseurs/FournisseurForm.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+// ✅ Vérifié
 import { Button } from "@/components/ui/button";
 import toast from "react-hot-toast";
 
@@ -21,6 +22,7 @@ export default function FournisseurForm({ fournisseur = {}, onSubmit, onCancel, 
 
   const handleSubmit = (e) => {
     e.preventDefault();
+    if (saving) return;
     const errs = {};
     if (!nom.trim()) errs.nom = "Nom requis";
     if (email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) errs.email = "Email invalide";
@@ -29,7 +31,13 @@ export default function FournisseurForm({ fournisseur = {}, onSubmit, onCancel, 
       toast.error("Veuillez corriger les erreurs");
       return;
     }
-    onSubmit?.({ nom, ville, telephone, email, actif });
+    const data = { nom, ville, telephone, email, actif };
+    console.log("DEBUG form", data);
+    try {
+      onSubmit?.(data);
+    } catch (err) {
+      console.log("DEBUG error", err);
+    }
   };
 
   return (

--- a/src/pages/fournisseurs/Fournisseurs.jsx
+++ b/src/pages/fournisseurs/Fournisseurs.jsx
@@ -1,4 +1,5 @@
 // src/pages/Fournisseurs.jsx
+// ✅ Vérifié
 import { useState, useEffect } from "react";
 import { useFournisseurs } from "@/hooks/useFournisseurs";
 import { useFournisseurStats } from "@/hooks/useFournisseurStats";
@@ -208,7 +209,9 @@ export default function Fournisseurs() {
             saving={saving}
             onCancel={() => { setShowCreate(false); setEditRow(null); }}
             onSubmit={async (data) => {
+              if (saving) return;
               setSaving(true);
+              console.log("DEBUG form", data);
               try {
                 if (editRow) {
                   await updateFournisseur(editRow.id, data);
@@ -221,6 +224,7 @@ export default function Fournisseurs() {
                 setEditRow(null);
                 getFournisseurs({ search });
               } catch (err) {
+                console.log("DEBUG error", err);
                 toast.error(err?.message || "Erreur enregistrement");
               }
               setSaving(false);

--- a/src/pages/mouvements/MouvementForm.jsx
+++ b/src/pages/mouvements/MouvementForm.jsx
@@ -1,7 +1,9 @@
 import { useState, useEffect } from "react";
+// ✅ Vérifié
 import { Button } from "@/components/ui/button";
 import { useMouvements } from "@/hooks/useMouvements";
 import { useProducts } from "@/hooks/useProducts";
+import toast from "react-hot-toast";
 
 export default function MouvementForm({ onClose }) {
   const { createMouvement } = useMouvements();
@@ -25,10 +27,24 @@ export default function MouvementForm({ onClose }) {
 
   const handleSubmit = async e => {
     e.preventDefault();
-    setLoading(true);
-    await createMouvement(form);
-    setLoading(false);
-    onClose?.();
+    if (loading) return;
+    if (!form.produit_id || !form.quantite) {
+      toast.error("Produit et quantité requis");
+      return;
+    }
+    console.log("DEBUG form", form);
+    try {
+      setLoading(true);
+      const { error } = await createMouvement(form);
+      if (error) throw error;
+      toast.success("Mouvement enregistré !");
+      onClose?.();
+    } catch (err) {
+      console.log("DEBUG error", err);
+      toast.error(err?.message || "Erreur lors de l'enregistrement");
+    } finally {
+      setLoading(false);
+    }
   };
 
   const handleProduitChange = val => {

--- a/src/pages/parametrage/RoleForm.jsx
+++ b/src/pages/parametrage/RoleForm.jsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+// ✅ Vérifié
 import { supabase } from "@/lib/supabase";
 import { useAuth } from "@/context/AuthContext";
 import { Button } from "@/components/ui/button";
@@ -18,6 +19,7 @@ export default function RoleForm({ role, onClose, onSaved }) {
 
   const handleSubmit = async e => {
     e.preventDefault();
+    if (saving) return;
     setSaving(true);
 
     // Anti-doublon création
@@ -35,33 +37,40 @@ export default function RoleForm({ role, onClose, onSaved }) {
       }
     }
 
-    let error = null;
-    let saved = null;
-    if (role?.id) {
-      const res = await supabase
-        .from("roles")
-        .update(values)
-        .eq("id", role.id)
-        .select()
-        .single();
-      error = res.error;
-      saved = res.data;
-    } else {
-      const res = await supabase
-        .from("roles")
-        .insert([{ ...values, mama_id }])
-        .select()
-        .single();
-      error = res.error;
-      saved = res.data;
-    }
-    setSaving(false);
-    if (!error && saved) {
-      toast.success("Rôle enregistré !");
-      if (onSaved) onSaved(saved);
-      if (onClose) onClose();
-    } else {
-      toast.error(error?.message || "Erreur à l'enregistrement !");
+    console.log("DEBUG form", values);
+    try {
+      let error = null;
+      let saved = null;
+      if (role?.id) {
+        const res = await supabase
+          .from("roles")
+          .update(values)
+          .eq("id", role.id)
+          .select()
+          .single();
+        error = res.error;
+        saved = res.data;
+      } else {
+        const res = await supabase
+          .from("roles")
+          .insert([{ ...values, mama_id }])
+          .select()
+          .single();
+        error = res.error;
+        saved = res.data;
+      }
+      if (!error && saved) {
+        toast.success("Rôle enregistré !");
+        onSaved?.(saved);
+        onClose?.();
+      } else {
+        throw error;
+      }
+    } catch (err) {
+      console.log("DEBUG error", err);
+      toast.error(err?.message || "Erreur à l'enregistrement !");
+    } finally {
+      setSaving(false);
     }
   };
 

--- a/src/pages/parametrage/UtilisateurForm.jsx
+++ b/src/pages/parametrage/UtilisateurForm.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+// ✅ Vérifié
 import { useUtilisateurs } from "@/hooks/useUtilisateurs";
 import { useRoles } from "@/hooks/useRoles";
 import { useMamas } from "@/hooks/useMamas";
@@ -24,6 +25,7 @@ export default function UtilisateurForm({ utilisateur, onClose }) {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    if (loading) return;
     setLoading(true);
     const data = {
       email,
@@ -31,6 +33,7 @@ export default function UtilisateurForm({ utilisateur, onClose }) {
       actif,
       mama_id: mama,
     };
+    console.log("DEBUG form", data);
     try {
       if (utilisateur?.id) {
         await updateUser(utilisateur.id, data);
@@ -40,10 +43,12 @@ export default function UtilisateurForm({ utilisateur, onClose }) {
         toast.success("Utilisateur ajouté !");
       }
       onClose?.();
-    } catch {
+    } catch (err) {
+      console.log("DEBUG error", err);
       toast.error("Erreur lors de l'enregistrement.");
+    } finally {
+      setLoading(false);
     }
-    setLoading(false);
   };
 
   return (

--- a/src/pages/stock/MouvementForm.jsx
+++ b/src/pages/stock/MouvementForm.jsx
@@ -1,6 +1,8 @@
 import { useState } from "react";
+// ✅ Vérifié
 import { useStock } from "@/hooks/useStock";
 import { Button } from "@/components/ui/button";
+import toast from "react-hot-toast";
 
 export default function MouvementForm({ onClose }) {
   const { createMouvement } = useStock();
@@ -9,10 +11,24 @@ export default function MouvementForm({ onClose }) {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    setLoading(true);
-    await createMouvement(form);
-    setLoading(false);
-    onClose?.();
+    if (loading) return;
+    if (!form.product_id || !form.quantite) {
+      toast.error("Produit et quantité requis");
+      return;
+    }
+    console.log("DEBUG form", form);
+    try {
+      setLoading(true);
+      const { error } = await createMouvement(form);
+      if (error) throw error;
+      toast.success("Mouvement enregistré !");
+      onClose?.();
+    } catch (err) {
+      console.log("DEBUG error", err);
+      toast.error(err?.message || "Erreur lors de l'enregistrement");
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (

--- a/src/pages/taches/TacheForm.jsx
+++ b/src/pages/taches/TacheForm.jsx
@@ -1,7 +1,9 @@
 import { useState } from "react";
+// ✅ Vérifié
 import { useNavigate } from "react-router-dom";
 import { useTaches } from "@/hooks/useTaches";
 import { Button } from "@/components/ui/button";
+import toast from "react-hot-toast";
 
 export default function TacheForm() {
   const { createTache } = useTaches();
@@ -15,6 +17,7 @@ export default function TacheForm() {
     notification: [],
     module_lie: "",
   });
+  const [loading, setLoading] = useState(false);
 
   const handleChange = e => setForm(f => ({ ...f, [e.target.name]: e.target.value }));
   const handleCheck = e => {
@@ -28,8 +31,19 @@ export default function TacheForm() {
 
   const handleSubmit = async e => {
     e.preventDefault();
-    await createTache(form);
-    navigate("/taches");
+    if (loading) return;
+    setLoading(true);
+    console.log("DEBUG form", form);
+    try {
+      await createTache(form);
+      toast.success("Tâche ajoutée !");
+      navigate("/taches");
+    } catch (err) {
+      console.log("DEBUG error", err);
+      toast.error("Erreur lors de l'enregistrement.");
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
@@ -72,7 +86,7 @@ export default function TacheForm() {
         <span>Module lié</span>
         <input className="input w-full" name="module_lie" value={form.module_lie} onChange={handleChange} />
       </label>
-      <Button type="submit">Enregistrer</Button>
+      <Button type="submit" disabled={loading}>Enregistrer</Button>
     </form>
   );
 }


### PR DESCRIPTION
## Summary
- verify supplier, feedback, fiche, mouvement, invoice and mama forms
- handle stock movement forms with validation and error logs
- add debug logging and loading guards in task forms

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*


------
https://chatgpt.com/codex/tasks/task_e_685bed72a5ec832dbe14678ead0f4813