### PR TITLE
Fix setup script foreign key order

### DIFF
--- a/db/full_setup.sql
+++ b/db/full_setup.sql
@@ -42,132 +42,6 @@ BEGIN
 END $$;
 
 
--- Harmonisation des anciens noms de colonnes
--- Renomme product_id en produit_id si nécessaire
-DO $$
-BEGIN
-  IF EXISTS (
-    SELECT 1 FROM information_schema.columns
-    WHERE table_name='facture_lignes' AND column_name='product_id'
-  ) AND NOT EXISTS (
-    SELECT 1 FROM information_schema.columns
-    WHERE table_name='facture_lignes' AND column_name='produit_id'
-  ) THEN
-    ALTER TABLE facture_lignes RENAME COLUMN product_id TO produit_id;
-  ELSIF NOT EXISTS (
-    SELECT 1 FROM information_schema.columns
-    WHERE table_name='facture_lignes' AND column_name='produit_id'
-  ) THEN
-    ALTER TABLE facture_lignes ADD COLUMN produit_id uuid references produits(id) on delete set null;
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM information_schema.columns
-    WHERE table_name='fiche_lignes' AND column_name='product_id'
-  ) AND NOT EXISTS (
-    SELECT 1 FROM information_schema.columns
-    WHERE table_name='fiche_lignes' AND column_name='produit_id'
-  ) THEN
-    ALTER TABLE fiche_lignes RENAME COLUMN product_id TO produit_id;
-  ELSIF NOT EXISTS (
-    SELECT 1 FROM information_schema.columns
-    WHERE table_name='fiche_lignes' AND column_name='produit_id'
-  ) THEN
-    ALTER TABLE fiche_lignes ADD COLUMN produit_id uuid references produits(id) on delete set null;
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM information_schema.columns
-    WHERE table_name='inventaire_lignes' AND column_name='product_id'
-  ) AND NOT EXISTS (
-    SELECT 1 FROM information_schema.columns
-    WHERE table_name='inventaire_lignes' AND column_name='produit_id'
-  ) THEN
-    ALTER TABLE inventaire_lignes RENAME COLUMN product_id TO produit_id;
-  ELSIF NOT EXISTS (
-    SELECT 1 FROM information_schema.columns
-    WHERE table_name='inventaire_lignes' AND column_name='produit_id'
-  ) THEN
-    ALTER TABLE inventaire_lignes ADD COLUMN produit_id uuid references produits(id) on delete set null;
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM information_schema.columns
-    WHERE table_name='mouvements_stock' AND column_name='product_id'
-  ) AND NOT EXISTS (
-    SELECT 1 FROM information_schema.columns
-    WHERE table_name='mouvements_stock' AND column_name='produit_id'
-  ) THEN
-    ALTER TABLE mouvements_stock RENAME COLUMN product_id TO produit_id;
-  ELSIF NOT EXISTS (
-    SELECT 1 FROM information_schema.columns
-    WHERE table_name='mouvements_stock' AND column_name='produit_id'
-  ) THEN
-    ALTER TABLE mouvements_stock ADD COLUMN produit_id uuid references produits(id) on delete set null;
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM information_schema.columns
-    WHERE table_name='requisitions' AND column_name='product_id'
-  ) AND NOT EXISTS (
-    SELECT 1 FROM information_schema.columns
-    WHERE table_name='requisitions' AND column_name='produit_id'
-  ) THEN
-    ALTER TABLE requisitions RENAME COLUMN product_id TO produit_id;
-  ELSIF NOT EXISTS (
-    SELECT 1 FROM information_schema.columns
-    WHERE table_name='requisitions' AND column_name='produit_id'
-  ) THEN
-    ALTER TABLE requisitions ADD COLUMN produit_id uuid references produits(id);
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM information_schema.columns
-    WHERE table_name='transferts' AND column_name='product_id'
-  ) AND NOT EXISTS (
-    SELECT 1 FROM information_schema.columns
-    WHERE table_name='transferts' AND column_name='produit_id'
-  ) THEN
-    ALTER TABLE transferts RENAME COLUMN product_id TO produit_id;
-  ELSIF NOT EXISTS (
-    SELECT 1 FROM information_schema.columns
-    WHERE table_name='transferts' AND column_name='produit_id'
-  ) THEN
-    ALTER TABLE transferts ADD COLUMN produit_id uuid references produits(id) on delete set null;
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM information_schema.columns
-    WHERE table_name='pertes' AND column_name='product_id'
-  ) AND NOT EXISTS (
-    SELECT 1 FROM information_schema.columns
-    WHERE table_name='pertes' AND column_name='produit_id'
-  ) THEN
-    ALTER TABLE pertes RENAME COLUMN product_id TO produit_id;
-  ELSIF NOT EXISTS (
-    SELECT 1 FROM information_schema.columns
-    WHERE table_name='pertes' AND column_name='produit_id'
-  ) THEN
-    ALTER TABLE pertes ADD COLUMN produit_id uuid references produits(id);
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM information_schema.columns
-    WHERE table_name='promotion_produits' AND column_name='product_id'
-  ) AND NOT EXISTS (
-    SELECT 1 FROM information_schema.columns
-    WHERE table_name='promotion_produits' AND column_name='produit_id'
-  ) THEN
-    ALTER TABLE promotion_produits RENAME COLUMN product_id TO produit_id;
-  ELSIF NOT EXISTS (
-    SELECT 1 FROM information_schema.columns
-    WHERE table_name='promotion_produits' AND column_name='produit_id'
-  ) THEN
-    ALTER TABLE promotion_produits ADD COLUMN produit_id uuid references produits(id) on delete cascade;
-  END IF;
-END $$;
-
-
 -- ------------------
 -- Tables de base
 -- ------------------
@@ -582,6 +456,131 @@ create table if not exists parametres (
     contacts jsonb,
     created_at timestamptz default now()
 );
+
+-- Harmonisation des anciens noms de colonnes
+-- Renomme product_id en produit_id si nécessaire
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='facture_lignes' AND column_name='product_id'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='facture_lignes' AND column_name='produit_id'
+  ) THEN
+    ALTER TABLE facture_lignes RENAME COLUMN product_id TO produit_id;
+  ELSIF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='facture_lignes' AND column_name='produit_id'
+  ) THEN
+    ALTER TABLE facture_lignes ADD COLUMN produit_id uuid references produits(id) on delete set null;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='fiche_lignes' AND column_name='product_id'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='fiche_lignes' AND column_name='produit_id'
+  ) THEN
+    ALTER TABLE fiche_lignes RENAME COLUMN product_id TO produit_id;
+  ELSIF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='fiche_lignes' AND column_name='produit_id'
+  ) THEN
+    ALTER TABLE fiche_lignes ADD COLUMN produit_id uuid references produits(id) on delete set null;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='inventaire_lignes' AND column_name='product_id'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='inventaire_lignes' AND column_name='produit_id'
+  ) THEN
+    ALTER TABLE inventaire_lignes RENAME COLUMN product_id TO produit_id;
+  ELSIF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='inventaire_lignes' AND column_name='produit_id'
+  ) THEN
+    ALTER TABLE inventaire_lignes ADD COLUMN produit_id uuid references produits(id) on delete set null;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='mouvements_stock' AND column_name='product_id'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='mouvements_stock' AND column_name='produit_id'
+  ) THEN
+    ALTER TABLE mouvements_stock RENAME COLUMN product_id TO produit_id;
+  ELSIF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='mouvements_stock' AND column_name='produit_id'
+  ) THEN
+    ALTER TABLE mouvements_stock ADD COLUMN produit_id uuid references produits(id) on delete set null;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='requisitions' AND column_name='product_id'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='requisitions' AND column_name='produit_id'
+  ) THEN
+    ALTER TABLE requisitions RENAME COLUMN product_id TO produit_id;
+  ELSIF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='requisitions' AND column_name='produit_id'
+  ) THEN
+    ALTER TABLE requisitions ADD COLUMN produit_id uuid references produits(id);
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='transferts' AND column_name='product_id'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='transferts' AND column_name='produit_id'
+  ) THEN
+    ALTER TABLE transferts RENAME COLUMN product_id TO produit_id;
+  ELSIF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='transferts' AND column_name='produit_id'
+  ) THEN
+    ALTER TABLE transferts ADD COLUMN produit_id uuid references produits(id) on delete set null;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='pertes' AND column_name='product_id'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='pertes' AND column_name='produit_id'
+  ) THEN
+    ALTER TABLE pertes RENAME COLUMN product_id TO produit_id;
+  ELSIF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='pertes' AND column_name='produit_id'
+  ) THEN
+    ALTER TABLE pertes ADD COLUMN produit_id uuid references produits(id);
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='promotion_produits' AND column_name='product_id'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='promotion_produits' AND column_name='produit_id'
+  ) THEN
+    ALTER TABLE promotion_produits RENAME COLUMN product_id TO produit_id;
+  ELSIF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='promotion_produits' AND column_name='produit_id'
+  ) THEN
+    ALTER TABLE promotion_produits ADD COLUMN produit_id uuid references produits(id) on delete cascade;
+  END IF;
+END $$;
 
 -- Indexes
 create index if not exists idx_users_mama on users(mama_id);


### PR DESCRIPTION
## Summary
- move harmonization block after table creation to avoid missing table errors

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b960cc218832daddbe2399fef0728