### PR TITLE
Implement fournisseurs module routes and RLS

### DIFF
--- a/db/Ajout.sql
+++ b/db/Ajout.sql
@@ -43,7 +43,14 @@ alter table if exists mamas
 alter table if exists fournisseurs
   add column if not exists ville text,
   add column if not exists tel text,
+  add column if not exists email text,
   add column if not exists contact text;
+alter table if exists fournisseurs enable row level security;
+alter table if exists fournisseurs force row level security;
+drop policy if exists fournisseurs_all on fournisseurs;
+create policy fournisseurs_all on fournisseurs
+  for all using (mama_id = (select mama_id FROM utilisateurs WHERE auth_id = auth.uid()))
+  with check (mama_id = (select mama_id FROM utilisateurs WHERE auth_id = auth.uid()));
 
 -- Table feedback : alignement avec les besoins du front
 alter table if exists feedback
@@ -310,6 +317,20 @@ alter table if exists fournisseur_produits enable row level security;
 alter table if exists fournisseur_produits force row level security;
 drop policy if exists fournisseur_produits_all on fournisseur_produits;
 create policy fournisseur_produits_all on fournisseur_produits
+  for all using (mama_id = (select mama_id FROM utilisateurs WHERE auth_id = auth.uid()))
+  with check (mama_id = (select mama_id FROM utilisateurs WHERE auth_id = auth.uid()));
+
+alter table if exists factures enable row level security;
+alter table if exists factures force row level security;
+drop policy if exists factures_all on factures;
+create policy factures_all on factures
+  for all using (mama_id = (select mama_id FROM utilisateurs WHERE auth_id = auth.uid()))
+  with check (mama_id = (select mama_id FROM utilisateurs WHERE auth_id = auth.uid()));
+
+alter table if exists facture_lignes enable row level security;
+alter table if exists facture_lignes force row level security;
+drop policy if exists facture_lignes_all on facture_lignes;
+create policy facture_lignes_all on facture_lignes
   for all using (mama_id = (select mama_id FROM utilisateurs WHERE auth_id = auth.uid()))
   with check (mama_id = (select mama_id FROM utilisateurs WHERE auth_id = auth.uid()));
 

--- a/src/pages/fournisseurs/FournisseurCreate.jsx
+++ b/src/pages/fournisseurs/FournisseurCreate.jsx
@@ -1,0 +1,16 @@
+import { useNavigate } from "react-router-dom";
+import SupplierForm from "@/components/fournisseurs/SupplierForm";
+import GlassCard from "@/components/ui/GlassCard";
+import { LiquidBackground } from "@/components/LiquidBackground";
+
+export default function FournisseurCreate() {
+  const navigate = useNavigate();
+  return (
+    <div className="relative min-h-screen flex items-center justify-center overflow-hidden p-6 text-white">
+      <LiquidBackground showParticles />
+      <GlassCard className="relative z-10">
+        <SupplierForm onClose={() => navigate(-1)} glass />
+      </GlassCard>
+    </div>
+  );
+}

--- a/src/pages/fournisseurs/FournisseurDetailPage.jsx
+++ b/src/pages/fournisseurs/FournisseurDetailPage.jsx
@@ -1,0 +1,17 @@
+import { useParams } from "react-router-dom";
+import GlassCard from "@/components/ui/GlassCard";
+import { LiquidBackground } from "@/components/LiquidBackground";
+import FournisseurDetail from "./FournisseurDetail";
+
+export default function FournisseurDetailPage() {
+  const { id } = useParams();
+  if (!id) return null;
+  return (
+    <div className="relative min-h-screen flex items-center justify-center overflow-hidden p-6 text-white">
+      <LiquidBackground showParticles />
+      <GlassCard className="relative z-10 w-full max-w-4xl">
+        <FournisseurDetail id={id} />
+      </GlassCard>
+    </div>
+  );
+}

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -15,6 +15,8 @@ import ProtectedRoute from "@/components/ProtectedRoute";
 
 const Dashboard = lazy(() => import("@/pages/Dashboard.jsx"));
 const Fournisseurs = lazy(() => import("@/pages/fournisseurs/Fournisseurs.jsx"));
+const FournisseurCreate = lazy(() => import("@/pages/fournisseurs/FournisseurCreate.jsx"));
+const FournisseurDetailPage = lazy(() => import("@/pages/fournisseurs/FournisseurDetailPage.jsx"));
 const Factures = lazy(() => import("@/pages/factures/Factures.jsx"));
 const FactureDetail = lazy(() => import("@/pages/factures/FactureDetail.jsx"));
 const ImportFactures = lazy(() => import("@/pages/factures/ImportFactures.jsx"));
@@ -125,6 +127,14 @@ export default function Router() {
           <Route
             path="/fournisseurs"
             element={<ProtectedRoute accessKey="fournisseurs"><Fournisseurs /></ProtectedRoute>}
+          />
+          <Route
+            path="/fournisseurs/nouveau"
+            element={<ProtectedRoute accessKey="fournisseurs"><FournisseurCreate /></ProtectedRoute>}
+          />
+          <Route
+            path="/fournisseurs/:id"
+            element={<ProtectedRoute accessKey="fournisseurs"><FournisseurDetailPage /></ProtectedRoute>}
           />
           <Route
             path="/fournisseurs/:id/api"


### PR DESCRIPTION
## Summary
- extend DB script for fournisseurs with email column and row-level security
- enable RLS on factures and facture_lignes
- create pages for creating and viewing suppliers
- wire new pages into router

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687b93e19420832d93973e075e8799c0