### PR TITLE
Fix mouvements_stock missing zone columns

### DIFF
--- a/db/full_setup.sql
+++ b/db/full_setup.sql
@@ -622,10 +622,32 @@ BEGIN
   ) THEN
     ALTER TABLE requisitions RENAME COLUMN zone TO zone_id;
   ELSIF NOT EXISTS (
-    SELECT 1 FROM information_schema.columns
-    WHERE table_name='requisitions' AND column_name='zone_id'
+      SELECT 1 FROM information_schema.columns
+      WHERE table_name='requisitions' AND column_name='zone_id'
+    ) THEN
+      ALTER TABLE requisitions ADD COLUMN zone_id uuid references zones_stock(id);
+  END IF;
+END $$;
+
+-- Ajout des colonnes zone_source_id et zone_destination_id si absentes
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_name='mouvements_stock'
   ) THEN
-    ALTER TABLE requisitions ADD COLUMN zone_id uuid references zones_stock(id);
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_name='mouvements_stock' AND column_name='zone_source_id'
+    ) THEN
+      ALTER TABLE mouvements_stock ADD COLUMN zone_source_id uuid references zones_stock(id);
+    END IF;
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_name='mouvements_stock' AND column_name='zone_destination_id'
+    ) THEN
+      ALTER TABLE mouvements_stock ADD COLUMN zone_destination_id uuid references zones_stock(id);
+    END IF;
   END IF;
 END $$;
 


### PR DESCRIPTION
## Summary
- ensure `mouvements_stock` table has `zone_source_id` and `zone_destination_id` columns before creating indexes

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686cf354d020832d8220176f55954d58