### PR TITLE
Fix menu forms and PDF queries

### DIFF
--- a/src/pages/menus/MenuDuJourForm.jsx
+++ b/src/pages/menus/MenuDuJourForm.jsx
@@ -8,7 +8,9 @@ export default function MenuDuJourForm({ menu, fiches = [], onClose }) {
   const { addMenuDuJour, editMenuDuJour } = useMenuDuJour();
   const [nom, setNom] = useState(menu?.nom || "");
   const [date, setDate] = useState(menu?.date || "");
-  const [selectedFiches, setSelectedFiches] = useState(menu?.fiches?.map(f => f.id) || []);
+  const [selectedFiches, setSelectedFiches] = useState(
+    menu?.fiches?.map(f => f.fiche_id) || []
+  );
   const [file, setFile] = useState(null);
   const [fileUrl, setFileUrl] = useState(menu?.document || "");
   const [loading, setLoading] = useState(false);

--- a/src/pages/menus/MenuForm.jsx
+++ b/src/pages/menus/MenuForm.jsx
@@ -8,7 +8,9 @@ export default function MenuForm({ menu, fiches = [], onClose }) {
   const { createMenu, updateMenu } = useMenus();
   const [nom, setNom] = useState(menu?.nom || "");
   const [date, setDate] = useState(menu?.date || "");
-  const [selectedFiches, setSelectedFiches] = useState(menu?.fiches?.map(f => f.id) || []);
+  const [selectedFiches, setSelectedFiches] = useState(
+    menu?.fiches?.map(f => f.fiche_id) || []
+  );
   const [ficheInput, setFicheInput] = useState("");
   const [file, setFile] = useState(null);
   const [fileUrl, setFileUrl] = useState(menu?.document || "");

--- a/src/pages/menus/MenuPDF.jsx
+++ b/src/pages/menus/MenuPDF.jsx
@@ -12,19 +12,16 @@ export default function MenuPDF({ id }) {
       if (!mama_id) return;
       const { data: menuData } = await supabase
         .from("menus")
-        .select("*")
+        .select(
+          "*, fiches:menu_fiches(fiche_id, fiche:fiches(id, nom, type, categorie))"
+        )
         .eq("id", id)
         .eq("mama_id", mama_id)
         .single();
 
       if (menuData) {
         setMenu(menuData);
-        const { data: fichesData } = await supabase
-          .from("fiches")
-          .select("*")
-          .in("id", menuData.fiches || [])
-          .eq("mama_id", mama_id);
-        setFiches(fichesData || []);
+        setFiches(menuData.fiches?.map(f => f.fiche) || []);
       }
     };
 


### PR DESCRIPTION
## Summary
- initialize MenuForm and MenuDuJourForm with `fiche_id`
- join `menu_fiches` when loading a menu PDF

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685ff7c518ec832d864972f5d12b87ab