### PR TITLE
Audit sécurisation paramétrage

### DIFF
--- a/docs/parametrage.md
+++ b/docs/parametrage.md
@@ -1,0 +1,10 @@
+# Paramétrage Modules
+
+Cette section décrit brièvement les pages de gestion des utilisateurs, rôles, permissions et établissements.
+
+- **Utilisateurs** : recherche, tri, pagination et export Excel. Les actions de modification ou suppression sont filtrées par `mama_id` et réservées aux administrateurs concernés.
+- **Rôles** : création et édition des rôles d'un établissement. Les opérations sont restreintes à la `mama_id` courante.
+- **Mamas** : gestion des établissements. Seul un `superadmin` peut créer ou supprimer n'importe quel établissement. Les utilisateurs standards ne peuvent éditer que leur propre `mama`.
+- **Permissions** : attribution fine des droits par module pour chaque rôle. Les requêtes sont sécurisées par `mama_id`.
+
+Les hooks associés appliquent également ces contraintes afin de compléter les politiques RLS du backend.

--- a/src/hooks/useMamas.js
+++ b/src/hooks/useMamas.js
@@ -27,6 +27,7 @@ export function useMamas() {
 
   // 2. Ajouter un établissement
   async function addMama(mama) {
+    if (role !== "superadmin") return { error: "Action non autorisée" };
     setLoading(true);
     setError(null);
     const { error } = await supabase
@@ -39,12 +40,16 @@ export function useMamas() {
 
   // 3. Modifier un établissement
   async function updateMama(id, updateFields) {
+    if (role !== "superadmin" && id !== mama_id)
+      return { error: "Action non autorisée" };
     setLoading(true);
     setError(null);
-    const { error } = await supabase
+    let query = supabase
       .from("mamas")
       .update(updateFields)
       .eq("id", id);
+    if (role !== "superadmin") query = query.eq("id", mama_id);
+    const { error } = await query;
     if (error) setError(error);
     setLoading(false);
     await fetchMamas();

--- a/src/hooks/useRoles.js
+++ b/src/hooks/useRoles.js
@@ -5,7 +5,7 @@ import * as XLSX from "xlsx";
 import { saveAs } from "file-saver";
 
 export function useRoles() {
-  useAuth();
+  const { mama_id, role } = useAuth();
   const [roles, setRoles] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
@@ -26,11 +26,12 @@ export function useRoles() {
 
   // 2. Ajouter un rôle
   async function addRole(roleData) {
+    if (!mama_id) return { error: "Aucun mama_id" };
     setLoading(true);
     setError(null);
     const { error } = await supabase
       .from("roles")
-      .insert([roleData]);
+      .insert([{ ...roleData, mama_id }]);
     if (error) setError(error);
     setLoading(false);
     await fetchRoles();
@@ -38,12 +39,15 @@ export function useRoles() {
 
   // 3. Modifier un rôle
   async function updateRole(id, updateFields) {
+    if (!mama_id && role !== "superadmin") return { error: "Aucun mama_id" };
     setLoading(true);
     setError(null);
-    const { error } = await supabase
+    let query = supabase
       .from("roles")
       .update(updateFields)
       .eq("id", id);
+    if (role !== "superadmin") query = query.eq("mama_id", mama_id);
+    const { error } = await query;
     if (error) setError(error);
     setLoading(false);
     await fetchRoles();

--- a/src/hooks/useUtilisateurs.js
+++ b/src/hooks/useUtilisateurs.js
@@ -50,10 +50,12 @@ export function useUtilisateurs() {
     if (!mama_id && role !== "superadmin") return { error: "Aucun mama_id" };
     setLoading(true);
     setError(null);
-    const { error } = await supabase
+    let query = supabase
       .from("utilisateurs")
       .update(updateFields)
       .eq("id", id);
+    if (role !== "superadmin") query = query.eq("mama_id", mama_id);
+    const { error } = await query;
     if (error) setError(error);
     setLoading(false);
     await fetchUsers();
@@ -64,10 +66,12 @@ export function useUtilisateurs() {
     if (!mama_id && role !== "superadmin") return { error: "Aucun mama_id" };
     setLoading(true);
     setError(null);
-    const { error } = await supabase
+    let query = supabase
       .from("utilisateurs")
       .update({ actif })
       .eq("id", id);
+    if (role !== "superadmin") query = query.eq("mama_id", mama_id);
+    const { error } = await query;
     if (error) setError(error);
     setLoading(false);
     await fetchUsers();
@@ -78,10 +82,12 @@ export function useUtilisateurs() {
     if (!mama_id && role !== "superadmin") return { error: "Aucun mama_id" };
     setLoading(true);
     setError(null);
-    const { error } = await supabase
+    let query = supabase
       .from("utilisateurs")
       .update({ actif: false })
       .eq("id", id);
+    if (role !== "superadmin") query = query.eq("mama_id", mama_id);
+    const { error } = await query;
     if (error) setError(error);
     setLoading(false);
     await fetchUsers();

--- a/src/pages/parametrage/MamaForm.jsx
+++ b/src/pages/parametrage/MamaForm.jsx
@@ -45,12 +45,12 @@ export default function MamaForm({ mama, onClose, onSaved }) {
       let error = null;
       let saved = null;
       if (mama?.id) {
-        const res = await supabase
+        let query = supabase
           .from("mamas")
           .update(values)
-          .eq("id", mama.id)
-          .select()
-          .single();
+          .eq("id", mama.id);
+        if (role !== "superadmin") query = query.eq("id", myMama);
+        const res = await query.select().single();
         error = res.error;
         saved = res.data;
       } else {

--- a/src/pages/parametrage/Mamas.jsx
+++ b/src/pages/parametrage/Mamas.jsx
@@ -22,16 +22,22 @@ export default function Mamas() {
 
   const fetchMamas = async () => {
     setLoading(true);
-    const { data, error } = await supabase
-      .from("mamas")
-      .select("*")
-      .order("nom", { ascending: true });
+    let query = supabase.from("mamas").select("*");
+    if (role !== "superadmin") query = query.eq("id", myMama);
+    const { data, error } = await query.order("nom", { ascending: true });
     if (!error) setMamas(data || []);
     setLoading(false);
   };
 
   const handleDelete = async id => {
-    const { error } = await supabase.from("mamas").delete().eq("id", id);
+    if (role !== "superadmin" && id !== myMama) {
+      toast.error("Action non autorisée");
+      return;
+    }
+    const { error } = await supabase
+      .from("mamas")
+      .delete()
+      .eq("id", id);
     if (!error) {
       toast.success("Établissement supprimé.");
       fetchMamas();


### PR DESCRIPTION
## Summary
- enforce mama_id checks in hooks: users, roles, mamas
- secure Permissions form with current mama filtering
- tighten Mamas page delete and fetch logic
- restrict Mama form update query
- document paramétrage modules

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685cfd3e48f8832d96e3761f114ee09f