### PR TITLE
Fix access rights handling

### DIFF
--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -3,18 +3,18 @@ import { useAuth } from "@/context/AuthContext";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 
 export default function ProtectedRoute({ children, accessKey }) {
-  const { session, user, mama_id, loading, access_rights, isSuperadmin } =
+  const { session, user, mama_id, loading, pending, access_rights, isSuperadmin } =
     useAuth();
 
-  if (loading || access_rights === null)
+  if (loading || pending || access_rights === null)
     return <LoadingSpinner message="Chargement..." />;
   if (!session || !user) return <Navigate to="/login" />;
   if (!mama_id) return <Navigate to="/pending" />;
 
   // Vérifie les droits si une clé est fournie
   if (accessKey) {
-    const rights = Array.isArray(access_rights) ? access_rights : [];
-    const isAllowed = isSuperadmin || rights.includes(accessKey);
+    const rights = typeof access_rights === "object" ? access_rights : {};
+    const isAllowed = isSuperadmin || rights[accessKey];
     if (!isAllowed) {
       console.log('Access denied', {
         user,

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -8,8 +8,8 @@ export default function Sidebar() {
 
   if (loading || access_rights === null) return null;
   const showAll = role === "superadmin";
-  const rights = Array.isArray(access_rights) ? access_rights : [];
-  const has = (key) => showAll || rights.includes(key);
+  const rights = typeof access_rights === "object" ? access_rights : {};
+  const has = (key) => showAll || rights[key];
 
   return (
     <aside className="w-64 bg-white/5 backdrop-blur-xl text-white p-4 h-screen shadow-md text-shadow">

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -7,6 +7,18 @@ import { supabase } from "@/lib/supabase";
 import { loginUser } from "@/lib/loginUser";
 import toast from "react-hot-toast";
 
+function parseRights(input) {
+  if (!input) return {};
+  if (Array.isArray(input)) {
+    return input.reduce((acc, key) => {
+      if (typeof key === 'string') acc[key] = true;
+      return acc;
+    }, {});
+  }
+  if (typeof input === 'object') return input;
+  return {};
+}
+
 // Contexte global Auth
 // Exported separately for hooks like src/hooks/useAuth.js
 // eslint-disable-next-line react-refresh/only-export-components
@@ -17,7 +29,7 @@ export function AuthProvider({ children }) {
   const [userData, setUserData] = useState({
     role: null,
     mama_id: null,
-    access_rights: null,
+    access_rights: {},
     auth_id: null,
     actif: true,
     user_id: null,
@@ -95,7 +107,7 @@ export function AuthProvider({ children }) {
       setUserData({
         role: null,
         mama_id: null,
-        access_rights: null,
+        access_rights: {},
         auth_id: null,
         actif: true,
         user_id: null,
@@ -135,7 +147,7 @@ export function AuthProvider({ children }) {
       setUserData({
         role: meta.role ?? null,
         mama_id: meta.mama_id ?? null,
-        access_rights: Array.isArray(meta.access_rights) ? meta.access_rights : null,
+        access_rights: parseRights(meta.access_rights),
         auth_id: session.user.id,
         actif: true,
         user_id: session.user.id,
@@ -151,7 +163,7 @@ export function AuthProvider({ children }) {
       setUserData({
         role: null,
         mama_id: null,
-        access_rights: null,
+        access_rights: {},
         auth_id: session.user.id,
         actif: false,
         user_id: session.user.id,
@@ -163,11 +175,7 @@ export function AuthProvider({ children }) {
     setUserData({
       role: data?.role ?? meta.role ?? null,
       mama_id: data?.mama_id ?? meta.mama_id ?? null,
-      access_rights: Array.isArray(data?.access_rights)
-        ? data.access_rights
-        : Array.isArray(meta.access_rights)
-        ? meta.access_rights
-        : [],
+      access_rights: parseRights(data?.access_rights ?? meta.access_rights),
       auth_id: session.user.id,
       actif: data?.actif ?? true,
       user_id: session.user.id,
@@ -194,7 +202,7 @@ export function AuthProvider({ children }) {
         setUserData({
           role: null,
           mama_id: null,
-          access_rights: null,
+          access_rights: {},
           auth_id: null,
           actif: true,
           user_id: null,
@@ -222,7 +230,7 @@ export function AuthProvider({ children }) {
     setUserData({
       role: null,
       mama_id: null,
-      access_rights: null,
+      access_rights: {},
       auth_id: null,
       actif: true,
       user_id: null,
@@ -246,6 +254,10 @@ export function AuthProvider({ children }) {
     isAdmin: userData.role === "admin" || userData.role === "superadmin",
     isSuperadmin: userData.role === "superadmin",
   };
+
+  useEffect(() => {
+    console.log("[AUTH DEBUG]", { session, userData });
+  }, [session, userData]);
 
   return (
     <AuthContext.Provider value={value}>

--- a/src/layout/Sidebar.jsx
+++ b/src/layout/Sidebar.jsx
@@ -28,7 +28,8 @@ export default function Sidebar() {
     return <aside className="w-64 p-4" />;
   }
 
-  const has = (key) => access_rights.includes(key);
+  const rights = typeof access_rights === "object" ? access_rights : {};
+  const has = (key) => rights[key];
 
   const Item = ({ to, icon, label }) => (
     <Link

--- a/src/pages/auth/Login.jsx
+++ b/src/pages/auth/Login.jsx
@@ -71,7 +71,7 @@ export default function Login() {
         return;
       }
 
-      if (!Array.isArray(access_rights) || access_rights.length === 0) {
+      if (!pending && Object.keys(access_rights || {}).length === 0) {
         navigate("/unauthorized");
         return;
       }

--- a/test/router.test.jsx
+++ b/test/router.test.jsx
@@ -7,7 +7,7 @@ import RouterConfig from '../src/router.jsx';
 process.env.VITE_SUPABASE_URL = 'https://example.supabase.co';
 process.env.VITE_SUPABASE_ANON_KEY = 'key';
 
-const authState = { isAuthenticated: false, access_rights: ['dashboard'], loading: false };
+const authState = { isAuthenticated: false, access_rights: { dashboard: true }, loading: false };
 vi.mock('@/context/AuthContext', () => ({
   useAuth: () => authState
 }));


### PR DESCRIPTION
## Summary
- keep `access_rights` as an object in AuthContext
- log session and user data in `[AUTH DEBUG]`
- avoid Unauthorized while auth is loading or pending
- handle rights object in Sidebar and ProtectedRoute
- update login check and router test

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685fbe80fcbc832d841828a14198104a