### PR TITLE
Audit utilisateurs: fix hooks and add indexes

### DIFF
--- a/db/full_setup.sql
+++ b/db/full_setup.sql
@@ -1963,6 +1963,20 @@ create table if not exists public.utilisateurs (
     created_at timestamptz default now()
 );
 
+-- Ensure unique constraint on auth_id and indexes for performant lookups
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'utilisateurs_auth_id_key'
+  ) THEN
+    ALTER TABLE public.utilisateurs
+      ADD CONSTRAINT utilisateurs_auth_id_key UNIQUE (auth_id);
+  END IF;
+END $$;
+
+create index if not exists idx_utilisateurs_auth_id on public.utilisateurs(auth_id);
+create index if not exists idx_utilisateurs_mama_id on public.utilisateurs(mama_id);
+
 alter table public.utilisateurs enable row level security;
 drop policy if exists utilisateurs_select on public.utilisateurs;
 create policy utilisateurs_select on public.utilisateurs

--- a/src/hooks/useUsers.js
+++ b/src/hooks/useUsers.js
@@ -34,12 +34,13 @@ export function useUsers() {
 
   // 2. Ajouter un utilisateur (invitation)
   async function addUser(user) {
-    if (!mama_id) return { error: "Aucun mama_id" };
+    const targetMama = role === "superadmin" ? user.mama_id : mama_id;
+    if (!targetMama) return { error: "Aucun mama_id" };
     setLoading(true);
     setError(null);
     const { error } = await supabase
       .from("utilisateurs")
-      .insert([{ ...user, mama_id }]);
+      .insert([{ ...user, mama_id: targetMama }]);
     if (error) setError(error);
     setLoading(false);
     await fetchUsers();
@@ -50,11 +51,13 @@ export function useUsers() {
     if (!mama_id && role !== "superadmin") return { error: "Aucun mama_id" };
     setLoading(true);
     setError(null);
-    const { error } = await supabase
+    let fields = updateFields;
+    let query = supabase
       .from("utilisateurs")
-      .update(updateFields)
-      .eq("id", id)
-      .eq("mama_id", mama_id);
+      .update(fields)
+      .eq("id", id);
+    if (role !== "superadmin") query = query.eq("mama_id", mama_id);
+    const { error } = await query;
     if (error) setError(error);
     setLoading(false);
     await fetchUsers();
@@ -65,11 +68,12 @@ export function useUsers() {
     if (!mama_id && role !== "superadmin") return { error: "Aucun mama_id" };
     setLoading(true);
     setError(null);
-    const { error } = await supabase
+    let query = supabase
       .from("utilisateurs")
       .update({ actif })
-      .eq("id", id)
-      .eq("mama_id", mama_id);
+      .eq("id", id);
+    if (role !== "superadmin") query = query.eq("mama_id", mama_id);
+    const { error } = await query;
     if (error) setError(error);
     setLoading(false);
     await fetchUsers();
@@ -80,11 +84,12 @@ export function useUsers() {
     if (!mama_id && role !== "superadmin") return { error: "Aucun mama_id" };
     setLoading(true);
     setError(null);
-    const { error } = await supabase
+    let query = supabase
       .from("utilisateurs")
       .update({ actif: false })
-      .eq("id", id)
-      .eq("mama_id", mama_id);
+      .eq("id", id);
+    if (role !== "superadmin") query = query.eq("mama_id", mama_id);
+    const { error } = await query;
     if (error) setError(error);
     setLoading(false);
     await fetchUsers();

--- a/src/hooks/useUtilisateurs.js
+++ b/src/hooks/useUtilisateurs.js
@@ -34,12 +34,13 @@ export function useUtilisateurs() {
 
   // 2. Ajouter un utilisateur (invitation)
   async function addUser(user) {
-    if (!mama_id) return { error: "Aucun mama_id" };
+    const targetMama = role === "superadmin" ? user.mama_id : mama_id;
+    if (!targetMama) return { error: "Aucun mama_id" };
     setLoading(true);
     setError(null);
     const { error } = await supabase
       .from("utilisateurs")
-      .insert([{ ...user, mama_id }]);
+      .insert([{ ...user, mama_id: targetMama }]);
     if (error) setError(error);
     setLoading(false);
     await fetchUsers();

--- a/test/useUtilisateurs.test.js
+++ b/test/useUtilisateurs.test.js
@@ -1,0 +1,68 @@
+import { renderHook, act } from '@testing-library/react';
+import { vi, beforeEach, test, expect } from 'vitest';
+
+const query = {
+  select: vi.fn(() => query),
+  order: vi.fn(() => query),
+  eq: vi.fn(() => query),
+  ilike: vi.fn(() => query),
+  insert: vi.fn(() => query),
+  update: vi.fn(() => query),
+  delete: vi.fn(() => query),
+  then: (fn) => Promise.resolve(fn({ data: [], error: null })),
+};
+const fromMock = vi.fn(() => query);
+vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
+
+const authMock = vi.fn(() => ({ mama_id: 'm1', role: 'admin' }));
+vi.mock('@/context/AuthContext', () => ({ useAuth: authMock }));
+
+let useUtilisateurs;
+
+beforeEach(async () => {
+  ({ useUtilisateurs } = await import('@/hooks/useUtilisateurs'));
+  fromMock.mockClear();
+  query.select.mockClear();
+  query.order.mockClear();
+  query.eq.mockClear();
+  query.ilike.mockClear();
+  query.insert.mockClear();
+  query.update.mockClear();
+  query.delete.mockClear();
+});
+
+test('fetchUsers applies filters', async () => {
+  const { result } = renderHook(() => useUtilisateurs());
+  await act(async () => {
+    await result.current.fetchUsers({ search: 'foo', actif: true, filterRole: 'admin' });
+  });
+  expect(fromMock).toHaveBeenCalledWith('utilisateurs');
+  expect(query.select).toHaveBeenCalledWith('id, email, actif, mama_id, role, access_rights');
+  expect(query.order).toHaveBeenCalledWith('email', { ascending: true });
+  expect(query.eq.mock.calls).toContainEqual(['mama_id', 'm1']);
+  expect(query.ilike).toHaveBeenCalledWith('email', '%foo%');
+  expect(query.eq.mock.calls).toContainEqual(['role', 'admin']);
+  expect(query.eq.mock.calls).toContainEqual(['actif', true]);
+});
+
+test('addUser inserts with current mama_id', async () => {
+  const { result } = renderHook(() => useUtilisateurs());
+  await act(async () => {
+    await result.current.addUser({ email: 'a' });
+  });
+  expect(query.insert).toHaveBeenCalledWith([{ email: 'a', mama_id: 'm1' }]);
+});
+
+test('superadmin bypasses mama filter', async () => {
+  authMock.mockReturnValueOnce({ mama_id: null, role: 'superadmin' });
+  ({ useUtilisateurs } = await import('@/hooks/useUtilisateurs'));
+  const { result } = renderHook(() => useUtilisateurs());
+  await act(async () => {
+    await result.current.addUser({ email: 'b', mama_id: 'm2' });
+    await result.current.updateUser('id1', { role: 'user' });
+  });
+  expect(query.insert).toHaveBeenCalledWith([{ email: 'b', mama_id: 'm2' }]);
+  expect(query.update).toHaveBeenCalledWith({ role: 'user' });
+  expect(query.eq).toHaveBeenCalledWith('id', 'id1');
+  expect(query.eq.mock.calls.some(c => c[0] === 'mama_id')).toBe(false);
+});


### PR DESCRIPTION
## Summary
- add unique constraint and indexes on `utilisateurs`
- correct `useUtilisateurs` and `useUsers` to handle superadmin mama_id logic
- add tests for `useUtilisateurs`

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ff848c614832d8685142dff15b829