### PR TITLE
Fix view column rename

### DIFF
--- a/db/full_setup.sql
+++ b/db/full_setup.sql
@@ -690,6 +690,45 @@ BEGIN
   END IF;
 END $$;
 
+-- Renommer la colonne product_id en produit_id dans les vues existantes
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'v_product_price_trend'
+      AND column_name = 'product_id'
+  ) THEN
+    EXECUTE 'ALTER VIEW v_product_price_trend RENAME COLUMN product_id TO produit_id';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'v_products_last_price'
+      AND column_name = 'product_id'
+  ) THEN
+    EXECUTE 'ALTER VIEW v_products_last_price RENAME COLUMN product_id TO produit_id';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'stock_mouvements'
+      AND column_name = 'product_id'
+  ) THEN
+    EXECUTE 'ALTER VIEW stock_mouvements RENAME COLUMN product_id TO produit_id';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'stocks'
+      AND column_name = 'product_id'
+  ) THEN
+    EXECUTE 'ALTER VIEW stocks RENAME COLUMN product_id TO produit_id';
+  END IF;
+END $$;
 -- Ajout des colonnes zone_source_id et zone_destination_id si absentes
 DO $$
 BEGIN


### PR DESCRIPTION
## Summary
- ensure `product_id` column is renamed to `produit_id` in legacy views

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686d4ea15e88832db288986711bd1fbd