### PR TITLE
Fix add column checks in full_setup.sql

### DIFF
--- a/db/full_setup.sql
+++ b/db/full_setup.sql
@@ -748,21 +748,30 @@ BEGIN
     ALTER TABLE menus ADD COLUMN actif boolean default true;
   END IF;
 
-  IF NOT EXISTS (
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_name='centres_de_cout'
+  ) AND NOT EXISTS (
     SELECT 1 FROM information_schema.columns
     WHERE table_name='centres_de_cout' AND column_name='actif'
   ) THEN
     ALTER TABLE centres_de_cout ADD COLUMN actif boolean default true;
   END IF;
 
-  IF NOT EXISTS (
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_name='promotions'
+  ) AND NOT EXISTS (
     SELECT 1 FROM information_schema.columns
     WHERE table_name='promotions' AND column_name='actif'
   ) THEN
     ALTER TABLE promotions ADD COLUMN actif boolean default true;
   END IF;
 
-  IF NOT EXISTS (
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_name='fournisseurs_api_config'
+  ) AND NOT EXISTS (
     SELECT 1 FROM information_schema.columns
     WHERE table_name='fournisseurs_api_config' AND column_name='actif'
   ) THEN


### PR DESCRIPTION
## Summary
- check table existence before altering optional tables

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686cf0f74e98832d8f8894c57a05cf5b