### PR TITLE
Audit fixes for unités module

### DIFF
--- a/src/components/parametrage/ParamUnites.jsx
+++ b/src/components/parametrage/ParamUnites.jsx
@@ -7,7 +7,7 @@ import { saveAs } from "file-saver";
 import * as XLSX from "xlsx";
 
 export default function ParamUnites() {
-  const { unites, fetchUnites, addUnite, editUnite, deleteUnite } = useUnites();
+  const { unites, fetchUnites, addUnite, updateUnite, deleteUnite } = useUnites();
   const { mama_id } = useAuth();
   const [form, setForm] = useState({ nom: "", id: null });
   const [editMode, setEditMode] = useState(false);
@@ -38,10 +38,10 @@ export default function ParamUnites() {
     setLoading(true);
     try {
       if (editMode) {
-        await editUnite(form.id, { nom: form.nom });
+        await updateUnite(form.id, form.nom);
         toast.success("Unité modifiée !");
       } else {
-        await addUnite({ nom: form.nom });
+        await addUnite(form.nom);
         toast.success("Unité ajoutée !");
       }
       setEditMode(false);

--- a/src/hooks/useUnites.js
+++ b/src/hooks/useUnites.js
@@ -95,6 +95,11 @@ export function useUnites() {
     await fetchUnites();
   }
 
+  // Convenience wrapper for single deletion
+  async function deleteUnite(id) {
+    return batchDeleteUnites([id]);
+  }
+
   // 5. Export Excel
   function exportUnitesToExcel() {
     const datas = (unites || []).map(u => ({
@@ -132,6 +137,7 @@ export function useUnites() {
     fetchUnites,
     addUnite,
     updateUnite,
+    deleteUnite,
     batchDeleteUnites,
     exportUnitesToExcel,
     importUnitesFromExcel,


### PR DESCRIPTION
## Summary
- fix ParamUnites to use correct hook methods
- expose `deleteUnite` helper in hook

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_685ff59fd9f0832db403e731196abfdd