### PR TITLE
Add RGPD page with footer

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,0 +1,17 @@
+import { Link } from "react-router-dom";
+
+export default function Footer() {
+  return (
+    <footer className="w-full bg-[#2e2e3a] text-[#f8f8fa] text-sm py-4 px-6 flex flex-col sm:flex-row items-center justify-between rounded-t-2xl shadow-lg z-50">
+      <span className="font-semibold tracking-wide mb-2 sm:mb-0">MamaStock 2025</span>
+      <span className="flex items-center gap-4">
+        <Link to="/rgpd" className="underline hover:text-[#ff5a5f] transition">
+          Données &amp; Confidentialité
+        </Link>
+        <span className="italic text-[#f8f8fa]/80">
+          Simplifiez la gestion, concentrez-vous sur l’essentiel.
+        </span>
+      </span>
+    </footer>
+  );
+}

--- a/src/layout/Layout.jsx
+++ b/src/layout/Layout.jsx
@@ -2,6 +2,7 @@ import { Outlet, useLocation } from "react-router-dom";
 import Sidebar from "@/layout/Sidebar";
 import useAuth from "@/hooks/useAuth";
 import toast from "react-hot-toast";
+import Footer from "@/components/Footer";
 
 export default function Layout() {
   const { pathname } = useLocation();
@@ -11,8 +12,9 @@ export default function Layout() {
   return (
     <div className="flex h-screen overflow-auto text-shadow">
       <Sidebar />
-      <main className="flex-1 p-4">
-        <div className="flex justify-end items-center gap-2 mb-4">
+      <div className="flex flex-col flex-1">
+        <main className="flex-1 p-4 overflow-auto">
+          <div className="flex justify-end items-center gap-2 mb-4">
           {user && (
             <>
               <span>{user.email}</span>
@@ -32,9 +34,11 @@ export default function Layout() {
               </button>
             </>
           )}
-        </div>
-        <Outlet />
-      </main>
+          </div>
+          <Outlet />
+        </main>
+        <Footer />
+      </div>
     </div>
   );
 }

--- a/src/pages/Accueil.jsx
+++ b/src/pages/Accueil.jsx
@@ -1,6 +1,11 @@
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { motion as Motion } from "framer-motion";
+import logoMamaStock from "@/assets/logo-mamastock.png";
 import { Link, useNavigate } from "react-router-dom";
 import { useEffect } from "react";
 import useAuth from "@/hooks/useAuth";
+import Footer from "@/components/Footer";
 
 export default function Accueil() {
   const { session, user } = useAuth();
@@ -13,21 +18,36 @@ export default function Accueil() {
   }, [session, user, navigate]);
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 p-4 text-center">
-      <div className="space-y-6 max-w-md">
-        <h1 className="text-2xl font-bold">Simplifiez votre gestion F&amp;B</h1>
-        <p>
-          MamaStock centralise vos fournisseurs, vos produits et vos factures pour un suivi des coûts en toute simplicité.
-        </p>
-        {!session && (
-          <Link
-            to="/login"
-            className="inline-block bg-mamastock-gold hover:bg-mamastock-gold-hover text-black px-6 py-3 rounded-md transition"
-          >
-            Se connecter
-          </Link>
-        )}
+    <div className="flex flex-col min-h-[100vh] bg-[#f8f8fa] relative">
+      <div className="flex-grow flex flex-col items-center justify-center px-4">
+        <Motion.div
+          initial={{ opacity: 0, y: 24 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.8 }}
+          className="w-full max-w-md"
+        >
+          <Card className="rounded-2xl shadow-xl p-6 flex flex-col items-center bg-white">
+            <img
+              src={logoMamaStock}
+              alt="MamaStock"
+              className="w-24 h-24 mb-4 rounded-xl shadow"
+            />
+            <h1 className="text-2xl sm:text-3xl font-bold text-[#2e2e3a] text-center mb-2">
+              Simplifiez votre gestion F&amp;B
+            </h1>
+            <p className="text-[#2e2e3a]/70 text-center mb-6 text-base sm:text-lg">
+              MamaStock centralise vos fournisseurs, vos produits et vos factures
+              pour un suivi des coûts en toute simplicité.
+            </p>
+            {!session && (
+              <Button className="bg-[#ff5a5f] text-white rounded-xl px-8 py-3 text-lg font-semibold hover:bg-[#e04b50] transition" size="lg">
+                <Link to="/login">Se connecter</Link>
+              </Button>
+            )}
+          </Card>
+        </Motion.div>
       </div>
+      <Footer />
     </div>
   );
 }

--- a/src/pages/Rgpd.jsx
+++ b/src/pages/Rgpd.jsx
@@ -1,0 +1,36 @@
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Link } from "react-router-dom";
+import Footer from "@/components/Footer";
+
+export default function Rgpd() {
+  return (
+    <div className="flex flex-col min-h-[100vh] bg-[#f8f8fa]">
+      <div className="flex-grow flex flex-col items-center px-4 pt-16">
+        <Card className="max-w-2xl w-full mx-auto p-8 rounded-2xl shadow-xl bg-white">
+          <h1 className="text-2xl sm:text-3xl font-bold text-[#2e2e3a] mb-4">
+            Données &amp; Confidentialité
+          </h1>
+          <p className="text-[#2e2e3a]/80 mb-4">
+            MamaStock attache une grande importance à la protection de vos données personnelles.<br />
+            <br />
+            <b>Quels types de données&nbsp;?</b> <br />
+            Les données collectées (emails, identifiants, informations de gestion F&amp;B) servent uniquement à faire fonctionner l’application, à améliorer votre expérience, et à sécuriser l’accès.
+            <br /><br />
+            <b>Confidentialité&nbsp;:</b><br />
+            Les données ne sont ni vendues, ni partagées à des tiers extérieurs à l’application.<br />
+            Seules les personnes autorisées au sein de votre établissement y ont accès.
+            <br /><br />
+            <b>Droits&nbsp;:</b><br />
+            À tout moment, vous pouvez demander la consultation, la modification ou la suppression de vos données en contactant votre administrateur ou l’équipe MamaStock.<br />
+            Pour toute question&nbsp;: <a href="mailto:support@mamastock.com" className="underline text-[#ff5a5f]">support@mamastock.com</a>
+          </p>
+          <Button className="bg-[#ff5a5f] text-white rounded-xl px-6 py-2 mt-4 hover:bg-[#e04b50]">
+            <Link to="/">Retour à l’accueil</Link>
+          </Button>
+        </Card>
+      </div>
+      <Footer />
+    </div>
+  );
+}

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -42,6 +42,7 @@ const AccessRights = lazy(() => import("@/pages/parametrage/AccessRights.jsx"));
 const Onboarding = lazy(() => import("@/pages/public/Onboarding.jsx"));
 const Accueil = lazy(() => import("@/pages/Accueil.jsx"));
 const Signup = lazy(() => import("@/pages/public/Signup.jsx"));
+const Rgpd = lazy(() => import("@/pages/Rgpd.jsx"));
 const PagePrivacy = lazy(() => import("@/pages/public/PagePrivacy.jsx"));
 const PageMentions = lazy(() => import("@/pages/public/PageMentions.jsx"));
 const AideContextuelle = lazy(() => import("@/pages/AideContextuelle.jsx"));
@@ -88,6 +89,7 @@ export default function Router() {
         <Route path="/pending" element={<Pending />} />
         <Route path="/unauthorized" element={<Unauthorized />} />
         <Route path="/blocked" element={<Blocked />} />
+        <Route path="/rgpd" element={<Rgpd />} />
         <Route path="/privacy" element={<PagePrivacy />} />
         <Route path="/mentions" element={<PageMentions />} />
         <Route path="/" element={<Layout />}>


### PR DESCRIPTION
## Summary
- update Home page style with login CTA and animation
- create RGPD privacy page
- add global footer component and use it across pages
- expose `/rgpd` route

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685fb7463554832da3c39661a43ac2b9