### PR TITLE
Remove manual PMP editing

### DIFF
--- a/src/components/produits/ProduitForm.jsx
+++ b/src/components/produits/ProduitForm.jsx
@@ -19,7 +19,6 @@ export default function ProduitForm({ produit, familles = [], unites = [], onSuc
   const [famille, setFamille] = useState(produit?.famille || "");
   const [unite, setUnite] = useState(produit?.unite || "");
   const [mainSupplierId, setMainSupplierId] = useState(produit?.main_supplier_id || "");
-  const [pmp, setPmp] = useState(produit?.pmp || "");
   const [stock_reel, setStockReel] = useState(produit?.stock_reel || 0);
   const [stock_min, setStockMin] = useState(produit?.stock_min || 0);
   const [actif, setActif] = useState(produit?.actif ?? true);
@@ -44,7 +43,6 @@ export default function ProduitForm({ produit, familles = [], unites = [], onSuc
       setFamille(produit.famille || "");
       setUnite(produit.unite || "");
       setMainSupplierId(produit.main_supplier_id || "");
-      setPmp(produit.pmp || "");
       setStockReel(produit.stock_reel || 0);
       setStockMin(produit.stock_min || 0);
       setActif(produit.actif ?? true);
@@ -71,7 +69,6 @@ export default function ProduitForm({ produit, familles = [], unites = [], onSuc
       famille,
       unite,
       main_supplier_id: mainSupplierId || null,
-      pmp: Number(pmp),
       stock_reel: Number(stock_reel),
       stock_min: Number(stock_min),
       actif,
@@ -206,17 +203,18 @@ export default function ProduitForm({ produit, familles = [], unites = [], onSuc
           Upload
         </button>
       </div>
-      <div>
-        <label className="block text-sm mb-1 font-medium">PMP (€)</label>
-        <input
-          type="number"
-          className="input input-bordered w-28"
-          value={pmp}
-          onChange={e => setPmp(e.target.value)}
-          min={0}
-          step="0.01"
-        />
-      </div>
+      {editing && (
+        <div>
+          <label className="block text-sm mb-1 font-medium">PMP (€)</label>
+          <input
+            type="number"
+            className="input input-bordered w-28"
+            value={produit?.pmp || 0}
+            readOnly
+            disabled
+          />
+        </div>
+      )}
       <div>
         <label className="block text-sm mb-1 font-medium">Stock réel</label>
         <input

--- a/src/pages/produits/Produits.jsx
+++ b/src/pages/produits/Produits.jsx
@@ -41,7 +41,6 @@ export default function Produits() {
         nom: row.nom,
         famille: row.famille,
         unite: row.unite,
-        pmp: Number(row.pmp) || 0,
         stock_reel: Number(row.stock_reel) || 0,
         stock_min: Number(row.stock_min) || 0,
         actif: row.actif !== false,

--- a/test/ProduitForm.test.jsx
+++ b/test/ProduitForm.test.jsx
@@ -35,3 +35,26 @@ test('renders additional product inputs', () => {
   expect(screen.getByLabelText(/Allergènes/)).toBeInTheDocument();
   expect(screen.getByLabelText(/Stock minimum/)).toBeInTheDocument();
 });
+
+test('PMP input read-only or hidden', () => {
+  mockHook = () => ({ addProduct: vi.fn(), updateProduct: vi.fn(), loading: false });
+  // create mode: no PMP field
+  const { rerender } = render(
+    <ProduitForm familles={[]} unites={[]} onSuccess={vi.fn()} onClose={vi.fn()} />
+  );
+  expect(screen.queryByLabelText(/PMP/)).toBeNull();
+
+  // edit mode: PMP displayed but disabled
+  rerender(
+    <ProduitForm
+      produit={{ id: '1', nom: 'p', famille: 'f', unite: 'u', pmp: 5 }}
+      familles={[]}
+      unites={[]}
+      onSuccess={vi.fn()}
+      onClose={vi.fn()}
+    />
+  );
+  const input = screen.getByDisplayValue('5');
+  expect(input).toBeDisabled();
+  expect(input).toHaveValue(5);
+});

--- a/test/useProductsView.test.js
+++ b/test/useProductsView.test.js
@@ -1,0 +1,29 @@
+import { renderHook, act } from '@testing-library/react';
+import { vi, beforeEach, test, expect } from 'vitest';
+
+const rangeMock = vi.fn(() => Promise.resolve({ data: [], count: 0, error: null }));
+const orderMock2 = vi.fn(() => ({ range: rangeMock }));
+const orderMock1 = vi.fn(() => ({ order: orderMock2 }));
+const eqMock = vi.fn(() => ({ order: orderMock1 }));
+const selectMock = vi.fn(() => ({ eq: eqMock, order: orderMock1, range: rangeMock }));
+const fromMock = vi.fn(() => ({ select: selectMock }));
+
+vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
+vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
+
+let useProducts;
+
+beforeEach(async () => {
+  ({ useProducts } = await import('@/hooks/useProducts'));
+  fromMock.mockClear();
+  selectMock.mockClear();
+});
+
+test('fetchProducts queries view with mama_id filter', async () => {
+  const { result } = renderHook(() => useProducts());
+  await act(async () => {
+    await result.current.fetchProducts();
+  });
+  expect(fromMock).toHaveBeenCalledWith('v_products_last_price');
+  expect(selectMock).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- avoid manually editing PMP in product form
- ignore PMP column during Excel import
- show read-only PMP value when editing
- test that view `v_products_last_price` is used by `useProducts`
- test PMP field is read-only or hidden

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686122bfb11c832dbd14c6f3fdb00980