### PR TITLE
Fix quoting in drop users block

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ SQL scripts are stored in [`sql/`](./sql). To initialise a local Supabase instan
 
 ```bash
 supabase start
-supabase db reset --file sql/full_setup.sql --seed sql/seed.sql
+supabase db reset --file db/full_setup.sql --seed sql/seed.sql
 # Optionally switch the schema to French names
 supabase db execute < db/rename_to_french.sql
 ```

--- a/db/full_setup.sql
+++ b/db/full_setup.sql
@@ -43,11 +43,11 @@ BEGIN
     SELECT 1
     FROM pg_class c
     JOIN pg_namespace n ON n.oid = c.relnamespace
-    WHERE n.nspname = 'public' AND c.relname = 'users' AND c.relkind IN (''r'',''p'')
+    WHERE n.nspname = 'public' AND c.relname = 'users' AND c.relkind IN ('r','p')
   ) THEN
     EXECUTE 'DROP TABLE public.users CASCADE';
   END IF;
-END$$;
+END $$;
 create table if not exists users (
     id uuid primary key default uuid_generate_v4(),
     email text not null unique,
@@ -2135,7 +2135,7 @@ begin
   else
     raise notice 'cron.schedule not available';
   end if;
-end$$;
+END $$;
 
 create or replace function fn_calc_budgets(mama_id_param uuid, periode_param text)
 returns table(famille text, budget_prevu numeric, total_reel numeric, ecart_pct numeric)

--- a/docs/fiches_techniques.md
+++ b/docs/fiches_techniques.md
@@ -14,7 +14,7 @@ Ce module permet de gérer les fiches de production :
 - `src/hooks/useFicheCoutHistory.js`
 
 Les données sont sécurisées par RLS avec le `mama_id` dans `sql/rls.sql`.
-Des triggers (`refresh_fiche_cost`) calculent automatiquement `cout_total` et `cout_par_portion` (voir `sql/full_setup.sql`).
+Des triggers (`refresh_fiche_cost`) calculent automatiquement `cout_total` et `cout_par_portion` (voir `db/full_setup.sql`).
 
 ## Reprise
 Pour reprendre le développement :


### PR DESCRIPTION
## Summary
- fix quoting in DO block dropping default Supabase users table
- unify END markers to `END $$;` for consistency
- correct full setup path in docs

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68625377138c832da282f1b3e90d12e5