### PR TITLE
Ensure idempotent index creation in SQL setup

### DIFF
--- a/db/full_setup.sql
+++ b/db/full_setup.sql
@@ -145,8 +145,24 @@ BEGIN
   END IF;
 END $$;
 
-create index if not exists idx_utilisateurs_auth_id on utilisateurs(auth_id);
-create index if not exists idx_utilisateurs_mama_id on utilisateurs(mama_id);
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_utilisateurs_auth_id' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_utilisateurs_auth_id ON utilisateurs(auth_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_utilisateurs_mama_id' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_utilisateurs_mama_id ON utilisateurs(mama_id);
+  END IF;
+END $$;
 
 -- Helper functions used in RLS policies
 create or replace function current_user_mama_id()
@@ -517,20 +533,124 @@ create table if not exists parametres (
     created_at timestamptz default now()
 );
 
-create index if not exists idx_requisitions_date on requisitions("date");
-create index if not exists idx_transferts_mama on transferts(mama_id);
-create index if not exists idx_transferts_produit on transferts(produit_id);
-create index if not exists idx_zones_stock_mama on zones_stock(mama_id);
-create index if not exists idx_zones_stock_actif on zones_stock(actif);
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_requisitions_date' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_requisitions_date ON requisitions("date");
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_transferts_mama' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_transferts_mama ON transferts(mama_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_transferts_produit' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_transferts_produit ON transferts(produit_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_zones_stock_mama' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_zones_stock_mama ON zones_stock(mama_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_zones_stock_actif' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_zones_stock_actif ON zones_stock(actif);
+  END IF;
+END $$;
 -- Index pour accélérer la recherche par zone dans les mouvements de stock
-create index if not exists idx_mouvements_stock_zone_source on mouvements_stock(zone_source_id);
-create index if not exists idx_mouvements_stock_zone_destination on mouvements_stock(zone_destination_id);
-create index if not exists idx_mouvements_stock_sous_type on mouvements_stock(sous_type);
-create index if not exists idx_mouvements_stock_zone on mouvements_stock(zone);
-create index if not exists idx_mouvements_stock_motif on mouvements_stock(motif);
-create index if not exists idx_inventaire_zones_mama on inventaire_zones(mama_id);
-create index if not exists idx_ventes_boissons_mama on ventes_boissons(mama_id);
-create index if not exists idx_ventes_boissons_boisson on ventes_boissons(boisson_id);
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_mouvements_stock_zone_source' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_mouvements_stock_zone_source ON mouvements_stock(zone_source_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_mouvements_stock_zone_destination' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_mouvements_stock_zone_destination ON mouvements_stock(zone_destination_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_mouvements_stock_sous_type' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_mouvements_stock_sous_type ON mouvements_stock(sous_type);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_mouvements_stock_zone' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_mouvements_stock_zone ON mouvements_stock(zone);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_mouvements_stock_motif' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_mouvements_stock_motif ON mouvements_stock(motif);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_inventaire_zones_mama' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_inventaire_zones_mama ON inventaire_zones(mama_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_ventes_boissons_mama' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_ventes_boissons_mama ON ventes_boissons(mama_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_ventes_boissons_boisson' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_ventes_boissons_boisson ON ventes_boissons(boisson_id);
+  END IF;
+END $$;
 create or replace view stock_mouvements as select * from mouvements_stock;
 grant select on stock_mouvements to authenticated;
 create or replace view stocks as select * from mouvements_stock;
@@ -938,11 +1058,51 @@ create table if not exists mouvements_centres_cout (
 );
 
 -- Index pour des requêtes plus rapides
-create index if not exists idx_centres_de_cout_mama on centres_de_cout(mama_id);
-create index if not exists idx_centres_de_cout_nom on centres_de_cout(nom);
-create index if not exists idx_mouvements_cc_mama on mouvements_centres_cout(mama_id);
-create index if not exists idx_mouvements_cc_mouvement on mouvements_centres_cout(mouvement_id);
-create index if not exists idx_mouvements_cc_centre on mouvements_centres_cout(centre_cout_id);
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_centres_de_cout_mama' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_centres_de_cout_mama ON centres_de_cout(mama_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_centres_de_cout_nom' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_centres_de_cout_nom ON centres_de_cout(nom);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_mouvements_cc_mama' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_mouvements_cc_mama ON mouvements_centres_cout(mama_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_mouvements_cc_mouvement' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_mouvements_cc_mouvement ON mouvements_centres_cout(mouvement_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_mouvements_cc_centre' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_mouvements_cc_centre ON mouvements_centres_cout(centre_cout_id);
+  END IF;
+END $$;
 
 -- Politiques de sécurité au niveau des lignes
 alter table centres_de_cout enable row level security;
@@ -984,10 +1144,42 @@ create table if not exists journaux_utilisateur (
     created_at timestamptz default now()
 );
 
-create index if not exists idx_journaux_utilisateur_mama on journaux_utilisateur(mama_id);
-create index if not exists idx_journaux_utilisateur_user on journaux_utilisateur(user_id);
-create index if not exists idx_journaux_utilisateur_done on journaux_utilisateur(done_by);
-create index if not exists idx_journaux_utilisateur_date on journaux_utilisateur(created_at);
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_journaux_utilisateur_mama' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_journaux_utilisateur_mama ON journaux_utilisateur(mama_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_journaux_utilisateur_user' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_journaux_utilisateur_user ON journaux_utilisateur(user_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_journaux_utilisateur_done' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_journaux_utilisateur_done ON journaux_utilisateur(done_by);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_journaux_utilisateur_date' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_journaux_utilisateur_date ON journaux_utilisateur(created_at);
+  END IF;
+END $$;
 
 alter table journaux_utilisateur enable row level security;
 alter table journaux_utilisateur force row level security;
@@ -1133,8 +1325,24 @@ create table if not exists pertes (
     created_at timestamptz default now(),
     created_by uuid references users(id)
 );
-create index if not exists idx_pertes_mama on pertes(mama_id);
-create index if not exists idx_pertes_produit on pertes(produit_id);
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_pertes_mama' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_pertes_mama ON pertes(mama_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_pertes_produit' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_pertes_produit ON pertes(produit_id);
+  END IF;
+END $$;
 
 -- RLS pour la table pertes
 alter table pertes enable row level security;
@@ -1328,7 +1536,15 @@ language sql stable security definer as $$
 $$;
 
 -- Index pour la connexion utilisateur par email
-create index if not exists idx_users_email on users(email);
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_users_email' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_users_email ON users(email);
+  END IF;
+END $$;
 
 
 -- Table d'audit des changements de prix
@@ -1342,7 +1558,15 @@ create table if not exists fiche_prix_history (
     created_at timestamptz default now(),
     changed_at timestamptz default now()
 );
-create index if not exists idx_fiche_prix_history_fiche on fiche_prix_history(fiche_id);
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_fiche_prix_history_fiche' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_fiche_prix_history_fiche ON fiche_prix_history(fiche_id);
+  END IF;
+END $$;
 
 alter table fiche_prix_history enable row level security;
 alter table fiche_prix_history force row level security;
@@ -1369,10 +1593,42 @@ after update on fiches_techniques
 for each row execute function log_fiche_prix_change();
 
 -- Index pour accélérer les requêtes de mouvements
-create index if not exists idx_mouvements_stock_mama on mouvements_stock(mama_id);
-create index if not exists idx_mouvements_stock_produit on mouvements_stock(produit_id);
-create index if not exists idx_mouvements_stock_date on mouvements_stock("date");
-create index if not exists idx_mouvements_stock_type on mouvements_stock(type);
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_mouvements_stock_mama' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_mouvements_stock_mama ON mouvements_stock(mama_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_mouvements_stock_produit' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_mouvements_stock_produit ON mouvements_stock(produit_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_mouvements_stock_date' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_mouvements_stock_date ON mouvements_stock("date");
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_mouvements_stock_type' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_mouvements_stock_type ON mouvements_stock(type);
+  END IF;
+END $$;
 
 
 -- Fonction de statistiques pour le tableau de bord
@@ -1411,10 +1667,42 @@ create table if not exists taches (
     created_at timestamptz default now(),
     updated_at timestamptz default now()
 );
-create index if not exists idx_taches_mama on taches(mama_id);
-create index if not exists idx_taches_echeance on taches(date_echeance);
-create index if not exists idx_taches_statut on taches(statut);
-create index if not exists idx_taches_priorite on taches(priorite);
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_taches_mama' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_taches_mama ON taches(mama_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_taches_echeance' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_taches_echeance ON taches(date_echeance);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_taches_statut' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_taches_statut ON taches(statut);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_taches_priorite' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_taches_priorite ON taches(priorite);
+  END IF;
+END $$;
 
 alter table taches enable row level security;
 alter table taches force row level security;
@@ -1441,10 +1729,42 @@ create table if not exists tache_instances (
     done_by uuid references users(id),
     created_at timestamptz default now()
 );
-create index if not exists idx_tache_instances_tache on tache_instances(tache_id);
-create index if not exists idx_tache_instances_date on tache_instances(date_echeance);
-create index if not exists idx_tache_instances_statut on tache_instances(statut);
-create index if not exists idx_tache_instances_done on tache_instances(done_by);
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_tache_instances_tache' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_tache_instances_tache ON tache_instances(tache_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_tache_instances_date' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_tache_instances_date ON tache_instances(date_echeance);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_tache_instances_statut' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_tache_instances_statut ON tache_instances(statut);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_tache_instances_done' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_tache_instances_done ON tache_instances(done_by);
+  END IF;
+END $$;
 
 alter table tache_instances enable row level security;
 alter table tache_instances force row level security;
@@ -1460,7 +1780,15 @@ grant execute on function top_produits(uuid, date, date, integer) to authenticat
 grant execute on function mouvements_without_alloc(integer) to authenticated;
 
 -- Index pour accélérer la recherche de factures
-create index if not exists idx_factures_reference on factures(reference);
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_factures_reference' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_factures_reference ON factures(reference);
+  END IF;
+END $$;
 
 
 -- Table des ventes pour l'ingénierie de menu
@@ -1474,8 +1802,24 @@ create table if not exists ventes_fiches_carte (
   updated_at timestamptz default now(),
   unique (fiche_id, periode, mama_id)
 );
-create index if not exists idx_vfc_fiche_periode_mama on ventes_fiches_carte(fiche_id, periode, mama_id);
-create index if not exists idx_vfc_periode on ventes_fiches_carte(periode);
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_vfc_fiche_periode_mama' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_vfc_fiche_periode_mama ON ventes_fiches_carte(fiche_id, periode, mama_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_vfc_periode' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_vfc_periode ON ventes_fiches_carte(periode);
+  END IF;
+END $$;
 
 alter table ventes_fiches_carte enable row level security;
 alter table ventes_fiches_carte force row level security;
@@ -1511,11 +1855,51 @@ create table if not exists promotion_produits (
     unique (promotion_id, produit_id)
 );
 
-create index if not exists idx_promotions_mama on promotions(mama_id);
-create index if not exists idx_promotions_actif on promotions(actif);
-create index if not exists idx_promo_prod_mama on promotion_produits(mama_id);
-create index if not exists idx_promo_prod_promotion on promotion_produits(promotion_id);
-create index if not exists idx_promo_prod_produit on promotion_produits(produit_id);
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_promotions_mama' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_promotions_mama ON promotions(mama_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_promotions_actif' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_promotions_actif ON promotions(actif);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_promo_prod_mama' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_promo_prod_mama ON promotion_produits(mama_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_promo_prod_promotion' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_promo_prod_promotion ON promotion_produits(promotion_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_promo_prod_produit' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_promo_prod_produit ON promotion_produits(produit_id);
+  END IF;
+END $$;
 
 alter table promotions enable row level security;
 alter table promotions force row level security;
@@ -1594,9 +1978,33 @@ create table if not exists audit_entries (
     created_at timestamptz default now(),
     changed_at timestamptz default now()
 );
-create index if not exists idx_audit_entries_mama on audit_entries(mama_id);
-create index if not exists idx_audit_entries_table on audit_entries(table_name);
-create index if not exists idx_audit_entries_date on audit_entries(changed_at);
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_audit_entries_mama' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_audit_entries_mama ON audit_entries(mama_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_audit_entries_table' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_audit_entries_table ON audit_entries(table_name);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_audit_entries_date' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_audit_entries_date ON audit_entries(changed_at);
+  END IF;
+END $$;
 
 alter table audit_entries enable row level security;
 alter table audit_entries force row level security;
@@ -1634,7 +2042,15 @@ create table if not exists planning_previsionnel (
     created_by uuid references users(id) on delete set null,
     created_at timestamptz default now()
 );
-create index if not exists idx_planning_mama on planning_previsionnel(mama_id, date_prevue);
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_planning_mama' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_planning_mama ON planning_previsionnel(mama_id, date_prevue);
+  END IF;
+END $$;
 alter table planning_previsionnel enable row level security;
 alter table planning_previsionnel force row level security;
 drop policy if exists planning_previsionnel_all on planning_previsionnel;
@@ -1657,7 +2073,15 @@ create table if not exists alert_rules (
     enabled boolean default true,
     created_at timestamptz default now()
 );
-create index if not exists idx_alert_rules_mama on alert_rules(mama_id);
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_alert_rules_mama' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_alert_rules_mama ON alert_rules(mama_id);
+  END IF;
+END $$;
 alter table alert_rules enable row level security;
 alter table alert_rules force row level security;
 drop policy if exists alert_rules_all on alert_rules;
@@ -1674,7 +2098,15 @@ create table if not exists alert_logs (
     stock_reel numeric,
     created_at timestamptz default now()
 );
-create index if not exists idx_alert_logs_mama on alert_logs(mama_id);
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_alert_logs_mama' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_alert_logs_mama ON alert_logs(mama_id);
+  END IF;
+END $$;
 alter table alert_logs enable row level security;
 alter table alert_logs force row level security;
 drop policy if exists alert_logs_all on alert_logs;
@@ -1719,7 +2151,15 @@ create table if not exists incoming_invoices (
     processed boolean default false,
     created_at timestamptz default now()
 );
-create index if not exists idx_incoming_invoices_mama on incoming_invoices(mama_id);
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_incoming_invoices_mama' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_incoming_invoices_mama ON incoming_invoices(mama_id);
+  END IF;
+END $$;
 
 alter table incoming_invoices enable row level security;
 alter table incoming_invoices force row level security;
@@ -1762,7 +2202,15 @@ create table if not exists documents (
     uploaded_by uuid references users(id) on delete set null,
     created_at timestamptz default now()
 );
-create index if not exists idx_documents_mama on documents(mama_id);
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_documents_mama' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_documents_mama ON documents(mama_id);
+  END IF;
+END $$;
 
 alter table documents enable row level security;
 alter table documents force row level security;
@@ -2433,8 +2881,24 @@ BEGIN
     ALTER TABLE fournisseurs_api_config ADD COLUMN IF NOT EXISTS actif boolean default true;
   END IF;
 END $$;
-create index if not exists idx_fournisseurs_api_config_fourn on fournisseurs_api_config(fournisseur_id);
-create index if not exists idx_fournisseurs_api_config_mama on fournisseurs_api_config(mama_id);
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_fournisseurs_api_config_fourn' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_fournisseurs_api_config_fourn ON fournisseurs_api_config(fournisseur_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_fournisseurs_api_config_mama' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_fournisseurs_api_config_mama ON fournisseurs_api_config(mama_id);
+  END IF;
+END $$;
 alter table fournisseurs_api_config enable row level security;
 alter table fournisseurs_api_config force row level security;
 drop policy if exists fournisseurs_api_config_all on fournisseurs_api_config;
@@ -2444,66 +2908,495 @@ create policy fournisseurs_api_config_all on fournisseurs_api_config
 
 -- L'inscription manuelle renseigne désormais la table utilisateurs, aucun trigger sur auth.users n'est nécessaire
 -- Indexes
-create index if not exists idx_users_mama on users(mama_id);
-create index if not exists idx_users_role on users(role_id);
-create index if not exists idx_users_actif on users(actif);
-create index if not exists idx_fournisseurs_mama on fournisseurs(mama_id);
-create index if not exists idx_fournisseurs_nom on fournisseurs(nom);
-create index if not exists idx_fournisseurs_ville on fournisseurs(ville);
-create index if not exists idx_fournisseurs_actif on fournisseurs(actif);
-create index if not exists idx_produits_mama on produits(mama_id);
-create index if not exists idx_produits_nom on produits(nom);
-create index if not exists idx_produits_actif on produits(actif);
-create index if not exists idx_produits_famille on produits(famille_id);
-create index if not exists idx_produits_unite on produits(unite_id);
-create index if not exists idx_produits_fournisseur_principal on produits(fournisseur_principal_id);
-create index if not exists idx_factures_mama on factures(mama_id);
-create index if not exists idx_factures_date on factures("date");
-create index if not exists idx_factures_fournisseur on factures(fournisseur_id);
-create index if not exists idx_factures_statut on factures(statut);
-create index if not exists idx_fiches_mama on fiches(mama_id);
-create index if not exists idx_fiches_nom on fiches(nom);
-create index if not exists idx_fiches_actif on fiches(actif);
-create index if not exists idx_fiches_famille on fiches(famille_id);
-create index if not exists idx_inventaires_mama on inventaires(mama_id);
-create index if not exists idx_familles_mama on familles(mama_id);
-create index if not exists idx_unites_mama on unites(mama_id);
-create index if not exists idx_fournisseur_produits_mama on fournisseur_produits(mama_id);
-create index if not exists idx_fournisseur_produits_produit on fournisseur_produits(produit_id);
-create index if not exists idx_fournisseur_produits_fournisseur on fournisseur_produits(fournisseur_id);
-create index if not exists idx_fournisseur_produits_produit_date on fournisseur_produits(produit_id, date_livraison desc);
-create index if not exists idx_facture_lignes_mama on facture_lignes(mama_id);
-create index if not exists idx_facture_lignes_facture on facture_lignes(facture_id);
-create index if not exists idx_facture_lignes_produit on facture_lignes(produit_id);
-create index if not exists idx_fiche_lignes_mama on fiche_lignes(mama_id);
-create index if not exists idx_fiche_lignes_fiche on fiche_lignes(fiche_id);
-create index if not exists idx_fiche_lignes_produit on fiche_lignes(produit_id);
-create index if not exists idx_fiche_cout_history_mama on fiche_cout_history(mama_id);
-create index if not exists idx_fiche_cout_history_fiche on fiche_cout_history(fiche_id);
-create index if not exists idx_inventaire_lignes_mama on inventaire_lignes(mama_id);
-create index if not exists idx_inventaire_lignes_inventaire on inventaire_lignes(inventaire_id);
-create index if not exists idx_inventaire_lignes_produit on inventaire_lignes(produit_id);
-create index if not exists idx_parametres_mama on parametres(mama_id);
-create index if not exists idx_fournisseur_contacts_mama on fournisseur_contacts(mama_id);
-create index if not exists idx_fournisseur_contacts_fournisseur on fournisseur_contacts(fournisseur_id);
-create index if not exists idx_fournisseur_notes_mama on fournisseur_notes(mama_id);
-create index if not exists idx_fournisseur_notes_fournisseur on fournisseur_notes(fournisseur_id);
-create index if not exists idx_permissions_mama on permissions(mama_id);
-create index if not exists idx_permissions_role on permissions(role_id);
-create index if not exists idx_permissions_user on permissions(user_id);
-create index if not exists idx_menus_mama on menus(mama_id);
-create index if not exists idx_menus_date on menus("date");
-create index if not exists idx_menu_fiches_menu on menu_fiches(menu_id);
-create index if not exists idx_menu_fiches_fiche on menu_fiches(fiche_id);
-create index if not exists idx_requisitions_mama on requisitions(mama_id);
-create index if not exists idx_requisitions_produit on requisitions(produit_id);
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_users_mama' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_users_mama ON users(mama_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_users_role' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_users_role ON users(role_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_users_actif' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_users_actif ON users(actif);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_fournisseurs_mama' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_fournisseurs_mama ON fournisseurs(mama_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_fournisseurs_nom' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_fournisseurs_nom ON fournisseurs(nom);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_fournisseurs_ville' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_fournisseurs_ville ON fournisseurs(ville);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_fournisseurs_actif' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_fournisseurs_actif ON fournisseurs(actif);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_produits_mama' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_produits_mama ON produits(mama_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_produits_nom' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_produits_nom ON produits(nom);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_produits_actif' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_produits_actif ON produits(actif);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_produits_famille' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_produits_famille ON produits(famille_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_produits_unite' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_produits_unite ON produits(unite_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_produits_fournisseur_principal' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_produits_fournisseur_principal ON produits(fournisseur_principal_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_factures_mama' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_factures_mama ON factures(mama_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_factures_date' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_factures_date ON factures("date");
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_factures_fournisseur' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_factures_fournisseur ON factures(fournisseur_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_factures_statut' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_factures_statut ON factures(statut);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_fiches_mama' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_fiches_mama ON fiches(mama_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_fiches_nom' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_fiches_nom ON fiches(nom);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_fiches_actif' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_fiches_actif ON fiches(actif);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_fiches_famille' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_fiches_famille ON fiches(famille_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_inventaires_mama' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_inventaires_mama ON inventaires(mama_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_familles_mama' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_familles_mama ON familles(mama_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_unites_mama' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_unites_mama ON unites(mama_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_fournisseur_produits_mama' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_fournisseur_produits_mama ON fournisseur_produits(mama_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_fournisseur_produits_produit' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_fournisseur_produits_produit ON fournisseur_produits(produit_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_fournisseur_produits_fournisseur' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_fournisseur_produits_fournisseur ON fournisseur_produits(fournisseur_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_fournisseur_produits_produit_date' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_fournisseur_produits_produit_date ON fournisseur_produits(produit_id, date_livraison desc);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_facture_lignes_mama' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_facture_lignes_mama ON facture_lignes(mama_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_facture_lignes_facture' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_facture_lignes_facture ON facture_lignes(facture_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_facture_lignes_produit' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_facture_lignes_produit ON facture_lignes(produit_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_fiche_lignes_mama' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_fiche_lignes_mama ON fiche_lignes(mama_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_fiche_lignes_fiche' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_fiche_lignes_fiche ON fiche_lignes(fiche_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_fiche_lignes_produit' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_fiche_lignes_produit ON fiche_lignes(produit_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_fiche_cout_history_mama' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_fiche_cout_history_mama ON fiche_cout_history(mama_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_fiche_cout_history_fiche' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_fiche_cout_history_fiche ON fiche_cout_history(fiche_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_inventaire_lignes_mama' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_inventaire_lignes_mama ON inventaire_lignes(mama_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_inventaire_lignes_inventaire' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_inventaire_lignes_inventaire ON inventaire_lignes(inventaire_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_inventaire_lignes_produit' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_inventaire_lignes_produit ON inventaire_lignes(produit_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_parametres_mama' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_parametres_mama ON parametres(mama_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_fournisseur_contacts_mama' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_fournisseur_contacts_mama ON fournisseur_contacts(mama_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_fournisseur_contacts_fournisseur' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_fournisseur_contacts_fournisseur ON fournisseur_contacts(fournisseur_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_fournisseur_notes_mama' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_fournisseur_notes_mama ON fournisseur_notes(mama_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_fournisseur_notes_fournisseur' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_fournisseur_notes_fournisseur ON fournisseur_notes(fournisseur_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_permissions_mama' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_permissions_mama ON permissions(mama_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_permissions_role' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_permissions_role ON permissions(role_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_permissions_user' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_permissions_user ON permissions(user_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_menus_mama' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_menus_mama ON menus(mama_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_menus_date' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_menus_date ON menus("date");
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_menu_fiches_menu' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_menu_fiches_menu ON menu_fiches(menu_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_menu_fiches_fiche' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_menu_fiches_fiche ON menu_fiches(fiche_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_requisitions_mama' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_requisitions_mama ON requisitions(mama_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_requisitions_produit' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_requisitions_produit ON requisitions(produit_id);
+  END IF;
+END $$;
 DO $$
 BEGIN
   IF EXISTS (
     SELECT 1 FROM information_schema.columns
     WHERE table_name='requisitions' AND column_name='zone_id'
   ) THEN
-    CREATE INDEX IF NOT EXISTS idx_requisitions_zone ON requisitions(zone_id);
+    IF NOT EXISTS (
+      SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE c.relkind = 'i' AND c.relname = 'idx_requisitions_zone' AND n.nspname = 'public'
+    ) THEN
+      CREATE INDEX idx_requisitions_zone ON requisitions(zone_id);
+    END IF;
   END IF;
 END $$;
 DO $$
@@ -2564,9 +3457,33 @@ BEGIN
   END IF;
 END $$;
 
-create index if not exists idx_ft_carte on fiches_techniques(carte_actuelle, type_carte, sous_type_carte);
-create index if not exists idx_ft_prix on fiches_techniques(prix_vente);
-create index if not exists idx_ft_nom on fiches_techniques(nom);
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_ft_carte' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_ft_carte ON fiches_techniques(carte_actuelle, type_carte, sous_type_carte);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_ft_prix' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_ft_prix ON fiches_techniques(prix_vente);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_ft_nom' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_ft_nom ON fiches_techniques(nom);
+  END IF;
+END $$;
 
 alter table fiches_techniques enable row level security;
 alter table fiches_techniques force row level security;
@@ -2623,10 +3540,42 @@ values (
   'a49aeafd-6f60-4f68-a267-d7d27c1a1381',
   'admin@mamastock.com',
   crypt('vegeta', gen_salt('bf')),
-create index if not exists idx_mouvements_stock_mama on mouvements_stock(mama_id);
-create index if not exists idx_mouvements_stock_produit on mouvements_stock(produit_id);
-create index if not exists idx_mouvements_stock_date on mouvements_stock("date");
-create index if not exists idx_mouvements_stock_type on mouvements_stock(type);
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_mouvements_stock_mama' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_mouvements_stock_mama ON mouvements_stock(mama_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_mouvements_stock_produit' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_mouvements_stock_produit ON mouvements_stock(produit_id);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_mouvements_stock_date' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_mouvements_stock_date ON mouvements_stock("date");
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_mouvements_stock_type' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_mouvements_stock_type ON mouvements_stock(type);
+  END IF;
+END $$;
 
 -- Ajout de la colonne date_debut pour les inventaires
 DO $$
@@ -2639,12 +3588,52 @@ BEGIN
   END IF;
 END $$;
 
-create index if not exists idx_inventaires_date on inventaires("date");
-create index if not exists idx_inventaires_date_debut on inventaires(date_debut);
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_inventaires_date' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_inventaires_date ON inventaires("date");
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_inventaires_date_debut' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_inventaires_date_debut ON inventaires(date_debut);
+  END IF;
+END $$;
 
-create index if not exists idx_produits_famille_txt on produits(famille);
-create index if not exists idx_produits_unite_txt on produits(unite);
-create index if not exists idx_produits_code on produits(code);
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_produits_famille_txt' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_produits_famille_txt ON produits(famille);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_produits_unite_txt' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_produits_unite_txt ON produits(unite);
+  END IF;
+END $$;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_produits_code' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_produits_code ON produits(code);
+  END IF;
+END $$;
 
 -- Fonction de statistiques pour le tableau de bord
 create or replace function dashboard_stats(
@@ -2671,7 +3660,15 @@ grant execute on function top_produits(uuid, date, date, integer) to authenticat
 grant execute on function mouvements_without_alloc(integer) to authenticated;
 
 -- Index pour accélérer la recherche de factures
-create index if not exists idx_factures_reference on factures(reference);
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'i' AND c.relname = 'idx_factures_reference' AND n.nspname = 'public'
+  ) THEN
+    CREATE INDEX idx_factures_reference ON factures(reference);
+  END IF;
+END $$;
 
 -- Colonnes optionnelles sur mouvements_stock pour stocker les détails
 DO $$
@@ -2699,13 +3696,28 @@ END $$;
 DO $$
 BEGIN
   IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='mouvements_stock' AND column_name='sous_type') THEN
-    CREATE INDEX IF NOT EXISTS idx_mouvements_stock_sous_type ON mouvements_stock(sous_type);
+    IF NOT EXISTS (
+      SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE c.relkind = 'i' AND c.relname = 'idx_mouvements_stock_sous_type' AND n.nspname = 'public'
+    ) THEN
+      CREATE INDEX idx_mouvements_stock_sous_type ON mouvements_stock(sous_type);
+    END IF;
   END IF;
   IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='mouvements_stock' AND column_name='zone') THEN
-    CREATE INDEX IF NOT EXISTS idx_mouvements_stock_zone ON mouvements_stock(zone);
+    IF NOT EXISTS (
+      SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE c.relkind = 'i' AND c.relname = 'idx_mouvements_stock_zone' AND n.nspname = 'public'
+    ) THEN
+      CREATE INDEX idx_mouvements_stock_zone ON mouvements_stock(zone);
+    END IF;
   END IF;
   IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='mouvements_stock' AND column_name='motif') THEN
-    CREATE INDEX IF NOT EXISTS idx_mouvements_stock_motif ON mouvements_stock(motif);
+    IF NOT EXISTS (
+      SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE c.relkind = 'i' AND c.relname = 'idx_mouvements_stock_motif' AND n.nspname = 'public'
+    ) THEN
+      CREATE INDEX idx_mouvements_stock_motif ON mouvements_stock(motif);
+    END IF;
   END IF;
 END $$;
   (select id from roles where nom = 'admin'),


### PR DESCRIPTION
## Summary
- make full_setup.sql idempotent for index creation
- add pg_class/pg_namespace check before creating indexes

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f7b9cf690832d8276ac8dcf9c9f22