### PR TITLE
Improve daily menus hooks

### DIFF
--- a/src/hooks/useMenuDuJour.js
+++ b/src/hooks/useMenuDuJour.js
@@ -3,10 +3,11 @@ import { useMenus } from "@/hooks/useMenus";
 export function useMenuDuJour() {
   const {
     menus,
+    total,
     loading,
     error,
-    fetchMenus,
-    addMenu,
+    getMenus,
+    createMenu,
     updateMenu,
     deleteMenu,
     toggleMenuActive,
@@ -16,10 +17,11 @@ export function useMenuDuJour() {
 
   return {
     menusDuJour: menus,
+    total,
     loading,
     error,
-    fetchMenusDuJour: fetchMenus,
-    addMenuDuJour: addMenu,
+    fetchMenusDuJour: getMenus,
+    addMenuDuJour: createMenu,
     editMenuDuJour: updateMenu,
     deleteMenuDuJour: deleteMenu,
     toggleMenuDuJourActive: toggleMenuActive,

--- a/src/pages/menus/MenuDuJour.jsx
+++ b/src/pages/menus/MenuDuJour.jsx
@@ -22,10 +22,10 @@ export default function MenuDuJour() {
 
   useEffect(() => {
     if (!authLoading && mama_id) {
-      fetchMenusDuJour();
+      fetchMenusDuJour({ search, date: dateFilter || undefined });
       fetchFiches();
     }
-  }, [authLoading, mama_id, fetchMenusDuJour, fetchFiches]);
+  }, [authLoading, mama_id, search, dateFilter, fetchMenusDuJour, fetchFiches]);
 
   const menusFiltres = menusDuJour.filter(m =>
     (!search || m.nom?.toLowerCase().includes(search.toLowerCase())) &&
@@ -46,7 +46,7 @@ export default function MenuDuJour() {
   const handleDelete = async (menu) => {
     if (window.confirm(`Supprimer le menu du jour "${menu.nom}" ?`)) {
       await deleteMenuDuJour(menu.id);
-      await fetchMenusDuJour();
+      fetchMenusDuJour({ search, date: dateFilter || undefined });
       toast.success("Menu du jour supprimé.");
     }
   };
@@ -128,7 +128,7 @@ export default function MenuDuJour() {
         <MenuDuJourForm
           menu={selected}
           fiches={fiches}
-          onClose={() => { setShowForm(false); setSelected(null); fetchMenusDuJour(); }}
+          onClose={() => { setShowForm(false); setSelected(null); fetchMenusDuJour({ search, date: dateFilter || undefined }); }}
         />
       )}
       {showDetail && selected && (

--- a/src/pages/menus/Menus.jsx
+++ b/src/pages/menus/Menus.jsx
@@ -11,7 +11,7 @@ import * as XLSX from "xlsx";
 import { motion as Motion } from "framer-motion";
 
 export default function Menus() {
-  const { menus, getMenus, deleteMenu } = useMenus();
+  const { menus, total, getMenus, deleteMenu } = useMenus();
   const { fiches, fetchFiches } = useFiches();
   const { mama_id, loading: authLoading } = useAuth();
   const [showForm, setShowForm] = useState(false);
@@ -23,32 +23,44 @@ export default function Menus() {
   const [monthFilter, setMonthFilter] = useState("");
   const [page, setPage] = useState(1);
 
-  const getWeek = (dateStr) => {
-    const d = new Date(dateStr);
-    d.setUTCDate(d.getUTCDate() + 4 - (d.getUTCDay() || 7));
-    const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
-    const weekNo = Math.ceil(((d - yearStart) / 86400000 + 1) / 7);
-    return `${d.getUTCFullYear()}-W${String(weekNo).padStart(2, "0")}`;
+  const perPage = 10;
+
+  const loadMenus = () => {
+    const opts = {
+      search,
+      date: dateFilter || undefined,
+      offset: (page - 1) * perPage,
+      limit: perPage,
+    };
+    if (weekFilter) {
+      const [year, wk] = weekFilter.split("-W");
+      const first = new Date(year, 0, 1 + (wk - 1) * 7);
+      const start = new Date(first.setDate(first.getDate() - first.getDay() + 1));
+      const end = new Date(start);
+      end.setDate(start.getDate() + 6);
+      opts.start = start.toISOString().slice(0, 10);
+      opts.end = end.toISOString().slice(0, 10);
+    }
+    if (monthFilter) {
+      const [y, m] = monthFilter.split("-");
+      const start = new Date(y, m - 1, 1);
+      const end = new Date(y, m, 0);
+      opts.start = start.toISOString().slice(0, 10);
+      opts.end = end.toISOString().slice(0, 10);
+    }
+    getMenus(opts);
+    fetchFiches();
   };
 
-  // Récupération initiale des menus et fiches
+  // Chargement initial et à chaque filtre
   useEffect(() => {
     if (!authLoading && mama_id) {
-      getMenus();
-      fetchFiches();
+      loadMenus();
     }
-  }, [authLoading, mama_id, getMenus, fetchFiches]);
+  }, [authLoading, mama_id, search, dateFilter, weekFilter, monthFilter, page, getMenus, fetchFiches]);
 
-  const menusFiltres = menus.filter(m => {
-    if (search && !m.nom?.toLowerCase().includes(search.toLowerCase())) return false;
-    if (dateFilter && m.date !== dateFilter) return false;
-    if (weekFilter && getWeek(m.date) !== weekFilter) return false;
-    if (monthFilter && m.date.slice(0, 7) !== monthFilter) return false;
-    return true;
-  });
-  const perPage = 10;
-  const pageCount = Math.ceil(menusFiltres.length / perPage);
-  const paginatedMenus = menusFiltres.slice((page - 1) * perPage, page * perPage);
+  const pageCount = Math.ceil(total / perPage);
+  const paginatedMenus = menus;
 
   const exportExcel = () => {
     const wb = XLSX.utils.book_new();
@@ -64,7 +76,7 @@ export default function Menus() {
   const handleDelete = async (menu) => {
     if (window.confirm(`Supprimer le menu "${menu.nom}" ?`)) {
       await deleteMenu(menu.id);
-      await getMenus();
+      loadMenus();
       toast.success("Menu supprimé.");
     }
   };
@@ -190,7 +202,7 @@ export default function Menus() {
         <MenuForm
           menu={selected}
           fiches={fiches}
-          onClose={() => { setShowForm(false); setSelected(null); getMenus(); }}
+          onClose={() => { setShowForm(false); setSelected(null); loadMenus(); }}
         />
       )}
       {showDetail && selected && (

--- a/test/useMenuDuJour.test.js
+++ b/test/useMenuDuJour.test.js
@@ -1,10 +1,13 @@
 import { renderHook, act } from '@testing-library/react';
 import { vi, beforeEach, test, expect } from 'vitest';
 
-const orderMock = vi.fn(() => Promise.resolve({ data: [{ id: 'm1' }], error: null }));
-const ilikeMock = vi.fn(() => ({ order: orderMock }));
-const eqMock = vi.fn(() => ({ ilike: ilikeMock, order: orderMock }));
-const selectMock = vi.fn(() => ({ eq: eqMock, order: orderMock }));
+const rangeMock = vi.fn(() => Promise.resolve({ data: [{ id: 'm1' }], count: 1, error: null }));
+const orderMock = vi.fn(() => ({ range: rangeMock }));
+const lteMock = vi.fn(() => ({ order: orderMock }));
+const gteMock = vi.fn(() => ({ lte: lteMock, order: orderMock }));
+const ilikeMock = vi.fn(() => ({ gte: gteMock, lte: lteMock, order: orderMock }));
+const eqMock = vi.fn(() => ({ ilike: ilikeMock, gte: gteMock, lte: lteMock, order: orderMock }));
+const selectMock = vi.fn(() => ({ eq: eqMock, ilike: ilikeMock, gte: gteMock, lte: lteMock, order: orderMock }));
 const fromMock = vi.fn(() => ({ select: selectMock }));
 
 vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
@@ -27,8 +30,9 @@ test('fetchMenusDuJour retrieves menus', async () => {
     await result.current.fetchMenusDuJour();
   });
   expect(fromMock).toHaveBeenCalledWith('menus');
-  expect(selectMock).toHaveBeenCalledWith('*, fiches:menu_fiches(fiche_id, fiche: fiches(id, nom))');
+  expect(selectMock).toHaveBeenCalledWith('*, fiches:menu_fiches(fiche_id, fiche: fiches(id, nom))', { count: 'exact' });
   expect(eqMock).toHaveBeenCalledWith('mama_id', 'm1');
   expect(orderMock).toHaveBeenCalledWith('date', { ascending: false });
+  expect(rangeMock).toHaveBeenCalledWith(0, 49);
   expect(result.current.menusDuJour).toEqual([{ id: 'm1' }]);
 });


### PR DESCRIPTION
## Summary
- add audit logging and pagination support in `useMenus`
- expose totals via `useMenuDuJour`
- fetch menus with server-side filters and pagination
- refresh lists after CRUD actions
- update unit test for new query chain

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ff802e0fc832db02af5f849d211c0