### PR TITLE
Align user roles with role_id

### DIFF
--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -11,6 +11,7 @@ export default function useAuth() {
     mama_id: ctx.userData?.mama_id ?? ctx.mama_id,
     access_rights: ctx.userData?.access_rights ?? ctx.access_rights,
     role: ctx.userData?.role ?? ctx.role,
+    role_id: ctx.userData?.role_id ?? ctx.role_id,
     email: ctx.userData?.email ?? ctx.email,
     actif: ctx.userData?.actif ?? ctx.actif,
     loading,

--- a/src/hooks/useUtilisateurs.js
+++ b/src/hooks/useUtilisateurs.js
@@ -19,7 +19,9 @@ export function useUtilisateurs() {
     setError(null);
     let query = supabase
       .from("utilisateurs")
-      .select("id, email, actif, mama_id, access_rights, role:roles(nom)")
+      .select(
+        "id, email, actif, mama_id, role_id, role:roles(nom), access_rights"
+      )
       .order("email", { ascending: true });
 
     if (role !== "superadmin") query = query.eq("mama_id", mama_id);
@@ -28,7 +30,11 @@ export function useUtilisateurs() {
     if (typeof actif === "boolean") query = query.eq("actif", actif);
 
     const { data, error } = await query;
-    setUsers(Array.isArray(data) ? data : []);
+    const cleaned = (Array.isArray(data) ? data : []).map(u => ({
+      ...u,
+      role: u.role?.nom ?? u.role,
+    }));
+    setUsers(cleaned);
     setLoading(false);
     if (error) setError(error);
     return data || [];

--- a/src/pages/parametrage/Utilisateurs.jsx
+++ b/src/pages/parametrage/Utilisateurs.jsx
@@ -48,7 +48,7 @@ export default function Utilisateurs() {
   const mapped = users.map(u => ({
     ...u,
     mamaNom: mamas.find(m => m.id === u.mama_id)?.nom || u.mama_id,
-    roleNom: roles.find(r => r.nom === u.role)?.nom || u.role,
+    roleNom: roles.find(r => r.id === u.role_id)?.nom || u.role,
   }));
   const filtres = mapped.filter(u =>
     (!search || u.email?.toLowerCase().includes(search.toLowerCase())) &&

--- a/test/useUtilisateurs.test.js
+++ b/test/useUtilisateurs.test.js
@@ -40,7 +40,7 @@ test('fetchUsers applies filters', async () => {
     await result.current.fetchUsers({ search: 'foo', actif: true, filterRole: 'admin' });
   });
   expect(fromMock).toHaveBeenCalledWith('utilisateurs');
-  expect(query.select).toHaveBeenCalledWith('id, email, actif, mama_id, access_rights, role:roles(nom)');
+  expect(query.select).toHaveBeenCalledWith('id, email, actif, mama_id, role_id, role:roles(nom), access_rights');
   expect(query.order).toHaveBeenCalledWith('email', { ascending: true });
   expect(query.eq.mock.calls).toContainEqual(['mama_id', 'm1']);
   expect(query.ilike).toHaveBeenCalledWith('email', '%foo%');


### PR DESCRIPTION
## Summary
- fetch role_id and join role name in `AuthContext`
- expose role_id from `useAuth`
- load role_id in user management hooks and pages
- update tests for new query string

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874040960cc832d85c7b6161e058b7e