### PR TITLE
Fix factures module db compliance

### DIFF
--- a/src/hooks/useInvoices.js
+++ b/src/hooks/useInvoices.js
@@ -43,7 +43,7 @@ export function useInvoices() {
     setError(null);
     const { data, error } = await supabase
       .from("factures")
-      .select("id, date_facture:date, numero_facture:reference, montant_total:montant, statut")
+      .select("id, date_facture:date, numero_facture:reference, montant_total:total_ttc, statut")
       .eq("mama_id", mama_id)
       .eq("fournisseur_id", fournisseur_id)
       .order("date", { ascending: false });
@@ -138,7 +138,7 @@ export function useInvoices() {
       numero: f.reference,
       date: f.date,
       fournisseur: f.fournisseur?.nom,
-      montant: f.montant,
+      montant: f.total_ttc,
       statut: f.statut,
       mama_id: f.mama_id,
     }));

--- a/src/hooks/useSupplierProducts.js
+++ b/src/hooks/useSupplierProducts.js
@@ -20,7 +20,7 @@ export function useSupplierProducts() {
       const { data, error } = await supabase
         .from("supplier_products")
         .select(
-        "*, product:products(nom, famille, unite), achats:factures(date_facture:date, numero_facture:reference, montant_total:montant)"
+        "*, product:products(nom, famille, unite), achats:factures(date_facture:date, numero_facture:reference, montant_total:total_ttc)"
         )
         .eq("fournisseur_id", fournisseur_id)
         .eq("mama_id", mama_id);
@@ -39,7 +39,7 @@ export function useSupplierProducts() {
     const { data } = await supabase
       .from("supplier_products")
       .select(
-        "*, product:products(nom, famille, unite), achats:factures(date_facture:date, numero_facture:reference, montant_total:montant)"
+        "*, product:products(nom, famille, unite), achats:factures(date_facture:date, numero_facture:reference, montant_total:total_ttc)"
       )
       .eq("fournisseur_id", fournisseur_id)
       .eq("mama_id", mama_id);

--- a/src/pages/factures/FactureDetail.jsx
+++ b/src/pages/factures/FactureDetail.jsx
@@ -72,7 +72,7 @@ export default function FactureDetail({ facture: factureProp, onClose }) {
         <h2 className="font-bold text-xl mb-4">Détail de la facture #{facture.id}</h2>
         <div><b>Date :</b> {facture.date}</div>
         <div><b>Fournisseur :</b> {facture.fournisseur?.nom}</div>
-        <div><b>Montant :</b> {facture.montant?.toFixed(2)} €</div>
+        <div><b>Montant :</b> {facture.total_ttc?.toFixed(2)} €</div>
         <div><b>Statut :</b> {facture.statut}</div>
         <div>
           <b>Justificatif :</b> {facture.justificatif ?

--- a/src/pages/factures/FactureForm.jsx
+++ b/src/pages/factures/FactureForm.jsx
@@ -12,7 +12,6 @@ export default function FactureForm({ facture, suppliers = [], onClose }) {
   const [date, setDate] = useState(facture?.date || "");
   const [fournisseur_id, setFournisseurId] = useState(facture?.fournisseur_id || "");
   const [reference, setReference] = useState(facture?.reference || "");
-  const [commentaire, setCommentaire] = useState(facture?.commentaire || "");
   const [statut, setStatut] = useState(facture?.statut || "en attente");
   const [lignes, setLignes] = useState(facture?.lignes || [
     { product_id: "", quantite: 1, prix_unitaire: 0, tva: 20 }
@@ -54,7 +53,6 @@ export default function FactureForm({ facture, suppliers = [], onClose }) {
       date,
       fournisseur_id,
       reference,
-      commentaire,
       statut,
       total_ht,
       total_tva,
@@ -104,13 +102,6 @@ export default function FactureForm({ facture, suppliers = [], onClose }) {
         placeholder="Numéro"
         value={reference}
         onChange={e => setReference(e.target.value)}
-      />
-      <input
-        className="input mb-2"
-        type="text"
-        placeholder="Commentaire"
-        value={commentaire}
-        onChange={e => setCommentaire(e.target.value)}
       />
       <select
         className="input mb-2"

--- a/src/pages/factures/Factures.jsx
+++ b/src/pages/factures/Factures.jsx
@@ -130,7 +130,7 @@ export default function Factures() {
               <td className="border px-4 py-2">{facture.reference || facture.id}</td>
               <td className="border px-4 py-2">{facture.date}</td>
               <td className="border px-4 py-2">{facture.fournisseur?.nom}</td>
-              <td className="border px-4 py-2">{(facture.total_ttc || facture.montant)?.toFixed(2)} €</td>
+              <td className="border px-4 py-2">{facture.total_ttc?.toFixed(2)} €</td>
               <td className="border px-4 py-2">
                 <span className={STATUTS[facture.statut] || "badge"}>{facture.statut}</span>
               </td>

--- a/src/pages/fournisseurs/FournisseurDetail.jsx
+++ b/src/pages/fournisseurs/FournisseurDetail.jsx
@@ -34,7 +34,8 @@ export default function FournisseurDetail({ id }) {
             const { count } = await supabase
               .from("facture_lignes")
               .select("id", { count: "exact", head: true })
-              .eq("facture_id", f.id);
+              .eq("facture_id", f.id)
+              .eq("mama_id", mama_id);
             return { ...f, nb_produits: count || 0 };
           })
         );

--- a/test/useInvoices.test.js
+++ b/test/useInvoices.test.js
@@ -24,7 +24,7 @@ test('fetchInvoicesBySupplier selects fields with aliases', async () => {
     await result.current.fetchInvoicesBySupplier('s1');
   });
   expect(fromMock).toHaveBeenCalledWith('factures');
-  expect(queryChain.select).toHaveBeenCalledWith('id, date_facture:date, numero_facture:reference, montant_total:montant, statut');
+  expect(queryChain.select).toHaveBeenCalledWith('id, date_facture:date, numero_facture:reference, montant_total:total_ttc, statut');
   expect(queryChain.eq).toHaveBeenNthCalledWith(1, 'mama_id', 'm1');
   expect(queryChain.eq).toHaveBeenNthCalledWith(2, 'fournisseur_id', 's1');
   expect(orderMock).toHaveBeenCalledWith('date', { ascending: false });


### PR DESCRIPTION
## Summary
- remove unused `commentaire` field from invoice form
- filter supplier detail line counts by mama_id
- use date range for monthly filter
- sanitize invoice line insertion
- use `total_ttc` column instead of legacy `montant`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ff2980364832d91802e0cc8a41c98