### PR TITLE
Fix rename helper to skip missing relations

### DIFF
--- a/db/full_setup.sql
+++ b/db/full_setup.sql
@@ -45,7 +45,9 @@ begin
     join pg_namespace n on n.oid = c.relnamespace
     where n.nspname = 'public' and c.relname = rel;
 
-  if kind in ('v','m') then
+  if kind is null then
+    return;
+  elsif kind in ('v','m') then
     -- Views and materialized views
     execute format('ALTER VIEW public.%I RENAME COLUMN %I TO %I', rel, old_col, new_col);
   elsif kind in ('r','p') then


### PR DESCRIPTION
## Summary
- handle missing relations in the SQL helper used for renaming

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e830e48d4832d9ec5e785b0032d0b