### PR TITLE
Fix auth rights and debug logging

### DIFF
--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -6,7 +6,8 @@ export default function ProtectedRoute({ children, accessKey }) {
   const { session, user, mama_id, loading, access_rights, isSuperadmin } =
     useAuth();
 
-  if (loading) return <LoadingSpinner message="Chargement..." />;
+  if (loading || access_rights === null)
+    return <LoadingSpinner message="Chargement..." />;
   if (!session || !user) return <Navigate to="/login" />;
   if (!mama_id) return <Navigate to="/pending" />;
 
@@ -14,7 +15,16 @@ export default function ProtectedRoute({ children, accessKey }) {
   if (accessKey) {
     const rights = Array.isArray(access_rights) ? access_rights : [];
     const isAllowed = isSuperadmin || rights.includes(accessKey);
-    if (!isAllowed) return <Navigate to="/unauthorized" />;
+    if (!isAllowed) {
+      console.log('Access denied', {
+        user,
+        mama_id,
+        accessKey,
+        access_rights: rights,
+        session,
+      });
+      return <Navigate to="/unauthorized" />;
+    }
   }
 
   return children;

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -6,7 +6,7 @@ export default function Sidebar() {
   const { access_rights, role, loading } = useAuth();
   const { pathname } = useLocation();
 
-  if (loading) return null;
+  if (loading || access_rights === null) return null;
   const showAll = role === "superadmin";
   const rights = Array.isArray(access_rights) ? access_rights : [];
   const has = (key) => showAll || rights.includes(key);

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -17,7 +17,7 @@ export function AuthProvider({ children }) {
   const [userData, setUserData] = useState({
     role: null,
     mama_id: null,
-    access_rights: [],
+    access_rights: null,
     auth_id: null,
     actif: true,
     user_id: null,
@@ -95,7 +95,7 @@ export function AuthProvider({ children }) {
       setUserData({
         role: null,
         mama_id: null,
-        access_rights: [],
+        access_rights: null,
         auth_id: null,
         actif: true,
         user_id: null,
@@ -151,7 +151,7 @@ export function AuthProvider({ children }) {
       setUserData({
         role: null,
         mama_id: null,
-        access_rights: [],
+        access_rights: null,
         auth_id: session.user.id,
         actif: false,
         user_id: session.user.id,
@@ -194,7 +194,7 @@ export function AuthProvider({ children }) {
         setUserData({
           role: null,
           mama_id: null,
-          access_rights: [],
+          access_rights: null,
           auth_id: null,
           actif: true,
           user_id: null,
@@ -222,7 +222,7 @@ export function AuthProvider({ children }) {
     setUserData({
       role: null,
       mama_id: null,
-      access_rights: [],
+      access_rights: null,
       auth_id: null,
       actif: true,
       user_id: null,

--- a/src/layout/Sidebar.jsx
+++ b/src/layout/Sidebar.jsx
@@ -24,7 +24,7 @@ export default function Sidebar() {
   const { access_rights, loading, user, logout, session } = useAuth();
   const { pathname } = useLocation();
 
-  if (loading || !access_rights) {
+  if (loading || access_rights === null) {
     return <aside className="w-64 p-4" />;
   }
 

--- a/src/lib/loginUser.js
+++ b/src/lib/loginUser.js
@@ -1,12 +1,6 @@
-import { createClient } from '@supabase/supabase-js';
+import { supabase } from './supabase';
 
-// Supabase credentials
-const SUPABASE_URL = 'https://jhpfdeolleprmvtchoxt.supabase.co';
-const SUPABASE_ANON_KEY =
-  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImpocGZkZW9sbGVwcm12dGNob3h0Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDY3MjI4MzMsImV4cCI6MjA2MjI5ODgzM30.f_J81QTBK4cvFoFUvlY6XNmuS5DSMLUdT_ZQQ7FpOFQ';
-
-// Initialize the Supabase client with provided credentials
-const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+// Use the shared Supabase client from src/lib/supabase.js
 
 /**
  * Authenticates a user with email and password.

--- a/src/pages/auth/Login.jsx
+++ b/src/pages/auth/Login.jsx
@@ -71,7 +71,7 @@ export default function Login() {
         return;
       }
 
-      if (!access_rights || access_rights.length === 0) {
+      if (!Array.isArray(access_rights) || access_rights.length === 0) {
         navigate("/unauthorized");
         return;
       }

--- a/src/pages/debug/AuthDebug.jsx
+++ b/src/pages/debug/AuthDebug.jsx
@@ -2,7 +2,17 @@
 import useAuth from "@/hooks/useAuth";
 
 export default function AuthDebug() {
-  const { user_id, role, mama_id, access_rights, session } = useAuth();
+  const {
+    user_id,
+    role,
+    mama_id,
+    access_rights,
+    session,
+    loading,
+    pending,
+    isAdmin,
+    isSuperadmin,
+  } = useAuth();
 
   return (
     <div className="p-4 text-sm text-white bg-black space-y-2">
@@ -13,6 +23,10 @@ export default function AuthDebug() {
         role,
         mama_id,
         access_rights,
+        loading,
+        pending,
+        isAdmin,
+        isSuperadmin,
         claims: session?.user,
       }, null, 2)}</pre>
     </div>


### PR DESCRIPTION
## Summary
- ensure single Supabase client and remove extra createClient usage
- expose loading status for rights and wait before guarding access
- log details when access is denied
- show more info on debug auth page
- treat access rights as `null` until loaded

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685fba0950a4832daaed2c4eeae9fad1