### PR TITLE
Audit fiches techniques

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1002,3 +1002,13 @@
 ## 2025-06-28 Step 189
 - Reconfirmed removal of `users_mamas` after latest review; grep found nothing.
 - Reinstalled dependencies and executed `npm run lint` and `npm test` successfully.
+
+## 2025-06-28 Step 190
+- Audited fiches techniques module for SQL integrity and mama_id filtering.
+- Added error propagation in `useFiches` create/update functions to surface Supabase issues.
+- Ran `npm run lint` and `npm test` successfully after modifications.
+
+## 2025-06-28 Step 191
+- Continued audit of fiches techniques module.
+- Hardened deletion and advanced fiche operations with explicit error propagation.
+- `npm run lint` and `npm test` executed successfully after changes.

--- a/src/hooks/useFichesTechniques.js
+++ b/src/hooks/useFichesTechniques.js
@@ -29,31 +29,58 @@ export function useFichesTechniques() {
   }
 
   async function addFicheTechnique(ft) {
+    if (!mama_id) return { error: "Aucun mama_id" };
+    setLoading(true);
+    setError(null);
     const { error } = await supabase
       .from("fiches_techniques")
       .insert([{ ...ft, mama_id }]);
-    if (error) throw error;
+    if (error) {
+      setLoading(false);
+      setError(error);
+      throw error;
+    }
     await fetchFichesTechniques();
+    setLoading(false);
+    return { data: true };
   }
 
   async function updateFicheTechnique(id, updateFields) {
+    if (!mama_id) return { error: "Aucun mama_id" };
+    setLoading(true);
+    setError(null);
     const { error } = await supabase
       .from("fiches_techniques")
       .update(updateFields)
       .eq("id", id)
       .eq("mama_id", mama_id);
-    if (error) throw error;
+    if (error) {
+      setLoading(false);
+      setError(error);
+      throw error;
+    }
     await fetchFichesTechniques();
+    setLoading(false);
+    return { data: id };
   }
 
   async function deleteFicheTechnique(id) {
+    if (!mama_id) return { error: "Aucun mama_id" };
+    setLoading(true);
+    setError(null);
     const { error } = await supabase
       .from("fiches_techniques")
       .update({ actif: false })
       .eq("id", id)
       .eq("mama_id", mama_id);
-    if (error) throw error;
+    if (error) {
+      setLoading(false);
+      setError(error);
+      throw error;
+    }
     await fetchFichesTechniques();
+    setLoading(false);
+    return { data: id };
   }
 
   return {


### PR DESCRIPTION
## Summary
- harden `useFiches` delete operation
- add loading/error handling in advanced fiche hooks
- document audit step

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ff3ffa76c832d921de0d0b42dc4fe