### PR TITLE
Fix pending logic in ProtectedRoute

### DIFF
--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -29,14 +29,14 @@ export default function ProtectedRoute({ children, accessKey }) {
   if (loading || access_rights === null)
     return <LoadingSpinner message="Chargement..." />;
 
-  if (pending && location.pathname !== "/pending")
-    return <Navigate to="/pending" replace />;
+  if (pending === true) return <LoadingSpinner message="Chargement..." />;
 
   if (!session || !isAuthenticated) {
     if (location.pathname !== "/login")
       return <Navigate to="/login" replace />;
     return null;
   }
+
   if (!userData) {
     if (location.pathname !== "/unauthorized")
       return <Navigate to="/unauthorized" replace />;
@@ -53,6 +53,13 @@ export default function ProtectedRoute({ children, accessKey }) {
     if (!isAllowed && location.pathname !== "/unauthorized")
       return <Navigate to="/unauthorized" replace />;
   }
+
+  console.log("ProtectedRoute: access granted", {
+    path: location.pathname,
+    session: !!session,
+    userDataLoaded: !!userData,
+    pending,
+  });
 
   return children;
 }

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -7,9 +7,13 @@ export default function useAuth() {
   return {
     session: ctx.session,
     userData: ctx.userData,
-    mama_id: ctx.mama_id,
-    access_rights: ctx.access_rights,
-    role: ctx.role,
+    mama_id: ctx.userData?.mama_id ?? ctx.mama_id,
+    access_rights: ctx.userData?.access_rights ?? ctx.access_rights,
+    role: ctx.userData?.role ?? ctx.role,
     loading,
+    pending: ctx.pending,
+    isAuthenticated: ctx.isAuthenticated,
+    isSuperadmin: ctx.isSuperadmin,
+    error: ctx.error,
   };
 }


### PR DESCRIPTION
## Summary
- expose additional auth state in `useAuth` including `pending`
- refine `ProtectedRoute` to handle `pending` explicitly and log states

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686100d7b8f4832da3805e212e68aed7