### PR TITLE
Fix login workflow and pending screen

### DIFF
--- a/src/lib/loginUser.js
+++ b/src/lib/loginUser.js
@@ -1,37 +1,11 @@
-import { supabase } from './supabase';
+import { supabase } from "./supabase";
 
-// Use the shared Supabase client from src/lib/supabase.js
-
-/**
- * Authenticates a user with email and password.
- * @param {string} email - User email address
- * @param {string} password - User password
- * @returns {Promise<{user: object, access_token: string, refresh_token: string}|{errorCode: string|number, errorMessage: string}>}
- */
+// Simple wrapper used by the AuthContext and auth pages
 export async function login(email, password) {
-  try {
-    const { data, error } = await supabase.auth.signInWithPassword({ email, password });
-    if (error) {
-      console.error('Login error:', error);
-      const message = error.message || error.error_description || 'Unknown error';
-      let code = error.status || error.code || 'auth_error';
-      // Attempt to categorise common errors
-      if (/user.*not.*found/i.test(message)) code = 'user_not_found';
-      else if (/invalid.*login|wrong.*password|mot de passe/i.test(message)) code = 'invalid_password';
-      return { errorCode: code, errorMessage: message };
-    }
-    if (!data?.session || !data.user) {
-      console.error('Login succeeded but session or user is missing', data);
-      return { errorCode: 'invalid_response', errorMessage: 'Réponse Supabase invalide' };
-    }
-    const { session, user } = data;
-    return {
-      user,
-      access_token: session.access_token,
-      refresh_token: session.refresh_token,
-    };
-  } catch (err) {
-    console.error('Unexpected error during login:', err);
-    return { errorCode: 'unexpected_error', errorMessage: err.message || 'Erreur inconnue' };
-  }
+  const { data, error } = await supabase.auth.signInWithPassword({
+    email,
+    password,
+  });
+  if (error) throw error;
+  return data;
 }

--- a/src/pages/auth/Login.jsx
+++ b/src/pages/auth/Login.jsx
@@ -7,6 +7,7 @@ import useFormErrors from "@/hooks/useFormErrors";
 import GlassCard from "@/components/ui/GlassCard";
 import PageWrapper from "@/components/ui/PageWrapper";
 import PrimaryButton from "@/components/ui/PrimaryButton";
+import { login as loginUser } from "../../lib/loginUser";
 
 export default function Login() {
   const [email, setEmail] = useState("");
@@ -15,12 +16,7 @@ export default function Login() {
   const { errors, setError, clearErrors } = useFormErrors();
   const navigate = useNavigate();
 
-  const {
-    session,
-    userData,
-    login,
-    loading: authLoading,
-  } = useAuth();
+  const { session, userData, loading: authLoading } = useAuth();
 
   const [totp, setTotp] = useState("");
   const [twoFA, setTwoFA] = useState(false);
@@ -51,20 +47,10 @@ export default function Login() {
 
     setLoading(true);
     try {
-      const { error, twofaRequired } = await login({
-        email: email.trim(),
-        password,
-        totp,
-      });
-
+      const { error } = await loginUser(email.trim(), password);
       if (error) {
-        if (twofaRequired) {
-          setTwoFA(true);
-          setError("totp", error);
-        } else {
-          setError("password", error);
-        }
-        toast.error(error?.message || error || "Échec de la connexion");
+        setError("password", error.message || error);
+        toast.error(error.message || "Échec de la connexion");
         return;
       }
 

--- a/src/pages/auth/Pending.jsx
+++ b/src/pages/auth/Pending.jsx
@@ -1,8 +1,6 @@
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import GlassCard from "@/components/ui/GlassCard";
-import PageWrapper from "@/components/ui/PageWrapper";
-import PrimaryButton from "@/components/ui/PrimaryButton";
 import useAuth from "@/hooks/useAuth";
 
 export default function Pending() {
@@ -12,13 +10,13 @@ export default function Pending() {
   useEffect(() => {
     if (userData) navigate("/dashboard");
   }, [userData, navigate]);
+
   return (
-    <PageWrapper>
-      <GlassCard className="flex flex-col items-center text-center gap-4">
-        <h1 className="text-3xl font-bold text-gold">Compte en cours de création…</h1>
-        <p>Votre compte est en cours de création, merci de patienter...</p>
-        <PrimaryButton onClick={() => navigate("/logout")}>Se déconnecter</PrimaryButton>
+    <div className="flex items-center justify-center min-h-screen bg-blue-100 backdrop-blur-md bg-opacity-40">
+      <GlassCard>
+        <h2 className="text-xl font-semibold text-center text-mamastock">Compte en cours de création…</h2>
+        <p className="text-center mt-2">Merci de patienter pendant l'initialisation de votre compte.</p>
       </GlassCard>
-    </PageWrapper>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- simplify loginUser.js and export named login function
- update AuthContext to use refreshed login flow and handle pending users
- fetch user data via auth_id with maybeSingle
- show improved pending account message
- update Login page to use new login helper

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860176acd18832daa6c1ccb80f51986