### PR TITLE
Implement requisitions module

### DIFF
--- a/.codex_progress.json
+++ b/.codex_progress.json
@@ -3,7 +3,7 @@
     "/receptions",
     "/recettes",
     "/requisitions",
-    "/requisitions/new",
+    "/requisitions/nouvelle",
     "/requisitions/:id",
     "/tableaux-de-bord",
     "/comparatif",

--- a/src/hooks/useStockRequisitionne.js
+++ b/src/hooks/useStockRequisitionne.js
@@ -1,0 +1,34 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { useState, useEffect } from "react";
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/context/AuthContext";
+
+export function useStockRequisitionne() {
+  const { mama_id } = useAuth();
+  const [stock, setStock] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  async function fetchStock() {
+    if (!mama_id) return [];
+    setLoading(true);
+    const { data, error } = await supabase
+      .from("v_stock_requisitionne")
+      .select("*")
+      .eq("mama_id", mama_id);
+    setLoading(false);
+    if (error) {
+      console.error("❌ Erreur fetchStockRequisitionne:", error.message);
+      return [];
+    }
+    setStock(data || []);
+    return data || [];
+  }
+
+  useEffect(() => {
+    fetchStock();
+  }, [mama_id]);
+
+  return { stock, fetchStock, loading };
+}
+
+export default useStockRequisitionne;

--- a/src/pages/requisitions/RequisitionDetail.jsx
+++ b/src/pages/requisitions/RequisitionDetail.jsx
@@ -27,22 +27,27 @@ function RequisitionDetailPage() {
       <h1 className="text-3xl font-bold text-mamastock-gold mb-6">Détail de la réquisition</h1>
       <GlassCard className="p-4 space-y-2">
         <div>
-          <strong>Type :</strong> {requisition.type}
+          <strong>Statut :</strong> {requisition.statut}
         </div>
         <div>
-          <strong>Date :</strong> {requisition.date_requisition}
+          <strong>Date :</strong> {requisition.date}
         </div>
         <div>
-          <strong>Zone :</strong> {requisition.zone_id}
+          <strong>Zone source :</strong> {requisition.zone_source_id}
         </div>
         <div>
-          <strong>Produit :</strong> {requisition.produit_id}
-        </div>
-        <div>
-          <strong>Quantité :</strong> {requisition.quantite}
+          <strong>Zone destination :</strong> {requisition.zone_destination_id}
         </div>
         <div>
           <strong>Commentaire :</strong> {requisition.commentaire}
+        </div>
+        <div>
+          <strong>Lignes :</strong>
+          <ul className="list-disc ml-5">
+            {(requisition.lignes || []).map((l) => (
+              <li key={l.id}>{l.produit_id} - {l.quantite}</li>
+            ))}
+          </ul>
         </div>
       </GlassCard>
     </div>

--- a/src/pages/requisitions/RequisitionForm.jsx
+++ b/src/pages/requisitions/RequisitionForm.jsx
@@ -16,9 +16,10 @@ function RequisitionFormPage() {
   const { products, loading: loadingProducts } = useProducts();
   const { zones, fetchZones } = useZones();
 
-  const [type, setType] = useState("");
+  const [statut, setStatut] = useState("");
   const [commentaire, setCommentaire] = useState("");
-  const [zone_id, setZone] = useState("");
+  const [zone_source_id, setZoneSource] = useState("");
+  const [zone_destination_id, setZoneDest] = useState("");
   const [articles, setArticles] = useState([{ produit_id: "", quantite: 1 }]);
   const [submitting, setSubmitting] = useState(false);
 
@@ -36,24 +37,22 @@ function RequisitionFormPage() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    if (!type || !zone_id || articles.some(a => !a.produit_id || !a.quantite)) {
+    if (!statut || !zone_destination_id || articles.some(a => !a.produit_id || !a.quantite)) {
       toast.error("Tous les champs sont obligatoires");
       return;
     }
     if (submitting) return;
-    const payloads = articles.map(a => ({
-      produit_id: a.produit_id,
-      quantite: Number(a.quantite),
-      zone_id,
-      type,
+    const payload = {
+      statut,
       commentaire,
-    }));
+      zone_source_id: zone_source_id || null,
+      zone_destination_id,
+      lignes: articles.map(a => ({ produit_id: a.produit_id, quantite: a.quantite })),
+    };
     try {
       setSubmitting(true);
-      for (const p of payloads) {
-        const { error } = await createRequisition(p);
-        if (error) throw new Error(error.message);
-      }
+      const { error } = await createRequisition(payload);
+      if (error) throw new Error(error.message);
       toast.success("Réquisition créée !");
       navigate("/requisitions");
     } catch (err) {
@@ -75,11 +74,11 @@ function RequisitionFormPage() {
         <form onSubmit={handleSubmit} className="space-y-4">
 
         <div>
-          <label className="block text-sm font-medium mb-1">Type</label>
+          <label className="block text-sm font-medium mb-1">Statut</label>
           <input
             type="text"
-            value={type}
-            onChange={(e) => setType(e.target.value)}
+            value={statut}
+            onChange={(e) => setStatut(e.target.value)}
             className="w-full border rounded px-3 py-2"
             required
           />
@@ -95,21 +94,34 @@ function RequisitionFormPage() {
           />
         </div>
 
-        <div>
-          <label className="block text-sm font-medium mb-1">Zone</label>
-          <select
-            value={zone_id}
-            onChange={(e) => setZone(e.target.value)}
-            className="w-full border rounded px-3 py-2"
-            required
-          >
-            <option value="">Sélectionner…</option>
-            {zones.map((z) => (
-              <option key={z.id} value={z.id}>
-                {z.nom}
-              </option>
-            ))}
-          </select>
+        <div className="flex gap-4">
+          <div className="flex-1">
+            <label className="block text-sm font-medium mb-1">Zone source</label>
+            <select
+              value={zone_source_id}
+              onChange={(e) => setZoneSource(e.target.value)}
+              className="w-full border rounded px-3 py-2"
+            >
+              <option value="">Sélectionner…</option>
+              {zones.map((z) => (
+                <option key={z.id} value={z.id}>{z.nom}</option>
+              ))}
+            </select>
+          </div>
+          <div className="flex-1">
+            <label className="block text-sm font-medium mb-1">Zone destination</label>
+            <select
+              value={zone_destination_id}
+              onChange={(e) => setZoneDest(e.target.value)}
+              className="w-full border rounded px-3 py-2"
+              required
+            >
+              <option value="">Sélectionner…</option>
+              {zones.map((z) => (
+                <option key={z.id} value={z.id}>{z.nom}</option>
+              ))}
+            </select>
+          </div>
         </div>
 
         <div>

--- a/src/pages/requisitions/Requisitions.jsx
+++ b/src/pages/requisitions/Requisitions.jsx
@@ -1,97 +1,49 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useEffect } from "react";
-import { supabase } from "@/lib/supabase";
 import { useAuth } from "@/context/AuthContext";
 import { useZones } from "@/hooks/useZones";
+import { useRequisitions } from "@/hooks/useRequisitions";
 import toast, { Toaster } from "react-hot-toast";
 import * as XLSX from "xlsx";
 import jsPDF from "jspdf";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 import "jspdf-autotable";
 import { Button } from "@/components/ui/button";
-import { Dialog, DialogTrigger, DialogContent } from "@radix-ui/react-dialog";
+import { Link } from "react-router-dom";
 
 export default function Requisitions() {
-  const { mama_id, user_id, loading: authLoading } = useAuth();
+  const { mama_id, loading: authLoading } = useAuth();
   const { zones, fetchZones } = useZones();
+  const { getRequisitions } = useRequisitions();
   const [requisitions, setRequisitions] = useState([]);
-  const [produits, setProduits] = useState([]);
-  const [search, setSearch] = useState("");
+  const [statut, setStatut] = useState("");
+  const [zone, setZone] = useState("");
+  const [page, setPage] = useState(1);
+  const [total, setTotal] = useState(0);
   const [periode, setPeriode] = useState({ debut: "", fin: "" });
-  const [showCreate, setShowCreate] = useState(false);
-  const [createReq, setCreateReq] = useState({ produit_id: "", quantite: 0, zone_id: "", commentaire: "", type: "" });
-  const [saving, setSaving] = useState(false);
 
   useEffect(() => {
     if (!mama_id || authLoading) return;
-    supabase.from("produits").select("*").eq("mama_id", mama_id)
-      .then(({ data }) => setProduits(data || []));
     fetchZones();
   }, [mama_id, authLoading]);
 
   useEffect(() => {
     if (!mama_id || authLoading || !periode.debut || !periode.fin) return;
-    supabase
-      .from("requisitions")
-      .select("*")
-      .eq("mama_id", mama_id)
-      .gte("date_requisition", periode.debut)
-      .lte("date_requisition", periode.fin)
-      .order("date_requisition", { ascending: false })
-      .then(({ data }) => setRequisitions(data || []));
-  }, [mama_id, authLoading, periode]);
+    getRequisitions({ zone, statut, debut: periode.debut, fin: periode.fin, page })
+      .then(({ data, count }) => { setRequisitions(data); setTotal(count); });
+  }, [mama_id, authLoading, periode, zone, statut, page]);
 
-  const filtered = requisitions.filter(
-    r =>
-      produits.find(p => p.id === r.produit_id)?.nom?.toLowerCase().includes(search.toLowerCase()) ||
-      zones.find(z => z.id === r.zone_id)?.nom?.toLowerCase().includes(search.toLowerCase()) ||
-      (r.commentaire || "").toLowerCase().includes(search.toLowerCase())
-  );
+  const filtered = requisitions;
 
-  // Saisie
-  const handleCreateReq = async e => {
-    e.preventDefault();
-    if (!createReq.produit_id || !createReq.quantite) {
-      toast.error("Sélectionne un produit et une quantité !");
-      return;
-    }
-    if (Number(createReq.quantite) <= 0) {
-      toast.error("Quantité invalide");
-      return;
-    }
-    setSaving(true);
-    const { error } = await supabase.from("requisitions").insert([
-      {
-        produit_id: createReq.produit_id,
-        quantite: Number(createReq.quantite),
-        zone_id: createReq.zone_id,
-        commentaire: createReq.commentaire,
-        mama_id,
-        auteur_id: user_id,
-        date_requisition: new Date().toISOString().slice(0, 10),
-        type: createReq.type || "",
-      },
-    ]);
-    if (!error) {
-      setShowCreate(false);
-      setCreateReq({ produit_id: "", quantite: 0, zone_id: "", commentaire: "", type: "" });
-      toast.success("Réquisition créée !");
-      setPeriode(p => ({ ...p }));
-    } else {
-      toast.error(error.message);
-    }
-    setSaving(false);
-  };
 
   // Export Excel
   const handleExportExcel = () => {
     const ws = XLSX.utils.json_to_sheet(
       filtered.map(r => ({
-        Produit: produits.find(p => p.id === r.produit_id)?.nom || "-",
-        Date: r.date_requisition,
-        Quantité: r.quantite,
-        Zone: zones.find(z => z.id === r.zone_id)?.nom || "-",
-        Commentaire: r.commentaire,
+        Numero: r.numero,
+        Date: r.date,
+        Statut: r.statut,
+        Zone: zones.find(z => z.id === r.zone_destination_id)?.nom || "-",
       }))
     );
     const wb = XLSX.utils.book_new();
@@ -106,13 +58,12 @@ export default function Requisitions() {
     doc.text("Historique Réquisitions", 10, 12);
     doc.autoTable({
       startY: 20,
-      head: [["Produit", "Date", "Quantité", "Zone", "Commentaire"]],
+      head: [["Numero", "Date", "Statut", "Zone"]],
       body: filtered.map(r => [
-        produits.find(p => p.id === r.produit_id)?.nom || "-",
-        r.date_requisition,
-        r.quantite,
-        zones.find(z => z.id === r.zone_id)?.nom || "-",
-        r.commentaire,
+        r.numero,
+        r.date,
+        r.statut,
+        zones.find(z => z.id === r.zone_destination_id)?.nom || "-",
       ]),
       styles: { fontSize: 9 },
     });
@@ -149,115 +100,58 @@ export default function Requisitions() {
             max={today}
           />
         </div>
-        <input
-          className="input input-bordered w-64"
-          placeholder="Recherche produit, zone ou commentaire"
-          value={search}
-          onChange={e => setSearch(e.target.value)}
-        />
+        <div>
+          <label className="block font-medium">Zone</label>
+          <select
+            className="input input-bordered"
+            value={zone}
+            onChange={e => setZone(e.target.value)}
+          >
+            <option value="">Toutes</option>
+            {zones.map(z => (
+              <option key={z.id} value={z.id}>{z.nom}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block font-medium">Statut</label>
+          <input
+            className="input input-bordered"
+            value={statut}
+            onChange={e => setStatut(e.target.value)}
+          />
+        </div>
         <Button onClick={handleExportExcel}>Export Excel</Button>
         <Button onClick={handleExportPDF}>Export PDF</Button>
-        <Button onClick={() => setShowCreate(true)}>+ Nouvelle réquisition</Button>
+        <Link to="/requisitions/nouvelle" className="btn">+ Nouvelle réquisition</Link>
       </div>
       <div className="bg-glass border border-borderGlass backdrop-blur shadow rounded-xl overflow-x-auto">
         <table className="min-w-full table-auto text-center">
           <thead>
             <tr>
+              <th className="px-2 py-1">Numéro</th>
               <th className="px-2 py-1">Date</th>
-              <th className="px-2 py-1">Produit</th>
-              <th className="px-2 py-1">Quantité</th>
-              <th className="px-2 py-1">Zone</th>
-              <th className="px-2 py-1">Commentaire</th>
+              <th className="px-2 py-1">Statut</th>
+              <th className="px-2 py-1">Zone destination</th>
             </tr>
           </thead>
           <tbody>
             {filtered.map(r => (
               <tr key={r.id}>
-                <td className="px-2 py-1">{r.date_requisition}</td>
-                <td className="px-2 py-1">
-                  {produits.find(p => p.id === r.produit_id)?.nom || "-"}
-                </td>
-                <td className="px-2 py-1">{r.quantite}</td>
-                <td className="px-2 py-1">{zones.find(z => z.id === r.zone_id)?.nom || '-'}</td>
-                <td className="px-2 py-1">{r.commentaire}</td>
+                <td className="px-2 py-1">{r.numero}</td>
+                <td className="px-2 py-1">{r.date}</td>
+                <td className="px-2 py-1">{r.statut}</td>
+                <td className="px-2 py-1">{zones.find(z => z.id === r.zone_destination_id)?.nom || '-'}</td>
               </tr>
             ))}
           </tbody>
         </table>
       </div>
-      {/* Modal création réquisition */}
-      <Dialog open={showCreate} onOpenChange={v => !v && setShowCreate(false)}>
-        <DialogContent className="bg-glass border border-borderGlass backdrop-blur rounded-2xl shadow-lg p-6 max-w-md">
-          <h2 className="font-bold mb-2">Nouvelle réquisition</h2>
-          <form
-            onSubmit={handleCreateReq}
-            className="space-y-3"
-          >
-            <div>
-              <label>Produit</label>
-              <select
-                className="input input-bordered w-full"
-                value={createReq.produit_id}
-                onChange={e =>
-                  setCreateReq(r => ({ ...r, produit_id: e.target.value }))
-                }
-              >
-                <option value="">Sélectionne…</option>
-                {produits.map(p => (
-                  <option key={p.id} value={p.id}>
-                    {p.nom}
-                  </option>
-                ))}
-              </select>
-            </div>
-            <div>
-              <label>Quantité</label>
-              <input
-                type="number"
-                className="input input-bordered w-24"
-                value={createReq.quantite}
-                onChange={e =>
-                  setCreateReq(r => ({ ...r, quantite: e.target.value }))
-                }
-                min={0}
-              />
-            </div>
-            <div>
-              <label>Zone</label>
-              <select
-                className="input input-bordered w-full"
-                value={createReq.zone_id}
-                onChange={e => setCreateReq(r => ({ ...r, zone_id: e.target.value }))}
-              >
-                <option value="">Sélectionner…</option>
-                {zones.map(z => (
-                  <option key={z.id} value={z.id}>{z.nom}</option>
-                ))}
-              </select>
-            </div>
-            <div>
-              <label>Type de service</label>
-              <input
-                className="input input-bordered w-full"
-                value={createReq.type}
-                onChange={e => setCreateReq(r => ({ ...r, type: e.target.value }))}
-              />
-            </div>
-            <div>
-              <label>Commentaire</label>
-              <textarea
-                className="input input-bordered w-full"
-                value={createReq.commentaire}
-                rows={2}
-                onChange={e =>
-                  setCreateReq(r => ({ ...r, commentaire: e.target.value }))
-                }
-              />
-            </div>
-            <Button type="submit" disabled={saving}>Créer</Button>
-          </form>
-        </DialogContent>
-      </Dialog>
+      <div className="flex justify-between items-center mt-4">
+        <Button disabled={page === 1} onClick={() => setPage(p => Math.max(1, p - 1))}>Précédent</Button>
+        <span>Page {page}</span>
+        <Button disabled={page * 10 >= total} onClick={() => setPage(p => p + 1)}>Suivant</Button>
+      </div>
     </div>
   );
 }

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -201,7 +201,7 @@ export default function Router() {
             element={<ProtectedRoute accessKey="requisitions"><Requisitions /></ProtectedRoute>}
           />
           <Route
-            path="/requisitions/new"
+            path="/requisitions/nouvelle"
             element={<ProtectedRoute accessKey="requisitions"><RequisitionForm /></ProtectedRoute>}
           />
           <Route

--- a/test/useStockRequisitionne.test.js
+++ b/test/useStockRequisitionne.test.js
@@ -1,0 +1,27 @@
+import { renderHook, act } from '@testing-library/react';
+import { vi, beforeEach, test, expect } from 'vitest';
+
+const queryObj = {
+  select: vi.fn(() => queryObj),
+  eq: vi.fn(() => ({ then: fn => Promise.resolve(fn({ data: [], error: null })) })),
+};
+const fromMock = vi.fn(() => queryObj);
+vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
+vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
+
+let useStockRequisitionne;
+
+beforeEach(async () => {
+  ({ useStockRequisitionne } = await import('@/hooks/useStockRequisitionne'));
+  fromMock.mockClear();
+  queryObj.select.mockClear();
+  queryObj.eq.mockClear();
+});
+
+test('fetchStock queries view with mama_id', async () => {
+  const { result } = renderHook(() => useStockRequisitionne());
+  await act(async () => { await result.current.fetchStock(); });
+  expect(fromMock).toHaveBeenCalledWith('v_stock_requisitionne');
+  expect(queryObj.select).toHaveBeenCalledWith('*');
+  expect(queryObj.eq).toHaveBeenCalledWith('mama_id', 'm1');
+});


### PR DESCRIPTION
## Summary
- add requisitions tables and view in Ajout.sql
- provide hook `useStockRequisitionne`
- overhaul requisition hooks and pages
- add tests for requisitions hooks
- route `/requisitions/nouvelle`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687b9d3f3b7c832dbc61196de1375900