### PR TITLE
Fix rename logic for produit_id

### DIFF
--- a/db/full_setup.sql
+++ b/db/full_setup.sql
@@ -54,6 +54,11 @@ BEGIN
     WHERE table_name='facture_lignes' AND column_name='produit_id'
   ) THEN
     ALTER TABLE facture_lignes RENAME COLUMN product_id TO produit_id;
+  ELSIF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='facture_lignes' AND column_name='produit_id'
+  ) THEN
+    ALTER TABLE facture_lignes ADD COLUMN produit_id uuid references produits(id) on delete set null;
   END IF;
 
   IF EXISTS (
@@ -64,6 +69,11 @@ BEGIN
     WHERE table_name='fiche_lignes' AND column_name='produit_id'
   ) THEN
     ALTER TABLE fiche_lignes RENAME COLUMN product_id TO produit_id;
+  ELSIF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='fiche_lignes' AND column_name='produit_id'
+  ) THEN
+    ALTER TABLE fiche_lignes ADD COLUMN produit_id uuid references produits(id) on delete set null;
   END IF;
 
   IF EXISTS (
@@ -74,6 +84,11 @@ BEGIN
     WHERE table_name='inventaire_lignes' AND column_name='produit_id'
   ) THEN
     ALTER TABLE inventaire_lignes RENAME COLUMN product_id TO produit_id;
+  ELSIF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='inventaire_lignes' AND column_name='produit_id'
+  ) THEN
+    ALTER TABLE inventaire_lignes ADD COLUMN produit_id uuid references produits(id) on delete set null;
   END IF;
 
   IF EXISTS (
@@ -84,6 +99,11 @@ BEGIN
     WHERE table_name='mouvements_stock' AND column_name='produit_id'
   ) THEN
     ALTER TABLE mouvements_stock RENAME COLUMN product_id TO produit_id;
+  ELSIF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='mouvements_stock' AND column_name='produit_id'
+  ) THEN
+    ALTER TABLE mouvements_stock ADD COLUMN produit_id uuid references produits(id) on delete set null;
   END IF;
 
   IF EXISTS (
@@ -94,6 +114,11 @@ BEGIN
     WHERE table_name='requisitions' AND column_name='produit_id'
   ) THEN
     ALTER TABLE requisitions RENAME COLUMN product_id TO produit_id;
+  ELSIF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='requisitions' AND column_name='produit_id'
+  ) THEN
+    ALTER TABLE requisitions ADD COLUMN produit_id uuid references produits(id);
   END IF;
 
   IF EXISTS (
@@ -104,6 +129,11 @@ BEGIN
     WHERE table_name='transferts' AND column_name='produit_id'
   ) THEN
     ALTER TABLE transferts RENAME COLUMN product_id TO produit_id;
+  ELSIF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='transferts' AND column_name='produit_id'
+  ) THEN
+    ALTER TABLE transferts ADD COLUMN produit_id uuid references produits(id) on delete set null;
   END IF;
 
   IF EXISTS (
@@ -114,6 +144,11 @@ BEGIN
     WHERE table_name='pertes' AND column_name='produit_id'
   ) THEN
     ALTER TABLE pertes RENAME COLUMN product_id TO produit_id;
+  ELSIF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='pertes' AND column_name='produit_id'
+  ) THEN
+    ALTER TABLE pertes ADD COLUMN produit_id uuid references produits(id);
   END IF;
 
   IF EXISTS (
@@ -124,6 +159,11 @@ BEGIN
     WHERE table_name='promotion_produits' AND column_name='produit_id'
   ) THEN
     ALTER TABLE promotion_produits RENAME COLUMN product_id TO produit_id;
+  ELSIF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='promotion_produits' AND column_name='produit_id'
+  ) THEN
+    ALTER TABLE promotion_produits ADD COLUMN produit_id uuid references produits(id) on delete cascade;
   END IF;
 END $$;
 


### PR DESCRIPTION
## Summary
- ensure `db/full_setup.sql` creates `produit_id` column when missing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ab3cdec3c832db6794de46a1426ed