### PR TITLE
Add invoice totals columns

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -649,3 +649,4 @@
 - Confirmed service worker registration via `npm run preview`.
 - `npm run lint`, `npm test`, `npm run build` et `npm run preview` passent sans erreur.
 - `npm run test:e2e` toujours ignore faute de navigateurs.
+- Ajout des champs de totaux aux factures et calcul automatique via trigger SQL.

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ The Playwright configuration automatically starts the dev server.
 - Invoice form supports OCR scanning of uploaded documents
 - Manage invoices from `/factures` with pages `/factures/nouveau` and `/factures/:id`
 - Index on `factures.reference` speeds up invoice search queries
+- Columns `total_ht`, `total_tva` and `total_ttc` are computed automatically via triggers
 - Index on `products.code` speeds up lookups by internal product code
 - Index on `fournisseurs.nom` speeds up supplier search queries
 - Automatic audit triggers log cost center changes and allocations

--- a/sql/complet.sql
+++ b/sql/complet.sql
@@ -113,6 +113,9 @@ create table if not exists factures (
     date date not null,
     fournisseur_id uuid references fournisseurs(id) on delete set null,
     montant numeric,
+    total_ht numeric default 0,
+    total_tva numeric default 0,
+    total_ttc numeric default 0,
     statut text,
     justificatif text,
     mama_id uuid not null references mamas(id),
@@ -125,6 +128,7 @@ create table if not exists facture_lignes (
     product_id uuid references products(id) on delete set null,
     quantite numeric not null,
     prix_unitaire numeric not null,
+    tva numeric default 0,
     total numeric generated always as (quantite * prix_unitaire) stored,
     mama_id uuid not null references mamas(id),
     created_at timestamptz default now()
@@ -408,10 +412,22 @@ for each row execute procedure update_product_pmp();
 -- Trigger to keep invoice total in sync with its lines
 create or replace function refresh_facture_total()
 returns trigger language plpgsql as $$
+declare
+  fid uuid := coalesce(new.facture_id, old.facture_id);
+  ht numeric;
+  tv numeric;
 begin
+  select sum(quantite * prix_unitaire),
+         sum(quantite * prix_unitaire * (coalesce(tva,0)/100))
+    into ht, tv
+    from facture_lignes
+   where facture_id = fid;
   update factures f
-    set montant = coalesce((select sum(total) from facture_lignes where facture_id = f.id),0)
-  where f.id = coalesce(new.facture_id, old.facture_id);
+     set montant   = coalesce(ht,0) + coalesce(tv,0),
+         total_ht  = coalesce(ht,0),
+         total_tva = coalesce(tv,0),
+         total_ttc = coalesce(ht,0) + coalesce(tv,0)
+   where f.id = fid;
   return new;
 end;
 $$;

--- a/sql/full_setup.sql
+++ b/sql/full_setup.sql
@@ -113,6 +113,9 @@ create table if not exists factures (
     date date not null,
     fournisseur_id uuid references fournisseurs(id) on delete set null,
     montant numeric,
+    total_ht numeric default 0,
+    total_tva numeric default 0,
+    total_ttc numeric default 0,
     statut text,
     justificatif text,
     mama_id uuid not null references mamas(id),
@@ -125,6 +128,7 @@ create table if not exists facture_lignes (
     product_id uuid references products(id) on delete set null,
     quantite numeric not null,
     prix_unitaire numeric not null,
+    tva numeric default 0,
     total numeric generated always as (quantite * prix_unitaire) stored,
     mama_id uuid not null references mamas(id),
     created_at timestamptz default now()
@@ -389,10 +393,22 @@ for each row execute procedure update_product_pmp();
 -- Trigger to keep invoice total in sync with its lines
 create or replace function refresh_facture_total()
 returns trigger language plpgsql as $$
+declare
+  fid uuid := coalesce(new.facture_id, old.facture_id);
+  ht numeric;
+  tv numeric;
 begin
+  select sum(quantite * prix_unitaire),
+         sum(quantite * prix_unitaire * (coalesce(tva,0)/100))
+    into ht, tv
+    from facture_lignes
+   where facture_id = fid;
   update factures f
-    set montant = coalesce((select sum(total) from facture_lignes where facture_id = f.id),0)
-  where f.id = coalesce(new.facture_id, old.facture_id);
+     set montant   = coalesce(ht,0) + coalesce(tv,0),
+         total_ht  = coalesce(ht,0),
+         total_tva = coalesce(tv,0),
+         total_ttc = coalesce(ht,0) + coalesce(tv,0)
+   where id = fid;
   return new;
 end;
 $$;


### PR DESCRIPTION
## Summary
- add `total_ht`, `total_tva`, `total_ttc` columns on `factures`
- add `tva` column to `facture_lignes`
- compute invoice totals in `refresh_facture_total` trigger
- document totals in README and PROGRESS

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685cf9d875b4832da637e0f52d9d88c0