### PR TITLE
Audit corrections for Products module

### DIFF
--- a/src/hooks/useProducts.js
+++ b/src/hooks/useProducts.js
@@ -84,8 +84,31 @@ export function useProducts() {
   async function duplicateProduct(id, { refresh = true } = {}) {
     const orig = products.find(p => p.id === id);
     if (!orig) return;
-    const copy = { ...orig, nom: `${orig.nom} (copie)` };
-    delete copy.id;
+    const {
+      famille,
+      unite,
+      main_supplier_id,
+      pmp,
+      stock_reel,
+      stock_min,
+      actif,
+      code,
+      allergenes,
+      image,
+    } = orig;
+    const copy = {
+      nom: `${orig.nom} (copie)`,
+      famille,
+      unite,
+      main_supplier_id,
+      pmp,
+      stock_reel,
+      stock_min,
+      actif,
+      code,
+      allergenes,
+      image,
+    };
     if (!mama_id) return { error: "Aucun mama_id" };
     setLoading(true);
     setError(null);


### PR DESCRIPTION
## Summary
- expose family and unit via joins in `v_products_last_price`
- sanitize duplicate product inserts
- enforce unique constraint `products_mama_id_nom_unite_key`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ff0fd5520832d9d26707f24343fbd