### PR TITLE
Add fournisseur API config hook and SQL indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,15 @@ SQL associé dans `sql/mama_stock_patch.sql` :
   pour les rôles autorisés
 - Droits `SELECT/INSERT/UPDATE/DELETE` pour le rôle `authenticated`.
 
+## Module API fournisseurs
+
+Ce module gère les paramètres de connexion aux API des fournisseurs
+(`fournisseurs_api_config`). Chaque configuration est liée à un fournisseur et à
+un `mama`. Les données sont protégées par RLS et les index sur
+`fournisseur_id` et `mama_id` accélèrent les requêtes. Le hook React
+`useFournisseurApiConfig` permet de charger, enregistrer ou supprimer cette
+configuration depuis l'interface.
+
 ## Module Analytique avancée
 
 La page `/stats/advanced` affiche des graphiques d'évolution mensuelle des achats

--- a/db/full_setup.sql
+++ b/db/full_setup.sql
@@ -2111,6 +2111,8 @@ create table if not exists fournisseurs_api_config (
   created_at timestamptz default now(),
   primary key(fournisseur_id, mama_id)
 );
+create index if not exists idx_fournisseurs_api_config_fourn on fournisseurs_api_config(fournisseur_id);
+create index if not exists idx_fournisseurs_api_config_mama on fournisseurs_api_config(mama_id);
 alter table fournisseurs_api_config enable row level security;
 alter table fournisseurs_api_config force row level security;
 drop policy if exists fournisseurs_api_config_all on fournisseurs_api_config;

--- a/docs/fournisseurs_api_config.md
+++ b/docs/fournisseurs_api_config.md
@@ -1,0 +1,38 @@
+# Module API fournisseurs
+
+Ce module permet de configurer les paramètres d'accès aux API des fournisseurs.
+Chaque fournisseur peut avoir une configuration propre contenant l'URL, le type
+d'API et un token d'accès. La table `fournisseurs_api_config` est protégée par
+RLS et utilise la clé primaire composée `(fournisseur_id, mama_id)`.
+
+```sql
+create table if not exists fournisseurs_api_config (
+  fournisseur_id uuid references fournisseurs(id) on delete cascade,
+  mama_id uuid not null references mamas(id),
+  url text,
+  type_api text default 'rest',
+  token text,
+  format_facture text default 'json',
+  actif boolean default true,
+  created_at timestamptz default now(),
+  primary key(fournisseur_id, mama_id)
+);
+create index if not exists idx_fournisseurs_api_config_fourn on fournisseurs_api_config(fournisseur_id);
+create index if not exists idx_fournisseurs_api_config_mama on fournisseurs_api_config(mama_id);
+```
+
+Les politiques RLS garantissent que chaque utilisateur n'accède qu'aux données
+de sa structure :
+
+```sql
+alter table fournisseurs_api_config enable row level security;
+alter table fournisseurs_api_config force row level security;
+create policy fournisseurs_api_config_all on fournisseurs_api_config
+  for all using (mama_id = current_user_mama_id())
+  with check (mama_id = current_user_mama_id());
+```
+
+Côté front, le hook `useFournisseurApiConfig` permet de charger, enregistrer ou
+supprimer la configuration via Supabase JS. Le formulaire
+`FournisseurApiSettingsForm` s'appuie sur ce hook et pré‑remplit la configuration
+existante.

--- a/src/hooks/useFournisseurApiConfig.js
+++ b/src/hooks/useFournisseurApiConfig.js
@@ -1,0 +1,64 @@
+import { useState } from 'react';
+import { supabase } from '@/lib/supabase';
+import { useAuth } from '@/context/AuthContext';
+import toast from 'react-hot-toast';
+
+export function useFournisseurApiConfig() {
+  const { mama_id } = useAuth();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  async function fetchConfig(fournisseur_id) {
+    if (!mama_id || !fournisseur_id) return null;
+    setLoading(true);
+    const { data, error } = await supabase
+      .from('fournisseurs_api_config')
+      .select('*')
+      .eq('mama_id', mama_id)
+      .eq('fournisseur_id', fournisseur_id)
+      .maybeSingle();
+    setLoading(false);
+    if (error) {
+      setError(error);
+      toast.error(error.message || 'Erreur chargement configuration');
+      return null;
+    }
+    return data;
+  }
+
+  async function saveConfig(fournisseur_id, config) {
+    if (!mama_id || !fournisseur_id) return { error: 'missing context' };
+    setLoading(true);
+    const { data, error } = await supabase
+      .from('fournisseurs_api_config')
+      .upsert([{ ...config, fournisseur_id, mama_id }], {
+        onConflict: ['fournisseur_id', 'mama_id'],
+      })
+      .select()
+      .single();
+    setLoading(false);
+    if (error) {
+      setError(error);
+      toast.error(error.message || 'Erreur sauvegarde configuration');
+    }
+    return { data, error };
+  }
+
+  async function deleteConfig(fournisseur_id) {
+    if (!mama_id || !fournisseur_id) return { error: 'missing context' };
+    setLoading(true);
+    const { error } = await supabase
+      .from('fournisseurs_api_config')
+      .delete()
+      .eq('fournisseur_id', fournisseur_id)
+      .eq('mama_id', mama_id);
+    setLoading(false);
+    if (error) {
+      setError(error);
+      toast.error(error.message || 'Erreur suppression configuration');
+    }
+    return { error };
+  }
+
+  return { loading, error, fetchConfig, saveConfig, deleteConfig };
+}

--- a/src/pages/fournisseurs/FournisseurApiSettingsForm.jsx
+++ b/src/pages/fournisseurs/FournisseurApiSettingsForm.jsx
@@ -1,12 +1,13 @@
 import { useEffect, useState } from "react";
-import { supabase } from "@/lib/supabase";
 import { useAuth } from "@/context/AuthContext";
 import { Button } from "@/components/ui/button";
 import toast from "react-hot-toast";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import { useFournisseurApiConfig } from "@/hooks/useFournisseurApiConfig";
 
 export default function FournisseurApiSettingsForm({ fournisseur_id }) {
   const { mama_id } = useAuth();
+  const { fetchConfig, saveConfig } = useFournisseurApiConfig();
   const [config, setConfig] = useState({
     url: "",
     type_api: "rest",
@@ -19,17 +20,11 @@ export default function FournisseurApiSettingsForm({ fournisseur_id }) {
 
   useEffect(() => {
     if (!mama_id || !fournisseur_id) return;
-    supabase
-      .from("fournisseurs_api_config")
-      .select("*")
-      .eq("mama_id", mama_id)
-      .eq("fournisseur_id", fournisseur_id)
-      .maybeSingle()
-      .then(({ data }) => {
-        if (data) setConfig(c => ({ ...c, ...data }));
-        setLoading(false);
-      });
-  }, [mama_id, fournisseur_id]);
+    fetchConfig(fournisseur_id).then(data => {
+      if (data) setConfig(c => ({ ...c, ...data }));
+      setLoading(false);
+    });
+  }, [mama_id, fournisseur_id, fetchConfig]);
 
   const handleChange = e => {
     const { name, value, type, checked } = e.target;
@@ -41,17 +36,10 @@ export default function FournisseurApiSettingsForm({ fournisseur_id }) {
     if (!mama_id || !fournisseur_id || saving) return;
     try {
       setSaving(true);
-      const { data, error } = await supabase
-        .from("fournisseurs_api_config")
-        .upsert(
-          [{ ...config, fournisseur_id, mama_id }],
-          { onConflict: ["fournisseur_id", "mama_id"] }
-        )
-        .select()
-        .single();
+      const { data, error } = await saveConfig(fournisseur_id, config);
       if (error) throw error;
       toast.success("Configuration sauvegardée");
-      setConfig(data);
+      if (data) setConfig(data);
     } catch (err) {
       toast.error(err.message || "Erreur lors de la sauvegarde");
     } finally {

--- a/test/FournisseurApiSettingsForm.test.jsx
+++ b/test/FournisseurApiSettingsForm.test.jsx
@@ -27,6 +27,7 @@ test('submits config with composite conflict keys', async () => {
   fireEvent.change(screen.getAllByRole('textbox')[0], { target: { value: 'http://api' } });
   await fireEvent.click(btn);
   expect(fromMock).toHaveBeenCalledWith('fournisseurs_api_config');
+  expect(fromMock.mock.calls.length).toBeGreaterThanOrEqual(2);
   await waitFor(() => {
     expect(upsertMock).toHaveBeenCalledWith(
       [

--- a/test/useFournisseurApiConfig.test.js
+++ b/test/useFournisseurApiConfig.test.js
@@ -1,0 +1,53 @@
+import { renderHook, act } from '@testing-library/react';
+import { vi, beforeEach, test, expect } from 'vitest';
+
+const queryObj = {
+  select: vi.fn(() => queryObj),
+  eq: vi.fn(() => queryObj),
+  maybeSingle: vi.fn(() => Promise.resolve({ data: { id: 'c1' }, error: null })),
+  upsert: vi.fn(() => ({ select: () => ({ single: vi.fn(() => Promise.resolve({ data: { id: 'c1' }, error: null })) }) })),
+  delete: vi.fn(() => queryObj),
+};
+
+const fromMock = vi.fn(() => queryObj);
+vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
+vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
+
+let useFournisseurApiConfig;
+
+beforeEach(async () => {
+  ({ useFournisseurApiConfig } = await import('@/hooks/useFournisseurApiConfig'));
+  fromMock.mockClear();
+  queryObj.select.mockClear();
+  queryObj.eq.mockClear();
+  queryObj.maybeSingle.mockClear();
+  queryObj.upsert.mockClear();
+  queryObj.delete.mockClear();
+});
+
+test('fetchConfig queries by composite key', async () => {
+  const { result } = renderHook(() => useFournisseurApiConfig());
+  await act(async () => { await result.current.fetchConfig('f1'); });
+  expect(fromMock).toHaveBeenCalledWith('fournisseurs_api_config');
+  expect(queryObj.select).toHaveBeenCalledWith('*');
+  expect(queryObj.eq).toHaveBeenCalledWith('mama_id', 'm1');
+  expect(queryObj.eq).toHaveBeenCalledWith('fournisseur_id', 'f1');
+  expect(queryObj.maybeSingle).toHaveBeenCalled();
+});
+
+test('saveConfig upserts with composite key', async () => {
+  const { result } = renderHook(() => useFournisseurApiConfig());
+  await act(async () => { await result.current.saveConfig('f1', { actif: true }); });
+  expect(queryObj.upsert).toHaveBeenCalledWith([
+    { actif: true, fournisseur_id: 'f1', mama_id: 'm1' }],
+    { onConflict: ['fournisseur_id', 'mama_id'] }
+  );
+});
+
+test('deleteConfig filters by keys', async () => {
+  const { result } = renderHook(() => useFournisseurApiConfig());
+  await act(async () => { await result.current.deleteConfig('f1'); });
+  expect(queryObj.delete).toHaveBeenCalled();
+  expect(queryObj.eq).toHaveBeenCalledWith('fournisseur_id', 'f1');
+  expect(queryObj.eq).toHaveBeenCalledWith('mama_id', 'm1');
+});


### PR DESCRIPTION
## Summary
- index `fournisseurs_api_config` by foreign keys
- create React hook `useFournisseurApiConfig`
- update supplier API settings form to use the hook
- document supplier API configuration module
- test hook and component behaviour

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fdbf6c190832da4ddf78c6cecae0a