### PR TITLE
Add Menu Engineering matrix and sidebar link

### DIFF
--- a/src/components/fiches/FicheRentabiliteCard.jsx
+++ b/src/components/fiches/FicheRentabiliteCard.jsx
@@ -6,6 +6,7 @@ export default function FicheRentabiliteCard({ fiche }) {
     nom,
     cout_portion,
     prix_vente,
+    ventes,
     marge,
     score_calc,
     classement,
@@ -15,6 +16,7 @@ export default function FicheRentabiliteCard({ fiche }) {
       <div className="font-semibold mb-1">{nom}</div>
       <div className="text-sm">Coût: {cout_portion?.toFixed(2)} €</div>
       <div className="text-sm">Prix: {prix_vente?.toFixed(2)} €</div>
+      <div className="text-sm">Ventes: {ventes}</div>
       <div className="text-sm">Marge: {marge?.toFixed(1)}%</div>
       <div className="text-sm">Score: {score_calc}</div>
       <div className="text-xs italic">{classement}</div>

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -61,18 +61,16 @@ export default function Sidebar() {
           </details>
         )}
 
-        {(has("documents") || has("analyse")) && (
-          <details open={pathname.startsWith("/documents") || pathname.startsWith("/analyse") || pathname.startsWith("/engineering")}>
+        {(has("documents") || has("analyse") || has("menu_engineering")) && (
+          <details open={pathname.startsWith("/documents") || pathname.startsWith("/analyse") || pathname.startsWith("/engineering") || pathname.startsWith("/menu-engineering")}>
             <summary className="cursor-pointer">Documents / Analyse</summary>
             <div className="ml-4 flex flex-col gap-1 mt-1">
               {has("documents") && <Link to="/documents">Documents</Link>}
-              {has("analyse") && (
-                <>
-                  <Link to="/analyse">Analyse</Link>
-                  <Link to="/analyse/menu-engineering">Menu Engineering</Link>
-                  <Link to="/engineering">Engineering</Link>
-                </>
+              {has("analyse") && <Link to="/analyse">Analyse</Link>}
+              {has("menu_engineering") && (
+                <Link to="/menu-engineering">Menu Engineering</Link>
               )}
+              {has("analyse") && <Link to="/engineering">Engineering</Link>}
             </div>
           </details>
         )}

--- a/src/pages/MenuEngineering.jsx
+++ b/src/pages/MenuEngineering.jsx
@@ -1,10 +1,23 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { useEffect, useState } from 'react';
-import { useMenuEngineering } from '@/hooks/useMenuEngineering';
-import { Toaster, toast } from 'react-hot-toast';
-import { Button } from '@/components/ui/button';
-import { useAuth } from '@/context/AuthContext';
-import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
+import { useEffect, useState } from 'react'
+import { useMenuEngineering } from '@/hooks/useMenuEngineering'
+import { Toaster, toast } from 'react-hot-toast'
+import { Button } from '@/components/ui/button'
+import { useAuth } from '@/context/AuthContext'
+import { LoadingSpinner } from '@/components/ui/LoadingSpinner'
+import {
+  ResponsiveContainer,
+  ScatterChart,
+  Scatter,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ReferenceLine,
+} from 'recharts'
+import FicheRentabiliteCard from '@/components/fiches/FicheRentabiliteCard'
+import html2canvas from 'html2canvas'
+import jsPDF from 'jspdf'
 
 function classify(items) {
   const ventes = items.map(i => i.ventes).sort((a,b)=>a-b);
@@ -26,15 +39,16 @@ export default function MenuEngineering() {
     const d = new Date();
     return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-01`;
   });
-  const { fetchData, saveVente } = useMenuEngineering();
-  const { mama_id, loading: authLoading } = useAuth();
-  const [rows, setRows] = useState([]);
+  const { fetchData, saveVente } = useMenuEngineering()
+  const { mama_id, loading: authLoading } = useAuth()
+  const [rows, setRows] = useState([])
+  const [filters, setFilters] = useState({ categorie: '', performance: '', marge: '' })
 
   useEffect(() => {
     if (!authLoading && mama_id) {
-      fetchData(periode).then(res => setRows(classify(res)));
+      fetchData(periode).then(res => setRows(classify(res)))
     }
-  }, [periode, fetchData, authLoading, mama_id]);
+  }, [periode, fetchData, authLoading, mama_id])
 
   const handleChange = async (fiche, val) => {
     await saveVente(fiche.id, periode, Number(val));
@@ -43,16 +57,86 @@ export default function MenuEngineering() {
     setRows(classify(res));
   };
 
+  const filtered = rows.filter(r => {
+    if (filters.categorie && r.famille !== filters.categorie) return false
+    if (filters.performance && r.classement !== filters.performance) return false
+    if (filters.marge && r.marge < Number(filters.marge)) return false
+    return true
+  })
+
+  const median = arr => {
+    const s = [...arr].sort((a,b) => a - b)
+    return s.length ? s[Math.floor(s.length / 2)] : 0
+  }
+
+  const medianPop = median(filtered.map(d => d.popularite * 100))
+  const medianMarge = median(filtered.map(d => d.marge))
+
+  const exportPdf = async () => {
+    const el = document.getElementById('matrix')
+    if (!el) return
+    const canvas = await html2canvas(el)
+    const pdf = new jsPDF()
+    const img = canvas.toDataURL('image/png')
+    pdf.addImage(img, 'PNG', 10, 10, 190, 0)
+    pdf.save('menu_engineering.pdf')
+  }
+
   if (authLoading) return <LoadingSpinner message="Chargement..." />;
   if (!mama_id) return null;
 
   return (
-    <div className="p-8 max-w-4xl mx-auto">
+    <div className="p-8 max-w-5xl mx-auto space-y-4">
       <Toaster />
-      <h1 className="text-2xl font-bold mb-4">Menu Engineering</h1>
-      <div className="flex items-center gap-2 mb-4">
-        <input type="month" value={periode.slice(0,7)} onChange={e => setPeriode(e.target.value+'-01')} className="input" />
-        <Button onClick={() => fetchData(periode).then(res => setRows(classify(res)))}>Rafraîchir</Button>
+      <h1 className="text-2xl font-bold">Menu Engineering</h1>
+      <div className="flex flex-wrap items-center gap-2">
+        <input
+          type="month"
+          value={periode.slice(0, 7)}
+          onChange={e => setPeriode(e.target.value + '-01')}
+          className="input"
+        />
+        <input
+          className="input"
+          placeholder="Catégorie"
+          value={filters.categorie}
+          onChange={e => setFilters(f => ({ ...f, categorie: e.target.value }))}
+        />
+        <select
+          className="input"
+          value={filters.performance}
+          onChange={e => setFilters(f => ({ ...f, performance: e.target.value }))}
+        >
+          <option value="">Toutes</option>
+          <option value="Star">Star</option>
+          <option value="Plow Horse">Plow Horse</option>
+          <option value="Puzzle">Puzzle</option>
+          <option value="Dog">Dog</option>
+        </select>
+        <input
+          type="number"
+          placeholder="Marge >="
+          className="input w-24"
+          value={filters.marge}
+          onChange={e => setFilters(f => ({ ...f, marge: e.target.value }))}
+        />
+        <Button onClick={() => fetchData(periode).then(res => setRows(classify(res)))}>
+          Rafraîchir
+        </Button>
+        <Button variant="outline" onClick={exportPdf}>Export</Button>
+      </div>
+      <div id="matrix" className="w-full h-80 bg-glass border border-borderGlass backdrop-blur rounded">
+        <ResponsiveContainer width="100%" height="100%">
+          <ScatterChart>
+            <CartesianGrid />
+            <XAxis type="number" dataKey="x" name="Popularité" unit="%" />
+            <YAxis type="number" dataKey="y" name="Marge" unit="%" />
+            <Tooltip cursor={{ strokeDasharray: '3 3' }} />
+            <ReferenceLine x={medianPop} stroke="grey" />
+            <ReferenceLine y={medianMarge} stroke="grey" />
+            <Scatter data={filtered} fill="#8884d8" />
+          </ScatterChart>
+        </ResponsiveContainer>
       </div>
       <table className="min-w-full table-auto">
         <thead>
@@ -67,7 +151,7 @@ export default function MenuEngineering() {
           </tr>
         </thead>
         <tbody>
-          {rows.map(r => (
+          {filtered.map(r => (
             <tr key={r.id}>
               <td className="px-2 py-1">{r.nom}</td>
               <td className="px-2 py-1">{r.famille || '-'}</td>
@@ -82,6 +166,11 @@ export default function MenuEngineering() {
           ))}
         </tbody>
       </table>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mt-4">
+        {filtered.map(f => (
+          <FicheRentabiliteCard key={f.id} fiche={f} />
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -312,8 +312,8 @@ export default function Router() {
             element={<ProtectedRoute accessKey="analyse"><AnalytiqueDashboard /></ProtectedRoute>}
           />
           <Route
-            path="/analyse/menu-engineering"
-            element={<ProtectedRoute accessKey="analyse"><MenuEngineering /></ProtectedRoute>}
+            path="/menu-engineering"
+            element={<ProtectedRoute accessKey="menu_engineering"><MenuEngineering /></ProtectedRoute>}
           />
           <Route path="/engineering" element={<EngineeringMenu />} />
           <Route


### PR DESCRIPTION
## Summary
- display ventes KPI in `FicheRentabiliteCard`
- add filters and scatter matrix to `MenuEngineering` page
- expose route `/menu-engineering` secured via `menu_engineering` rights
- link new page from sidebar

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ba7a9d6f0832dae44ccc48e0e0926