### PR TITLE
Add NotFound route and update navigation docs

### DIFF
--- a/.codex_progress.json
+++ b/.codex_progress.json
@@ -10,7 +10,8 @@
     "/surcouts",
     "/logout",
     "/parametrage/permissions",
-    "/debug/auth"
+    "/debug/auth",
+    "/404"
   ],
   "all_modules_checked": true,
   "navigation_complete": true

--- a/NAVIGATION_SETUP_STATUS.md
+++ b/NAVIGATION_SETUP_STATUS.md
@@ -23,3 +23,4 @@ Final verification 22/06/2025: navigation works as expected.
 Final check 22/06/2025: toutes les routes fonctionnent après installation des dépendances.
 
 Dernier test 22/06/2025 : `npm run lint` et `npm test` passent après `npm install`.
+Test additionnel 2025-06-26 : ajout de la page NotFound. Toutes les commandes `npm run lint`, `npm test` et `npm run build` réussissent après `npm install`.

--- a/codex-progress.md
+++ b/codex-progress.md
@@ -75,3 +75,8 @@
 - Login et logout vérifiés, Layout affiche utilisateur et rôle.
 - Route `/` redirige selon la session.
 - `npm install`, `npm run lint`, `npm test` passent.
+
+## Étape 19 – Page NotFound : ✅
+- Ajout de la page `NotFound` dans le routeur.
+- La route `*` affiche maintenant `NotFound.jsx` au lieu de rediriger.
+- Nouvelle installation des dépendances et vérification des commandes lint, test et build.

--- a/docs/navigation_access_files.md
+++ b/docs/navigation_access_files.md
@@ -1,0 +1,12 @@
+# Fichiers de Navigation et Droits
+
+Les composants et contextes gérant la navigation et les droits d'accès se trouvent principalement dans `src/` :
+
+- `src/router.jsx` : configuration globale des routes et redirections.
+- `src/context/AuthContext.jsx` : contexte d'authentification fournissant session, rôle et `access_rights`.
+- `src/components/ProtectedRoute.jsx` : wrapper contrôlant l'accès aux routes selon la clé fournie.
+- `src/layout/Sidebar.jsx` : menu latéral affichant les liens en fonction des `access_rights`.
+- `src/layout/Layout.jsx` : agencement général des pages protégées avec barre latérale.
+- `src/components/layout/Sidebar.jsx` : ancienne version de la sidebar utilisée par `AdminLayout`.
+
+Les tests liés se trouvent dans `test/router.test.jsx`.

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -7,6 +7,7 @@ import Unauthorized from "@/pages/auth/Unauthorized";
 import Pending from "@/pages/auth/Pending";
 import Blocked from "@/pages/auth/Blocked";
 import AuthDebug from "@/pages/debug/AuthDebug";
+import NotFound from "@/pages/NotFound";
 import ProtectedRoute from "@/components/ProtectedRoute";
 
 const Dashboard = lazy(() => import("@/pages/Dashboard.jsx"));
@@ -274,7 +275,7 @@ export default function Router() {
             path="/debug/auth"
             element={<ProtectedRoute accessKey="dashboard"><AuthDebug /></ProtectedRoute>}
           />
-          <Route path="*" element={<Navigate to="/dashboard" replace />} />
+          <Route path="*" element={<NotFound />} />
         </Route>
       </Routes>
     </Suspense>


### PR DESCRIPTION
## Summary
- document all navigation, access and rights files
- support a proper 404 page in `router.jsx`
- record new progress step and update navigation status

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm run preview` (terminated manually)

------
https://chatgpt.com/codex/tasks/task_e_685cff81fcd0832da58ce46ca2ed10d6