### PR TITLE
Fix handle_new_user function default mama

### DIFF
--- a/db/full_setup.sql
+++ b/db/full_setup.sql
@@ -2179,7 +2179,7 @@ returns trigger language plpgsql security definer set search_path=public as $$
 begin
   insert into public.utilisateurs(auth_id, email, mama_id, role, access_rights)
   values (new.id, new.email,
-          (select id from public.mamas where actif limit 1),
+          (select id from public.mamas limit 1),
           'user', '{}'::jsonb)
   on conflict do nothing;
   return new;


### PR DESCRIPTION
## Summary
- avoid referencing non-existing `mamas.actif` column

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68624ba1e610832da18dcef432829dde