### PR TITLE
Audit fournisseurs API config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,3 +119,4 @@
 
 
 - Step 131: additional verification cycle; searched again for `users_mamas` and found none. Ran `npm install`, `npm run lint` and `npm test` successfully.
+- Step 132: audited FournisseursAPIConfig module; added listConfigs API, updated docs and tests.

--- a/README.md
+++ b/README.md
@@ -357,8 +357,8 @@ Ce module gère les paramètres de connexion aux API des fournisseurs
 (`fournisseurs_api_config`). Chaque configuration est liée à un fournisseur et à
 un `mama`. Les données sont protégées par RLS et les index sur
 `fournisseur_id` et `mama_id` accélèrent les requêtes. Le hook React
-`useFournisseurApiConfig` permet de charger, enregistrer ou supprimer cette
-configuration depuis l'interface.
+`useFournisseurApiConfig` permet de charger, enregistrer, lister ou supprimer ces
+configurations depuis l'interface.
 
 ## Module Analytique avancée
 

--- a/docs/fournisseurs_api_config.md
+++ b/docs/fournisseurs_api_config.md
@@ -17,8 +17,10 @@ create table if not exists fournisseurs_api_config (
   created_at timestamptz default now(),
   primary key(fournisseur_id, mama_id)
 );
-create index if not exists idx_fournisseurs_api_config_fourn on fournisseurs_api_config(fournisseur_id);
-create index if not exists idx_fournisseurs_api_config_mama on fournisseurs_api_config(mama_id);
+create index if not exists idx_fournisseurs_api_config_fournisseur_id
+  on fournisseurs_api_config(fournisseur_id);
+create index if not exists idx_fournisseurs_api_config_mama_id
+  on fournisseurs_api_config(mama_id);
 ```
 
 Les politiques RLS garantissent que chaque utilisateur n'accède qu'aux données
@@ -33,6 +35,7 @@ create policy fournisseurs_api_config_all on fournisseurs_api_config
 ```
 
 Côté front, le hook `useFournisseurApiConfig` permet de charger, enregistrer ou
-supprimer la configuration via Supabase JS. Le formulaire
+supprimer la configuration via Supabase JS. Il expose aussi `listConfigs` pour
+rechercher et paginer les entrées par fournisseur et statut. Le formulaire
 `FournisseurApiSettingsForm` s'appuie sur ce hook et pré‑remplit la configuration
 existante.

--- a/src/hooks/useFournisseurApiConfig.js
+++ b/src/hooks/useFournisseurApiConfig.js
@@ -60,5 +60,26 @@ export function useFournisseurApiConfig() {
     return { error };
   }
 
-  return { loading, error, fetchConfig, saveConfig, deleteConfig };
+  async function listConfigs({ fournisseur_id, actif, page = 1, limit = 20 } = {}) {
+    if (!mama_id) return { data: [], count: 0, error: null };
+    setLoading(true);
+    let query = supabase
+      .from('fournisseurs_api_config')
+      .select('*', { count: 'exact' })
+      .eq('mama_id', mama_id)
+      .order('fournisseur_id');
+    if (fournisseur_id) query = query.eq('fournisseur_id', fournisseur_id);
+    if (actif !== undefined && actif !== null) query = query.eq('actif', actif);
+    if (limit) query = query.range((page - 1) * limit, page * limit - 1);
+    const { data, count, error } = await query;
+    setLoading(false);
+    if (error) {
+      setError(error);
+      toast.error(error.message || 'Erreur chargement configurations');
+      return { data: [], count: 0, error };
+    }
+    return { data, count, error: null };
+  }
+
+  return { loading, error, fetchConfig, saveConfig, deleteConfig, listConfigs };
 }

--- a/test/useFournisseurApiConfig.test.js
+++ b/test/useFournisseurApiConfig.test.js
@@ -4,6 +4,8 @@ import { vi, beforeEach, test, expect } from 'vitest';
 const queryObj = {
   select: vi.fn(() => queryObj),
   eq: vi.fn(() => queryObj),
+  order: vi.fn(() => queryObj),
+  range: vi.fn(() => queryObj),
   maybeSingle: vi.fn(() => Promise.resolve({ data: { id: 'c1' }, error: null })),
   upsert: vi.fn(() => ({ select: () => ({ single: vi.fn(() => Promise.resolve({ data: { id: 'c1' }, error: null })) }) })),
   delete: vi.fn(() => queryObj),
@@ -50,4 +52,16 @@ test('deleteConfig filters by keys', async () => {
   expect(queryObj.delete).toHaveBeenCalled();
   expect(queryObj.eq).toHaveBeenCalledWith('fournisseur_id', 'f1');
   expect(queryObj.eq).toHaveBeenCalledWith('mama_id', 'm1');
+});
+
+test('listConfigs applies filters and pagination', async () => {
+  const { result } = renderHook(() => useFournisseurApiConfig());
+  await act(async () => {
+    await result.current.listConfigs({ actif: true, page: 2, limit: 10 });
+  });
+  expect(fromMock).toHaveBeenCalledWith('fournisseurs_api_config');
+  expect(queryObj.select).toHaveBeenCalledWith('*', { count: 'exact' });
+  expect(queryObj.eq).toHaveBeenCalledWith('mama_id', 'm1');
+  expect(queryObj.eq).toHaveBeenCalledWith('actif', true);
+  expect(queryObj.range).toHaveBeenCalledWith(10, 19);
 });


### PR DESCRIPTION
## Summary
- document index names for `fournisseurs_api_config`
- expose `listConfigs` in `useFournisseurApiConfig`
- describe new hook usage in README
- extend unit tests for new API
- log audit step in `CHANGELOG.md`

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ff87cebe4832dad0c933a2e2e1e5f