### PR TITLE
Fix sidebar/render after login

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -105,13 +105,25 @@ export function AuthProvider({ children }) {
 
   const value = {
     userData,
+    /** Authenticated user object from Supabase */
+    user: session?.user || null,
+    /** Convenience alias for `session?.user?.id` */
+    user_id: session?.user?.id ?? null,
+    /** Direct session object returned by Supabase */
     session,
+    /** Authentication state */
     loading,
     error,
+    /** Indicates the session is available but userData has not been fetched yet */
     pending: !!session && !userData,
+    /** Selected fields from userData for easy access */
+    role: userData?.role,
+    mama_id: userData?.mama_id,
+    access_rights: userData?.access_rights,
     login,
     signup,
     logout,
+    /** Helpers */
     isAuthenticated: !!session?.user?.id,
     isAdmin: userData?.role === "admin" || userData?.role === "superadmin",
     isSuperadmin: userData?.role === "superadmin",

--- a/src/layout/Layout.jsx
+++ b/src/layout/Layout.jsx
@@ -3,6 +3,7 @@ import Sidebar from "@/layout/Sidebar";
 import useAuth from "@/hooks/useAuth";
 import toast from "react-hot-toast";
 import Footer from "@/components/Footer";
+import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 import {
   LiquidBackground,
   WavesBackground,
@@ -12,8 +13,24 @@ import {
 
 export default function Layout() {
   const { pathname } = useLocation();
-  const { user, role, logout } = useAuth();
+  const {
+    session,
+    userData,
+    role,
+    mama_id,
+    access_rights,
+    loading,
+    logout,
+  } = useAuth();
+  console.log("Layout", { session, userData, role, mama_id, access_rights });
+
   if (pathname === "/login" || pathname === "/unauthorized") return <Outlet />;
+
+  if (loading) return <LoadingSpinner message="Chargement..." />;
+  if (!session || !userData)
+    return <LoadingSpinner message="Chargement utilisateur..." />;
+
+  const user = session.user;
 
   return (
     <div className="relative flex h-screen overflow-auto text-shadow">

--- a/src/layout/Sidebar.jsx
+++ b/src/layout/Sidebar.jsx
@@ -1,5 +1,6 @@
 import { Link, useLocation } from "react-router-dom";
 import { useAuth } from "@/context/AuthContext";
+import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 import toast from "react-hot-toast";
 import {
   Boxes,
@@ -21,11 +22,17 @@ import {
 } from "lucide-react";
 
 export default function Sidebar() {
-  const { access_rights, loading, user, logout, session } = useAuth();
+  const { access_rights, loading, user, role, mama_id, logout, session } =
+    useAuth();
   const { pathname } = useLocation();
+  console.log("Sidebar", { user, role, mama_id, access_rights });
 
   if (loading || access_rights === null) {
-    return <aside className="w-64 p-4" />;
+    return (
+      <aside className="w-64 p-4">
+        <LoadingSpinner message="Chargement menu..." />
+      </aside>
+    );
   }
 
   const rights = typeof access_rights === "object" ? access_rights : {};


### PR DESCRIPTION
## Summary
- expose user, role, mama_id and access_rights from `AuthContext`
- show a loading spinner in `Layout` and log auth values
- log auth details in `Sidebar` and show a spinner while loading

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686103f54fb4832db088efb260eb9eae