### PR TITLE
Fix fiches techniques hooks and schema

### DIFF
--- a/db/Ajout.sql
+++ b/db/Ajout.sql
@@ -59,6 +59,19 @@ create policy feedback_all on feedback
   for all using (mama_id = current_user_mama_id())
   with check (mama_id = current_user_mama_id());
 
+-- Table fiches_techniques : alignement avec le front
+alter table if exists fiches_techniques
+  add column if not exists nom text,
+  add column if not exists famille_id uuid references familles(id),
+  add column if not exists portions numeric default 1,
+  add column if not exists rendement numeric,
+  add column if not exists prix_vente numeric,
+  add column if not exists carte_actuelle boolean default false,
+  add column if not exists type_carte text,
+  add column if not exists sous_type_carte text,
+  add column if not exists cout_total numeric,
+  add column if not exists cout_par_portion numeric;
+
 -- Table planning_previsionnel : alignement avec le front
 alter table if exists planning_previsionnel
   add column if not exists notes text,

--- a/src/hooks/useFiches.js
+++ b/src/hooks/useFiches.js
@@ -14,16 +14,17 @@ export function useFiches() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
 
-  // Liste paginée des fiches
-  async function getFiches({ search = "", actif = null, page = 1, limit = 20 } = {}) {
+  // Liste paginée des fiches techniques
+  async function getFiches({ search = "", actif = null, page = 1, limit = 20, sortBy = "nom", asc = true } = {}) {
     if (!mama_id) return [];
     setLoading(true);
     setError(null);
+    const sortField = ["nom", "cout_par_portion"].includes(sortBy) ? sortBy : "nom";
     let query = supabase
-      .from("fiches")
+      .from("fiches_techniques")
       .select("*, famille:familles(id, nom), lignes:fiche_lignes(id)", { count: "exact" })
       .eq("mama_id", mama_id)
-      .order("nom", { ascending: true })
+      .order(sortField, { ascending: asc })
       .range((page - 1) * limit, page * limit - 1);
     if (search) query = query.ilike("nom", `%${search}%`);
     if (typeof actif === "boolean") query = query.eq("actif", actif);
@@ -40,7 +41,7 @@ export function useFiches() {
     if (!id || !mama_id) return null;
     setLoading(true);
     const { data, error } = await supabase
-      .from("fiches")
+      .from("fiches_techniques")
       .select(
         "*, famille:familles(id, nom), lignes:fiche_lignes(*, produit:produits(id, nom, unite:unites(nom), pmp))"
       )
@@ -58,7 +59,7 @@ export function useFiches() {
     setLoading(true);
     setError(null);
     const { data, error: insertError } = await supabase
-      .from("fiches")
+      .from("fiches_techniques")
       .insert([{ ...fiche, mama_id }])
       .select("id")
       .single();
@@ -88,7 +89,7 @@ export function useFiches() {
     setLoading(true);
     setError(null);
     const { error: updateError } = await supabase
-      .from("fiches")
+      .from("fiches_techniques")
       .update(fiche)
       .eq("id", id)
       .eq("mama_id", mama_id);
@@ -127,7 +128,7 @@ export function useFiches() {
     setLoading(true);
     setError(null);
     const { error: deleteError } = await supabase
-      .from("fiches")
+      .from("fiches_techniques")
       .update({ actif: false })
       .eq("id", id)
       .eq("mama_id", mama_id);

--- a/src/pages/fiches/FicheDetail.jsx
+++ b/src/pages/fiches/FicheDetail.jsx
@@ -1,6 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState } from "react";
-import { useParams } from "react-router-dom";
+import { useParams, Navigate } from "react-router-dom";
+import { useAuth } from "@/context/AuthContext";
 import { Button } from "@/components/ui/button";
 import * as XLSX from "xlsx";
 import jsPDF from "jspdf";
@@ -13,6 +14,7 @@ import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip } from "rec
 export default function FicheDetail({ fiche: ficheProp, onClose }) {
   const { id: routeId } = useParams();
   const { getFicheById } = useFiches();
+  const { access_rights } = useAuth();
   const [fiche, setFiche] = useState(ficheProp || null);
   const { history, fetchFicheCoutHistory } = useFicheCoutHistory();
   const [simPrix, setSimPrix] = useState(null);
@@ -32,6 +34,10 @@ export default function FicheDetail({ fiche: ficheProp, onClose }) {
   }, [fiche?.id, fetchFicheCoutHistory, fiche?.prix_vente]);
 
   if (!fiche) return <LoadingSpinner message="Chargement..." />;
+
+  if (!access_rights?.fiches_techniques?.peut_voir) {
+    return <Navigate to="/unauthorized" replace />;
+  }
 
   function exportExcel() {
     const rows = fiche.lignes?.map(l => ({

--- a/src/pages/fiches/FicheForm.jsx
+++ b/src/pages/fiches/FicheForm.jsx
@@ -1,5 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useEffect } from "react";
+import { Navigate } from "react-router-dom";
+import { useAuth } from "@/context/AuthContext";
 import { useFiches } from "@/hooks/useFiches";
 import { useProducts } from "@/hooks/useProducts";
 import { useFamilles } from "@/hooks/useFamilles";
@@ -10,6 +12,7 @@ import { Button } from "@/components/ui/button";
 import toast from "react-hot-toast";
 
 export default function FicheForm({ fiche, onClose }) {
+  const { access_rights } = useAuth();
   const { createFiche, updateFiche } = useFiches();
   const { products, fetchProducts } = useProducts();
   const { familles, fetchFamilles } = useFamilles();
@@ -22,6 +25,10 @@ export default function FicheForm({ fiche, onClose }) {
   );
   const [prixVente, setPrixVente] = useState(fiche?.prix_vente || 0);
   const [loading, setLoading] = useState(false);
+
+  if (!access_rights?.fiches_techniques?.peut_voir) {
+    return <Navigate to="/unauthorized" replace />;
+  }
 
   const { results: prodOptions, searchProduits } = useProduitsAutocomplete();
   const { results: ficheOptions, searchFiches } = useFichesAutocomplete();

--- a/src/pages/fiches/Fiches.jsx
+++ b/src/pages/fiches/Fiches.jsx
@@ -1,5 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState } from "react";
+import { Navigate } from "react-router-dom";
 import { useFiches } from "@/hooks/useFiches";
 import { useAuth } from "@/context/AuthContext";
 import FicheForm from "./FicheForm.jsx";
@@ -22,19 +23,20 @@ export default function Fiches() {
     exportFichesToExcel,
     exportFichesToPDF,
   } = useFiches();
-  const { mama_id, loading: authLoading } = useAuth();
+  const { mama_id, loading: authLoading, access_rights } = useAuth();
   const [showForm, setShowForm] = useState(false);
   const [showDetail, setShowDetail] = useState(false);
   const [selected, setSelected] = useState(null);
   const [search, setSearch] = useState("");
   const [page, setPage] = useState(1);
+  const [sortBy, setSortBy] = useState("nom");
 
   // Chargement
   useEffect(() => {
     if (!authLoading && mama_id) {
-      getFiches({ search, page, limit: PAGE_SIZE });
+      getFiches({ search, page, limit: PAGE_SIZE, sortBy });
     }
-  }, [authLoading, mama_id, search, page, getFiches]);
+  }, [authLoading, mama_id, search, page, sortBy, getFiches]);
 
   const exportExcel = () => exportFichesToExcel();
   const exportPdf = () => exportFichesToPDF();
@@ -42,6 +44,10 @@ export default function Fiches() {
   const fichesFiltres = fiches;
   if (authLoading || loading) {
     return <LoadingSpinner message="Chargement..." />;
+  }
+
+  if (!access_rights?.fiches_techniques?.peut_voir) {
+    return <Navigate to="/unauthorized" replace />;
   }
 
 
@@ -57,6 +63,14 @@ export default function Fiches() {
           className="input"
           placeholder="Recherche fiche"
         />
+        <select
+          className="input"
+          value={sortBy}
+          onChange={e => setSortBy(e.target.value)}
+        >
+          <option value="nom">Tri: Nom</option>
+          <option value="cout_par_portion">Tri: Coût/portion</option>
+        </select>
         {/* Ajout d’un filtre famille si besoin */}
         <Button onClick={() => { setSelected(null); setShowForm(true); }}>
           Ajouter une fiche


### PR DESCRIPTION
## Summary
- use correct `fiches_techniques` table in hooks with sorting option
- restrict views using `access_rights.fiches_techniques.peut_voir`
- allow sorting by cost or name on fiche list
- add missing columns for fiches techniques in schema update script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b654a4b94832dac7da9293830aba9