### PR TITLE
Enhance liquid glass preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,25 @@ The default router redirects unauthenticated visitors from `/` to `/login` and
 shows the dashboard when logged in. `index.html` contains PWA metadata with the
 favicon, manifest and splash screen so you can install the app on mobile.
 
+### Liquid glass theme
+
+The UI uses an animated "liquid glass" look across every page. Waves and
+bubble particles are rendered behind glass panels and dialogs, with a glow that
+follows the mouse on desktop and a ripple effect on mobile. A preview of the
+theme can be enabled by appending `?preview` to the URL on the home or login
+pages. Colours adapt automatically to light or dark mode through the
+`ThemeProvider`.
+
+Background animations accept an optional `intensity` prop so pages can tune
+the opacity of the glow. When previewing, you can also append
+`&intensity=1.5` (for example) to the URL to increase or decrease the
+transparency.
+
+Reusable components `LiquidBackground`, `WavesBackground`, `MouseLight` and
+`TouchLight` are available under `src/components/LiquidBackground`. Include
+them at the root of a page or layout to display the animated waves, bubble
+particles and interactive lights.
+
 Le script `src/registerSW.js` enregistre automatiquement un service worker pour activer l'usage hors ligne. Lancez `npm run preview` ou servez le dossier `dist` pour vérifier que l'enregistrement fonctionne.
 ### Database
 

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -2,13 +2,13 @@ import { Link } from "react-router-dom";
 
 export default function Footer() {
   return (
-    <footer className="w-full bg-[#2e2e3a] text-[#f8f8fa] text-sm py-4 px-6 flex flex-col sm:flex-row items-center justify-between rounded-t-2xl shadow-lg z-50">
+    <footer className="w-full bg-glass backdrop-blur-md border-t border-white/10 text-white/90 text-sm py-4 px-6 flex flex-col sm:flex-row items-center justify-between rounded-t-2xl shadow-lg">
       <span className="font-semibold tracking-wide mb-2 sm:mb-0">MamaStock 2025</span>
       <span className="flex items-center gap-4">
-        <Link to="/rgpd" className="underline hover:text-[#ff5a5f] transition">
+        <Link to="/rgpd" className="underline hover:text-mamastockGold transition">
           Données &amp; Confidentialité
         </Link>
-        <span className="italic text-[#f8f8fa]/80">
+        <span className="italic opacity-80">
           Simplifiez la gestion, concentrez-vous sur l’essentiel.
         </span>
       </span>

--- a/src/components/LiquidBackground/BubblesParticles.jsx
+++ b/src/components/LiquidBackground/BubblesParticles.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+export default function BubblesParticles({
+  count = 12,
+  className = '',
+  color = 'rgba(255,255,255,0.15)',
+}) {
+  const bubbles = Array.from({ length: count }).map((_, i) => {
+    const delay = (Math.random() * 8).toFixed(2);
+    const size = Math.floor(Math.random() * 24) + 12;
+    const left = Math.random() * 100;
+    const duration = (10 + Math.random() * 10).toFixed(2);
+    const style = {
+      left: `${left}%`,
+      width: size,
+      height: size,
+      animationDelay: `${delay}s`,
+      animationDuration: `${duration}s`,
+      background: color,
+    };
+    return <span key={i} className="bubble" style={style} />;
+  });
+  return <div className={`absolute inset-0 overflow-hidden pointer-events-none ${className}`}>{bubbles}</div>;
+}

--- a/src/components/LiquidBackground/LiquidBackground.jsx
+++ b/src/components/LiquidBackground/LiquidBackground.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import BubblesParticles from './BubblesParticles';
+
+export default function LiquidBackground({
+  className = '',
+  showParticles = false,
+  particles = 12,
+  intensity = 1,
+}) {
+  const style1 = { opacity: 0.4 * intensity };
+  const style2 = { opacity: 0.2 * intensity };
+  const style3 = { opacity: 0.15 * intensity };
+  return (
+    <div className={`absolute inset-0 overflow-hidden pointer-events-none ${className}`}>
+      <div
+        className="absolute -top-10 -left-20 w-[480px] h-[420px] bg-gradient-to-br from-[#bfa14d] via-[#fff8e1]/70 to-transparent blur-[90px] rounded-full animate-liquid"
+        style={style1}
+      />
+      <div
+        className="absolute bottom-[-20%] right-[-18%] w-[480px] h-[420px] bg-gradient-to-br from-[#fff8e1]/90 via-white/60 to-transparent blur-[80px] rounded-full animate-liquid2"
+        style={style2}
+      />
+      <div
+        className="absolute top-1/3 left-1/2 -translate-x-1/2 w-[280px] h-[180px] bg-white/20 blur-2xl rounded-[36%_54%_41%_59%/50%_41%_59%_50%] animate-liquid3"
+        style={style3}
+      />
+      {showParticles && <BubblesParticles count={particles} />}
+    </div>
+  );
+}

--- a/src/components/LiquidBackground/MouseLight.jsx
+++ b/src/components/LiquidBackground/MouseLight.jsx
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+
+export default function MouseLight({ className = '' }) {
+  const [pos, setPos] = useState({ x: -9999, y: -9999 });
+  useEffect(() => {
+    const handleMove = (e) => setPos({ x: e.clientX, y: e.clientY });
+    window.addEventListener('pointermove', handleMove);
+    return () => window.removeEventListener('pointermove', handleMove);
+  }, []);
+  return (
+    <div
+      className={`hidden md:block fixed inset-0 pointer-events-none mix-blend-overlay ${className}`}
+      style={{
+        background: `radial-gradient(circle at ${pos.x}px ${pos.y}px, rgba(255,255,255,0.25), transparent 80%)`,
+        transition: 'background 0.15s',
+      }}
+    />
+  );
+}

--- a/src/components/LiquidBackground/TouchLight.jsx
+++ b/src/components/LiquidBackground/TouchLight.jsx
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+
+export default function TouchLight({ className = '' }) {
+  const [ripple, setRipple] = useState(null);
+
+  useEffect(() => {
+    const handleTouch = (e) => {
+      const t = e.touches[0];
+      if (!t) return;
+      const x = t.clientX;
+      const y = t.clientY;
+      setRipple({ x, y, id: Date.now() });
+    };
+    window.addEventListener('touchstart', handleTouch);
+    return () => window.removeEventListener('touchstart', handleTouch);
+  }, []);
+
+  return (
+    <div className={`md:hidden fixed inset-0 pointer-events-none ${className}`}>
+      {ripple && (
+        <span
+          key={ripple.id}
+          className="absolute block w-40 h-40 bg-white/20 rounded-full -translate-x-1/2 -translate-y-1/2 animate-touch-fade"
+          style={{ left: ripple.x, top: ripple.y }}
+          onAnimationEnd={() => setRipple(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/LiquidBackground/WavesBackground.jsx
+++ b/src/components/LiquidBackground/WavesBackground.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export default function WavesBackground({ className = '' }) {
+  return (
+    <div className={`absolute inset-x-0 bottom-0 h-32 overflow-hidden pointer-events-none ${className}`} aria-hidden="true">
+      <svg className="wave text-white/10 fill-current" viewBox="0 0 1440 320">
+        <path d="M0 160L48 149.3C96 139 192 117 288 138.7C384 160 480 224 576 245.3C672 267 768 245 864 218.7C960 192 1056 160 1152 149.3C1248 139 1344 149 1392 154.7L1440 160V320H1392C1344 320 1248 320 1152 320C1056 320 960 320 864 320C768 320 672 320 576 320C480 320 384 320 288 320C192 320 96 320 48 320H0Z" />
+      </svg>
+      <svg className="wave text-white/5 fill-current" viewBox="0 0 1440 320">
+        <path d="M0 160L48 138.7C96 117 192 75 288 74.7C384 75 480 117 576 144C672 171 768 181 864 170.7C960 160 1056 128 1152 112C1248 96 1344 96 1392 96L1440 96V320H1392C1344 320 1248 320 1152 320C1056 320 960 320 864 320C768 320 672 320 576 320C480 320 384 320 288 320C192 320 96 320 48 320H0Z" />
+      </svg>
+    </div>
+  );
+}

--- a/src/components/LiquidBackground/index.js
+++ b/src/components/LiquidBackground/index.js
@@ -1,0 +1,5 @@
+export { default as LiquidBackground } from './LiquidBackground';
+export { default as BubblesParticles } from './BubblesParticles';
+export { default as WavesBackground } from './WavesBackground';
+export { default as MouseLight } from './MouseLight';
+export { default as TouchLight } from './TouchLight';

--- a/src/components/analytics/CostCenterAllocationModal.jsx
+++ b/src/components/analytics/CostCenterAllocationModal.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Dialog, DialogContent, DialogOverlay } from "@radix-ui/react-dialog";
+import ModalGlass from "@/components/ui/ModalGlass";
 import { Button } from "@/components/ui/button";
 import { useCostCenters } from "@/hooks/useCostCenters";
 import { useMouvementCostCenters } from "@/hooks/useMouvementCostCenters";
@@ -75,13 +75,11 @@ export default function CostCenterAllocationModal({ mouvementId, productId, open
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogOverlay className="fixed inset-0 bg-black/40" />
-      <DialogContent className="glass-liquid rounded-xl p-6 max-w-lg">
+    <ModalGlass open={open} onClose={() => onOpenChange(false)}>
         <h3 className="font-bold mb-4 text-lg">Ventilation cost centers</h3>
         <form onSubmit={handleSubmit} className="space-y-2">
           {suggestions.length > 0 && (
-            <div className="text-xs mb-2 p-2 bg-gray-50 rounded">
+            <div className="text-xs mb-2 p-2 bg-glass border border-borderGlass backdrop-blur rounded">
               Suggestions:
               <ul className="list-disc list-inside">
                 {suggestions.map(s => (
@@ -127,7 +125,6 @@ export default function CostCenterAllocationModal({ mouvementId, productId, open
             <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>Annuler</Button>
           </div>
         </form>
-      </DialogContent>
-    </Dialog>
+    </ModalGlass>
   );
 }

--- a/src/components/dashboard/DashboardCard.jsx
+++ b/src/components/dashboard/DashboardCard.jsx
@@ -2,19 +2,19 @@ import { motion as Motion } from "framer-motion";
 
 export default function DashboardCard({ title, value, icon, type = "default", progress = null, children }) {
   const colorClass = {
-    default: "bg-white text-mamastockText",
-    stock: "bg-blue-50 text-blue-800",
-    ca: "bg-green-50 text-green-800",
-    cost: "bg-orange-50 text-orange-800",
-    alert: "bg-red-50 text-red-800"
-  }[type] || "bg-white text-mamastockText";
+    default: "text-white",
+    stock: "text-blue-200",
+    ca: "text-green-200",
+    cost: "text-orange-200",
+    alert: "text-red-200"
+  }[type] || "text-white";
 
   return (
     <Motion.div
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.3 }}
-      className={`rounded-2xl shadow-md p-4 flex flex-col items-center min-w-[180px] ${colorClass}`}
+      className={`bg-glass border border-borderGlass backdrop-blur rounded-2xl shadow-md p-4 flex flex-col items-center min-w-[180px] ${colorClass}`}
     >
       <div className="flex items-center space-x-2">
         {icon && <span className="text-2xl">{icon}</span>}
@@ -22,7 +22,7 @@ export default function DashboardCard({ title, value, icon, type = "default", pr
       </div>
       <div className="text-3xl font-extrabold my-2">{value}</div>
       {progress !== null &&
-        <div className="w-full h-2 rounded bg-gray-200 mt-1">
+        <div className="w-full h-2 rounded bg-white/20 mt-1">
           <div className="h-2 rounded bg-mamastockGold" style={{ width: `${progress}%` }} />
         </div>
       }

--- a/src/components/export/FicheExportView.jsx
+++ b/src/components/export/FicheExportView.jsx
@@ -9,7 +9,7 @@ export default function FicheExportView({ fiches = [] }) {
           )}
           <table className="w-full text-sm border mb-4">
             <thead>
-              <tr className="bg-gray-100">
+              <tr className="bg-white/10">
                 <th className="border px-2 py-1">Ingrédient</th>
                 <th className="border px-2 py-1">Qté</th>
                 <th className="border px-2 py-1">Unité</th>

--- a/src/components/help/DocumentationPanel.jsx
+++ b/src/components/help/DocumentationPanel.jsx
@@ -13,7 +13,7 @@ export default function DocumentationPanel({ open, onOpenChange }) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogOverlay className="fixed inset-0 bg-black/40" />
-      <DialogContent className="fixed right-0 top-0 bottom-0 w-96 bg-white p-4 overflow-y-auto">
+      <DialogContent className="fixed right-0 top-0 bottom-0 w-96 bg-glass border border-borderGlass backdrop-blur p-4 overflow-y-auto">
         <input
           className="input input-bordered w-full mb-4"
           placeholder="Recherche..."

--- a/src/components/help/FeedbackForm.jsx
+++ b/src/components/help/FeedbackForm.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Dialog, DialogContent, DialogOverlay } from "@/components/ui/dialog";
+import ModalGlass from "@/components/ui/ModalGlass";
 import { supabase } from "@/lib/supabase";
 import { Button } from "@/components/ui/button";
 import { useAuth } from "@/context/AuthContext";
@@ -31,9 +31,7 @@ export default function FeedbackForm({ open, onOpenChange }) {
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogOverlay className="fixed inset-0 bg-black/40" />
-      <DialogContent className="glass-liquid rounded-xl p-6 max-w-md">
+    <ModalGlass open={open} onClose={() => onOpenChange(false)}>
         <h3 className="text-lg font-semibold mb-4">Besoin d'aide ?</h3>
         <form onSubmit={handleSubmit} className="space-y-2">
           <input
@@ -70,8 +68,7 @@ export default function FeedbackForm({ open, onOpenChange }) {
             </Button>
           </div>
         </form>
-      </DialogContent>
-    </Dialog>
+    </ModalGlass>
   );
 }
 

--- a/src/components/help/GuidedTour.jsx
+++ b/src/components/help/GuidedTour.jsx
@@ -35,7 +35,7 @@ export default function GuidedTour({ steps = [], module }) {
           initial={{ opacity: 0, scale: 0.8 }}
           animate={{ opacity: 1, scale: 1 }}
           exit={{ opacity: 0 }}
-          className="fixed z-50 bg-white text-black p-4 rounded shadow-xl"
+          className="fixed z-50 bg-glass border border-borderGlass backdrop-blur text-white p-4 rounded-xl shadow-xl"
           style={{ top: coords.top, left: coords.left }}
         >
           <p className="mb-2 text-sm">{step.content}</p>

--- a/src/components/ia/RecommandationsBox.jsx
+++ b/src/components/ia/RecommandationsBox.jsx
@@ -27,7 +27,7 @@ export default function RecommandationsBox({ filter }) {
         <div
           key={idx}
           onClick={() => rec.onClick?.(rec) || refresh()}
-          className="flex items-center gap-2 bg-white rounded-lg p-2 shadow cursor-pointer hover:bg-gray-50 text-sm"
+          className="flex items-center gap-2 bg-glass border border-borderGlass backdrop-blur rounded-lg p-2 shadow cursor-pointer hover:bg-white/20 text-sm"
         >
           <span>{rec.type === 'alert' ? '🔍' : '🧠'}</span>
           <span className="flex-1">{rec.message}</span>

--- a/src/components/inventaires/InventaireDetail.jsx
+++ b/src/components/inventaires/InventaireDetail.jsx
@@ -30,7 +30,7 @@ export default function InventaireDetail({ inventaire, onClose }) {
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
-      <div className="bg-white rounded-xl shadow-lg p-8 min-w-[400px] max-w-[95vw] flex flex-col gap-2 relative">
+      <div className="bg-glass border border-borderGlass backdrop-blur rounded-2xl shadow-lg p-8 min-w-[400px] max-w-[95vw] flex flex-col gap-2 relative">
         <Button variant="outline" className="absolute top-2 right-2" onClick={onClose}>Fermer</Button>
         <h2 className="font-bold text-xl mb-4">{inventaire.nom}</h2>
         <div><b>Date :</b> {inventaire.date}</div>
@@ -43,7 +43,7 @@ export default function InventaireDetail({ inventaire, onClose }) {
         </div>
         <div className="my-4">
           <h3 className="font-bold mb-2">Lignes d’inventaire</h3>
-          <table className="min-w-full bg-gray-50 rounded">
+          <table className="min-w-full bg-glass border border-borderGlass rounded backdrop-blur">
             <thead>
               <tr>
                 <th>Produit</th>
@@ -72,7 +72,7 @@ export default function InventaireDetail({ inventaire, onClose }) {
         </div>
         <div className="my-4">
           <h3 className="font-bold mb-2">Mouvements liés</h3>
-          <table className="min-w-full bg-gray-50 rounded">
+          <table className="min-w-full bg-glass border border-borderGlass rounded backdrop-blur">
             <thead>
               <tr>
                 <th>Date</th>

--- a/src/components/inventaires/InventaireForm.jsx
+++ b/src/components/inventaires/InventaireForm.jsx
@@ -133,7 +133,10 @@ export default function InventaireForm({ inventaire, onClose }) {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="bg-white p-6 rounded-lg shadow-md max-w-2xl mx-auto">
+    <form
+      onSubmit={handleSubmit}
+      className="bg-glass border border-borderGlass backdrop-blur p-6 rounded-2xl shadow-lg max-w-2xl mx-auto"
+    >
       <h2 className="text-lg font-bold mb-4">
         {inventaire ? "Modifier l’inventaire" : "Ajouter un inventaire"}
       </h2>

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -12,7 +12,7 @@ export default function Sidebar() {
   const has = (key) => showAll || rights[key];
 
   return (
-    <aside className="w-64 bg-white/5 backdrop-blur-xl text-white p-4 h-screen shadow-md text-shadow">
+    <aside className="w-64 bg-glass border border-white/10 backdrop-blur-xl text-white p-4 h-screen shadow-md text-shadow">
       <div className="mb-6">
         <MamaLogo width={140} />
       </div>

--- a/src/components/parametrage/ParamAccess.jsx
+++ b/src/components/parametrage/ParamAccess.jsx
@@ -1,6 +1,7 @@
 import { usePermissions } from "@/hooks/usePermissions";
 import { useRoles } from "@/hooks/useRoles";
 import { Button } from "@/components/ui/button";
+import TableContainer from "@/components/ui/TableContainer";
 import { useEffect } from "react";
 import { useAuth } from "@/context/AuthContext";
 import { Toaster, toast } from "react-hot-toast";
@@ -34,16 +35,17 @@ export default function ParamAccess() {
     <div>
       <Toaster position="top-right" />
       <h2 className="font-bold text-xl mb-4">Grille d’accès par rôle</h2>
-      <table className="min-w-full bg-white rounded-xl shadow-md text-xs">
-        <thead>
-          <tr>
-            <th>Rôle</th>
-            {modules.map(m => <th key={m}>{m}</th>)}
-          </tr>
-        </thead>
-        <tbody>
-          {roles.map(r => (
-            <tr key={r.id}>
+      <TableContainer className="mt-2">
+        <table className="min-w-full text-xs">
+          <thead>
+            <tr>
+              <th>Rôle</th>
+              {modules.map(m => <th key={m}>{m}</th>)}
+            </tr>
+          </thead>
+          <tbody>
+            {roles.map(r => (
+              <tr key={r.id}>
               <td>{r.nom}</td>
               {modules.map(m => {
                 const current = permissions.find(p => p.role_id === r.id && p.module === m);
@@ -60,7 +62,8 @@ export default function ParamAccess() {
             </tr>
           ))}
         </tbody>
-      </table>
+        </table>
+      </TableContainer>
     </div>
   );
 }

--- a/src/components/parametrage/ParamCostCenters.jsx
+++ b/src/components/parametrage/ParamCostCenters.jsx
@@ -2,6 +2,7 @@ import { useCostCenters } from "@/hooks/useCostCenters";
 import { useState, useEffect, useRef } from "react";
 import { useAuth } from "@/context/AuthContext";
 import { Button } from "@/components/ui/button";
+import TableContainer from "@/components/ui/TableContainer";
 import { Toaster, toast } from "react-hot-toast";
 import * as XLSX from "xlsx";
 
@@ -144,27 +145,29 @@ export default function ParamCostCenters() {
           data-testid="import-cc-input"
         />
       </div>
-      <table className="min-w-full bg-white rounded-xl shadow-md text-xs">
-        <thead>
-          <tr>
-            <th>Nom</th>
-            <th>Actif</th>
-            <th>Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {filtered.map(c => (
-            <tr key={c.id}>
-              <td>{c.nom}</td>
-              <td>{c.actif ? "✅" : "❌"}</td>
-              <td>
-                <Button size="sm" variant="outline" onClick={() => handleEdit(c)}>Éditer</Button>
-                <Button size="sm" variant="ghost" onClick={() => handleDelete(c.id)}>Supprimer</Button>
-              </td>
+      <TableContainer className="mt-2">
+        <table className="min-w-full text-xs">
+          <thead>
+            <tr>
+              <th>Nom</th>
+              <th>Actif</th>
+              <th>Actions</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {filtered.map(c => (
+              <tr key={c.id}>
+                <td>{c.nom}</td>
+                <td>{c.actif ? "✅" : "❌"}</td>
+                <td>
+                  <Button size="sm" variant="outline" onClick={() => handleEdit(c)}>Éditer</Button>
+                  <Button size="sm" variant="ghost" onClick={() => handleDelete(c.id)}>Supprimer</Button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </TableContainer>
     </div>
   );
 }

--- a/src/components/parametrage/ParamFamilles.jsx
+++ b/src/components/parametrage/ParamFamilles.jsx
@@ -1,5 +1,6 @@
 import { useFamilles } from "@/hooks/useFamilles";
 import { Button } from "@/components/ui/button";
+import TableContainer from "@/components/ui/TableContainer";
 import { useState, useEffect } from "react";
 import { useAuth } from "@/context/AuthContext";
 import { Toaster, toast } from "react-hot-toast";
@@ -105,25 +106,27 @@ export default function ParamFamilles() {
         onChange={e => setSearch(e.target.value)}
       />
       <Button variant="outline" className="mb-2" onClick={exportExcel}>Export Excel</Button>
-      <table className="min-w-full bg-white rounded-xl shadow-md text-xs">
-        <thead>
-          <tr>
-            <th>Nom</th>
-            <th>Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {filtered.map(f => (
-            <tr key={f.id}>
-              <td>{f.nom}</td>
-              <td>
-                <Button size="sm" variant="outline" onClick={() => handleEdit(f)}>Modifier</Button>
-                <Button size="sm" variant="outline" onClick={() => handleDelete(f.id)}>Supprimer</Button>
-              </td>
+      <TableContainer className="mt-2">
+        <table className="min-w-full text-xs">
+          <thead>
+            <tr>
+              <th>Nom</th>
+              <th>Actions</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {filtered.map(f => (
+              <tr key={f.id}>
+                <td>{f.nom}</td>
+                <td>
+                  <Button size="sm" variant="outline" onClick={() => handleEdit(f)}>Modifier</Button>
+                  <Button size="sm" variant="outline" onClick={() => handleDelete(f.id)}>Supprimer</Button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </TableContainer>
     </div>
   );
 }

--- a/src/components/parametrage/ParamRoles.jsx
+++ b/src/components/parametrage/ParamRoles.jsx
@@ -1,5 +1,6 @@
 import { useRoles } from "@/hooks/useRoles";
 import { Button } from "@/components/ui/button";
+import TableContainer from "@/components/ui/TableContainer";
 import { useState, useEffect } from "react";
 import { useAuth } from "@/context/AuthContext";
 import { Toaster, toast } from "react-hot-toast";
@@ -77,25 +78,27 @@ export default function ParamRoles() {
           </Button>
         )}
       </form>
-      <table className="min-w-full bg-white rounded-xl shadow-md text-xs">
-        <thead>
-          <tr>
-            <th>Nom</th>
-            <th>Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {roles.map(r => (
-            <tr key={r.id}>
-              <td>{r.nom}</td>
-              <td>
-                <Button size="sm" variant="outline" onClick={() => handleEdit(r)}>Modifier</Button>
-                <Button size="sm" variant="outline" onClick={() => handleDelete(r.id)}>Supprimer</Button>
-              </td>
+      <TableContainer className="mt-2">
+        <table className="min-w-full text-xs">
+          <thead>
+            <tr>
+              <th>Nom</th>
+              <th>Actions</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {roles.map(r => (
+              <tr key={r.id}>
+                <td>{r.nom}</td>
+                <td>
+                  <Button size="sm" variant="outline" onClick={() => handleEdit(r)}>Modifier</Button>
+                  <Button size="sm" variant="outline" onClick={() => handleDelete(r.id)}>Supprimer</Button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </TableContainer>
     </div>
   );
 }

--- a/src/components/parametrage/ParamUnites.jsx
+++ b/src/components/parametrage/ParamUnites.jsx
@@ -1,5 +1,6 @@
 import { useUnites } from "@/hooks/useUnites";
 import { Button } from "@/components/ui/button";
+import TableContainer from "@/components/ui/TableContainer";
 import { useState, useEffect } from "react";
 import { useAuth } from "@/context/AuthContext";
 import { Toaster, toast } from "react-hot-toast";
@@ -88,25 +89,27 @@ export default function ParamUnites() {
         )}
       </form>
       <Button variant="outline" className="mb-2" onClick={exportExcel}>Export Excel</Button>
-      <table className="min-w-full bg-white rounded-xl shadow-md text-xs">
-        <thead>
-          <tr>
-            <th>Nom</th>
-            <th>Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {unites.map(u => (
-            <tr key={u.id}>
-              <td>{u.nom}</td>
-              <td>
-                <Button size="sm" variant="outline" onClick={() => handleEdit(u)}>Modifier</Button>
-                <Button size="sm" variant="outline" onClick={() => handleDelete(u.id)}>Supprimer</Button>
-              </td>
+      <TableContainer className="mt-2">
+        <table className="min-w-full text-xs">
+          <thead>
+            <tr>
+              <th>Nom</th>
+              <th>Actions</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {unites.map(u => (
+              <tr key={u.id}>
+                <td>{u.nom}</td>
+                <td>
+                  <Button size="sm" variant="outline" onClick={() => handleEdit(u)}>Modifier</Button>
+                  <Button size="sm" variant="outline" onClick={() => handleDelete(u.id)}>Supprimer</Button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </TableContainer>
     </div>
   );
 }

--- a/src/components/parametrage/UtilisateurRow.jsx
+++ b/src/components/parametrage/UtilisateurRow.jsx
@@ -68,7 +68,7 @@ export default function UtilisateurRow({ utilisateur, onEdit, onToggleActive }) 
       </tr>
       {showHistory && (
         <tr>
-          <td colSpan={4} className="bg-gray-50">
+          <td colSpan={4} className="bg-glass border border-borderGlass backdrop-blur">
             <div>
               <b>Connexions récentes :</b>
               <ul>

--- a/src/components/produits/ProduitDetail.jsx
+++ b/src/components/produits/ProduitDetail.jsx
@@ -1,7 +1,7 @@
 // src/components/produits/ProduitDetail.jsx
 import { useEffect, useState } from "react";
 import { useProducts } from "@/hooks/useProducts";
-import { Dialog, DialogContent } from "@radix-ui/react-dialog";
+import ModalGlass from "@/components/ui/ModalGlass";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend } from "recharts";
 import * as XLSX from "xlsx";
@@ -33,8 +33,7 @@ export default function ProduitDetail({ produitId, open, onClose }) {
   };
 
   return (
-    <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent className="bg-white/80 backdrop-blur-2xl border border-mamastockGold/20 rounded-2xl shadow-2xl p-8 max-w-2xl w-full">
+    <ModalGlass open={open} onClose={onClose}>
         <h2 className="text-lg font-bold text-mamastockGold mb-3">Historique des prix d’achat</h2>
         {loading ? (
           <div className="flex justify-center py-6">
@@ -83,7 +82,6 @@ export default function ProduitDetail({ produitId, open, onClose }) {
           <button onClick={exportExcel} className="btn btn-secondary">Export Excel</button>
           <button onClick={onClose} className="btn">Fermer</button>
         </div>
-      </DialogContent>
-    </Dialog>
+    </ModalGlass>
   );
 }

--- a/src/components/produits/ProduitFormModal.jsx
+++ b/src/components/produits/ProduitFormModal.jsx
@@ -1,6 +1,5 @@
 // src/components/produits/ProduitFormModal.jsx
-import { motion as Motion, AnimatePresence } from "framer-motion";
-import { X } from "lucide-react";
+import ModalGlass from "@/components/ui/ModalGlass";
 import ProduitForm from "./ProduitForm";
 import { useEffect } from "react";
 
@@ -15,38 +14,14 @@ export default function ProduitFormModal({ open, produit, familles, unites, onCl
   }, [open, onClose]);
 
   return (
-    <AnimatePresence>
-      {open && (
-        <Motion.div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-[2px]"
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-        >
-          <Motion.div
-            className="relative bg-white/80 dark:bg-[#181f31]/90 rounded-2xl shadow-2xl border border-mamastockGold/30 p-0 overflow-hidden min-w-[350px] max-w-lg w-full backdrop-blur-[8px] shadow-[0_8px_42px_0_#bfa14d33,0_2px_16px_0_#0f1c2e22]"
-            initial={{ y: 80, opacity: 0, scale: 0.94 }}
-            animate={{ y: 0, opacity: 1, scale: 1 }}
-            exit={{ y: 60, opacity: 0, scale: 0.95 }}
-            transition={{ type: "spring", duration: 0.37 }}
-          >
-            <button
-              onClick={onClose}
-              className="absolute top-3 right-3 z-10 p-2 bg-white/40 rounded-full shadow hover:bg-mamastockGold/70 transition"
-              title="Fermer"
-            >
-              <X size={18} />
-            </button>
-            <ProduitForm
-              produit={produit}
-              familles={familles}
-              unites={unites}
-              onSuccess={onSuccess}
-              onClose={onClose}
-            />
-          </Motion.div>
-        </Motion.div>
-      )}
-    </AnimatePresence>
+    <ModalGlass open={open} onClose={onClose}>
+      <ProduitForm
+        produit={produit}
+        familles={familles}
+        unites={unites}
+        onSuccess={onSuccess}
+        onClose={onClose}
+      />
+    </ModalGlass>
   );
 }

--- a/src/components/security/TwoFactorSetup.jsx
+++ b/src/components/security/TwoFactorSetup.jsx
@@ -40,7 +40,7 @@ export default function TwoFactorSetup() {
   return (
     <div className="space-y-4">
       {!enabled && secret && (
-        <div className="p-4 bg-white rounded shadow">
+        <div className="p-4 bg-glass border border-borderGlass backdrop-blur rounded-2xl shadow">
           <p>Scannez ce QR code dans votre application d'authentification puis entrez le code :</p>
           {secret && (
             <QRCode value={`otpauth://totp/MamaStock?secret=${secret}`} />

--- a/src/components/simulation/SimulationDetailsModal.jsx
+++ b/src/components/simulation/SimulationDetailsModal.jsx
@@ -1,5 +1,6 @@
 import ModalGlass from "@/components/ui/ModalGlass";
 import Button from "@/components/ui/Button";
+import TableContainer from "@/components/ui/TableContainer";
 import * as XLSX from "xlsx";
 import { saveAs } from "file-saver";
 
@@ -19,24 +20,26 @@ export default function SimulationDetailsModal({ open, onClose, result }) {
   return (
     <ModalGlass open={open} onClose={onClose}>
       <h2 className="text-lg font-bold mb-2">Détails des besoins</h2>
-      <table className="min-w-full text-sm bg-white text-black rounded mb-4">
-        <thead>
-          <tr>
-            <th className="px-2">Produit</th>
-            <th className="px-2">Quantité</th>
-            <th className="px-2">Valeur</th>
-          </tr>
-        </thead>
-        <tbody>
-          {(result?.produits || []).map((p, idx) => (
-            <tr key={idx}>
-              <td className="px-2">{p.product_nom || p.product_id}</td>
-              <td className="px-2">{p.quantite}</td>
-              <td className="px-2">{p.valeur}</td>
+      <TableContainer className="mb-4">
+        <table className="min-w-full text-sm text-white">
+          <thead>
+            <tr>
+              <th className="px-2">Produit</th>
+              <th className="px-2">Quantité</th>
+              <th className="px-2">Valeur</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {(result?.produits || []).map((p, idx) => (
+              <tr key={idx}>
+                <td className="px-2">{p.product_nom || p.product_id}</td>
+                <td className="px-2">{p.quantite}</td>
+                <td className="px-2">{p.valeur}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </TableContainer>
       <div className="flex justify-end gap-2">
         <Button onClick={exportExcel}>Export Excel</Button>
         <Button onClick={onClose}>Fermer</Button>

--- a/src/components/stock/StockDetail.jsx
+++ b/src/components/stock/StockDetail.jsx
@@ -26,14 +26,14 @@ export default function StockDetail({ produit, mouvements, onClose }) {
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
-      <div className="bg-white rounded-xl shadow-lg p-8 min-w-[400px] max-w-[95vw] flex flex-col gap-2 relative">
+      <div className="bg-glass border border-borderGlass backdrop-blur rounded-2xl shadow-lg p-8 min-w-[400px] max-w-[95vw] flex flex-col gap-2 relative">
         <Button variant="outline" className="absolute top-2 right-2" onClick={onClose}>Fermer</Button>
         <h2 className="font-bold text-xl mb-4">{produit.nom} — Mouvements</h2>
         <div className="mb-2">Zone : {produit.zone || "N/A"}</div>
         <div className="mb-2">Stock réel : {produit.stock_reel} {produit.unite}</div>
         <div className="mb-2">Valorisation : {(produit.pmp * produit.stock_reel).toFixed(2)} €</div>
         <div>
-          <table className="min-w-full bg-gray-50 rounded text-xs">
+          <table className="min-w-full bg-glass border border-borderGlass rounded backdrop-blur text-xs">
             <thead>
               <tr>
                 <th>Date</th>

--- a/src/components/stock/StockMouvementForm.jsx
+++ b/src/components/stock/StockMouvementForm.jsx
@@ -40,7 +40,10 @@ export default function StockMouvementForm({ produit, onClose }) {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="bg-white p-6 rounded-lg shadow-md max-w-md mx-auto">
+    <form
+      onSubmit={handleSubmit}
+      className="bg-glass border border-borderGlass backdrop-blur p-6 rounded-2xl shadow-lg max-w-md mx-auto"
+    >
       <h2 className="text-lg font-bold mb-4">Mouvement de stock</h2>
       <div className="mb-2">Produit : <b>{produit?.nom}</b></div>
       <select

--- a/src/components/ui/AutoCompleteField.jsx
+++ b/src/components/ui/AutoCompleteField.jsx
@@ -39,7 +39,7 @@ export default function AutoCompleteField({
         list={`list-${label}`}
         value={inputValue}
         onChange={handleInputChange}
-        className={`bg-white text-black ${isValid ? "border-2 border-mamastockGold shadow" : ""}`}
+        className={`bg-white/20 dark:bg-[#202638]/50 backdrop-blur rounded-lg border border-white/30 text-white ${isValid ? "border-mamastockGold shadow" : ""}`}
         aria-label={label}
         aria-autocomplete="list"
         role="combobox"

--- a/src/components/ui/Button.jsx
+++ b/src/components/ui/Button.jsx
@@ -1,7 +1,7 @@
-export function Button({ children, ...props }) {
+export function Button({ children, className = '', ...props }) {
   return (
     <button
-      className="px-4 py-2 rounded-xl bg-yellow-400 hover:bg-yellow-300 text-black font-semibold shadow transition-all"
+      className={`btn ${className}`}
       {...props}
     >
       {children}

--- a/src/components/ui/Card.jsx
+++ b/src/components/ui/Card.jsx
@@ -1,6 +1,8 @@
-export function Card({ title, children }) {
+export function Card({ title, children, className = '' }) {
   return (
-    <div className="bg-zinc-800 text-white rounded-2xl shadow-lg">
+    <div
+      className={`bg-glass border border-borderGlass backdrop-blur rounded-2xl shadow-lg ${className}`}
+    >
       {title && <h2 className="text-xl font-bold mb-4 p-6 pb-0">{title}</h2>}
       {children}
     </div>

--- a/src/components/ui/InputField.jsx
+++ b/src/components/ui/InputField.jsx
@@ -1,11 +1,19 @@
-export default function InputField({ label, value, onChange, error, ...props }) {
+export default function InputField({
+  label,
+  value,
+  onChange,
+  error,
+  className = "",
+  inputClass = "",
+  ...props
+}) {
   return (
-    <div className="mb-4">
-      <label className="block text-sm text-gray-300 mb-1">{label}</label>
+    <div className={`mb-4 ${className}`}>
+      <label className="block text-sm text-white mb-1">{label}</label>
       <input
         value={value}
         onChange={onChange}
-        className={`w-full p-2 bg-zinc-900 border rounded-xl ${error ? "border-red-500" : "border-zinc-600"}`}
+        className={`input w-full ${error ? "border-red-500" : "border-white/20"} ${inputClass}`}
         {...props}
       />
       {error && <p className="text-red-500 text-sm mt-1">{error}</p>}

--- a/src/components/ui/PageWrapper.jsx
+++ b/src/components/ui/PageWrapper.jsx
@@ -1,7 +1,25 @@
-export default function PageWrapper({ children, className = '' }) {
+import {
+  LiquidBackground,
+  WavesBackground,
+  MouseLight,
+  TouchLight,
+} from "@/components/LiquidBackground";
+import { useLocation } from "react-router-dom";
+
+export default function PageWrapper({ children, className = '', intensity = 1 }) {
+  const { search } = useLocation();
+  const params = new URLSearchParams(search);
+  const previewIntensity = parseFloat(params.get('intensity'));
+  const finalIntensity = params.has('preview') && !Number.isNaN(previewIntensity)
+    ? Math.min(Math.max(previewIntensity, 0.2), 2)
+    : intensity;
   return (
-    <div className="min-h-screen flex items-center justify-center bg-background p-[clamp(1rem,4vw,2rem)]">
-      <div className={`w-full max-w-md ${className}`}>{children}</div>
+    <div className="relative min-h-screen flex items-center justify-center bg-background p-[clamp(1rem,4vw,2rem)] overflow-hidden">
+      <LiquidBackground showParticles intensity={finalIntensity} />
+      <WavesBackground className="opacity-40" />
+      <MouseLight />
+      <TouchLight />
+      <div className={`w-full max-w-md relative z-10 bg-glass border border-borderGlass backdrop-blur p-6 rounded-2xl shadow-lg ${className}`}>{children}</div>
     </div>
   );
 }

--- a/src/components/ui/PreviewBanner.jsx
+++ b/src/components/ui/PreviewBanner.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Link, useLocation } from 'react-router-dom';
+
+export default function PreviewBanner() {
+  const { search } = useLocation();
+  if (!new URLSearchParams(search).has('preview')) return null;
+  const params = new URLSearchParams(search);
+  const intensity = params.get('intensity');
+  params.delete('preview');
+  const exitUrl = `${window.location.pathname}?${params.toString()}`.replace(/\?$/, '');
+  return (
+    <div className="fixed top-2 left-1/2 -translate-x-1/2 bg-glass backdrop-blur border border-borderGlass text-white px-4 py-1 rounded-xl z-50 text-sm shadow">
+      Aperçu du thème actif
+      {intensity && ` (intensité ${intensity})`} -{' '}
+      <Link to={exitUrl} className="underline">Quitter</Link>
+    </div>
+  );
+}

--- a/src/components/ui/PrimaryButton.jsx
+++ b/src/components/ui/PrimaryButton.jsx
@@ -1,7 +1,7 @@
 export default function PrimaryButton({ children, className = '', ...props }) {
   return (
     <button
-      className={`bg-gold hover:bg-[#d8b03c] text-black font-semibold rounded-xl px-4 py-2 transition ${className}`}
+      className={`bg-mamastockGold hover:bg-mamastockGoldHover text-black font-semibold rounded-xl px-4 py-2 shadow transition ${className}`}
       {...props}
     >
       {children}

--- a/src/components/ui/SecondaryButton.jsx
+++ b/src/components/ui/SecondaryButton.jsx
@@ -1,7 +1,7 @@
 export default function SecondaryButton({ children, className = '', ...props }) {
   return (
     <button
-      className={`border border-white/50 text-white rounded-xl px-4 py-2 hover:bg-white/10 transition ${className}`}
+      className={`border border-white/40 text-white rounded-xl px-4 py-2 hover:bg-white/10 backdrop-blur transition ${className}`}
       {...props}
     >
       {children}

--- a/src/components/ui/SmartDialog.jsx
+++ b/src/components/ui/SmartDialog.jsx
@@ -31,7 +31,7 @@ export default function SmartDialog({ open, onClose, title, children }) {
                 exit={{ opacity: 0, scale: 0.95 }}
                 transition={{ type: "spring", stiffness: 260, damping: 20 }}
               >
-                <div className="relative bg-white dark:bg-[#202638] rounded-xl shadow-xl p-6 w-full max-w-lg">
+                <div className="relative bg-glass border border-borderGlass backdrop-blur rounded-2xl shadow-xl p-6 w-full max-w-lg">
                   {title && (
                     <DialogTitle className="text-lg font-semibold mb-4">
                       {title}

--- a/src/components/ui/StatCard.jsx
+++ b/src/components/ui/StatCard.jsx
@@ -1,6 +1,6 @@
 export default function StatCard({ label, value, variation = null, icon: Icon }) {
   return (
-    <div className="bg-zinc-800 text-white rounded-xl shadow p-4 flex items-center gap-3">
+    <div className="bg-glass border border-borderGlass backdrop-blur rounded-xl shadow p-4 flex items-center gap-3">
       {Icon && <Icon className="w-5 h-5 text-mamastock-gold" />}
       <div className="flex flex-col">
         <span className="text-xs text-gray-400">{label}</span>

--- a/src/components/ui/TableContainer.jsx
+++ b/src/components/ui/TableContainer.jsx
@@ -3,7 +3,7 @@ import React from "react";
 export default function TableContainer({ className = "", children, ...props }) {
   return (
     <div
-      className={`bg-white/5 backdrop-blur-lg rounded-xl shadow-md overflow-x-auto ${className}`}
+      className={`bg-glass border border-borderGlass backdrop-blur-lg rounded-xl shadow-md overflow-x-auto ${className}`}
       {...props}
     >
       {children}

--- a/src/components/ui/badge.jsx
+++ b/src/components/ui/badge.jsx
@@ -3,7 +3,7 @@
 export function Badge({ children, color = "gold", className = "", ariaLabel }) {
   const colorClasses = {
     gold: "bg-mamastock-gold text-white",
-    gray: "bg-gray-200 text-gray-800",
+    gray: "bg-white/20 text-white backdrop-blur",
     red: "bg-red-500 text-white",
     green: "bg-green-500 text-white",
     blue: "bg-blue-500 text-white",

--- a/src/components/ui/button.jsx
+++ b/src/components/ui/button.jsx
@@ -1,7 +1,7 @@
-export function Button({ children, ...props }) {
+export function Button({ children, className = '', ...props }) {
   return (
     <button
-      className="px-4 py-2 rounded-xl bg-yellow-400 hover:bg-yellow-300 text-black font-semibold shadow transition-all"
+      className={`px-4 py-2 rounded-xl bg-glass border border-borderGlass backdrop-blur hover:bg-white/10 text-white font-semibold shadow transition ${className}`}
       {...props}
     >
       {children}

--- a/src/components/ui/card.jsx
+++ b/src/components/ui/card.jsx
@@ -1,6 +1,8 @@
-export function Card({ title, children }) {
+export function Card({ title, children, className = '' }) {
   return (
-    <div className="bg-zinc-800 text-white rounded-2xl shadow-lg">
+    <div
+      className={`bg-glass border border-borderGlass backdrop-blur rounded-2xl shadow-lg ${className}`}
+    >
       {title && <h2 className="text-xl font-bold mb-4 p-6 pb-0">{title}</h2>}
       {children}
     </div>

--- a/src/components/ui/select.jsx
+++ b/src/components/ui/select.jsx
@@ -13,7 +13,7 @@ export function Select({
       value={value}
       onChange={onChange}
       aria-label={ariaLabel || "Sélection"}
-      className={`w-full p-2 border border-mamastock-gold rounded-md bg-white text-mamastock-text focus:outline-none focus:ring-2 focus:ring-mamastock-gold ${className}`}
+      className={`w-full p-2 border border-white/30 rounded-md bg-white/10 text-white backdrop-blur focus:outline-none focus:ring-2 focus:ring-mamastockGold ${className}`}
       {...props}
     >
       {children}

--- a/src/components/utilisateurs/UtilisateurDetail.jsx
+++ b/src/components/utilisateurs/UtilisateurDetail.jsx
@@ -8,7 +8,7 @@ export default function UtilisateurDetail({ utilisateur, onClose }) {
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
-      <div className="bg-white rounded-xl shadow-lg p-8 min-w-[400px] max-w-[95vw] flex flex-col gap-2 relative">
+      <div className="bg-glass border border-borderGlass backdrop-blur rounded-2xl shadow-lg p-8 min-w-[400px] max-w-[95vw] flex flex-col gap-2 relative">
         <Button variant="outline" className="absolute top-2 right-2" onClick={onClose}>Fermer</Button>
         <h2 className="font-bold text-xl mb-4">{utilisateur.email}</h2>
         <div><b>Rôle :</b> {utilisateur.role}</div>

--- a/src/components/utilisateurs/UtilisateurForm.jsx
+++ b/src/components/utilisateurs/UtilisateurForm.jsx
@@ -44,7 +44,10 @@ export default function UtilisateurForm({ utilisateur, onClose }) {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="bg-white p-6 rounded-lg shadow-md max-w-xl mx-auto">
+    <form
+      onSubmit={handleSubmit}
+      className="bg-glass border border-borderGlass backdrop-blur p-6 rounded-2xl shadow-lg max-w-xl mx-auto"
+    >
       <h2 className="text-lg font-bold mb-4">
         {utilisateur ? "Modifier l’utilisateur" : "Ajouter un utilisateur"}
       </h2>

--- a/src/context/ThemeProvider.jsx
+++ b/src/context/ThemeProvider.jsx
@@ -32,8 +32,14 @@ export function ThemeProvider({ children }) {
   }, [settings.primary_color, settings.secondary_color]);
 
   useEffect(() => {
-    if (settings.dark_mode) document.documentElement.classList.add("dark");
-    else document.documentElement.classList.remove("dark");
+    if (typeof settings.dark_mode === "boolean") {
+      if (settings.dark_mode) document.documentElement.classList.add("dark");
+      else document.documentElement.classList.remove("dark");
+    } else {
+      const prefers = window.matchMedia("(prefers-color-scheme: dark)").matches;
+      if (prefers) document.documentElement.classList.add("dark");
+      else document.documentElement.classList.remove("dark");
+    }
   }, [settings.dark_mode]);
 
   const value = {

--- a/src/globals.css
+++ b/src/globals.css
@@ -69,17 +69,28 @@ a:hover {
   @apply bg-blue-600 text-white;
 }
 .badge-user {
-  @apply bg-gray-400 text-white;
+  @apply bg-white/20 text-white backdrop-blur;
 }
 
 /* Input custom */
 .input {
   @apply px-3 py-2 rounded-lg border border-white/20 bg-white/10 text-white placeholder-white/70 focus:outline-none;
 }
+.textarea {
+  @apply px-3 py-2 rounded-lg border border-white/20 bg-white/10 text-white placeholder-white/70 focus:outline-none;
+}
+.select {
+  @apply px-3 py-2 rounded-lg border border-white/20 bg-white/10 text-white backdrop-blur focus:outline-none;
+}
 
 /* Dark mode auto */
 html.dark body {
   @apply bg-background text-text;
+}
+@media (prefers-color-scheme: dark) {
+  html:not(.dark) body {
+    @apply bg-background text-text;
+  }
 }
 /* Animations LiquidGlass & glass panel */
 .animate-liquid { animation: glassMove 12s ease-in-out infinite alternate; }
@@ -139,3 +150,44 @@ html.dark body {
   border-color: var(--primary-color);
 }
 
+
+/* Liquid bubbles */
+.bubble {
+  position: absolute;
+  bottom: -2rem;
+  background: rgba(255, 255, 255, 0.15);
+  border-radius: 9999px;
+  animation-name: bubble-rise;
+  animation-timing-function: linear;
+  animation-iteration-count: infinite;
+}
+@keyframes bubble-rise {
+  from { transform: translateY(0) scale(1); opacity: 0; }
+  50% { opacity: 0.6; }
+  to { transform: translateY(-110vh) scale(1.2); opacity: 0; }
+}
+
+/* Waves */
+.wave {
+  position: absolute;
+  left: 0;
+  width: 200%;
+  height: 100%;
+  animation: wave-slide 12s linear infinite;
+}
+.wave:nth-child(2) {
+  top: -10%;
+  opacity: 0.6;
+  animation-duration: 18s;
+}
+@keyframes wave-slide {
+  from { transform: translateX(0); }
+  to { transform: translateX(-50%); }
+}
+
+/* Touch ripple animation */
+@keyframes touch-fade {
+  from { transform: scale(0); opacity: 0.6; }
+  to { transform: scale(1.2); opacity: 0; }
+}
+.animate-touch-fade { animation: touch-fade 0.6s ease-out forwards; }

--- a/src/layout/AdminLayout.jsx
+++ b/src/layout/AdminLayout.jsx
@@ -1,5 +1,11 @@
 import Sidebar from "@/components/layout/Sidebar";
 import Navbar from "@/layout/Navbar";
+import {
+  LiquidBackground,
+  WavesBackground,
+  MouseLight,
+  TouchLight,
+} from "@/components/LiquidBackground";
 
 /**
  * Layout général pour les pages accessibles aux admins/managers.
@@ -7,11 +13,13 @@ import Navbar from "@/layout/Navbar";
  */
 export default function AdminLayout({ children }) {
   return (
-    <div
-      className="flex min-h-screen text-white text-shadow"
-    >
+    <div className="relative flex min-h-screen text-white text-shadow overflow-hidden">
+      <LiquidBackground showParticles />
+      <WavesBackground className="opacity-40" />
+      <MouseLight />
+      <TouchLight />
       <Sidebar />
-      <div className="flex flex-col flex-1">
+      <div className="flex flex-col flex-1 relative z-10">
         <Navbar />
         <main className="flex-1 p-6 overflow-auto">{children}</main>
       </div>

--- a/src/layout/Layout.jsx
+++ b/src/layout/Layout.jsx
@@ -3,6 +3,12 @@ import Sidebar from "@/layout/Sidebar";
 import useAuth from "@/hooks/useAuth";
 import toast from "react-hot-toast";
 import Footer from "@/components/Footer";
+import {
+  LiquidBackground,
+  WavesBackground,
+  MouseLight,
+  TouchLight,
+} from "@/components/LiquidBackground";
 
 export default function Layout() {
   const { pathname } = useLocation();
@@ -10,9 +16,13 @@ export default function Layout() {
   if (pathname === "/login" || pathname === "/unauthorized") return <Outlet />;
 
   return (
-    <div className="flex h-screen overflow-auto text-shadow">
+    <div className="relative flex h-screen overflow-auto text-shadow">
+      <LiquidBackground showParticles />
+      <WavesBackground className="opacity-40" />
+      <MouseLight />
+      <TouchLight />
       <Sidebar />
-      <div className="flex flex-col flex-1">
+      <div className="flex flex-col flex-1 relative z-10">
         <main className="flex-1 p-4 overflow-auto">
           <div className="flex justify-end items-center gap-2 mb-4">
           {user && (

--- a/src/layout/Navbar.jsx
+++ b/src/layout/Navbar.jsx
@@ -38,7 +38,7 @@ export default function Navbar() {
   };
 
   return (
-    <nav className="bg-white/5 backdrop-blur-xl text-white px-6 py-4 flex items-center justify-between shadow-md text-shadow">
+    <nav className="glass-panel border-b border-white/10 backdrop-blur-xl text-white px-6 py-4 flex items-center justify-between shadow-md text-shadow">
       {/* Logo / Titre */}
       <div className="flex items-center gap-4">
         <button onClick={toggleSidebar} className="md:hidden text-mamastock-gold text-2xl" aria-label="Ouvrir le menu">
@@ -55,13 +55,16 @@ export default function Navbar() {
           <input
             type="text"
             value={term}
-            onChange={e => { setTerm(e.target.value); search(e.target.value); }}
+            onChange={(e) => {
+              setTerm(e.target.value);
+              search(e.target.value);
+            }}
             placeholder={t('search')}
-            className="input input-bordered text-black w-48"
+            className="input w-48"
             aria-label={t('search')}
           />
           {results.length > 0 && (
-            <div className="absolute z-10 bg-white text-black w-full shadow-lg mt-1 text-xs rounded">
+            <div className="absolute z-10 bg-glass backdrop-blur border border-borderGlass text-white w-full shadow-lg mt-1 text-xs rounded">
               {results.map(r => (
                 <div key={r.type + r.id} className="px-2 py-1 border-b last:border-0">
                   {r.type}: {r.nom}
@@ -73,7 +76,7 @@ export default function Navbar() {
         <LanguageSelector />
         <button
           onClick={toggleDark}
-          className="bg-mamastock-gold text-black px-3 py-1 rounded-md text-sm"
+          className="btn px-3 py-1 text-sm"
           title={t('toggleTheme')}
           aria-label={t('toggleTheme')}
           aria-pressed={dark}

--- a/src/layout/Sidebar.jsx
+++ b/src/layout/Sidebar.jsx
@@ -44,7 +44,7 @@ export default function Sidebar() {
   );
 
   return (
-    <aside className="w-64 bg-white/5 backdrop-blur-xl text-white p-4 h-screen shadow-md text-shadow hidden md:block animate-fade-in-down">
+    <aside className="w-64 bg-glass border border-white/10 backdrop-blur-xl text-white p-4 h-screen shadow-md text-shadow hidden md:block animate-fade-in-down">
       <nav className="flex flex-col gap-4 text-sm">
         {has("dashboard") && (
           <Item to="/dashboard" icon={<Home size={16} />} label="Dashboard" />

--- a/src/layout/ViewerLayout.jsx
+++ b/src/layout/ViewerLayout.jsx
@@ -1,4 +1,10 @@
 import Navbar from "@/layout/Navbar";
+import {
+  LiquidBackground,
+  WavesBackground,
+  MouseLight,
+  TouchLight,
+} from "@/components/LiquidBackground";
 
 /**
  * Layout pour les utilisateurs en lecture seule (viewer).
@@ -6,12 +12,14 @@ import Navbar from "@/layout/Navbar";
  */
 export default function ViewerLayout({ children }) {
   return (
-    <div
-      className="flex flex-col min-h-screen text-white text-shadow"
-    >
+    <div className="relative flex flex-col min-h-screen text-white text-shadow overflow-hidden">
+      <LiquidBackground showParticles />
+      <WavesBackground className="opacity-40" />
+      <MouseLight />
+      <TouchLight />
       <Navbar />
-      <main className="flex-1 px-4 py-6 flex justify-center items-start overflow-y-auto">
-        <div className="w-full max-w-5xl bg-glass backdrop-blur-lg rounded-xl shadow-md p-6">
+      <main className="flex-1 px-4 py-6 flex justify-center items-start overflow-y-auto relative z-10">
+        <div className="w-full max-w-5xl bg-glass backdrop-blur-lg border border-borderGlass rounded-xl shadow-md p-6">
           {children}
         </div>
       </main>

--- a/src/pages/Accueil.jsx
+++ b/src/pages/Accueil.jsx
@@ -1,13 +1,26 @@
 import { motion as Motion } from "framer-motion";
 import logoMamaStock from "@/assets/logo-mamastock.png";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useNavigate, useLocation } from "react-router-dom";
 import { useEffect } from "react";
 import useAuth from "@/hooks/useAuth";
 import Footer from "@/components/Footer";
+import PreviewBanner from "@/components/ui/PreviewBanner";
+import {
+  LiquidBackground,
+  WavesBackground,
+  MouseLight,
+  TouchLight,
+} from "@/components/LiquidBackground";
 
 export default function Accueil() {
   const { session, user } = useAuth();
   const navigate = useNavigate();
+  const { search } = useLocation();
+  const params = new URLSearchParams(search);
+  const previewIntensity = parseFloat(params.get('intensity'));
+  const intensity = params.has('preview') && !Number.isNaN(previewIntensity)
+    ? Math.min(Math.max(previewIntensity, 0.2), 2)
+    : 1;
 
   useEffect(() => {
     if (session && user) {
@@ -16,15 +29,20 @@ export default function Accueil() {
   }, [session, user, navigate]);
 
   return (
-    <div className="flex flex-col min-h-screen bg-[#1E3A8A] text-white relative">
-      <div className="flex-grow flex flex-col items-center justify-center px-4">
+    <div className="relative flex flex-col min-h-screen text-white overflow-hidden">
+      <LiquidBackground showParticles intensity={intensity} />
+      <WavesBackground className="opacity-40" />
+      <MouseLight />
+      <TouchLight />
+      <PreviewBanner />
+      <div className="flex-grow flex flex-col items-center justify-center px-4 relative z-10">
         <Motion.div
           initial={{ opacity: 0, scale: 0.9 }}
           animate={{ opacity: 1, scale: 1 }}
           transition={{ duration: 0.8 }}
           className="w-full max-w-md"
         >
-          <div className="backdrop-blur-lg bg-white/10 border border-white/20 rounded-3xl shadow-xl p-6 flex flex-col items-center">
+          <div className="bg-glass border border-borderGlass backdrop-blur-lg rounded-3xl shadow-xl p-6 flex flex-col items-center">
             <img
               src={logoMamaStock}
               alt="MamaStock"

--- a/src/pages/Alertes.jsx
+++ b/src/pages/Alertes.jsx
@@ -4,6 +4,7 @@ import { useProducts } from "@/hooks/useProducts";
 import { useAuth } from "@/context/AuthContext";
 import { Button } from "@/components/ui/button";
 import { Select } from "@/components/ui/select";
+import TableContainer from "@/components/ui/TableContainer";
 import { Search } from "lucide-react";
 import { Toaster, toast } from "react-hot-toast";
 
@@ -88,7 +89,9 @@ export default function Alertes() {
         />
         <Search className="absolute left-2 top-2.5 text-white" size={18} />
       </div>
-      <table className="min-w-full bg-white rounded-xl shadow-md">
+      <div className="mt-4">
+        <TableContainer>
+          <table className="min-w-full text-sm">
         <thead>
           <tr>
             <th className="px-2 py-1">Produit</th>
@@ -117,8 +120,10 @@ export default function Alertes() {
               </td>
             </tr>
           )}
-        </tbody>
-      </table>
+          </tbody>
+        </table>
+        </TableContainer>
+      </div>
     </div>
   );
 }

--- a/src/pages/AuditTrail.jsx
+++ b/src/pages/AuditTrail.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useAuditTrail } from "@/hooks/useAuditTrail";
 import { useAuth } from "@/context/AuthContext";
 import { Button } from "@/components/ui/button";
+import TableContainer from "@/components/ui/TableContainer";
 import { Toaster } from "react-hot-toast";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 
@@ -54,36 +55,38 @@ export default function AuditTrail() {
         />
         <Button type="submit">Filtrer</Button>
       </form>
-      <table className="min-w-full bg-white rounded-xl shadow-md">
-        <thead>
-          <tr>
-            <th className="px-2 py-1">Date</th>
-            <th className="px-2 py-1">Table</th>
-            <th className="px-2 py-1">Opération</th>
-            <th className="px-2 py-1">Utilisateur</th>
-            <th className="px-2 py-1">Ancien</th>
-            <th className="px-2 py-1">Nouveau</th>
-          </tr>
-        </thead>
-        <tbody>
-          {entries.map((e) => (
-            <tr key={e.id} className="align-top">
-              <td className="px-2 py-1 whitespace-nowrap">
-                {new Date(e.changed_at).toLocaleString()}
-              </td>
-              <td className="px-2 py-1">{e.table_name}</td>
-              <td className="px-2 py-1">{e.operation}</td>
-              <td className="px-2 py-1">{e.utilisateurs?.email || e.changed_by}</td>
-              <td className="px-2 py-1 font-mono break-all">
-                {JSON.stringify(e.old_data)}
-              </td>
-              <td className="px-2 py-1 font-mono break-all">
-                {JSON.stringify(e.new_data)}
-              </td>
+      <TableContainer className="mt-4">
+        <table className="min-w-full text-xs">
+          <thead>
+            <tr>
+              <th className="px-2 py-1">Date</th>
+              <th className="px-2 py-1">Table</th>
+              <th className="px-2 py-1">Opération</th>
+              <th className="px-2 py-1">Utilisateur</th>
+              <th className="px-2 py-1">Ancien</th>
+              <th className="px-2 py-1">Nouveau</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {entries.map((e) => (
+              <tr key={e.id} className="align-top">
+                <td className="border px-2 py-1 whitespace-nowrap">
+                  {new Date(e.changed_at).toLocaleString()}
+                </td>
+                <td className="border px-2 py-1">{e.table_name}</td>
+                <td className="border px-2 py-1">{e.operation}</td>
+                <td className="border px-2 py-1">{e.utilisateurs?.email || e.changed_by}</td>
+                <td className="border px-2 py-1 font-mono break-all">
+                  {JSON.stringify(e.old_data)}
+                </td>
+                <td className="border px-2 py-1 font-mono break-all">
+                  {JSON.stringify(e.new_data)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </TableContainer>
     </div>
   );
 }

--- a/src/pages/BarManager.jsx
+++ b/src/pages/BarManager.jsx
@@ -8,7 +8,9 @@ import jsPDF from "jspdf";
 import "jspdf-autotable";
 import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip, Legend } from "recharts";
 import { Button } from "@/components/ui/button";
+import { Select } from "@/components/ui/select";
 import { Dialog, DialogContent, DialogTrigger } from "@radix-ui/react-dialog";
+import TableContainer from "@/components/ui/TableContainer";
 import { motion as Motion, AnimatePresence } from "framer-motion";
 
 const FOOD_COST_SEUIL = 28;
@@ -156,31 +158,31 @@ export default function BarManager() {
       <h1 className="text-2xl font-bold text-blue-700 mb-4">Bar Manager — Analyses avancées</h1>
       {/* Période, recherche, export */}
       <div className="flex flex-wrap gap-2 mb-4 items-end">
-        <select
-          className="select select-bordered"
+        <Select
           value={periode}
           onChange={e => setPeriode(e.target.value)}
+          className="w-32"
         >
           {PERIODES.map(p => (
             <option key={p.value} value={p.value}>{p.label}</option>
           ))}
-        </select>
+        </Select>
         <input
           type="date"
-          className="input input-bordered"
+          className="input"
           value={dates.debut}
           onChange={e => setDates(d => ({ ...d, debut: e.target.value }))}
           disabled={periode !== "custom"}
         />
         <input
           type="date"
-          className="input input-bordered"
+          className="input"
           value={dates.fin}
           onChange={e => setDates(d => ({ ...d, fin: e.target.value }))}
           disabled={periode !== "custom"}
         />
         <input
-          className="input input-bordered w-64"
+          className="input w-64"
           placeholder="Recherche (nom/type/contenance)"
           value={search}
           onChange={e => setSearch(e.target.value)}
@@ -189,7 +191,7 @@ export default function BarManager() {
         <Button onClick={handleExportPDF}>Export PDF</Button>
       </div>
       {/* Stat globales */}
-      <div className="bg-white shadow rounded-xl p-4 mb-6 flex flex-wrap gap-6">
+      <div className="bg-glass backdrop-blur border border-borderGlass rounded-xl shadow p-4 mb-6 flex flex-wrap gap-6">
         <div>
           <span className="font-semibold text-blue-700">Ventes totales :</span>
           <span className="font-bold"> {ventesTot} </span>
@@ -213,7 +215,7 @@ export default function BarManager() {
         </div>
       </div>
       {/* Graphe top ventes */}
-      <div className="bg-white shadow rounded-xl p-4 mb-6">
+      <div className="bg-glass backdrop-blur border border-borderGlass rounded-xl shadow p-4 mb-6">
         <h2 className="font-bold mb-2">Top 10 ventes (période sélectionnée)</h2>
         <ResponsiveContainer width="100%" height={200}>
           <BarChart data={topVentes}>
@@ -227,7 +229,7 @@ export default function BarManager() {
         </ResponsiveContainer>
       </div>
       {/* Graphe top marges */}
-      <div className="bg-white shadow rounded-xl p-4 mb-6">
+      <div className="bg-glass backdrop-blur border border-borderGlass rounded-xl shadow p-4 mb-6">
         <h2 className="font-bold mb-2">Top 10 marges boissons</h2>
         <ResponsiveContainer width="100%" height={200}>
           <BarChart data={topMarge}>
@@ -241,7 +243,7 @@ export default function BarManager() {
         </ResponsiveContainer>
       </div>
       {/* Tableau interactif */}
-      <div className="bg-white shadow rounded-xl overflow-x-auto">
+      <TableContainer className="mt-4">
         <table className="min-w-full table-auto">
           <thead>
             <tr>
@@ -265,7 +267,7 @@ export default function BarManager() {
                   exit={{ opacity: 0, y: -10 }}
                   transition={{ duration: 0.2 }}
                 >
-                  <td className="px-2 py-1">
+                  <td className="border px-2 py-1">
                     <Dialog>
                       <DialogTrigger asChild>
                         <Button variant="link" className="text-blue-700 p-0 h-auto min-w-0 underline">
@@ -273,7 +275,7 @@ export default function BarManager() {
                         </Button>
                       </DialogTrigger>
                       <DialogContent
-                        className="bg-white rounded-xl shadow-lg p-6 max-w-md z-[1000]"
+                        className="bg-glass backdrop-blur-lg border border-borderGlass rounded-xl shadow-lg p-6 max-w-md z-[1000]"
                       >
                         <h2 className="font-bold text-xl mb-2">{b.nom}</h2>
                         <p>
@@ -309,18 +311,18 @@ export default function BarManager() {
                   <td className="px-2 py-1">{b.type || b.famille || "-"}</td>
                   <td className="px-2 py-1">{b.cout_portion ? Number(b.cout_portion).toFixed(2) : "-"}</td>
                   <td className="px-2 py-1">{b.prix_vente ? Number(b.prix_vente).toFixed(2) : "-"}</td>
-                  <td className={"px-2 py-1 font-semibold " + (b.foodCost > FOOD_COST_SEUIL ? "text-red-600" : "")}>
+                  <td className={"border px-2 py-1 font-semibold " + (b.foodCost > FOOD_COST_SEUIL ? "text-red-600" : "")}>
                     {b.foodCost ? b.foodCost.toFixed(1) : "-"}
                   </td>
-                  <td className="px-2 py-1">{b.quantiteVendue}</td>
-                  <td className="px-2 py-1">{b.totalMarge ? b.totalMarge.toFixed(2) : "-"}</td>
-                  <td className="px-2 py-1">{b.totalCA ? b.totalCA.toFixed(2) : "-"}</td>
+                  <td className="border px-2 py-1">{b.quantiteVendue}</td>
+                  <td className="border px-2 py-1">{b.totalMarge ? b.totalMarge.toFixed(2) : "-"}</td>
+                  <td className="border px-2 py-1">{b.totalCA ? b.totalCA.toFixed(2) : "-"}</td>
                 </Motion.tr>
               ))}
             </AnimatePresence>
           </tbody>
         </table>
-      </div>
+      </TableContainer>
     </div>
   );
 }

--- a/src/pages/CartePlats.jsx
+++ b/src/pages/CartePlats.jsx
@@ -3,6 +3,7 @@ import { useAuth } from "@/context/AuthContext";
 import { supabase } from "@/lib/supabase";
 import toast, { Toaster } from "react-hot-toast";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import TableContainer from "@/components/ui/TableContainer";
 
 const FOOD_COST_SEUIL = 35;
 
@@ -48,48 +49,50 @@ export default function CartePlats() {
     <div className="p-8 max-w-3xl mx-auto">
       <Toaster />
       <h1 className="text-2xl font-bold text-mamastock-gold mb-4">Carte des plats actifs</h1>
-      <table className="min-w-full table-auto">
-        <thead>
-          <tr>
-            <th className="px-2 py-1">Nom</th>
-            <th className="px-2 py-1">Famille</th>
-            <th className="px-2 py-1">Coût/portion (€)</th>
-            <th className="px-2 py-1">Prix vente (€)</th>
-            <th className="px-2 py-1">Food cost (%)</th>
-          </tr>
-        </thead>
-        <tbody>
-          {fiches.map(f => {
-            const foodCost =
-              f.prix_vente && f.cout_portion
-                ? ((f.cout_portion / f.prix_vente) * 100).toFixed(1)
-                : null;
-            return (
-              <tr key={f.id}>
-                <td className="px-2 py-1">{f.nom}</td>
-                <td className="px-2 py-1">{f.famille || "-"}</td>
-                <td className="px-2 py-1">{f.cout_portion ? Number(f.cout_portion).toFixed(2) : "-"}</td>
-                <td className="px-2 py-1">
-                  <input
-                    type="number"
-                    min={0}
-                    step="0.01"
-                    className="input input-bordered w-24"
-                    value={f.prix_vente ?? ""}
-                    disabled={savingId === f.id}
-                    onChange={e =>
-                      handleChangePV(f, e.target.value ? Number(e.target.value) : null)
-                    }
-                  />
-                </td>
-                <td className={"px-2 py-1 font-semibold " + (foodCost > FOOD_COST_SEUIL ? "text-red-600" : "")}>
-                  {foodCost ?? "-"}
-                </td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
+      <TableContainer className="mt-2">
+        <table className="min-w-full table-auto">
+          <thead>
+            <tr>
+              <th className="px-2 py-1">Nom</th>
+              <th className="px-2 py-1">Famille</th>
+              <th className="px-2 py-1">Coût/portion (€)</th>
+              <th className="px-2 py-1">Prix vente (€)</th>
+              <th className="px-2 py-1">Food cost (%)</th>
+            </tr>
+          </thead>
+          <tbody>
+            {fiches.map(f => {
+              const foodCost =
+                f.prix_vente && f.cout_portion
+                  ? ((f.cout_portion / f.prix_vente) * 100).toFixed(1)
+                  : null;
+              return (
+                <tr key={f.id}>
+                  <td className="border px-2 py-1">{f.nom}</td>
+                  <td className="border px-2 py-1">{f.famille || "-"}</td>
+                  <td className="border px-2 py-1">{f.cout_portion ? Number(f.cout_portion).toFixed(2) : "-"}</td>
+                  <td className="border px-2 py-1">
+                    <input
+                      type="number"
+                      min={0}
+                      step="0.01"
+                      className="input input-bordered w-24"
+                      value={f.prix_vente ?? ""}
+                      disabled={savingId === f.id}
+                      onChange={e =>
+                        handleChangePV(f, e.target.value ? Number(e.target.value) : null)
+                      }
+                    />
+                  </td>
+                  <td className={"border px-2 py-1 font-semibold " + (foodCost > FOOD_COST_SEUIL ? "text-red-600" : "")}>
+                    {foodCost ?? "-"}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </TableContainer>
     </div>
   );
 }

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,5 +1,6 @@
 import { useAuth } from "@/context/AuthContext";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import GlassCard from "@/components/ui/GlassCard";
 
 export default function Dashboard() {
   const { user } = useAuth();
@@ -7,9 +8,11 @@ export default function Dashboard() {
   if (!user) return <LoadingSpinner message="Chargement..." />;
 
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-bold mb-2">Bienvenue sur MamaStock</h1>
-      <p>Connecté avec : {user.email}</p>
+    <div className="p-6 flex justify-center">
+      <GlassCard className="w-full max-w-md text-center">
+        <h1 className="text-2xl font-bold mb-2">Bienvenue sur MamaStock</h1>
+        <p>Connecté avec : {user.email}</p>
+      </GlassCard>
     </div>
   );
 }

--- a/src/pages/Documents.jsx
+++ b/src/pages/Documents.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useDocuments } from "@/hooks/useDocuments";
 import { useAuth } from "@/context/AuthContext";
 import { Button } from "@/components/ui/button";
+import GlassCard from "@/components/ui/GlassCard";
 import { Search } from "lucide-react";
 import toast from "react-hot-toast";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
@@ -42,16 +43,17 @@ export default function Documents() {
   if (error) return <div className="p-8 text-red-600">{error}</div>;
 
   return (
-    <div className="p-8 container mx-auto">
+    <div className="p-8 container mx-auto space-y-6">
       <h1 className="text-2xl font-bold mb-4">Documents</h1>
-      <form onSubmit={handleAdd} className="flex gap-2 mb-4 items-end">
-        <input
-          className="input"
-          placeholder="Titre"
-          value={title}
-          onChange={(e) => setTitle(e.target.value)}
-          required
-        />
+      <GlassCard className="p-4">
+        <form onSubmit={handleAdd} className="flex flex-wrap gap-2 items-end">
+          <input
+            className="input"
+            placeholder="Titre"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            required
+          />
         <input
           className="input flex-1"
           placeholder="URL"
@@ -60,7 +62,8 @@ export default function Documents() {
           required
         />
         <Button type="submit">Ajouter</Button>
-      </form>
+        </form>
+      </GlassCard>
       <div className="relative w-64 mb-4">
         <input
           type="search"
@@ -71,23 +74,25 @@ export default function Documents() {
         />
         <Search className="absolute left-2 top-2.5 text-white" size={18} />
       </div>
-      <ul className="list-disc pl-6">
-        {docs.map((d) => (
-          <li key={d.id} className="mb-1">
-            <a
-              href={d.file_url}
-              target="_blank"
-              rel="noreferrer"
-              className="text-mamastock-gold underline"
-            >
-              {d.title}
-            </a>
-          </li>
-        ))}
-        {docs.length === 0 && (
-          <li className="text-gray-400">Aucun résultat trouvé.</li>
-        )}
-      </ul>
+      <GlassCard className="p-4">
+        <ul className="list-disc pl-6 space-y-1">
+          {docs.map((d) => (
+            <li key={d.id} className="mb-1">
+              <a
+                href={d.file_url}
+                target="_blank"
+                rel="noreferrer"
+                className="text-mamastock-gold underline"
+              >
+                {d.title}
+              </a>
+            </li>
+          ))}
+          {docs.length === 0 && (
+            <li className="text-gray-400">Aucun résultat trouvé.</li>
+          )}
+        </ul>
+      </GlassCard>
     </div>
   );
 }

--- a/src/pages/HelpCenter.jsx
+++ b/src/pages/HelpCenter.jsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { useHelpArticles } from "@/hooks/useHelpArticles";
 import { useAuth } from "@/context/AuthContext";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import GlassCard from "@/components/ui/GlassCard";
 
 export default function HelpCenter() {
   const { mama_id } = useAuth();
@@ -18,9 +19,11 @@ export default function HelpCenter() {
       {error && <div className="text-red-500">{error}</div>}
       <ul className="space-y-4">
         {items.map((a) => (
-          <li key={a.id} className="bg-white/40 rounded-lg p-4 shadow">
-            <h2 className="font-semibold text-lg mb-2">{a.title}</h2>
-            <p className="whitespace-pre-line text-sm">{a.content}</p>
+          <li key={a.id} className="list-none">
+            <GlassCard>
+              <h2 className="font-semibold text-lg mb-2">{a.title}</h2>
+              <p className="whitespace-pre-line text-sm">{a.content}</p>
+            </GlassCard>
           </li>
         ))}
       </ul>

--- a/src/pages/Journal.jsx
+++ b/src/pages/Journal.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useAuth } from "@/context/AuthContext";
 import { useLogs } from "@/hooks/useLogs";
 import { Button } from "@/components/ui/button";
+import TableContainer from "@/components/ui/TableContainer";
 import { Toaster } from "react-hot-toast";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 
@@ -25,9 +26,9 @@ export default function Journal() {
   };
 
   return (
-    <div className="p-6 container mx-auto">
+    <div className="p-6 container mx-auto space-y-4">
       <Toaster position="top-right" />
-      <form onSubmit={handleSubmit} className="flex gap-2 mb-4">
+      <form onSubmit={handleSubmit} className="flex gap-2 mb-4 flex-wrap items-end">
         <input
           className="input"
           placeholder="Recherche action"
@@ -53,26 +54,28 @@ export default function Journal() {
           Export Excel
         </Button>
       </form>
-      <table className="min-w-full bg-white rounded-xl shadow-md text-xs">
-        <thead>
-          <tr>
-            <th className="px-2 py-1">Date</th>
-            <th className="px-2 py-1">Action</th>
-            <th className="px-2 py-1">Utilisateur</th>
-          </tr>
-        </thead>
-        <tbody>
-          {logs.map(l => (
-            <tr key={l.id}>
-              <td className="px-2 py-1">
-                {new Date(l.created_at).toLocaleString()}
-              </td>
-              <td className="px-2 py-1">{l.action}</td>
-              <td className="px-2 py-1">{l.utilisateurs?.email || l.done_by}</td>
+      <TableContainer>
+        <table className="min-w-full text-xs">
+          <thead>
+            <tr>
+              <th className="px-2 py-1">Date</th>
+              <th className="px-2 py-1">Action</th>
+              <th className="px-2 py-1">Utilisateur</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {logs.map(l => (
+              <tr key={l.id}>
+                <td className="border px-2 py-1">
+                  {new Date(l.created_at).toLocaleString()}
+                </td>
+                <td className="border px-2 py-1">{l.action}</td>
+                <td className="border px-2 py-1">{l.utilisateurs?.email || l.done_by}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </TableContainer>
     </div>
   );
 }

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -1,16 +1,20 @@
 import { Link } from "react-router-dom";
+import {
+  LiquidBackground,
+  WavesBackground,
+  MouseLight,
+  TouchLight,
+} from "@/components/LiquidBackground";
 
 export default function NotFound() {
   return (
-    <div className="relative min-h-screen flex items-center justify-center bg-gradient-to-br from-[#0f1c2e] via-[#232a34] to-[#bfa14d] overflow-hidden">
-      {/* Liquid background animations */}
-      <div className="absolute inset-0 -z-10">
-        <div className="absolute -top-10 -left-20 w-[480px] h-[420px] bg-gradient-to-br from-[#bfa14d] via-[#fff8e1]/70 to-transparent blur-[90px] rounded-full opacity-40 animate-liquid" />
-        <div className="absolute bottom-[-20%] right-[-18%] w-[480px] h-[420px] bg-gradient-to-br from-[#fff8e1]/90 via-white/60 to-transparent blur-[80px] rounded-full opacity-20 animate-liquid2" />
-        <div className="absolute top-1/3 left-1/2 -translate-x-1/2 w-[280px] h-[180px] bg-white/20 blur-2xl rounded-[36%_54%_41%_59%/50%_41%_59%_50%] opacity-15 animate-liquid3" />
-      </div>
+    <div className="relative min-h-screen flex items-center justify-center overflow-hidden text-white">
+      <LiquidBackground showParticles />
+      <WavesBackground className="opacity-40" />
+      <MouseLight />
+      <TouchLight />
 
-      <div className="rounded-2xl shadow-2xl bg-white/30 dark:bg-[#202638]/40 border border-white/30 backdrop-blur-xl px-12 py-16 text-center glass-panel">
+      <div className="relative z-10 rounded-2xl shadow-2xl bg-glass border border-borderGlass backdrop-blur-xl px-12 py-16 text-center">
         <h1 className="text-6xl font-bold text-mamastockGold mb-4 drop-shadow-md">404</h1>
         <p className="text-xl text-mamastockText mb-6">Page non trouvée</p>
         <Link

--- a/src/pages/Onboarding.jsx
+++ b/src/pages/Onboarding.jsx
@@ -2,6 +2,7 @@ import { useOnboarding } from "@/hooks/useOnboarding";
 import { Button } from "@/components/ui/button";
 import { Toaster } from "react-hot-toast";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import GlassCard from "@/components/ui/GlassCard";
 
 const steps = [
   "Bienvenue sur MamaStock !",
@@ -21,15 +22,17 @@ export default function Onboarding() {
   };
 
   return (
-    <div className="p-8 container mx-auto text-center max-w-lg">
-      <Toaster position="top-right" />
-      <h1 className="text-2xl font-bold mb-4">Onboarding</h1>
-      <p className="mb-6">{steps[step]}</p>
-      {step < steps.length - 1 ? (
-        <Button onClick={next}>Étape suivante</Button>
-      ) : (
-        <p className="font-semibold">Onboarding terminé 🎉</p>
-      )}
+    <div className="p-8 flex justify-center">
+      <GlassCard className="w-full max-w-lg text-center space-y-6">
+        <Toaster position="top-right" />
+        <h1 className="text-2xl font-bold">Onboarding</h1>
+        <p>{steps[step]}</p>
+        {step < steps.length - 1 ? (
+          <Button onClick={next}>Étape suivante</Button>
+        ) : (
+          <p className="font-semibold">Onboarding terminé 🎉</p>
+        )}
+      </GlassCard>
     </div>
   );
 }

--- a/src/pages/Pertes.jsx
+++ b/src/pages/Pertes.jsx
@@ -3,6 +3,7 @@ import { usePertes } from "@/hooks/usePertes";
 import { useProducts } from "@/hooks/useProducts";
 import { useAuth } from "@/context/AuthContext";
 import { Button } from "@/components/ui/button";
+import TableContainer from "@/components/ui/TableContainer";
 import { Toaster, toast } from "react-hot-toast";
 
 export default function Pertes() {
@@ -69,8 +70,9 @@ export default function Pertes() {
         <input name="motif" className="input flex-1" placeholder="Motif" value={form.motif} onChange={handleChange} />
         <Button type="submit" disabled={saving}>Ajouter</Button>
       </form>
-      <table className="min-w-full text-xs bg-white rounded-xl shadow-md">
-        <thead>
+      <TableContainer className="mt-4">
+        <table className="min-w-full text-xs">
+          <thead>
           <tr>
             <th className="px-2 py-1">Date</th>
             <th className="px-2 py-1">Produit</th>
@@ -91,8 +93,9 @@ export default function Pertes() {
               </td>
             </tr>
           ))}
-        </tbody>
-      </table>
+          </tbody>
+        </table>
+      </TableContainer>
     </div>
   );
 }

--- a/src/pages/Planning.jsx
+++ b/src/pages/Planning.jsx
@@ -4,6 +4,8 @@ import { useAuth } from "@/context/AuthContext";
 import { Button } from "@/components/ui/button";
 import { Toaster, toast } from "react-hot-toast";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import GlassCard from "@/components/ui/GlassCard";
+import TableContainer from "@/components/ui/TableContainer";
 
 export default function Planning() {
   const { mama_id } = useAuth();
@@ -41,41 +43,45 @@ export default function Planning() {
   if (error) return <div className="p-8 text-red-600">{error}</div>;
 
   return (
-    <div className="p-8 container mx-auto">
+    <div className="p-8 container mx-auto space-y-6">
       <Toaster position="top-right" />
-      <h1 className="text-2xl font-bold mb-4">Planning prévisionnel</h1>
-      <form onSubmit={handleAdd} className="flex gap-2 mb-4 items-end">
-        <input
-          type="date"
-          className="input"
-          value={date}
-          onChange={(e) => setDate(e.target.value)}
-          required
-        />
-        <input
-          className="input flex-1"
-          placeholder="Notes"
-          value={notes}
-          onChange={(e) => setNotes(e.target.value)}
-        />
-        <Button type="submit" disabled={saving}>Ajouter</Button>
-      </form>
-      <table className="min-w-full text-sm bg-white rounded-xl shadow-md">
-        <thead>
-          <tr>
-            <th className="px-2 py-1">Date</th>
-            <th className="px-2 py-1">Notes</th>
-          </tr>
-        </thead>
-        <tbody>
-          {items.map((p) => (
-            <tr key={p.id}>
-              <td className="px-2 py-1 whitespace-nowrap">{p.date_prevue}</td>
-              <td className="px-2 py-1">{p.notes}</td>
+      <GlassCard className="p-6 space-y-4">
+        <h1 className="text-2xl font-bold">Planning prévisionnel</h1>
+        <form onSubmit={handleAdd} className="flex gap-2 items-end">
+          <input
+            type="date"
+            className="input"
+            value={date}
+            onChange={(e) => setDate(e.target.value)}
+            required
+          />
+          <input
+            className="input flex-1"
+            placeholder="Notes"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+          />
+          <Button type="submit" disabled={saving}>Ajouter</Button>
+        </form>
+      </GlassCard>
+      <TableContainer>
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr>
+              <th className="px-2 py-1">Date</th>
+              <th className="px-2 py-1">Notes</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {items.map((p) => (
+              <tr key={p.id}>
+                <td className="px-2 py-1 whitespace-nowrap">{p.date_prevue}</td>
+                <td className="px-2 py-1">{p.notes}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </TableContainer>
     </div>
   );
 }

--- a/src/pages/Rgpd.jsx
+++ b/src/pages/Rgpd.jsx
@@ -2,11 +2,21 @@ import { Link } from "react-router-dom";
 import { motion as Motion } from "framer-motion";
 import GlassCard from "@/components/ui/GlassCard";
 import Footer from "@/components/Footer";
+import {
+  LiquidBackground,
+  WavesBackground,
+  MouseLight,
+  TouchLight,
+} from "@/components/LiquidBackground";
 
 export default function Rgpd() {
   return (
-    <div className="flex flex-col min-h-screen bg-[#1E3A8A] text-white">
-      <div className="flex-grow flex flex-col items-center px-4 py-16">
+    <div className="relative flex flex-col min-h-screen text-white overflow-hidden">
+      <LiquidBackground showParticles />
+      <WavesBackground className="opacity-40" />
+      <MouseLight />
+      <TouchLight />
+      <div className="flex-grow flex flex-col items-center px-4 py-16 relative z-10">
         <Motion.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
@@ -73,7 +83,7 @@ export default function Rgpd() {
               <Motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
                 <Link
                   to="/"
-                  className="inline-block px-6 py-2 rounded-xl bg-white/20 hover:bg-white/30 transition backdrop-blur"
+                  className="inline-block px-6 py-2 rounded-xl bg-glass border border-borderGlass hover:bg-white/20 transition backdrop-blur"
                 >
                   Retour à l’accueil
                 </Link>

--- a/src/pages/Stock.jsx
+++ b/src/pages/Stock.jsx
@@ -4,6 +4,7 @@ import { useAuth } from "@/context/AuthContext";
 import StockMouvementForm from "@/components/stock/StockMouvementForm";
 import StockDetail from "@/components/stock/StockDetail";
 import { Button } from "@/components/ui/button";
+import TableContainer from "@/components/ui/TableContainer";
 import { Toaster } from "react-hot-toast";
 import { saveAs } from "file-saver";
 import * as XLSX from "xlsx";
@@ -66,11 +67,12 @@ export default function Stock() {
         </Button>
         <Button variant="outline" onClick={exportExcel}>Export Excel</Button>
       </div>
-      <Motion.table
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        className="min-w-full bg-white rounded-xl shadow-md"
-      >
+      <TableContainer className="mt-4">
+        <Motion.table
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          className="min-w-full text-sm"
+        >
         <thead>
           <tr>
             <th className="px-4 py-2">Produit</th>
@@ -105,7 +107,8 @@ export default function Stock() {
             </tr>
           ))}
         </tbody>
-      </Motion.table>
+        </Motion.table>
+      </TableContainer>
       <div className="mt-4 flex gap-2">
         {Array.from({ length: nbPages }, (_, i) =>
           <Button

--- a/src/pages/Transferts.jsx
+++ b/src/pages/Transferts.jsx
@@ -8,6 +8,8 @@ import "jspdf-autotable";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogTrigger, DialogContent } from "@radix-ui/react-dialog";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import GlassCard from "@/components/ui/GlassCard";
+import TableContainer from "@/components/ui/TableContainer";
 import {
   ResponsiveContainer,
   BarChart,
@@ -236,14 +238,14 @@ export default function Transferts() {
   if (!isAuthenticated) return null;
 
   return (
-    <div className="p-8 max-w-7xl mx-auto">
+    <div className="p-8 max-w-7xl mx-auto space-y-6">
       <Toaster />
       <h1 className="text-2xl font-bold text-mamastock-gold mb-4">
         Transferts de stock inter-zones
       </h1>
       {/* Graphiques */}
       <div className="grid md:grid-cols-2 gap-6 mb-6">
-        <div className="bg-white shadow rounded-xl p-4">
+        <GlassCard className="p-4">
           <h2 className="font-bold mb-2">Top produits transférés (€)</h2>
           <ResponsiveContainer width="100%" height={180}>
             <BarChart data={topProduits}>
@@ -254,8 +256,8 @@ export default function Transferts() {
               <Bar dataKey="Euro" fill="#2196f3" name="Coût (€)" />
             </BarChart>
           </ResponsiveContainer>
-        </div>
-        <div className="bg-white shadow rounded-xl p-4">
+        </GlassCard>
+        <GlassCard className="p-4">
           <h2 className="font-bold mb-2">Valeur (€) par couple de zones</h2>
           <ResponsiveContainer width="100%" height={180}>
             <BarChart data={transfertsParZone}>
@@ -266,7 +268,7 @@ export default function Transferts() {
               <Bar dataKey="Euro" fill="#e53935" name="Total (€)" />
             </BarChart>
           </ResponsiveContainer>
-        </div>
+        </GlassCard>
       </div>
       {/* Total général */}
       <div className="mb-4 font-bold text-lg text-mamastock-gold">
@@ -306,7 +308,7 @@ export default function Transferts() {
         <Button onClick={handleExportPDF}>Export PDF</Button>
         <Button onClick={() => setShowCreate(true)}>+ Nouveau transfert</Button>
       </div>
-      <div className="bg-white shadow rounded-xl overflow-x-auto">
+      <TableContainer>
         <table className="min-w-full table-auto text-center">
           <thead>
             <tr>
@@ -343,7 +345,7 @@ export default function Transferts() {
                         Timeline
                       </Button>
                     </DialogTrigger>
-                    <DialogContent className="bg-white rounded-xl shadow-lg p-6 max-w-lg">
+                    <DialogContent className="bg-glass backdrop-blur-lg rounded-xl shadow-lg p-6 max-w-lg">
                       <h3 className="font-bold mb-2">
                         Timeline transferts : {t.nom}
                       </h3>
@@ -380,13 +382,13 @@ export default function Transferts() {
             ))}
           </tbody>
         </table>
-      </div>
+      </TableContainer>
       {/* Modal création transfert */}
       <Dialog
         open={showCreate}
         onOpenChange={(v) => !v && setShowCreate(false)}
       >
-        <DialogContent className="bg-white rounded-xl shadow-lg p-6 max-w-md">
+        <DialogContent className="bg-glass backdrop-blur-lg rounded-xl shadow-lg p-6 max-w-md">
           <h2 className="font-bold mb-2">Nouveau transfert de stock</h2>
           <form onSubmit={handleCreateTf} className="space-y-3">
             <div>

--- a/src/pages/Utilisateurs.jsx
+++ b/src/pages/Utilisateurs.jsx
@@ -5,6 +5,7 @@ import UtilisateurForm from "@/components/utilisateurs/UtilisateurForm";
 import UtilisateurDetail from "@/components/utilisateurs/UtilisateurDetail";
 import { Button } from "@/components/ui/button";
 import TableContainer from "@/components/ui/TableContainer";
+import GlassCard from "@/components/ui/GlassCard";
 import { Toaster, toast } from "react-hot-toast";
 import { saveAs } from "file-saver";
 import * as XLSX from "xlsx";
@@ -58,24 +59,26 @@ export default function Utilisateurs() {
   return (
     <div className="p-6 container mx-auto text-shadow">
       <Toaster position="top-right" />
-      <div className="flex flex-wrap gap-4 items-center mb-4">
-        <input
-          type="search"
-          value={search}
-          onChange={e => setSearch(e.target.value)}
-          className="input"
-          placeholder="Recherche email"
-        />
-        <select className="input" value={actifFilter} onChange={e => setActifFilter(e.target.value)}>
-          <option value="all">Tous</option>
-          <option value="true">Actif</option>
-          <option value="false">Inactif</option>
-        </select>
-        <Button onClick={() => { setSelected(null); setShowForm(true); }}>
-          Ajouter un utilisateur
-        </Button>
-        <Button variant="outline" onClick={exportExcel}>Export Excel</Button>
-      </div>
+      <GlassCard className="p-4 mb-4">
+        <div className="flex flex-wrap gap-4 items-end">
+          <input
+            type="search"
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            className="input"
+            placeholder="Recherche email"
+          />
+          <select className="input" value={actifFilter} onChange={e => setActifFilter(e.target.value)}>
+            <option value="all">Tous</option>
+            <option value="true">Actif</option>
+            <option value="false">Inactif</option>
+          </select>
+          <Button onClick={() => { setSelected(null); setShowForm(true); }}>
+            Ajouter un utilisateur
+          </Button>
+          <Button variant="outline" onClick={exportExcel}>Export Excel</Button>
+        </div>
+      </GlassCard>
       <TableContainer className="mb-4">
         <Motion.table
           initial={{ opacity: 0 }}

--- a/src/pages/Validations.jsx
+++ b/src/pages/Validations.jsx
@@ -4,6 +4,7 @@ import { useAuth } from "@/context/AuthContext";
 import { Button } from "@/components/ui/button";
 import { Toaster, toast } from "react-hot-toast";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import TableContainer from "@/components/ui/TableContainer";
 
 export default function Validations() {
   const { isAdmin, mama_id } = useAuth();
@@ -75,7 +76,8 @@ export default function Validations() {
           {saving ? "Envoi…" : "Demander"}
         </Button>
       </form>
-      <table className="min-w-full bg-white rounded-xl shadow-md">
+      <TableContainer className="mt-4">
+        <table className="min-w-full text-sm">
         <thead>
           <tr>
             <th className="px-2 py-1">Module</th>
@@ -103,7 +105,8 @@ export default function Validations() {
             </tr>
           ))}
         </tbody>
-      </table>
+        </table>
+      </TableContainer>
     </div>
   );
 }

--- a/src/pages/admin/AuditViewer.jsx
+++ b/src/pages/admin/AuditViewer.jsx
@@ -3,6 +3,7 @@ import { supabase } from "@/lib/supabase";
 import { useAuth } from "@/context/AuthContext";
 import { Button } from "@/components/ui/button";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import TableContainer from "@/components/ui/TableContainer";
 
 export default function AuditViewer() {
   const { mama_id } = useAuth();
@@ -75,7 +76,8 @@ export default function AuditViewer() {
       {loading ? (
         <LoadingSpinner message="Chargement..." />
       ) : (
-        <table className="min-w-full bg-white rounded-xl shadow-md">
+        <TableContainer className="mt-4">
+          <table className="min-w-full text-sm">
           <thead>
             <tr>
               <th className="px-2 py-1">Date</th>
@@ -100,7 +102,8 @@ export default function AuditViewer() {
               </tr>
             ))}
           </tbody>
-        </table>
+          </table>
+        </TableContainer>
       )}
     </div>
   );

--- a/src/pages/admin/StatsDashboard.jsx
+++ b/src/pages/admin/StatsDashboard.jsx
@@ -3,6 +3,7 @@ import { useUsageStats } from "@/hooks/useUsageStats";
 import { useAuth } from "@/context/AuthContext";
 import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip } from "recharts";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import GlassCard from "@/components/ui/GlassCard";
 
 export default function StatsDashboard() {
   const { mama_id } = useAuth();
@@ -31,7 +32,7 @@ export default function StatsDashboard() {
         <LoadingSpinner message="Chargement..." />
       ) : (
         <div className="grid gap-6">
-          <div className="bg-white rounded-xl shadow p-4">
+          <GlassCard>
             <h2 className="font-semibold mb-2">Modules les plus utilisés</h2>
             <ResponsiveContainer width="100%" height={300}>
               <BarChart data={modules}>
@@ -41,15 +42,15 @@ export default function StatsDashboard() {
                 <Bar dataKey="count" fill="#bfa14d" />
               </BarChart>
             </ResponsiveContainer>
-          </div>
-          <div className="bg-white rounded-xl shadow p-4">
+          </GlassCard>
+          <GlassCard>
             <h2 className="font-semibold mb-2">Erreurs fréquentes</h2>
             <ul className="list-disc pl-4">
               {errors.map((e) => (
                 <li key={e.description}>{e.description} ({e.count})</li>
               ))}
             </ul>
-          </div>
+          </GlassCard>
         </div>
       )}
     </div>

--- a/src/pages/analyse/MenuEngineering.jsx
+++ b/src/pages/analyse/MenuEngineering.jsx
@@ -40,7 +40,7 @@ export default function MenuEngineering() {
         <Button onClick={() => fetchData(filters)}>Rafraîchir</Button>
         <Button variant="outline" onClick={exportPdf}>Export</Button>
       </div>
-      <div id="matrix" className="w-full h-80 bg-white rounded">
+      <div id="matrix" className="w-full h-80 bg-glass border border-borderGlass backdrop-blur rounded">
         <ResponsiveContainer width="100%" height="100%">
           <ScatterChart>
             <CartesianGrid />

--- a/src/pages/analytique/AnalytiqueDashboard.jsx
+++ b/src/pages/analytique/AnalytiqueDashboard.jsx
@@ -3,6 +3,7 @@ import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip, PieChart, Pi
 import { Toaster } from "react-hot-toast";
 import * as XLSX from "xlsx";
 import { Button } from "@/components/ui/button";
+import GlassCard from "@/components/ui/GlassCard";
 import { useAuth } from "@/context/AuthContext";
 import { useCostCenters } from "@/hooks/useCostCenters";
 import { useFamilles } from "@/hooks/useFamilles";
@@ -61,7 +62,7 @@ export default function AnalytiqueDashboard() {
       </div>
       <Button variant="outline" className="mb-4" onClick={exportExcel}>Export Excel</Button>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <div className="bg-white p-4 rounded-xl shadow">
+        <GlassCard className="p-4">
           <h3 className="font-semibold mb-2">Consommation par activité</h3>
           <ResponsiveContainer width="100%" height={300}>
             <BarChart data={dataActivite}>
@@ -71,8 +72,8 @@ export default function AnalytiqueDashboard() {
               <Bar dataKey="sumv" fill="#8884d8" />
             </BarChart>
           </ResponsiveContainer>
-        </div>
-        <div className="bg-white p-4 rounded-xl shadow">
+        </GlassCard>
+        <GlassCard className="p-4">
           <h3 className="font-semibold mb-2">Ventilation produits</h3>
           <ResponsiveContainer width="100%" height={300}>
             <PieChart>
@@ -84,7 +85,7 @@ export default function AnalytiqueDashboard() {
               <Tooltip />
             </PieChart>
           </ResponsiveContainer>
-        </div>
+        </GlassCard>
       </div>
     </div>
   );

--- a/src/pages/auth/Login.jsx
+++ b/src/pages/auth/Login.jsx
@@ -6,6 +6,7 @@ import toast from "react-hot-toast";
 import useFormErrors from "@/hooks/useFormErrors";
 import GlassCard from "@/components/ui/GlassCard";
 import PageWrapper from "@/components/ui/PageWrapper";
+import PreviewBanner from "@/components/ui/PreviewBanner";
 import PrimaryButton from "@/components/ui/PrimaryButton";
 import { login as loginUser } from "../../lib/loginUser";
 
@@ -67,6 +68,7 @@ export default function Login() {
 
   return (
     <PageWrapper>
+      <PreviewBanner />
       <GlassCard className="flex flex-col items-center">
         <div className="mb-6">
           <MamaLogo width={96} />

--- a/src/pages/auth/Logout.jsx
+++ b/src/pages/auth/Logout.jsx
@@ -2,6 +2,8 @@ import { useEffect } from "react";
 import { supabase } from "@/lib/supabase";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-hot-toast";
+import PageWrapper from "@/components/ui/PageWrapper";
+import GlassCard from "@/components/ui/GlassCard";
 
 export default function Logout() {
   const navigate = useNavigate();
@@ -11,5 +13,9 @@ export default function Logout() {
       navigate("/login");
     });
   }, [navigate]);
-  return <div className="p-8 text-center">Déconnexion…</div>;
+  return (
+    <PageWrapper>
+      <GlassCard className="text-center">Déconnexion…</GlassCard>
+    </PageWrapper>
+  );
 }

--- a/src/pages/auth/Pending.jsx
+++ b/src/pages/auth/Pending.jsx
@@ -1,12 +1,13 @@
 import { GlassCard } from "@/components/ui/GlassCard";
+import PageWrapper from "@/components/ui/PageWrapper";
 
 export default function Pending() {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-900 to-blue-700 flex items-center justify-center">
-      <GlassCard>
-        <h1 className="text-2xl font-bold text-white mb-2">Compte en cours de création…</h1>
+    <PageWrapper>
+      <GlassCard className="text-center space-y-2">
+        <h1 className="text-2xl font-bold text-white">Compte en cours de création…</h1>
         <p className="text-white/80">Merci de patienter pendant la configuration de votre compte utilisateur.</p>
       </GlassCard>
-    </div>
+    </PageWrapper>
   );
 }

--- a/src/pages/catalogue/CatalogueSyncViewer.jsx
+++ b/src/pages/catalogue/CatalogueSyncViewer.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { supabase } from "@/lib/supabase";
 import { useAuth } from "@/context/AuthContext";
 import { Button } from "@/components/ui/button";
+import TableContainer from "@/components/ui/TableContainer";
 import toast from "react-hot-toast";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 
@@ -61,37 +62,39 @@ export default function CatalogueSyncViewer({ fournisseur_id }) {
   return (
     <div className="p-6">
       <h2 className="text-lg font-bold mb-4">Mises à jour catalogue</h2>
-      <table className="w-full table-auto text-sm">
-        <thead>
-          <tr>
-            <th className="px-2 py-1 text-left">Produit</th>
-            <th className="px-2 py-1">Ancien prix</th>
-            <th className="px-2 py-1">Nouveau prix</th>
-            <th className="px-2 py-1" />
-          </tr>
-        </thead>
-        <tbody>
-          {items.map((u) => (
-            <tr key={u.id}>
-              <td className="px-2 py-1">{u.produit?.nom || u.produit_id}</td>
-              <td className="px-2 py-1">{u.ancienne_valeur}</td>
-              <td className="px-2 py-1">{u.nouvelle_valeur}</td>
-              <td className="px-2 py-1 space-x-1">
-                <Button size="sm" onClick={() => acceptUpdate(u)}>
-                  Accepter
-                </Button>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  onClick={() => rejectUpdate(u.id)}
-                >
-                  Rejeter
-                </Button>
-              </td>
+      <TableContainer className="mt-2">
+        <table className="w-full table-auto text-sm">
+          <thead>
+            <tr>
+              <th className="px-2 py-1 text-left">Produit</th>
+              <th className="px-2 py-1">Ancien prix</th>
+              <th className="px-2 py-1">Nouveau prix</th>
+              <th className="px-2 py-1" />
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {items.map((u) => (
+              <tr key={u.id}>
+                <td className="border px-2 py-1">{u.produit?.nom || u.produit_id}</td>
+                <td className="border px-2 py-1">{u.ancienne_valeur}</td>
+                <td className="border px-2 py-1">{u.nouvelle_valeur}</td>
+                <td className="border px-2 py-1 space-x-1">
+                  <Button size="sm" onClick={() => acceptUpdate(u)}>
+                    Accepter
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => rejectUpdate(u.id)}
+                  >
+                    Rejeter
+                  </Button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </TableContainer>
     </div>
   );
 }

--- a/src/pages/commandes/CommandesEnvoyees.jsx
+++ b/src/pages/commandes/CommandesEnvoyees.jsx
@@ -4,6 +4,8 @@ import { useAuth } from "@/context/AuthContext";
 import { Button } from "@/components/ui/button";
 import { useFournisseurAPI } from "@/hooks/useFournisseurAPI";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import GlassCard from "@/components/ui/GlassCard";
+import TableContainer from "@/components/ui/TableContainer";
 
 export default function CommandesEnvoyees() {
   const { mama_id } = useAuth();
@@ -33,13 +35,15 @@ export default function CommandesEnvoyees() {
 
   return (
     <div className="p-6">
-      <h2 className="text-lg font-bold mb-4">Commandes envoyées</h2>
-      <table className="w-full table-auto text-sm">
-        <thead>
-          <tr>
-            <th className="px-2 py-1">Date</th>
-            <th className="px-2 py-1">Fournisseur</th>
-            <th className="px-2 py-1">Statut</th>
+      <GlassCard className="p-4">
+        <h2 className="text-lg font-bold mb-4">Commandes envoyées</h2>
+        <TableContainer>
+          <table className="w-full table-auto text-sm">
+          <thead>
+            <tr>
+              <th className="px-2 py-1">Date</th>
+              <th className="px-2 py-1">Fournisseur</th>
+              <th className="px-2 py-1">Statut</th>
             <th className="px-2 py-1" />
           </tr>
         </thead>
@@ -57,7 +61,9 @@ export default function CommandesEnvoyees() {
             </tr>
           ))}
         </tbody>
-      </table>
+        </table>
+        </TableContainer>
+      </GlassCard>
     </div>
   );
 }

--- a/src/pages/costboisson/CostBoisson.jsx
+++ b/src/pages/costboisson/CostBoisson.jsx
@@ -4,6 +4,8 @@ import { supabase } from "@/lib/supabase";
 import { Button } from "@/components/ui/button";
 import toast, { Toaster } from "react-hot-toast";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import GlassCard from "@/components/ui/GlassCard";
+import TableContainer from "@/components/ui/TableContainer";
 import * as XLSX from "xlsx";
 import jsPDF from "jspdf";
 import "jspdf-autotable";
@@ -215,7 +217,7 @@ export default function CostBoissons() {
         <Button onClick={handleExportPDF}>Exporter PDF</Button>
       </div>
       {/* Stats avancées */}
-      <div className="bg-white shadow rounded-xl p-4 mb-6 flex flex-wrap gap-6">
+      <GlassCard className="p-4 mb-6 flex flex-wrap gap-6">
         <div>
           <span className="font-semibold text-blue-700">Food cost moyen&nbsp;:</span>
           <span className={avgFC > FOOD_COST_SEUIL ? "text-red-600 font-bold" : "font-bold"}>
@@ -237,9 +239,9 @@ export default function CostBoissons() {
           <span className="font-semibold">Total boissons actives&nbsp;: </span>
           {filtered.length}
         </div>
-      </div>
+      </GlassCard>
       {/* Graphique top ventes */}
-      <div className="bg-white shadow rounded-xl p-4 mb-6">
+      <GlassCard className="p-4 mb-6">
         <h2 className="font-bold mb-2">Top 10 ventes boissons (période)</h2>
         <ResponsiveContainer width="100%" height={200}>
           <BarChart data={chartData}>
@@ -251,9 +253,9 @@ export default function CostBoissons() {
             <Bar dataKey="Marge (€)" fill="#e0a800" />
           </BarChart>
         </ResponsiveContainer>
-      </div>
+      </GlassCard>
       {/* Tableau interactif */}
-      <div className="bg-white shadow rounded-xl overflow-x-auto">
+      <TableContainer>
         <table className="min-w-full table-auto">
           <thead>
             <tr>
@@ -290,7 +292,7 @@ export default function CostBoissons() {
                           </Button>
                         </DialogTrigger>
                         <DialogContent
-                          className="bg-white rounded-xl shadow-lg p-6 max-w-md z-[1000]"
+                          className="bg-glass backdrop-blur-lg border border-borderGlass rounded-xl shadow-lg p-6 max-w-md z-[1000]"
                         >
                           <h2 className="font-bold text-xl mb-2">{b.nom}</h2>
                           <p>
@@ -364,7 +366,7 @@ export default function CostBoissons() {
                           <Button variant="ghost" className="text-sm">Voir fiche</Button>
                         </DialogTrigger>
                         <DialogContent
-                          className="bg-white rounded-xl shadow-lg p-6 max-w-md z-[1000]"
+                          className="bg-glass backdrop-blur-lg border border-borderGlass rounded-xl shadow-lg p-6 max-w-md z-[1000]"
                         >
                           <h2 className="font-bold text-xl mb-2">{b.nom}</h2>
                           <p>
@@ -383,7 +385,7 @@ export default function CostBoissons() {
             </AnimatePresence>
           </tbody>
         </table>
-      </div>
+      </TableContainer>
     </div>
   );
 }

--- a/src/pages/dashboard/DashboardBuilder.jsx
+++ b/src/pages/dashboard/DashboardBuilder.jsx
@@ -89,7 +89,7 @@ export default function DashboardBuilder() {
         className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6"
       >
         {ordered.map((w) => (
-          <Reorder.Item key={w.id} value={w} className="bg-white rounded-xl p-4 relative">
+          <Reorder.Item key={w.id} value={w} className="bg-glass backdrop-blur border border-borderGlass rounded-xl p-4 relative">
             <button
               className="absolute top-2 right-2 text-red-600"
               onClick={() => deleteWidget(current.id, w.id)}

--- a/src/pages/debug/AuthDebug.jsx
+++ b/src/pages/debug/AuthDebug.jsx
@@ -1,12 +1,15 @@
 // src/pages/debug/AuthDebug.jsx
 import useAuth from "@/hooks/useAuth";
+import GlassCard from "@/components/ui/GlassCard";
 
 export default function AuthDebug() {
   const { session, userData } = useAuth();
 
   return (
-    <pre className="p-4 text-sm text-white bg-black">
-      {JSON.stringify({ session, userData }, null, 2)}
-    </pre>
+    <div className="p-6 flex justify-center">
+      <GlassCard className="w-full max-w-xl overflow-auto text-xs">
+        <pre>{JSON.stringify({ session, userData }, null, 2)}</pre>
+      </GlassCard>
+    </div>
   );
 }

--- a/src/pages/debug/Debug.jsx
+++ b/src/pages/debug/Debug.jsx
@@ -1,14 +1,15 @@
 import React from "react";
 import { useAuth } from "@/context/AuthContext";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import GlassCard from "@/components/ui/GlassCard";
 
 export default function Debug() {
   const { session, role, mama_id, access_rights, loading: authLoading } = useAuth();
   if (authLoading) return <LoadingSpinner message="Chargement..." />;
 
   return (
-    <div className="min-h-screen bg-gray-100 p-8">
-      <div className="max-w-3xl mx-auto bg-white shadow-md rounded-lg p-6">
+    <div className="p-8 flex justify-center">
+      <GlassCard className="max-w-3xl w-full">
         <h1 className="text-2xl font-bold mb-4 text-mamastock-gold">🧪 Debug AuthContext</h1>
 
         <div className="space-y-3">
@@ -26,12 +27,12 @@ export default function Debug() {
           </div>
           <div>
             <strong>Access Rights :</strong>
-            <pre className="bg-gray-100 text-sm border rounded p-3 mt-2">
+            <pre className="bg-glass text-sm border border-borderGlass backdrop-blur rounded p-3 mt-2">
               {JSON.stringify(access_rights, null, 2)}
             </pre>
           </div>
         </div>
-      </div>
+      </GlassCard>
     </div>
   );
 }

--- a/src/pages/debug/DebugUser.jsx
+++ b/src/pages/debug/DebugUser.jsx
@@ -1,6 +1,7 @@
 // src/pages/debug/DebugUser.jsx
 import { useAuth } from "@/context/AuthContext";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import GlassCard from "@/components/ui/GlassCard";
 
 export default function DebugUser() {
   const { session, role, mama_id, access_rights, loading: authLoading } = useAuth();
@@ -8,9 +9,11 @@ export default function DebugUser() {
   if (authLoading) return <LoadingSpinner message="Chargement..." />;
 
   return (
-    <div className="p-6 text-white bg-black">
-      <h2 className="text-lg font-bold">🧪 DEBUG UTILISATEUR</h2>
-      <pre>{JSON.stringify({ session, role, mama_id, access_rights }, null, 2)}</pre>
+    <div className="p-6 flex justify-center">
+      <GlassCard className="w-full max-w-xl overflow-auto text-xs text-white">
+        <h2 className="text-lg font-bold mb-2">🧪 DEBUG UTILISATEUR</h2>
+        <pre>{JSON.stringify({ session, role, mama_id, access_rights }, null, 2)}</pre>
+      </GlassCard>
     </div>
   );
 }

--- a/src/pages/ecarts/Ecarts.jsx
+++ b/src/pages/ecarts/Ecarts.jsx
@@ -3,6 +3,7 @@ import { useAuth } from "@/context/AuthContext";
 import { useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import GlassCard from "@/components/ui/GlassCard";
 import { saveAs } from "file-saver";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 
@@ -46,7 +47,7 @@ export default function Ecarts() {
   };
 
   return (
-    <div className="p-6 text-white">
+    <div className="p-6 text-white space-y-6">
       <h1 className="text-3xl font-bold text-mamastockGold mb-4">Écarts d'inventaire</h1>
 
       <div className="flex flex-wrap gap-4 mb-4 items-center">
@@ -66,10 +67,7 @@ export default function Ecarts() {
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
           {ecarts.map((ecart) => (
-            <div
-              key={ecart.id}
-              className="bg-white/10 border border-mamastockGold rounded-xl p-4 hover:bg-white/20 transition"
-            >
+            <GlassCard key={ecart.id} className="p-4">
               <h2 className="text-lg font-semibold">{ecart.produit}</h2>
               <p className="text-sm text-gray-300">
                 Écart : <span className="font-bold">{ecart.ecart}</span>
@@ -82,7 +80,7 @@ export default function Ecarts() {
                   📅 {new Date(ecart.date).toLocaleDateString()}
                 </p>
               )}
-            </div>
+            </GlassCard>
           ))}
         </div>
       )}

--- a/src/pages/factures/FactureDetail.jsx
+++ b/src/pages/factures/FactureDetail.jsx
@@ -6,6 +6,7 @@ import jsPDF from "jspdf";
 import "jspdf-autotable";
 import { Button } from "@/components/ui/button";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import TableContainer from "@/components/ui/TableContainer";
 import { useInvoiceItems } from "@/hooks/useInvoiceItems";
 import { useFactures } from "@/hooks/useFactures";
 
@@ -66,8 +67,8 @@ export default function FactureDetail({ facture: factureProp, onClose }) {
   };
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
-      <div className="bg-white rounded-xl shadow-lg p-8 min-w-[400px] max-w-[95vw] flex flex-col gap-2 relative">
+    <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50">
+      <div className="bg-glass backdrop-blur-lg border border-borderGlass rounded-xl shadow-lg p-8 min-w-[400px] max-w-[95vw] flex flex-col gap-2 relative">
         <Button variant="outline" className="absolute top-2 right-2" onClick={onClose}>Fermer</Button>
         <h2 className="font-bold text-xl mb-4">Détail de la facture #{facture.id}</h2>
         <div><b>Date :</b> {facture.date}</div>
@@ -81,9 +82,10 @@ export default function FactureDetail({ facture: factureProp, onClose }) {
           }
         </div>
         {produitsFacture.length > 0 && (
-          <table className="mt-4 text-sm w-full border">
-            <thead>
-              <tr className="bg-gray-100">
+          <TableContainer className="mt-4">
+            <table className="min-w-full text-sm">
+            <thead className="bg-glass border-b border-borderGlass">
+              <tr>
                 <th className="px-2 py-1 border">Produit</th>
                 <th className="px-2 py-1 border">Quantité</th>
                 <th className="px-2 py-1 border">PU</th>
@@ -100,7 +102,8 @@ export default function FactureDetail({ facture: factureProp, onClose }) {
                 </tr>
               ))}
             </tbody>
-          </table>
+            </table>
+          </TableContainer>
         )}
         <div className="flex gap-2 mt-4">
           <Button variant="outline" onClick={exportExcel}>Export Excel</Button>

--- a/src/pages/factures/FactureForm.jsx
+++ b/src/pages/factures/FactureForm.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { useFactures } from "@/hooks/useFactures";
 import { useProducts } from "@/hooks/useProducts";
 import { Button } from "@/components/ui/button";
+import GlassCard from "@/components/ui/GlassCard";
 import toast from "react-hot-toast";
 import { uploadFile, deleteFile, pathFromUrl } from "@/hooks/useStorage";
 import { useInvoiceOcr } from "@/hooks/useInvoiceOcr";
@@ -85,10 +86,11 @@ export default function FactureForm({ facture, suppliers = [], onClose }) {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="bg-white p-6 rounded-lg shadow-md">
-      <h2 className="text-lg font-bold mb-4">
-        {facture ? "Modifier la facture" : "Ajouter une facture"}
-      </h2>
+    <GlassCard className="p-6">
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <h2 className="text-lg font-bold mb-4">
+          {facture ? "Modifier la facture" : "Ajouter une facture"}
+        </h2>
       <input
         className="input mb-2"
         type="date"
@@ -184,13 +186,14 @@ export default function FactureForm({ facture, suppliers = [], onClose }) {
           {ocrText}
         </div>
       )}
-      <div className="mt-4 p-2 bg-gray-100 rounded">
+      <div className="mt-4 p-2 bg-glass backdrop-blur rounded border border-borderGlass">
         Total HT: {lignes.reduce((s,l)=>s+l.quantite*l.prix_unitaire,0).toFixed(2)} € - TVA: {lignes.reduce((s,l)=>s+l.quantite*l.prix_unitaire*(l.tva||0)/100,0).toFixed(2)} € - TTC: {(lignes.reduce((s,l)=>s+l.quantite*l.prix_unitaire,0)+lignes.reduce((s,l)=>s+l.quantite*l.prix_unitaire*(l.tva||0)/100,0)).toFixed(2)} €
       </div>
       <div className="flex gap-2 mt-4">
         <Button type="submit" disabled={loading}>{facture ? "Modifier" : "Ajouter"}</Button>
         <Button variant="outline" type="button" onClick={onClose}>Annuler</Button>
       </div>
-    </form>
+      </form>
+    </GlassCard>
   );
 }

--- a/src/pages/factures/Factures.jsx
+++ b/src/pages/factures/Factures.jsx
@@ -6,6 +6,7 @@ import FactureForm from "./FactureForm.jsx";
 import FactureDetail from "./FactureDetail.jsx";
 import { Button } from "@/components/ui/button";
 import TableContainer from "@/components/ui/TableContainer";
+import GlassCard from "@/components/ui/GlassCard";
 import { Toaster, toast } from "react-hot-toast";
 import { saveAs } from "file-saver";
 import * as XLSX from "xlsx";
@@ -77,9 +78,9 @@ export default function Factures() {
   };
 
   return (
-    <div className="p-6 container mx-auto text-shadow">
+    <div className="p-6 container mx-auto text-shadow space-y-6">
       <Toaster position="top-right" />
-      <div className="flex flex-wrap gap-4 items-center mb-4">
+      <GlassCard className="flex flex-wrap gap-4 items-end">
         <input
           type="search"
           value={search}
@@ -107,7 +108,7 @@ export default function Factures() {
           Ajouter une facture
         </Button>
         <Button variant="outline" onClick={exportExcel}>Export Excel</Button>
-      </div>
+      </GlassCard>
       <TableContainer className="mb-4">
         <Motion.table
           initial={{ opacity: 0 }}

--- a/src/pages/factures/ImportFactures.jsx
+++ b/src/pages/factures/ImportFactures.jsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useInvoiceImport } from "@/hooks/useInvoiceImport";
 import { Button } from "@/components/ui/button";
+import GlassCard from "@/components/ui/GlassCard";
 import { Toaster, toast } from "react-hot-toast";
 
 export default function ImportFactures() {
@@ -16,14 +17,20 @@ export default function ImportFactures() {
   };
 
   return (
-    <div className="p-8 container mx-auto">
+    <div className="p-8 container mx-auto space-y-6">
       <Toaster position="top-right" />
       <h1 className="text-2xl font-bold mb-4">Import e-facture</h1>
-      <form onSubmit={handleSubmit} className="flex gap-2 items-end">
-        <input type="file" accept="application/json,application/xml" onChange={(e) => setFile(e.target.files[0])} />
-        <Button type="submit" disabled={loading}>Importer</Button>
-      </form>
-      {error && <p className="text-red-600 mt-2">{error}</p>}
+      <GlassCard>
+        <form onSubmit={handleSubmit} className="flex gap-2 items-end">
+          <input
+            type="file"
+            accept="application/json,application/xml"
+            onChange={(e) => setFile(e.target.files[0])}
+          />
+          <Button type="submit" disabled={loading}>Importer</Button>
+        </form>
+        {error && <p className="text-red-500 mt-2">{error}</p>}
+      </GlassCard>
     </div>
   );
 }

--- a/src/pages/fiches/FicheDetail.jsx
+++ b/src/pages/fiches/FicheDetail.jsx
@@ -66,7 +66,7 @@ export default function FicheDetail({ fiche: ficheProp, onClose }) {
   }
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+    <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50">
       <div className="bg-glass backdrop-blur-lg text-white rounded-xl shadow-lg p-8 min-w-[400px] max-w-[95vw] flex flex-col gap-2 relative text-shadow">
         <Button variant="outline" className="absolute top-2 right-2" onClick={onClose}>Fermer</Button>
         <h2 className="font-bold text-xl mb-4">{fiche.nom}</h2>
@@ -95,7 +95,7 @@ export default function FicheDetail({ fiche: ficheProp, onClose }) {
         </div>
         <div className="mt-6">
           <h3 className="font-semibold mb-2">Analyse rentabilité</h3>
-          <div className="h-32 bg-white rounded mb-2">
+          <div className="h-32 bg-glass border border-borderGlass backdrop-blur rounded mb-2">
             <ResponsiveContainer width="100%" height="100%">
               <LineChart data={(history || []).map(h => ({ date: new Date(h.date).toLocaleDateString('fr-FR'), marge: h.prix_vente && h.cout_portion ? ((h.prix_vente - h.cout_portion) / h.prix_vente) * 100 : null }))}>
                 <XAxis dataKey="date" hide />

--- a/src/pages/fournisseurs/FournisseurDetail.jsx
+++ b/src/pages/fournisseurs/FournisseurDetail.jsx
@@ -9,6 +9,8 @@ import { useAuth } from "@/context/AuthContext";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 import { ResponsiveContainer, LineChart, Line, BarChart, Bar, XAxis, YAxis, Tooltip, Legend } from "recharts";
 import { Button } from "@/components/ui/button";
+import GlassCard from "@/components/ui/GlassCard";
+import TableContainer from "@/components/ui/TableContainer";
 
 export default function FournisseurDetail({ id }) {
   const { mama_id } = useAuth();
@@ -83,7 +85,7 @@ export default function FournisseurDetail({ id }) {
       )}
       {/* Stats d’achats/factures */}
       <div className="grid md:grid-cols-2 gap-6">
-        <div className="glass-card p-4">
+        <GlassCard className="p-4">
           <h3 className="font-semibold mb-2">Évolution achats mensuels</h3>
           <ResponsiveContainer width="100%" height={150}>
             <LineChart data={stats}>
@@ -94,8 +96,8 @@ export default function FournisseurDetail({ id }) {
               <Line type="monotone" dataKey="total_achats" stroke="#bfa14d" name="Total Achats" />
             </LineChart>
           </ResponsiveContainer>
-        </div>
-        <div className="glass-card p-4">
+        </GlassCard>
+        <GlassCard className="p-4">
           <h3 className="font-semibold mb-2">Top produits achetés</h3>
           <ResponsiveContainer width="100%" height={150}>
             <BarChart data={topProducts}>
@@ -106,10 +108,10 @@ export default function FournisseurDetail({ id }) {
               <Bar dataKey="total" fill="#0f1c2e" name="Quantité achetée" />
             </BarChart>
           </ResponsiveContainer>
-        </div>
+        </GlassCard>
       </div>
       {/* Historique des achats */}
-      <div className="glass-table mt-4 p-2">
+      <TableContainer className="mt-4 p-2">
         <h3 className="font-semibold mb-2">Historique des achats</h3>
         <table className="w-full table-auto text-xs">
           <thead>
@@ -137,14 +139,7 @@ export default function FournisseurDetail({ id }) {
             ))}
           </tbody>
         </table>
-      </div>
-      <style>{`
-        .glass-card, .glass-table {
-          background: rgba(255,255,255,0.33);
-          backdrop-filter: blur(13px);
-          border-radius: 16px;
-        }
-      `}</style>
+      </TableContainer>
     </div>
   );
 }

--- a/src/pages/fournisseurs/comparatif/ComparatifPrix.jsx
+++ b/src/pages/fournisseurs/comparatif/ComparatifPrix.jsx
@@ -4,6 +4,7 @@ import PrixFournisseurs from "./PrixFournisseurs";
 import { supabase } from "@/lib/supabase";
 import { useAuth } from "@/context/AuthContext";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import { Select } from "@/components/ui/select";
 
 export default function ComparatifPrix() {
   const { mama_id } = useAuth();
@@ -53,12 +54,12 @@ export default function ComparatifPrix() {
           {error.message || "Erreur de chargement"}
         </p>
       )}
-      <select
+      <Select
         id="produit-select"
         value={produitId}
         onChange={(e) => setProduitId(e.target.value)}
-        className="border px-3 py-2 rounded w-full mb-4"
-        aria-label="Sélection produit"
+        className="mb-4"
+        ariaLabel="Sélection produit"
       >
         <option value="">-- Choisir un produit --</option>
         {produits.map((p) => (
@@ -66,7 +67,7 @@ export default function ComparatifPrix() {
             {p.nom}
           </option>
         ))}
-      </select>
+      </Select>
 
       {produitId && <PrixFournisseurs produitId={produitId} />}
     </div>

--- a/src/pages/fournisseurs/comparatif/PrixFournisseurs.jsx
+++ b/src/pages/fournisseurs/comparatif/PrixFournisseurs.jsx
@@ -1,6 +1,8 @@
 // src/pages/fournisseurs/comparatif/PrixFournisseurs.jsx
 import { useComparatif } from "@/hooks/useComparatif";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import GlassCard from "@/components/ui/GlassCard";
+import TableContainer from "@/components/ui/TableContainer";
 
 // Affiche le comparatif des prix par fournisseur pour un produit
 
@@ -24,9 +26,11 @@ export default function PrixFournisseurs({ produitId }) {
   }
 
   return (
-    <div className="border p-4 rounded text-sm bg-white shadow">
-      <table className="w-full text-left border-collapse">
-        <thead className="bg-gray-100">
+    <div className="text-sm">
+      <GlassCard className="p-4">
+        <TableContainer>
+          <table className="w-full text-left border-collapse">
+        <thead className="bg-glass border-b border-borderGlass">
           <tr>
             <th className="px-2 py-1">Fournisseur</th>
             <th className="px-2 py-1 text-right">Dernier prix</th>
@@ -44,7 +48,9 @@ export default function PrixFournisseurs({ produitId }) {
             </tr>
           ))}
         </tbody>
-      </table>
+          </table>
+        </TableContainer>
+      </GlassCard>
     </div>
   );
 }

--- a/src/pages/inventaire/EcartInventaire.jsx
+++ b/src/pages/inventaire/EcartInventaire.jsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, useCallback } from "react";
 import { supabase } from "@/lib/supabase";
 import { useAuth } from "@/context/AuthContext";
+import TableContainer from "@/components/ui/TableContainer";
+import InputField from "@/components/ui/InputField";
 
 function EcartInventairePage() {
   const params = new URLSearchParams(window.location.search);
@@ -115,37 +117,39 @@ function EcartInventairePage() {
   }, [mode, zone, date, mois, fetchEcarts, renderPDF, mama_id]);
 
   return (
-    <div className="p-6 bg-mamastock-bg min-h-screen">
+    <div className="p-6 space-y-6">
       <h1 className="text-2xl font-bold text-mamastock-gold mb-4">Écarts d'inventaire</h1>
 
       <div className="flex gap-4 mb-6">
-        <input
+        <InputField
+          label="Date"
           type="date"
           value={date}
           onChange={(e) => {
             setDate(e.target.value);
             setMois("");
           }}
-          className="border px-3 py-2 rounded"
+          className="flex-1"
         />
-        <input
+        <InputField
+          label="Zone"
           type="text"
           placeholder="Zone (ex: bar, cuisine...)"
           value={zone}
           onChange={(e) => setZone(e.target.value)}
-          className="border px-3 py-2 rounded"
+          className="flex-1"
         />
         <button
           onClick={renderPDF}
-          className="bg-mamastock-gold text-white font-bold px-4 py-2 rounded"
+          className="bg-mamastock-gold text-white font-bold px-4 py-2 rounded self-end h-10"
         >
           📄 Export PDF
         </button>
       </div>
 
-      <div className="overflow-x-auto">
-        <table className="w-full bg-white rounded-xl shadow text-sm">
-          <thead className="bg-gray-100 text-gray-600">
+      <TableContainer className="mt-4">
+        <table className="w-full text-sm">
+          <thead className="bg-glass border-b border-borderGlass text-white">
             <tr>
               <th className="p-3 text-left">Date</th>
               <th className="p-3 text-left">Produit</th>
@@ -157,7 +161,7 @@ function EcartInventairePage() {
           </thead>
           <tbody>
             {ecarts.map((e, idx) => (
-              <tr key={idx} className="border-b hover:bg-gray-50">
+              <tr key={idx} className="border-b hover:bg-white/5">
                 <td className="p-3">{e.date}</td>
                 <td className="p-3">{e.produit}</td>
                 <td className="p-3">{e.stock_theorique}</td>
@@ -170,7 +174,7 @@ function EcartInventairePage() {
             ))}
           </tbody>
         </table>
-      </div>
+      </TableContainer>
     </div>
   );
 }

--- a/src/pages/menus/MenuDetail.jsx
+++ b/src/pages/menus/MenuDetail.jsx
@@ -1,6 +1,7 @@
 import { saveAs } from "file-saver";
 import * as XLSX from "xlsx";
 import { Button } from "@/components/ui/button";
+import TableContainer from "@/components/ui/TableContainer";
 import toast from "react-hot-toast";
 
 export default function MenuDetail({ menu, onClose, onDuplicate }) {
@@ -30,31 +31,33 @@ export default function MenuDetail({ menu, onClose, onDuplicate }) {
   ];
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
-      <div className="bg-white rounded-xl shadow-lg p-8 min-w-[400px] max-w-[95vw] flex flex-col gap-2 relative">
+    <div className="fixed inset-0 bg-black/40 backdrop-blur-sm flex items-center justify-center z-50">
+      <div className="bg-glass backdrop-blur-lg border border-borderGlass rounded-xl shadow-lg p-8 min-w-[400px] max-w-[95vw] flex flex-col gap-2 relative">
         <Button variant="outline" className="absolute top-2 right-2" onClick={onClose}>Fermer</Button>
         <h2 className="font-bold text-xl mb-4">{menu.nom}</h2>
         <div><b>Date :</b> {menu.date}</div>
         <div>
           <b>Fiches :</b>
-          <table className="min-w-full text-sm mt-1">
-            <thead>
-              <tr>
-                <th className="px-2">Nom</th>
-                <th className="px-2">Portions</th>
-                <th className="px-2">Coût</th>
-              </tr>
-            </thead>
-            <tbody>
-              {fiches.map((f, i) => (
-                <tr key={i}>
-                  <td className="border px-2">{f.fiche?.nom}</td>
-                  <td className="border px-2 text-center">{f.fiche?.portions}</td>
-                  <td className="border px-2">{Number(f.fiche?.cout_total || 0).toFixed(2)} €</td>
+          <TableContainer className="mt-1">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr>
+                  <th className="px-2">Nom</th>
+                  <th className="px-2">Portions</th>
+                  <th className="px-2">Coût</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {fiches.map((f, i) => (
+                  <tr key={i}>
+                    <td className="border px-2">{f.fiche?.nom}</td>
+                    <td className="border px-2 text-center">{f.fiche?.portions}</td>
+                    <td className="border px-2">{Number(f.fiche?.cout_total || 0).toFixed(2)} €</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </TableContainer>
         </div>
         <div className="mt-2 flex gap-4">
           <div><b>Total :</b> {totalCout.toFixed(2)} €</div>

--- a/src/pages/menus/MenuDuJour.jsx
+++ b/src/pages/menus/MenuDuJour.jsx
@@ -5,6 +5,7 @@ import { useAuth } from "@/context/AuthContext";
 import MenuDuJourForm from "./MenuDuJourForm.jsx";
 import MenuDuJourDetail from "./MenuDuJourDetail.jsx";
 import { Button } from "@/components/ui/button";
+import TableContainer from "@/components/ui/TableContainer";
 import { Toaster, toast } from "react-hot-toast";
 import { saveAs } from "file-saver";
 import * as XLSX from "xlsx";
@@ -73,11 +74,8 @@ export default function MenuDuJour() {
         </Button>
         <Button variant="outline" onClick={exportExcel}>Export Excel</Button>
       </div>
-      <Motion.table
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        className="min-w-full bg-white rounded-xl shadow-md"
-      >
+      <TableContainer as={Motion.table} initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="mt-2">
+        <table className="min-w-full text-sm">
         <thead>
           <tr>
             <th className="px-4 py-2">Date</th>
@@ -123,7 +121,8 @@ export default function MenuDuJour() {
             </tr>
           ))}
         </tbody>
-      </Motion.table>
+        </table>
+      </TableContainer>
       {showForm && (
         <MenuDuJourForm
           menu={selected}

--- a/src/pages/menus/MenuDuJourDetail.jsx
+++ b/src/pages/menus/MenuDuJourDetail.jsx
@@ -25,8 +25,8 @@ export default function MenuDuJourDetail({ menu, onClose }) {
   ];
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
-      <div className="bg-white rounded-xl shadow-lg p-8 min-w-[400px] max-w-[95vw] flex flex-col gap-2 relative">
+    <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50">
+      <div className="bg-glass border border-borderGlass backdrop-blur rounded-2xl shadow-lg p-8 min-w-[400px] max-w-[95vw] flex flex-col gap-2 relative">
         <Button variant="outline" className="absolute top-2 right-2" onClick={onClose}>Fermer</Button>
         <h2 className="font-bold text-xl mb-4">{menu.nom}</h2>
         <div><b>Date :</b> {menu.date}</div>

--- a/src/pages/menus/MenuDuJourForm.jsx
+++ b/src/pages/menus/MenuDuJourForm.jsx
@@ -67,7 +67,10 @@ export default function MenuDuJourForm({ menu, fiches = [], onClose }) {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="bg-white p-6 rounded-lg shadow-md max-w-xl mx-auto">
+    <form
+      onSubmit={handleSubmit}
+      className="bg-glass border border-borderGlass backdrop-blur p-6 rounded-2xl shadow-lg max-w-xl mx-auto"
+    >
       <h2 className="text-lg font-bold mb-4">
         {menu ? "Modifier le menu du jour" : "Ajouter un menu du jour"}
       </h2>
@@ -87,7 +90,7 @@ export default function MenuDuJourForm({ menu, fiches = [], onClose }) {
       />
       <div className="mb-4">
         <label className="block font-semibold mb-2">Fiches du menu :</label>
-        <div className="max-h-48 overflow-auto border rounded p-2 bg-gray-50">
+        <div className="max-h-48 overflow-auto border border-borderGlass rounded p-2 bg-glass backdrop-blur">
           {fiches.map(f => (
             <label key={f.id} className="block">
               <input

--- a/src/pages/menus/MenuForm.jsx
+++ b/src/pages/menus/MenuForm.jsx
@@ -95,7 +95,10 @@ export default function MenuForm({ menu, fiches = [], onClose }) {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="bg-white p-6 rounded-lg shadow-md max-w-xl mx-auto">
+    <form
+      onSubmit={handleSubmit}
+      className="bg-glass border border-borderGlass backdrop-blur p-6 rounded-2xl shadow-lg max-w-xl mx-auto"
+    >
       <h2 className="text-lg font-bold mb-4">
         {menu ? "Modifier le menu" : "Ajouter un menu"}
       </h2>

--- a/src/pages/menus/Menus.jsx
+++ b/src/pages/menus/Menus.jsx
@@ -9,6 +9,7 @@ import { Toaster, toast } from "react-hot-toast";
 import { saveAs } from "file-saver";
 import * as XLSX from "xlsx";
 import { motion as Motion } from "framer-motion";
+import TableContainer from "@/components/ui/TableContainer";
 
 export default function Menus() {
   const { menus, total, getMenus, deleteMenu } = useMenus();
@@ -115,11 +116,12 @@ export default function Menus() {
         </Button>
         <Button variant="outline" onClick={exportExcel}>Export Excel</Button>
       </div>
-      <Motion.table
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        className="min-w-full bg-white rounded-xl shadow-md"
-      >
+      <TableContainer className="mt-4">
+        <Motion.table
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          className="min-w-full"
+        >
         <thead>
           <tr>
             <th className="px-4 py-2">Date</th>
@@ -180,7 +182,8 @@ export default function Menus() {
             </tr>
           ))}
         </tbody>
-      </Motion.table>
+        </Motion.table>
+      </TableContainer>
       <div className="flex justify-center gap-2 my-4">
         <Button
           variant="outline"

--- a/src/pages/mobile/MobileAccueil.jsx
+++ b/src/pages/mobile/MobileAccueil.jsx
@@ -1,9 +1,12 @@
 import { Link } from "react-router-dom";
+import { LiquidBackground, TouchLight } from "@/components/LiquidBackground";
 
 export default function MobileAccueil() {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-mamastock-bg text-white px-4 animate-fade-in">
-      <div className="w-full max-w-sm space-y-6 text-center">
+    <div className="relative min-h-screen flex items-center justify-center overflow-hidden text-white px-4">
+      <LiquidBackground showParticles />
+      <TouchLight />
+      <div className="w-full max-w-sm space-y-6 text-center relative z-10">
         <h2 className="text-2xl font-bold text-mamastockGold">📱 Menu Mobile</h2>
 
         <div className="flex flex-col gap-4">

--- a/src/pages/mobile/MobileInventaire.jsx
+++ b/src/pages/mobile/MobileInventaire.jsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from "react";
 import { supabase } from "@/lib/supabase";
 import { useAuth } from "@/context/AuthContext";
 import { useInventaires } from "@/hooks/useInventaires";
+import { LiquidBackground, TouchLight } from "@/components/LiquidBackground";
+import GlassCard from "@/components/ui/GlassCard";
 
 export default function MobileInventaire() {
   const { mama_id, loading: authLoading } = useAuth();
@@ -38,27 +40,31 @@ export default function MobileInventaire() {
   };
 
   return (
-    <div className="p-4">
-      <h2 className="text-lg font-bold mb-4">📦 Inventaire - Stock Final uniquement</h2>
-      <ul className="space-y-2">
-        {produits.map(p => (
-          <li key={p.id} className="flex justify-between items-center border p-2 rounded">
-            <span>{p.nom}</span>
-            <input
-              type="number"
-              className="w-20 border px-1"
-              value={stockFinal[p.id] || ""}
-              onChange={(e) => handleChange(p.id, e.target.value)}
-            />
-          </li>
-        ))}
-      </ul>
-      <button
-        onClick={handleSave}
-        className="mt-4 w-full bg-mamastock-gold text-white py-2 rounded hover:bg-mamastock-gold-hover"
-      >
-        Valider Inventaire
-      </button>
+    <div className="relative min-h-screen flex items-center justify-center overflow-hidden p-4 text-white">
+      <LiquidBackground showParticles />
+      <TouchLight />
+      <GlassCard className="w-full max-w-sm space-y-4 relative z-10">
+        <h2 className="text-lg font-bold">📦 Inventaire - Stock Final uniquement</h2>
+        <ul className="space-y-2">
+          {produits.map(p => (
+            <li key={p.id} className="flex justify-between items-center border p-2 rounded">
+              <span>{p.nom}</span>
+              <input
+                type="number"
+              className="w-20 border px-1 bg-transparent"
+                value={stockFinal[p.id] || ""}
+                onChange={(e) => handleChange(p.id, e.target.value)}
+              />
+            </li>
+          ))}
+        </ul>
+        <button
+          onClick={handleSave}
+          className="mt-4 w-full bg-mamastock-gold text-white py-2 rounded hover:bg-mamastock-gold-hover"
+        >
+          Valider Inventaire
+        </button>
+      </GlassCard>
     </div>
   );
 }

--- a/src/pages/mobile/MobileMouvement.jsx
+++ b/src/pages/mobile/MobileMouvement.jsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from "react";
 import { supabase } from "@/lib/supabase";
 import { toast } from "react-toastify";
 import { useAuth } from "@/context/AuthContext";
+import { LiquidBackground, TouchLight } from "@/components/LiquidBackground";
+import GlassCard from "@/components/ui/GlassCard";
 
 export default function MobileMouvement() {
   const { mama_id, loading: authLoading } = useAuth();
@@ -45,33 +47,37 @@ export default function MobileMouvement() {
   };
 
   return (
-    <div className="p-4 animate-fade-in">
-      <h2 className="text-xl font-bold mb-4 text-center">🚚 Mouvement rapide</h2>
+    <div className="relative min-h-screen flex items-center justify-center overflow-hidden p-4 text-white">
+      <LiquidBackground showParticles />
+      <TouchLight />
+      <GlassCard className="w-full max-w-sm space-y-4 relative z-10">
+        <h2 className="text-xl font-bold text-center">🚚 Mouvement rapide</h2>
 
-      <select
-        value={selectedId}
-        onChange={(e) => setSelectedId(e.target.value)}
-        className="w-full border border-gray-300 rounded p-2 mb-3"
-      >
-        <option value="">Sélectionner un produit</option>
-        {produits.map(p => <option key={p.id} value={p.id}>{p.nom}</option>)}
-      </select>
+        <select
+          value={selectedId}
+          onChange={(e) => setSelectedId(e.target.value)}
+          className="w-full border border-gray-300 rounded p-2 mb-3 bg-transparent"
+        >
+          <option value="">Sélectionner un produit</option>
+          {produits.map(p => <option key={p.id} value={p.id}>{p.nom}</option>)}
+        </select>
 
-      <input
-        type="number"
-        min={1}
-        value={quantite}
-        onChange={(e) => setQuantite(Number(e.target.value))}
-        className="w-full border border-gray-300 rounded p-2 mb-4"
-        placeholder="Quantité"
-      />
+        <input
+          type="number"
+          min={1}
+          value={quantite}
+          onChange={(e) => setQuantite(Number(e.target.value))}
+          className="w-full border border-gray-300 rounded p-2 mb-4 bg-transparent"
+          placeholder="Quantité"
+        />
 
-      <button
-        onClick={handleSubmit}
-        className="w-full bg-mamastock-gold text-white py-2 rounded hover:bg-mamastock-gold-hover transition"
-      >
-        Créer mouvement
-      </button>
+        <button
+          onClick={handleSubmit}
+          className="w-full bg-mamastock-gold text-white py-2 rounded hover:bg-mamastock-gold-hover transition"
+        >
+          Créer mouvement
+        </button>
+      </GlassCard>
     </div>
   );
 }

--- a/src/pages/mobile/MobileRequisition.jsx
+++ b/src/pages/mobile/MobileRequisition.jsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from "react";
 import { supabase } from "@/lib/supabase";
 import { toast } from "react-toastify";
 import { useAuth } from "@/context/AuthContext";
+import { LiquidBackground, TouchLight } from "@/components/LiquidBackground";
+import GlassCard from "@/components/ui/GlassCard";
 
 export default function MobileRequisition() {
   const { mama_id, loading: authLoading } = useAuth();
@@ -50,33 +52,37 @@ export default function MobileRequisition() {
   };
 
   return (
-    <div className="p-4 animate-fade-in">
-      <h2 className="text-xl font-bold mb-4 text-center">🔄 Réquisition rapide</h2>
+    <div className="relative min-h-screen flex items-center justify-center overflow-hidden p-4 text-white">
+      <LiquidBackground showParticles />
+      <TouchLight />
+      <GlassCard className="w-full max-w-sm space-y-4 relative z-10">
+        <h2 className="text-xl font-bold text-center">🔄 Réquisition rapide</h2>
 
-      <select
-        value={selectedId}
-        onChange={(e) => setSelectedId(e.target.value)}
-        className="w-full border border-gray-300 rounded p-2 mb-3"
-      >
-        <option value="">Sélectionner un produit</option>
-        {produits.map(p => <option key={p.id} value={p.id}>{p.nom}</option>)}
-      </select>
+        <select
+          value={selectedId}
+          onChange={(e) => setSelectedId(e.target.value)}
+          className="w-full border border-gray-300 rounded p-2 mb-3 bg-transparent"
+        >
+          <option value="">Sélectionner un produit</option>
+          {produits.map(p => <option key={p.id} value={p.id}>{p.nom}</option>)}
+        </select>
 
-      <input
-        type="number"
-        min={1}
-        value={quantite}
-        onChange={(e) => setQuantite(Number(e.target.value))}
-        className="w-full border border-gray-300 rounded p-2 mb-4"
-        placeholder="Quantité"
-      />
+        <input
+          type="number"
+          min={1}
+          value={quantite}
+          onChange={(e) => setQuantite(Number(e.target.value))}
+          className="w-full border border-gray-300 rounded p-2 mb-4 bg-transparent"
+          placeholder="Quantité"
+        />
 
-      <button
-        onClick={handleSubmit}
-        className="w-full bg-mamastock-gold text-white py-2 rounded hover:bg-mamastock-gold-hover transition"
-      >
-        Créer réquisition
-      </button>
+        <button
+          onClick={handleSubmit}
+          className="w-full bg-mamastock-gold text-white py-2 rounded hover:bg-mamastock-gold-hover transition"
+        >
+          Créer réquisition
+        </button>
+      </GlassCard>
     </div>
   );
 }

--- a/src/pages/mouvements/MouvementForm.jsx
+++ b/src/pages/mouvements/MouvementForm.jsx
@@ -50,8 +50,11 @@ export default function MouvementForm({ onClose }) {
   };
 
   return (
-    <div className="fixed inset-0 bg-black/30 flex items-center justify-center z-[60]">
-      <form onSubmit={handleSubmit} className="bg-white p-6 rounded shadow w-80 text-black">
+    <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-[60]">
+      <form
+        onSubmit={handleSubmit}
+        className="bg-glass border border-borderGlass backdrop-blur p-6 rounded-2xl shadow-lg w-80"
+      >
         <h2 className="font-bold mb-2">Nouveau mouvement</h2>
         <select
           className="input mb-2 w-full"

--- a/src/pages/notifications/NotificationsInbox.jsx
+++ b/src/pages/notifications/NotificationsInbox.jsx
@@ -3,6 +3,7 @@ import useNotifications from "@/hooks/useNotifications";
 import { Toaster } from "react-hot-toast";
 import { Button } from "@/components/ui/button";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import TableContainer from "@/components/ui/TableContainer";
 
 export default function NotificationsInbox() {
   const {
@@ -41,7 +42,8 @@ export default function NotificationsInbox() {
       </div>
       {loading && <LoadingSpinner message="Chargement..." />}
       {error && <div className="text-red-600">{error}</div>}
-      <table className="min-w-full">
+      <TableContainer className="mt-4">
+        <table className="min-w-full text-sm">
         <thead>
           <tr>
             <th className="px-2 py-1 text-left">Titre</th>
@@ -75,7 +77,8 @@ export default function NotificationsInbox() {
             </tr>
           )}
         </tbody>
-      </table>
+        </table>
+      </TableContainer>
     </div>
   );
 }

--- a/src/pages/parametrage/APIKeys.jsx
+++ b/src/pages/parametrage/APIKeys.jsx
@@ -3,6 +3,7 @@ import { Button } from '@/components/ui/button';
 import { useApiKeys } from '@/hooks/useApiKeys';
 import { Toaster, toast } from 'react-hot-toast';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
+import TableContainer from '@/components/ui/TableContainer';
 
 export default function APIKeys() {
   const { keys, loading, listKeys, createKey, revokeKey } = useApiKeys();
@@ -48,7 +49,7 @@ export default function APIKeys() {
           <Button type="submit">Créer</Button>
         </form>
       )}
-      <div className="bg-white shadow rounded-xl mt-6 overflow-x-auto">
+      <TableContainer className="mt-6">
         <table className="min-w-full table-auto text-center">
           <thead>
             <tr>
@@ -63,14 +64,14 @@ export default function APIKeys() {
           </thead>
           <tbody>
             {keys.map(k => (
-              <tr key={k.id} className="border-t">
-                <td>{k.name}</td>
-                <td>{k.scopes}</td>
-                <td>{k.role}</td>
-                <td>{k.created_at?.slice(0,16).replace('T',' ')}</td>
-                <td>{k.expiration?.slice(0,10) || '-'}</td>
-                <td>{k.revoked ? 'Révoquée' : 'Active'}</td>
-                <td>
+              <tr key={k.id}>
+                <td className="border px-2 py-1">{k.name}</td>
+                <td className="border px-2 py-1">{k.scopes}</td>
+                <td className="border px-2 py-1">{k.role}</td>
+                <td className="border px-2 py-1">{k.created_at?.slice(0,16).replace('T',' ')}</td>
+                <td className="border px-2 py-1">{k.expiration?.slice(0,10) || '-'}</td>
+                <td className="border px-2 py-1">{k.revoked ? 'Révoquée' : 'Active'}</td>
+                <td className="border px-2 py-1">
                   {!k.revoked && (
                     <Button size="sm" variant="destructive" onClick={() => revokeKey(k.id)}>Révoquer</Button>
                   )}
@@ -91,7 +92,7 @@ export default function APIKeys() {
             )}
           </tbody>
         </table>
-      </div>
+      </TableContainer>
     </div>
   );
 }

--- a/src/pages/parametrage/ExportComptaPage.jsx
+++ b/src/pages/parametrage/ExportComptaPage.jsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
+import { Select } from '@/components/ui/select';
+import TableContainer from '@/components/ui/TableContainer';
 import { Toaster } from 'react-hot-toast';
 import useExportCompta from '@/hooks/useExportCompta';
 
@@ -31,21 +33,21 @@ export default function ExportComptaPage() {
             type="month"
             value={mois}
             onChange={(e) => setMois(e.target.value)}
-            className="input input-bordered"
+            className="input"
           />
         </div>
         <div>
           <label className="block text-sm">Format</label>
-          <select
+          <Select
             value={format}
             onChange={(e) => setFormat(e.target.value)}
-            className="select select-bordered"
+            className="w-32"
           >
             <option value="csv">📄 CSV</option>
             <option value="xml">🧾 XML</option>
             <option value="json">JSON</option>
             <option value="txt">TXT</option>
-          </select>
+          </Select>
         </div>
         <Button onClick={handlePreview} disabled={loading}>
           Aperçu
@@ -56,13 +58,13 @@ export default function ExportComptaPage() {
       </div>
       <div className="flex gap-4 items-end">
         <input
-          className="input input-bordered flex-1"
+          className="input flex-1"
           placeholder="Endpoint ERP"
           value={endpoint}
           onChange={(e) => setEndpoint(e.target.value)}
         />
         <input
-          className="input input-bordered"
+          className="input"
           placeholder="Token"
           value={token}
           onChange={(e) => setToken(e.target.value)}
@@ -72,9 +74,9 @@ export default function ExportComptaPage() {
         </Button>
       </div>
       {preview.length > 0 && (
-        <div className="bg-white shadow rounded-xl overflow-x-auto">
+        <TableContainer>
           <table className="min-w-full table-auto text-sm">
-            <thead>
+            <thead className="bg-glass border-b border-borderGlass">
               <tr>
                 <th className="px-2 py-1">Date</th>
                 <th className="px-2 py-1">Fournisseur</th>
@@ -85,7 +87,7 @@ export default function ExportComptaPage() {
             </thead>
             <tbody>
               {preview.map((row, i) => (
-                <tr key={i} className="odd:bg-gray-50">
+                <tr key={i} className="odd:bg-white/5">
                   <td className="px-2 py-1">{row.date}</td>
                   <td className="px-2 py-1">{row.fournisseur}</td>
                   <td className="px-2 py-1 text-right">{row.ht.toFixed(2)}</td>
@@ -95,7 +97,7 @@ export default function ExportComptaPage() {
               ))}
             </tbody>
           </table>
-        </div>
+        </TableContainer>
       )}
     </div>
   );

--- a/src/pages/parametrage/InvitationsEnAttente.jsx
+++ b/src/pages/parametrage/InvitationsEnAttente.jsx
@@ -75,7 +75,7 @@ export default function InvitationsEnAttente() {
       <h1 className="text-2xl font-bold text-mamastock-gold mb-4">
         Invitations en attente
       </h1>
-      <div className="bg-white shadow rounded-xl overflow-x-auto">
+      <div className="bg-glass border border-borderGlass backdrop-blur shadow rounded-xl overflow-x-auto">
         <table className="min-w-full table-auto text-center">
           <thead>
             <tr>

--- a/src/pages/parametrage/Permissions.jsx
+++ b/src/pages/parametrage/Permissions.jsx
@@ -6,6 +6,7 @@ import { Dialog, DialogContent } from "@radix-ui/react-dialog";
 import PermissionsForm from "./PermissionsForm";
 import toast, { Toaster } from "react-hot-toast";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import TableContainer from "@/components/ui/TableContainer";
 
 export default function Permissions() {
   const { mama_id } = useAuth();
@@ -38,13 +39,13 @@ export default function Permissions() {
     <div className="p-8 max-w-4xl mx-auto">
       <Toaster />
       <h1 className="text-2xl font-bold text-mamastock-gold mb-4">Permissions des rôles</h1>
-      <div className="bg-white shadow rounded-xl overflow-x-auto mb-6">
+      <TableContainer className="mb-6">
         {loading ? (
           <div className="text-center py-8 text-gray-500">
             <LoadingSpinner message="Chargement…" />
           </div>
         ) : (
-          <table className="min-w-full table-auto text-center">
+          <table className="min-w-full table-auto text-center text-sm">
             <thead>
               <tr>
                 <th className="px-2 py-1">Rôle</th>
@@ -91,9 +92,9 @@ export default function Permissions() {
             </tbody>
           </table>
         )}
-      </div>
+      </TableContainer>
       <Dialog open={!!editRole} onOpenChange={v => !v && setEditRole(null)}>
-        <DialogContent className="bg-white rounded-xl shadow-lg p-6 max-w-xl">
+        <DialogContent className="bg-glass backdrop-blur-lg border border-borderGlass rounded-xl shadow-lg p-6 max-w-xl">
           {editRole && (
             <PermissionsForm
               role={editRole}

--- a/src/pages/parametrage/PermissionsAdmin.jsx
+++ b/src/pages/parametrage/PermissionsAdmin.jsx
@@ -6,6 +6,7 @@ import { Dialog, DialogContent } from "@radix-ui/react-dialog";
 import PermissionsForm from "./PermissionsForm";
 import toast, { Toaster } from "react-hot-toast";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import TableContainer from "@/components/ui/TableContainer";
 
 export default function PermissionsAdmin() {
   const { role } = useAuth();
@@ -75,13 +76,13 @@ export default function PermissionsAdmin() {
           </select>
         </label>
       </div>
-      <div className="bg-white shadow rounded-xl overflow-x-auto mb-6">
+      <TableContainer className="mb-6">
         {loading ? (
           <div className="text-center py-8 text-gray-500">
             <LoadingSpinner message="Chargement…" />
           </div>
         ) : (
-          <table className="min-w-full table-auto text-center">
+          <table className="min-w-full table-auto text-center text-sm">
             <thead>
               <tr>
                 <th className="px-2 py-1">Établissement</th>
@@ -136,9 +137,9 @@ export default function PermissionsAdmin() {
             </tbody>
           </table>
         )}
-      </div>
+      </TableContainer>
       <Dialog open={!!editRole} onOpenChange={v => !v && setEditRole(null)}>
-        <DialogContent className="bg-white rounded-xl shadow-lg p-6 max-w-xl">
+        <DialogContent className="bg-glass backdrop-blur-lg border border-borderGlass rounded-xl shadow-lg p-6 max-w-xl">
           {editRole && (
             <PermissionsForm
               role={editRole}

--- a/src/pages/parametrage/UtilisateurForm.jsx
+++ b/src/pages/parametrage/UtilisateurForm.jsx
@@ -49,7 +49,10 @@ export default function UtilisateurForm({ utilisateur, onClose }) {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="bg-white p-6 rounded-lg shadow-md max-w-xl mx-auto">
+    <form
+      onSubmit={handleSubmit}
+      className="bg-glass border border-borderGlass backdrop-blur p-6 rounded-2xl shadow-lg max-w-xl mx-auto"
+    >
       <h2 className="text-lg font-bold mb-4">
         {utilisateur ? "Modifier l’utilisateur" : "Ajouter un utilisateur"}
       </h2>

--- a/src/pages/planning/SimulationPlanner.jsx
+++ b/src/pages/planning/SimulationPlanner.jsx
@@ -5,6 +5,7 @@ import { useSimulation } from "@/hooks/useSimulation";
 import SimulationDetailsModal from "@/components/simulation/SimulationDetailsModal";
 import Button from "@/components/ui/Button";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import TableContainer from "@/components/ui/TableContainer";
 
 export default function SimulationPlanner() {
   const { mama_id, loading: authLoading } = useAuth();
@@ -69,7 +70,8 @@ export default function SimulationPlanner() {
       </div>
       {result && (
         <div className="mt-4">
-          <table className="min-w-full bg-white text-black text-sm rounded mb-2">
+          <TableContainer>
+            <table className="min-w-full text-sm">
             <thead>
               <tr>
                 <th className="px-2">Produit</th>
@@ -86,7 +88,8 @@ export default function SimulationPlanner() {
                 </tr>
               ))}
             </tbody>
-          </table>
+            </table>
+          </TableContainer>
           <div className="font-semibold">Total : {result.total} €</div>
           <Button className="mt-2" onClick={() => setOpen(true)}>
             Détails

--- a/src/pages/produits/ProduitDetail.jsx
+++ b/src/pages/produits/ProduitDetail.jsx
@@ -1,6 +1,15 @@
 import { useParams } from 'react-router-dom';
+import GlassCard from '@/components/ui/GlassCard';
+import { LiquidBackground } from '@/components/LiquidBackground';
 
 export default function ProduitDetail() {
   const { id } = useParams();
-  return <div>Page Produit Detail {id} (en construction)</div>;
+  return (
+    <div className="relative min-h-screen flex items-center justify-center overflow-hidden p-6 text-white">
+      <LiquidBackground showParticles />
+      <GlassCard className="relative z-10 max-w-md text-center">
+        Page Produit Detail {id} (en construction)
+      </GlassCard>
+    </div>
+  );
 }

--- a/src/pages/promotions/Promotions.jsx
+++ b/src/pages/promotions/Promotions.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { usePromotions } from "@/hooks/usePromotions";
 import { useAuth } from "@/context/AuthContext";
 import { Button } from "@/components/ui/button";
+import TableContainer from "@/components/ui/TableContainer";
 import { Toaster, toast } from "react-hot-toast";
 
 export default function Promotions() {
@@ -42,7 +43,8 @@ export default function Promotions() {
         />
         <Button onClick={() => setShowForm(true)}>Nouvelle promotion</Button>
       </div>
-      <table className="min-w-full bg-white rounded-xl shadow-md text-sm">
+      <TableContainer className="mt-2">
+        <table className="min-w-full text-sm">
         <thead>
           <tr>
             <th className="px-4 py-2">Nom</th>
@@ -70,7 +72,8 @@ export default function Promotions() {
             </tr>
           ))}
         </tbody>
-      </table>
+        </table>
+      </TableContainer>
       {showForm && (
         <PromotionForm
           promotion={editRow}
@@ -112,8 +115,8 @@ function PromotionForm({ promotion = {}, onClose, onSave, saving }) {
   });
 
   return (
-    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
-      <div className="bg-white rounded-xl p-6 shadow-lg w-96">
+    <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50">
+      <div className="bg-glass border border-borderGlass backdrop-blur rounded-2xl p-6 shadow-lg w-96">
         <h2 className="text-lg font-bold mb-4">{promotion.id ? "Modifier" : "Nouvelle"} promotion</h2>
         <form className="space-y-3" onSubmit={e => { e.preventDefault(); onSave(form); }}>
           <div>

--- a/src/pages/public/LandingPage.jsx
+++ b/src/pages/public/LandingPage.jsx
@@ -3,6 +3,12 @@ import { useEffect } from "react";
 import GlassCard from "@/components/ui/GlassCard";
 import PageIntro from "@/components/ui/PageIntro";
 import useAuth from "@/hooks/useAuth";
+import {
+  LiquidBackground,
+  WavesBackground,
+  MouseLight,
+  TouchLight,
+} from "@/components/LiquidBackground";
 
 export default function LandingPage() {
   const { isAuthenticated, loading } = useAuth();
@@ -13,8 +19,12 @@ export default function LandingPage() {
   }, [isAuthenticated, loading, navigate]);
 
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-[#0f1c2e] via-[#232a34] to-[#bfa14d] text-white p-4">
-      <GlassCard className="w-full max-w-2xl p-8 space-y-8 text-center">
+    <div className="relative min-h-screen flex flex-col items-center justify-center overflow-hidden text-white p-4">
+      <LiquidBackground showParticles />
+      <WavesBackground className="opacity-40" />
+      <MouseLight />
+      <TouchLight />
+      <GlassCard className="w-full max-w-2xl p-8 space-y-8 text-center relative z-10">
         <PageIntro />
         <div className="flex flex-col sm:flex-row gap-4 justify-center">
           <Link to="/login" className="px-6 py-3 rounded-xl bg-white/20 hover:bg-white/30 transition">
@@ -41,7 +51,7 @@ export default function LandingPage() {
           </p>
         </section>
       </GlassCard>
-      <footer className="mt-6 text-sm text-white/70">© MamaStock 2025</footer>
+      <footer className="mt-6 text-sm text-white/70 relative z-10">© MamaStock 2025</footer>
     </div>
   );
 }

--- a/src/pages/public/Onboarding.jsx
+++ b/src/pages/public/Onboarding.jsx
@@ -2,6 +2,13 @@ import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { motion as Motion } from "framer-motion";
 import { useOnboarding } from "@/hooks/useOnboarding";
+import GlassCard from "@/components/ui/GlassCard";
+import {
+  LiquidBackground,
+  WavesBackground,
+  MouseLight,
+  TouchLight,
+} from "@/components/LiquidBackground";
 
 const steps = [
   "Choisissez votre type d'établissement",
@@ -32,8 +39,12 @@ export default function Onboarding() {
   };
 
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center p-8 bg-gradient-to-br from-[#0f1c2e] via-[#232a34] to-[#bfa14d] text-white">
-      <div className="max-w-lg w-full text-center space-y-8">
+    <div className="relative min-h-screen flex items-center justify-center text-white overflow-hidden">
+      <LiquidBackground showParticles />
+      <WavesBackground className="opacity-40" />
+      <MouseLight />
+      <TouchLight />
+      <GlassCard className="w-full max-w-lg text-center space-y-8 relative z-10">
         <Motion.div
           key={step}
           initial={{ opacity: 0, y: 20 }}
@@ -51,19 +62,19 @@ export default function Onboarding() {
             {step < steps.length - 1 ? 'Suivant' : 'Terminer'}
           </button>
           <button
-            className="px-5 py-2 rounded bg-white/20 hover:bg-white/30 transition"
+            className="px-5 py-2 rounded bg-glass border border-borderGlass backdrop-blur hover:bg-white/20 transition"
             onClick={handleSkip}
           >
             Passer
           </button>
         </div>
-        <div className="h-2 bg-white/30 rounded-full overflow-hidden">
+        <div className="h-2 bg-white/20 rounded-full overflow-hidden">
           <div
             className="h-full bg-mamastockGold"
             style={{ width: `${((step + 1) / steps.length) * 100}%` }}
           />
         </div>
-      </div>
+      </GlassCard>
     </div>
   );
 }

--- a/src/pages/recettes/Recettes.jsx
+++ b/src/pages/recettes/Recettes.jsx
@@ -1,9 +1,13 @@
 import React from "react";
+import GlassCard from "@/components/ui/GlassCard";
+
 export default function Recettes() {
   return (
-    <div className="p-4">
-      <h1 className="text-2xl font-bold mb-4">Recettes</h1>
-      <p>Module Recettes en cours de développement.</p>
+    <div className="p-8 flex justify-center">
+      <GlassCard className="max-w-md text-center space-y-4">
+        <h1 className="text-2xl font-bold">Recettes</h1>
+        <p>Module Recettes en cours de développement.</p>
+      </GlassCard>
     </div>
   );
 }

--- a/src/pages/reporting/Reporting.jsx
+++ b/src/pages/reporting/Reporting.jsx
@@ -3,6 +3,7 @@ import { useAuth } from "@/context/AuthContext";
 import { useReporting } from "@/hooks/useReporting";
 import StatCard from "@/components/ui/StatCard";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import GlassCard from "@/components/ui/GlassCard";
 import {
   ResponsiveContainer,
   LineChart,
@@ -76,7 +77,7 @@ export default function Reporting() {
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        <div className="bg-white/10 p-4 rounded-xl">
+        <GlassCard className="p-4">
           <h2 className="font-semibold mb-2">Achats par mois</h2>
           {achats.length === 0 ? (
             <p className="text-center text-sm">Aucune donnée pour la période sélectionnée</p>
@@ -91,8 +92,8 @@ export default function Reporting() {
               </BarChart>
             </ResponsiveContainer>
           )}
-        </div>
-        <div className="bg-white/10 p-4 rounded-xl">
+        </GlassCard>
+        <GlassCard className="p-4">
           <h2 className="font-semibold mb-2">Coûts par famille</h2>
           {familles.length === 0 ? (
             <p className="text-center text-sm">Aucune donnée pour la période sélectionnée</p>
@@ -107,10 +108,10 @@ export default function Reporting() {
               </LineChart>
             </ResponsiveContainer>
           )}
-        </div>
+        </GlassCard>
       </div>
 
-      <div className="bg-white/10 p-4 rounded-xl mt-6 overflow-auto">
+      <GlassCard className="p-4 mt-6 overflow-auto">
         <h2 className="font-semibold mb-2">Écarts d'inventaire</h2>
         {ecarts.length === 0 ? (
           <p className="text-center text-sm text-gray-400">Aucune donnée pour la période sélectionnée</p>
@@ -132,10 +133,10 @@ export default function Reporting() {
             </tbody>
           </table>
         )}
-      </div>
+      </GlassCard>
 
       {ccData.length > 0 && (
-        <div className="bg-white/10 p-4 rounded-xl mt-6">
+        <GlassCard className="p-4 mt-6">
           <h2 className="font-semibold mb-2">Répartition par cost center</h2>
           <ResponsiveContainer width="100%" height={240}>
             <LineChart data={ccData}>
@@ -146,7 +147,7 @@ export default function Reporting() {
               <Line type="monotone" dataKey="valeur" stroke="#0f1c2e" />
             </LineChart>
           </ResponsiveContainer>
-        </div>
+        </GlassCard>
       )}
     </div>
   );

--- a/src/pages/reporting/ReportingPDF.jsx
+++ b/src/pages/reporting/ReportingPDF.jsx
@@ -2,7 +2,7 @@ import GraphCost from "./GraphCost";
 
 export default function ReportingPDF() {
   return (
-    <div className="bg-white p-6 rounded shadow">
+    <div className="bg-glass border border-borderGlass backdrop-blur p-6 rounded-2xl shadow-lg">
       <h2 className="text-xl font-bold text-mamastock-gold mb-4">Rapport complet</h2>
       <GraphCost />
       {/* Tu peux ajouter d’autres stats ici plus tard */}

--- a/src/pages/requisitions/RequisitionDetail.jsx
+++ b/src/pages/requisitions/RequisitionDetail.jsx
@@ -3,6 +3,7 @@ import { useRequisitions } from "@/hooks/useRequisitions";
 import { useEffect, useState } from "react";
 import { useAuth } from "@/context/AuthContext";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import GlassCard from "@/components/ui/GlassCard";
 
 function RequisitionDetailPage() {
   const { id } = useParams();
@@ -23,7 +24,7 @@ function RequisitionDetailPage() {
   return (
     <div className="p-6">
       <h1 className="text-3xl font-bold text-mamastock-gold mb-6">Détail de la réquisition</h1>
-      <div className="bg-white p-4 rounded shadow space-y-2">
+      <GlassCard className="p-4 space-y-2">
         <div>
           <strong>Type :</strong> {requisition.type}
         </div>
@@ -46,7 +47,7 @@ function RequisitionDetailPage() {
             ))}
           </ul>
         </div>
-      </div>
+      </GlassCard>
     </div>
   );
 }

--- a/src/pages/requisitions/RequisitionForm.jsx
+++ b/src/pages/requisitions/RequisitionForm.jsx
@@ -5,6 +5,7 @@ import { useProducts } from "@/hooks/useProducts";
 import { useAuth } from "@/context/AuthContext";
 import { Toaster, toast } from "react-hot-toast";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import GlassCard from "@/components/ui/GlassCard";
 
 function RequisitionFormPage() {
   const navigate = useNavigate();
@@ -62,10 +63,11 @@ function RequisitionFormPage() {
   }
 
   return (
-    <div className="p-6 bg-gray-100 min-h-screen">
+    <div className="p-6 space-y-6">
       <Toaster position="top-right" />
       <h1 className="text-3xl font-bold text-mamastock-gold mb-6">Nouvelle réquisition</h1>
-      <form onSubmit={handleSubmit} className="bg-white p-6 rounded shadow space-y-4">
+      <GlassCard className="p-6">
+        <form onSubmit={handleSubmit} className="space-y-4">
 
         <div>
           <label className="block text-sm font-medium mb-1">Type</label>
@@ -149,7 +151,8 @@ function RequisitionFormPage() {
             Enregistrer
           </button>
         </div>
-      </form>
+        </form>
+      </GlassCard>
     </div>
   );
 }

--- a/src/pages/requisitions/Requisitions.jsx
+++ b/src/pages/requisitions/Requisitions.jsx
@@ -151,7 +151,7 @@ export default function Requisitions() {
         <Button onClick={handleExportPDF}>Export PDF</Button>
         <Button onClick={() => setShowCreate(true)}>+ Nouvelle réquisition</Button>
       </div>
-      <div className="bg-white shadow rounded-xl overflow-x-auto">
+      <div className="bg-glass border border-borderGlass backdrop-blur shadow rounded-xl overflow-x-auto">
         <table className="min-w-full table-auto text-center">
           <thead>
             <tr>
@@ -179,7 +179,7 @@ export default function Requisitions() {
       </div>
       {/* Modal création réquisition */}
       <Dialog open={showCreate} onOpenChange={v => !v && setShowCreate(false)}>
-        <DialogContent className="bg-white rounded-xl shadow-lg p-6 max-w-md">
+        <DialogContent className="bg-glass border border-borderGlass backdrop-blur rounded-2xl shadow-lg p-6 max-w-md">
           <h2 className="font-bold mb-2">Nouvelle réquisition</h2>
           <form
             onSubmit={handleCreateReq}

--- a/src/pages/signalements/SignalementDetail.jsx
+++ b/src/pages/signalements/SignalementDetail.jsx
@@ -2,7 +2,7 @@ export default function SignalementDetail({ signalement }) {
   if (!signalement) return null;
 
   return (
-    <div className="p-2 border rounded mb-2 bg-white shadow">
+    <div className="p-2 border border-borderGlass rounded mb-2 bg-glass backdrop-blur shadow">
       <div className="font-bold text-mamastock-gold">{signalement.titre}</div>
       <div className="text-sm text-gray-700">{signalement.description}</div>
       <div className="text-xs mt-1 text-gray-500 italic">Statut : {signalement.statut}</div>

--- a/src/pages/signalements/SignalementForm.jsx
+++ b/src/pages/signalements/SignalementForm.jsx
@@ -35,7 +35,10 @@ export default function SignalementForm({ onCreated }) {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="bg-white p-4 rounded shadow mb-4">
+    <form
+      onSubmit={handleSubmit}
+      className="bg-glass border border-borderGlass backdrop-blur p-4 rounded-2xl shadow-lg mb-4"
+    >
       <h3 className="text-lg font-bold mb-2">Nouveau signalement</h3>
       <input
         type="text"

--- a/src/pages/signalements/Signalements.jsx
+++ b/src/pages/signalements/Signalements.jsx
@@ -1,6 +1,7 @@
 import { useSignalements } from "@/hooks/useSignalements";
 import { useAuth } from "@/context/AuthContext";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import GlassCard from "@/components/ui/GlassCard";
 
 export default function Signalements() {
   const { loading: authLoading } = useAuth();
@@ -36,15 +37,12 @@ export default function Signalements() {
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
         {signalements.map((sig) => (
-          <div
-            key={sig.id}
-            className="bg-white/10 border border-mamastock-gold rounded-xl p-4 hover:bg-white/20 transition"
-          >
+          <GlassCard key={sig.id} className="p-4">
             <h2 className="text-lg font-semibold">{sig.titre}</h2>
             <p className="text-sm text-gray-300">
               {sig.commentaire || "Sans commentaire"}
             </p>
-          </div>
+          </GlassCard>
         ))}
       </div>
     </div>

--- a/src/pages/simulation/Simulation.jsx
+++ b/src/pages/simulation/Simulation.jsx
@@ -1,6 +1,7 @@
 import { useSignalements } from "@/hooks/useSignalements";
 import { useAuth } from "@/context/AuthContext";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import GlassCard from "@/components/ui/GlassCard";
 
 export default function Simulation() {
   const { loading: authLoading } = useAuth();
@@ -32,15 +33,12 @@ export default function Simulation() {
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
         {signalements.map((sig) => (
-          <div
-            key={sig.id}
-            className="bg-white/10 border border-mamastock-gold rounded-xl p-4 hover:bg-white/20 transition"
-          >
+          <GlassCard key={sig.id} className="p-4">
             <h2 className="text-lg font-semibold">{sig.titre}</h2>
             <p className="text-sm text-gray-300">
               {sig.commentaire || "Sans commentaire"}
             </p>
-          </div>
+          </GlassCard>
         ))}
       </div>
     </div>

--- a/src/pages/stats/StatsConsolidation.jsx
+++ b/src/pages/stats/StatsConsolidation.jsx
@@ -3,6 +3,7 @@ import { useConsolidatedStats } from "@/hooks/useConsolidatedStats";
 import { useAuth } from "@/context/AuthContext";
 import { Toaster } from "react-hot-toast";
 import { Button } from "@/components/ui/button";
+import TableContainer from "@/components/ui/TableContainer";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 import * as XLSX from "xlsx";
 
@@ -31,8 +32,9 @@ export default function StatsConsolidation() {
       <Button variant="outline" className="mb-2" onClick={exportExcel}>
         Export Excel
       </Button>
-      <table className="min-w-full text-xs bg-white rounded-xl shadow-md">
-        <thead>
+      <TableContainer className="mt-2">
+        <table className="min-w-full text-xs">
+          <thead>
           <tr>
             <th className="px-2 py-1">Établissement</th>
             <th className="px-2 py-1">Stock valorisé (€)</th>
@@ -57,8 +59,9 @@ export default function StatsConsolidation() {
               </tr>
             ))
           )}
-        </tbody>
-      </table>
+          </tbody>
+        </table>
+      </TableContainer>
     </div>
   );
 }

--- a/src/pages/stats/StatsCostCenters.jsx
+++ b/src/pages/stats/StatsCostCenters.jsx
@@ -3,6 +3,7 @@ import { useCostCenterStats } from "@/hooks/useCostCenterStats";
 import { useAuth } from "@/context/AuthContext";
 import { Toaster } from "react-hot-toast";
 import { Button } from "@/components/ui/button";
+import TableContainer from "@/components/ui/TableContainer";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 import * as XLSX from "xlsx";
 
@@ -36,8 +37,9 @@ export default function StatsCostCenters() {
       <Button variant="outline" className="mb-2" onClick={exportExcel}>
         Export Excel
       </Button>
-      <table className="min-w-full text-xs bg-white rounded-xl shadow-md">
-        <thead>
+      <TableContainer className="mt-2">
+        <table className="min-w-full text-xs">
+          <thead>
           <tr>
             <th className="px-2 py-1">Cost Center</th>
             <th className="px-2 py-1">Quantité</th>
@@ -60,8 +62,9 @@ export default function StatsCostCenters() {
               </tr>
             ))
           )}
-        </tbody>
-      </table>
+          </tbody>
+        </table>
+      </TableContainer>
     </div>
   );
 }

--- a/src/pages/stats/StatsCostCentersPivot.jsx
+++ b/src/pages/stats/StatsCostCentersPivot.jsx
@@ -3,6 +3,7 @@ import { useCostCenterMonthlyStats } from "@/hooks/useCostCenterMonthlyStats";
 import { useAuth } from "@/context/AuthContext";
 import { Toaster } from "react-hot-toast";
 import { Button } from "@/components/ui/button";
+import TableContainer from "@/components/ui/TableContainer";
 import * as XLSX from "xlsx";
 
 export default function StatsCostCentersPivot() {
@@ -44,7 +45,7 @@ export default function StatsCostCentersPivot() {
       <Toaster position="top-right" />
       <h1 className="text-2xl font-bold mb-4">Ventilation mensuelle par Cost Center</h1>
       <Button variant="outline" className="mb-2" onClick={exportExcel}>Export Excel</Button>
-      <div className="overflow-x-auto bg-white rounded-xl shadow-md">
+      <TableContainer className="mt-2">
         <table className="min-w-full text-xs">
           <thead>
             <tr>
@@ -73,7 +74,7 @@ export default function StatsCostCentersPivot() {
             )}
           </tbody>
         </table>
-      </div>
+      </TableContainer>
     </div>
   );
 }

--- a/src/pages/stats/StatsFiches.jsx
+++ b/src/pages/stats/StatsFiches.jsx
@@ -4,6 +4,8 @@ import { supabase } from "@/lib/supabase";
 import toast, { Toaster } from "react-hot-toast";
 import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Legend, LineChart, Line } from "recharts";
 import { Button } from "@/components/ui/button";
+import TableContainer from "@/components/ui/TableContainer";
+import GlassCard from "@/components/ui/GlassCard";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 import * as XLSX from "xlsx";
 import { useFicheCoutHistory } from "@/hooks/useFicheCoutHistory";
@@ -111,7 +113,7 @@ export default function StatsFiches() {
 
       <div className="grid grid-cols-1 md:grid-cols-3 gap-8 mb-8">
         {/* Répartition par famille */}
-        <div className="bg-white shadow rounded-xl p-4">
+        <GlassCard className="p-4">
           <h2 className="text-lg font-bold mb-2">Répartition par famille</h2>
           <ResponsiveContainer width="100%" height={220}>
             <PieChart>
@@ -124,9 +126,9 @@ export default function StatsFiches() {
               <Legend />
             </PieChart>
           </ResponsiveContainer>
-        </div>
+        </GlassCard>
         {/* Top coût matière */}
-        <div className="bg-white shadow rounded-xl p-4">
+        <GlassCard className="p-4">
           <h2 className="text-lg font-bold mb-2">Top 10 fiches par coût matière</h2>
           <ResponsiveContainer width="100%" height={220}>
             <BarChart data={fichesSortedByCout}>
@@ -136,9 +138,9 @@ export default function StatsFiches() {
               <Bar dataKey="cout" fill="#bfa14d" />
             </BarChart>
           </ResponsiveContainer>
-        </div>
+        </GlassCard>
         {/* Actives/inactives */}
-        <div className="bg-white shadow rounded-xl p-4">
+        <GlassCard className="p-4">
           <h2 className="text-lg font-bold mb-2">Fiches actives/inactives</h2>
           <ResponsiveContainer width="100%" height={220}>
             <PieChart>
@@ -151,7 +153,7 @@ export default function StatsFiches() {
               <Legend />
             </PieChart>
           </ResponsiveContainer>
-        </div>
+        </GlassCard>
       </div>
 
       {/* Recherche & liste */}
@@ -163,7 +165,7 @@ export default function StatsFiches() {
           onChange={e => setSearch(e.target.value)}
         />
       </div>
-      <div className="bg-white shadow rounded-xl p-4 mb-8">
+      <TableContainer className="mb-8">
         <table className="min-w-full table-auto">
           <thead>
             <tr>
@@ -201,11 +203,11 @@ export default function StatsFiches() {
               ))}
           </tbody>
         </table>
-      </div>
+      </TableContainer>
 
       {/* Historique coût réel */}
       {selectedFiche && (
-        <div className="bg-white shadow rounded-xl p-4 mb-8">
+        <GlassCard className="p-4 mb-8">
           <div className="flex items-center justify-between">
             <h2 className="text-lg font-bold text-mamastock-gold mb-2">
               Historique coût matière : {selectedFiche.nom}
@@ -229,7 +231,7 @@ export default function StatsFiches() {
               ⚠️ Hausse du coût matière supérieure à 15% sur la période !
             </div>
           )}
-        </div>
+        </GlassCard>
       )}
 
       {/* Alertes générales */}

--- a/src/pages/stats/StatsStock.jsx
+++ b/src/pages/stats/StatsStock.jsx
@@ -3,6 +3,7 @@ import { useDashboardStats } from "@/hooks/useDashboardStats";
 import { useAuth } from "@/context/AuthContext";
 import { Toaster } from "react-hot-toast";
 import { Button } from "@/components/ui/button";
+import TableContainer from "@/components/ui/TableContainer";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 import * as XLSX from "xlsx";
 
@@ -38,7 +39,7 @@ export default function StatsStock() {
       <Button variant="outline" className="mb-2" onClick={exportExcel}>
         Export Excel
       </Button>
-      <div className="overflow-x-auto bg-white rounded-xl shadow-md">
+      <TableContainer className="mt-2">
         <table className="min-w-full text-xs">
           <thead>
             <tr>
@@ -71,7 +72,7 @@ export default function StatsStock() {
             )}
           </tbody>
         </table>
-      </div>
+      </TableContainer>
     </div>
   );
 }

--- a/src/pages/stock/Inventaire.jsx
+++ b/src/pages/stock/Inventaire.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { useStock } from "@/hooks/useStock";
 import { Button } from "@/components/ui/button";
+import TableContainer from "@/components/ui/TableContainer";
 
 export default function InventairePage() {
   const { getInventaires } = useStock();
@@ -19,28 +20,30 @@ export default function InventairePage() {
           <Link to="/stock/inventaires/new">Créer un nouvel inventaire</Link>
         </Button>
       </div>
-      <table className="min-w-full text-sm bg-white rounded shadow">
-        <thead>
-          <tr>
-            <th className="p-2 text-left">Nom</th>
-            <th className="p-2">Date</th>
-            <th className="p-2">Utilisateur</th>
-            <th className="p-2">État</th>
-            <th className="p-2">Écart total</th>
-          </tr>
-        </thead>
-        <tbody>
-          {inventaires.map((inv) => (
-            <tr key={inv.id}>
-              <td className="p-2">{inv.nom || inv.reference}</td>
-              <td className="p-2 text-center">{inv.date}</td>
-              <td className="p-2 text-center">{inv.utilisateurs?.username || "-"}</td>
-              <td className="p-2 text-center">{inv.cloture ? "validé" : "en cours"}</td>
-              <td className="p-2 text-center">{inv.ecart_total ?? "-"}</td>
+      <TableContainer className="mt-2">
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr>
+              <th className="p-2 text-left">Nom</th>
+              <th className="p-2">Date</th>
+              <th className="p-2">Utilisateur</th>
+              <th className="p-2">État</th>
+              <th className="p-2">Écart total</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {inventaires.map((inv) => (
+              <tr key={inv.id}>
+                <td className="p-2">{inv.nom || inv.reference}</td>
+                <td className="p-2 text-center">{inv.date}</td>
+                <td className="p-2 text-center">{inv.utilisateurs?.username || "-"}</td>
+                <td className="p-2 text-center">{inv.cloture ? "validé" : "en cours"}</td>
+                <td className="p-2 text-center">{inv.ecart_total ?? "-"}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </TableContainer>
     </div>
   );
 }

--- a/src/pages/stock/MouvementForm.jsx
+++ b/src/pages/stock/MouvementForm.jsx
@@ -29,8 +29,11 @@ export default function MouvementForm({ onClose }) {
   };
 
   return (
-    <div className="fixed inset-0 bg-black/20 flex items-center justify-center">
-      <form onSubmit={handleSubmit} className="bg-white p-6 rounded shadow w-80">
+    <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center">
+      <form
+        onSubmit={handleSubmit}
+        className="bg-glass border border-borderGlass backdrop-blur p-6 rounded-2xl shadow-lg w-80"
+      >
         <h2 className="font-bold mb-2">Nouveau mouvement</h2>
         <input
           className="input mb-2 w-full"

--- a/src/pages/stock/Mouvements.jsx
+++ b/src/pages/stock/Mouvements.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useStock } from "@/hooks/useStock";
 import { Button } from "@/components/ui/button";
+import TableContainer from "@/components/ui/TableContainer";
 import MouvementForm from "./MouvementForm";
 
 export default function MouvementsPage() {
@@ -17,28 +18,30 @@ export default function MouvementsPage() {
         <h1 className="text-xl font-bold">Mouvements de stock</h1>
         <Button onClick={() => setShowForm(true)}>Nouveau mouvement</Button>
       </div>
-      <table className="min-w-full text-sm bg-white rounded shadow">
-        <thead>
-          <tr>
-            <th className="p-2">Date</th>
-            <th className="p-2">Produit</th>
-            <th className="p-2">Quantité</th>
-            <th className="p-2">Type</th>
-            <th className="p-2">Utilisateur</th>
-          </tr>
-        </thead>
-        <tbody>
-          {mouvements.map((m) => (
-            <tr key={m.id}>
-              <td className="p-2 text-center">{m.date}</td>
-              <td className="p-2 text-center">{m.product_id}</td>
-              <td className="p-2 text-center">{m.quantite}</td>
-              <td className="p-2 text-center">{m.type}</td>
-              <td className="p-2 text-center">{m.created_by || "-"}</td>
+      <TableContainer className="mt-2">
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr>
+              <th className="p-2">Date</th>
+              <th className="p-2">Produit</th>
+              <th className="p-2">Quantité</th>
+              <th className="p-2">Type</th>
+              <th className="p-2">Utilisateur</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {mouvements.map((m) => (
+              <tr key={m.id}>
+                <td className="p-2 text-center">{m.date}</td>
+                <td className="p-2 text-center">{m.product_id}</td>
+                <td className="p-2 text-center">{m.quantite}</td>
+                <td className="p-2 text-center">{m.type}</td>
+                <td className="p-2 text-center">{m.created_by || "-"}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </TableContainer>
       {showForm && <MouvementForm onClose={() => setShowForm(false)} />}
     </div>
   );

--- a/src/pages/supervision/ComparateurFiches.jsx
+++ b/src/pages/supervision/ComparateurFiches.jsx
@@ -3,6 +3,7 @@ import { supabase } from "@/lib/supabase";
 import { useMultiMama } from "@/context/MultiMamaContext";
 import TableContainer from "@/components/ui/TableContainer";
 import { Button } from "@/components/ui/button";
+import GlassCard from "@/components/ui/GlassCard";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 
 export default function ComparateurFiches() {
@@ -23,42 +24,44 @@ export default function ComparateurFiches() {
   };
 
   return (
-    <div className="p-6 container mx-auto text-shadow">
-      <h1 className="text-2xl font-bold mb-4">Comparateur de fiches</h1>
-      <div className="flex gap-2 mb-4">
-        <input
-          className="input input-bordered"
-          placeholder="ID fiche"
-          value={ficheId}
-          onChange={(e) => setFicheId(e.target.value)}
-        />
-        <Button onClick={handleCompare} disabled={loading || !ficheId}>
-          Comparer
-        </Button>
-      </div>
-      {loading && <LoadingSpinner message="Chargement..." />}
-      {results.length > 0 && (
-        <TableContainer>
-          <table className="min-w-full text-center">
-            <thead>
-              <tr>
-                <th className="px-2 py-1">Mama</th>
-                <th className="px-2 py-1">Coût</th>
-                <th className="px-2 py-1">Rendement</th>
-              </tr>
-            </thead>
-            <tbody>
-              {results.map((r) => (
-                <tr key={r.mama_id}>
-                  <td className="px-2 py-1">{r.nom}</td>
-                  <td className="px-2 py-1">{r.cout || '-'}</td>
-                  <td className="px-2 py-1">{r.rendement || '-'}</td>
+    <div className="p-6 flex justify-center">
+      <GlassCard className="w-full max-w-3xl">
+        <h1 className="text-2xl font-bold mb-4">Comparateur de fiches</h1>
+        <div className="flex gap-2 mb-4">
+          <input
+            className="input"
+            placeholder="ID fiche"
+            value={ficheId}
+            onChange={(e) => setFicheId(e.target.value)}
+          />
+          <Button onClick={handleCompare} disabled={loading || !ficheId}>
+            Comparer
+          </Button>
+        </div>
+        {loading && <LoadingSpinner message="Chargement..." />}
+        {results.length > 0 && (
+          <TableContainer>
+            <table className="min-w-full text-center">
+              <thead>
+                <tr>
+                  <th className="px-2 py-1">Mama</th>
+                  <th className="px-2 py-1">Coût</th>
+                  <th className="px-2 py-1">Rendement</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </TableContainer>
-      )}
+              </thead>
+              <tbody>
+                {results.map((r) => (
+                  <tr key={r.mama_id}>
+                    <td className="px-2 py-1">{r.nom}</td>
+                    <td className="px-2 py-1">{r.cout || '-'}</td>
+                    <td className="px-2 py-1">{r.rendement || '-'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </TableContainer>
+        )}
+      </GlassCard>
     </div>
   );
 }

--- a/src/pages/supervision/GroupeParamForm.jsx
+++ b/src/pages/supervision/GroupeParamForm.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { supabase } from "@/lib/supabase";
 import { useAuth } from "@/context/AuthContext";
 import { Button } from "@/components/ui/button";
+import GlassCard from "@/components/ui/GlassCard";
 import toast from "react-hot-toast";
 
 export default function GroupeParamForm({ groupe, onClose, onSaved }) {
@@ -84,25 +85,26 @@ export default function GroupeParamForm({ groupe, onClose, onSaved }) {
   };
 
   return (
-    <form className="space-y-3 p-4" onSubmit={handleSubmit}>
-      <div>
+    <GlassCard className="p-4">
+      <form className="space-y-3" onSubmit={handleSubmit}>
+        <div>
         <label>Nom du groupe</label>
         <input
-          className="input input-bordered w-full"
+          className="input w-full"
           value={values.nom}
           onChange={(e) => setValues({ ...values, nom: e.target.value })}
           required
         />
       </div>
-      <div>
+        <div>
         <label>Description</label>
         <textarea
-          className="textarea textarea-bordered w-full"
+          className="textarea w-full"
           value={values.description}
           onChange={(e) => setValues({ ...values, description: e.target.value })}
         />
-      </div>
-      <div>
+        </div>
+        <div>
         <label className="block mb-1">Établissements</label>
         <div className="flex flex-col gap-1 max-h-40 overflow-y-auto border p-2 rounded">
           {mamas.map((m) => (
@@ -116,15 +118,16 @@ export default function GroupeParamForm({ groupe, onClose, onSaved }) {
             </label>
           ))}
         </div>
-      </div>
-      <div className="flex gap-4 mt-4">
-        <Button type="submit" disabled={saving}>
-          {saving ? "Enregistrement…" : "Enregistrer"}
-        </Button>
-        <Button type="button" variant="secondary" onClick={onClose} disabled={saving}>
-          Annuler
-        </Button>
-      </div>
-    </form>
+        </div>
+        <div className="flex gap-4 mt-4">
+          <Button type="submit" disabled={saving}>
+            {saving ? "Enregistrement…" : "Enregistrer"}
+          </Button>
+          <Button type="button" variant="secondary" onClick={onClose} disabled={saving}>
+            Annuler
+          </Button>
+        </div>
+      </form>
+    </GlassCard>
   );
 }

--- a/src/pages/supervision/SupervisionGroupe.jsx
+++ b/src/pages/supervision/SupervisionGroupe.jsx
@@ -3,6 +3,7 @@ import { supabase } from "@/lib/supabase";
 import { useMultiMama } from "@/context/MultiMamaContext";
 import TableContainer from "@/components/ui/TableContainer";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import GlassCard from "@/components/ui/GlassCard";
 
 export default function SupervisionGroupe() {
   const { mamas } = useMultiMama();
@@ -24,33 +25,35 @@ export default function SupervisionGroupe() {
   const display = stats.length ? stats : mamas.map((m) => ({ ...m, mama_id: m.id }));
 
   return (
-    <div className="p-6 container mx-auto text-shadow">
-      <h1 className="text-2xl font-bold mb-4">Supervision Groupe</h1>
-      {loading && <LoadingSpinner message="Chargement..." />}
-      <TableContainer>
-        <table className="min-w-full text-center">
-          <thead>
-            <tr>
-              <th className="px-2 py-1">Établissement</th>
-              <th className="px-2 py-1">Coût matière</th>
-              <th className="px-2 py-1">Factures</th>
-              <th className="px-2 py-1">Validation</th>
-              <th className="px-2 py-1">Inventaire</th>
-            </tr>
-          </thead>
-          <tbody>
-            {display.map((d) => (
-              <tr key={d.mama_id}>
-                <td className="px-2 py-1">{d.nom}</td>
-                <td className="px-2 py-1">{d.cout_matiere || '-'}</td>
-                <td className="px-2 py-1">{d.nb_factures || '-'}</td>
-                <td className="px-2 py-1">{d.taux_validation || '-'}</td>
-                <td className="px-2 py-1">{d.ecart_inventaire || '-'}</td>
+    <div className="p-6 flex justify-center">
+      <GlassCard className="w-full max-w-4xl">
+        <h1 className="text-2xl font-bold mb-4">Supervision Groupe</h1>
+        {loading && <LoadingSpinner message="Chargement..." />}
+        <TableContainer>
+          <table className="min-w-full text-center">
+            <thead>
+              <tr>
+                <th className="px-2 py-1">Établissement</th>
+                <th className="px-2 py-1">Coût matière</th>
+                <th className="px-2 py-1">Factures</th>
+                <th className="px-2 py-1">Validation</th>
+                <th className="px-2 py-1">Inventaire</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
-      </TableContainer>
+            </thead>
+            <tbody>
+              {display.map((d) => (
+                <tr key={d.mama_id}>
+                  <td className="px-2 py-1">{d.nom}</td>
+                  <td className="px-2 py-1">{d.cout_matiere || '-'}</td>
+                  <td className="px-2 py-1">{d.nb_factures || '-'}</td>
+                  <td className="px-2 py-1">{d.taux_validation || '-'}</td>
+                  <td className="px-2 py-1">{d.ecart_inventaire || '-'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </TableContainer>
+      </GlassCard>
     </div>
   );
 }

--- a/src/pages/surcouts/Surcouts.jsx
+++ b/src/pages/surcouts/Surcouts.jsx
@@ -1,9 +1,13 @@
 import React from "react";
+import GlassCard from "@/components/ui/GlassCard";
+
 export default function Surcouts() {
   return (
-    <div className="p-4">
-      <h1 className="text-2xl font-bold mb-4">Surcoûts</h1>
-      <p>Module Surcoûts en cours de développement.</p>
+    <div className="p-8 flex justify-center">
+      <GlassCard className="max-w-md text-center space-y-4">
+        <h1 className="text-2xl font-bold">Surcoûts</h1>
+        <p>Module Surcoûts en cours de développement.</p>
+      </GlassCard>
     </div>
   );
 }

--- a/src/pages/taches/Alertes.jsx
+++ b/src/pages/taches/Alertes.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { supabase } from "@/lib/supabase";
 import { useAuth } from "@/context/AuthContext";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import TableContainer from "@/components/ui/TableContainer";
 
 export default function Alertes() {
   const { mama_id, loading: authLoading } = useAuth();
@@ -27,29 +28,31 @@ export default function Alertes() {
     <div className="p-6 text-sm">
       <h1 className="text-2xl font-bold mb-4">Alertes</h1>
       {loading && <LoadingSpinner message="Chargement..." />}
-      <table className="min-w-full text-white">
-        <thead>
-          <tr>
-            <th className="px-2 py-1">Titre</th>
-            <th className="px-2 py-1">Type</th>
-            <th className="px-2 py-1">Date</th>
-          </tr>
-        </thead>
-        <tbody>
-          {alertes.map(a => (
-            <tr key={a.id} className="border-t">
-              <td className="px-2 py-1">{a.titre}</td>
-              <td className="px-2 py-1">{a.type}</td>
-              <td className="px-2 py-1">{new Date(a.created_at).toLocaleDateString()}</td>
-            </tr>
-          ))}
-          {alertes.length === 0 && !loading && (
+      <TableContainer className="mt-2">
+        <table className="min-w-full text-white text-sm">
+          <thead>
             <tr>
-              <td colSpan="3" className="py-4 text-center text-gray-500">Aucune alerte</td>
+              <th className="px-2 py-1">Titre</th>
+              <th className="px-2 py-1">Type</th>
+              <th className="px-2 py-1">Date</th>
             </tr>
-          )}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {alertes.map(a => (
+              <tr key={a.id} className="">
+                <td className="border px-2 py-1">{a.titre}</td>
+                <td className="border px-2 py-1">{a.type}</td>
+                <td className="border px-2 py-1">{new Date(a.created_at).toLocaleDateString()}</td>
+              </tr>
+            ))}
+            {alertes.length === 0 && !loading && (
+              <tr>
+                <td colSpan="3" className="py-4 text-center text-gray-500">Aucune alerte</td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </TableContainer>
     </div>
   );
 }

--- a/src/pages/taches/Taches.jsx
+++ b/src/pages/taches/Taches.jsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { useTaches } from "@/hooks/useTaches";
 import { Button } from "@/components/ui/button";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import TableContainer from "@/components/ui/TableContainer";
 
 export default function Taches() {
   const { taches, loading, error, getTaches } = useTaches();
@@ -18,7 +19,7 @@ export default function Taches() {
     <div className="p-6 text-sm">
       <div className="flex justify-between items-center mb-4">
         <h1 className="text-2xl font-bold">Tâches planifiées</h1>
-        <Link to="/taches/new" className="bg-white/10 backdrop-blur-lg text-white font-semibold py-2 px-4 rounded-xl shadow-md hover:shadow-lg">Créer une tâche</Link>
+        <Link to="/taches/new" className="btn">Créer une tâche</Link>
       </div>
       <div className="flex gap-2 mb-4">
         <select name="type" value={filters.type} onChange={handleChange} className="input">
@@ -40,6 +41,7 @@ export default function Taches() {
       </div>
       {loading && <LoadingSpinner message="Chargement..." />}
       {error && <div className="text-red-600">{error}</div>}
+      <TableContainer>
       <table className="min-w-full text-white">
         <thead>
           <tr>
@@ -65,6 +67,7 @@ export default function Taches() {
           )}
         </tbody>
       </table>
+      </TableContainer>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- parse `intensity` from the URL when previewing
- use the intensity setting on the home page background
- show the intensity value in the preview banner
- mention the `intensity` parameter in the README
- document the reusable liquid glass helpers

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68602237fce8832d9ff3f0676a06b7da