### PR TITLE
Fix stats_rotation_produit redeploy

### DIFF
--- a/db/full_setup.sql
+++ b/db/full_setup.sql
@@ -1155,8 +1155,9 @@ grant execute on function stats_achats_fournisseur(uuid, uuid) to authenticated;
 --
 -- Assure la compatibilité lors d'une réexécution du script en supprimant
 -- l'ancienne version utilisant le paramètre product_id_param si elle existe
---
-drop function if exists stats_rotation_produit(uuid, uuid);
+-- Supprime toute version existante de la fonction pour garantir
+-- la compatibilité avec les anciennes signatures (ex. product_id_param)
+drop function if exists stats_rotation_produit(uuid, uuid) cascade;
 -- Statistiques : rotation du produit par mois
 create or replace function stats_rotation_produit(mama_id_param uuid, produit_id_param uuid)
 returns table(mois text, quantite_sortie numeric)


### PR DESCRIPTION
## Summary
- drop `stats_rotation_produit` with `cascade` before recreating it in `full_setup.sql`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686d64acdcc4832d8e7ca7f2ad8b7e3a