### PR TITLE
Add advanced audit module

### DIFF
--- a/src/hooks/useAuditTrail.js
+++ b/src/hooks/useAuditTrail.js
@@ -14,12 +14,12 @@ export function useAuditTrail() {
     setLoading(true);
     let query = supabase
       .from("journal_audit")
-      .select("*, utilisateurs:changed_by(nom)")
-      .order("changed_at", { ascending: false })
+      .select("*, utilisateurs:utilisateur_id(nom)")
+      .order("date_action", { ascending: false })
       .limit(100);
-    if (table) query = query.eq("table_name", table);
-    if (start) query = query.gte("changed_at", start);
-    if (end) query = query.lte("changed_at", end);
+    if (table) query = query.eq("table_modifiee", table);
+    if (start) query = query.gte("date_action", start);
+    if (end) query = query.lte("date_action", end);
     const { data, error } = await query;
     setLoading(false);
     if (error) {

--- a/src/layout/Sidebar.jsx
+++ b/src/layout/Sidebar.jsx
@@ -148,6 +148,12 @@ export default function Sidebar() {
       ],
     },
     {
+      title: "Audit",
+      items: [
+        { module: "audit", to: "/audit", label: "Audit", icon: <History size={16} /> },
+      ],
+    },
+    {
       title: "Aide",
       items: [
         { module: "aide", to: "/aide", label: "Aide", icon: <HelpCircle size={16} /> },

--- a/src/pages/AuditTrail.jsx
+++ b/src/pages/AuditTrail.jsx
@@ -72,16 +72,16 @@ export default function AuditTrail() {
             {entries.map((e) => (
               <tr key={e.id} className="align-top">
                 <td className="border px-2 py-1 whitespace-nowrap">
-                  {new Date(e.changed_at).toLocaleString()}
+                  {new Date(e.date_action).toLocaleString()}
                 </td>
-                <td className="border px-2 py-1">{e.table_name}</td>
+                <td className="border px-2 py-1">{e.table_modifiee}</td>
                 <td className="border px-2 py-1">{e.operation}</td>
-                <td className="border px-2 py-1">{e.utilisateurs?.nom || e.changed_by}</td>
+                <td className="border px-2 py-1">{e.utilisateurs?.nom || e.utilisateur_id}</td>
                 <td className="border px-2 py-1 font-mono break-all">
-                  {JSON.stringify(e.old_data)}
+                  {JSON.stringify(e.donnees_avant)}
                 </td>
                 <td className="border px-2 py-1 font-mono break-all">
-                  {JSON.stringify(e.new_data)}
+                  {JSON.stringify(e.donnees_apres)}
                 </td>
               </tr>
             ))}

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -75,6 +75,7 @@ const Reporting = lazy(() => import("@/pages/reporting/Reporting.jsx"));
 const Consolidation = lazy(() => import("@/pages/Consolidation.jsx"));
 const CreateMama = lazy(() => import("@/pages/auth/CreateMama.jsx"));
 const Feedback = lazy(() => import("@/pages/Feedback.jsx"));
+const AuditTrail = lazy(() => import("@/pages/AuditTrail.jsx"));
 const Requisitions = lazy(() => import("@/pages/requisitions/Requisitions.jsx"));
 const RequisitionForm = lazy(() => import("@/pages/requisitions/RequisitionForm.jsx"));
 const RequisitionDetail = lazy(() => import("@/pages/requisitions/RequisitionDetail.jsx"));
@@ -375,6 +376,10 @@ export default function Router() {
           <Route
             path="/feedback"
             element={<ProtectedRoute accessKey="feedback"><Feedback /></ProtectedRoute>}
+          />
+          <Route
+            path="/audit"
+            element={<ProtectedRoute accessKey="audit"><AuditTrail /></ProtectedRoute>}
           />
           <Route
             path="/supervision"

--- a/test/useAuditTrail.test.js
+++ b/test/useAuditTrail.test.js
@@ -34,12 +34,12 @@ test('fetchEntries queries journal_audit with filters', async () => {
     await result.current.fetchEntries({ table: 'produits', start: '2024-01-01', end: '2024-01-31' });
   });
   expect(fromMock).toHaveBeenCalledWith('journal_audit');
-  expect(queryObj.select).toHaveBeenCalledWith('*, utilisateurs:changed_by(nom)');
-  expect(queryObj.order).toHaveBeenCalledWith('changed_at', { ascending: false });
+  expect(queryObj.select).toHaveBeenCalledWith('*, utilisateurs:utilisateur_id(nom)');
+  expect(queryObj.order).toHaveBeenCalledWith('date_action', { ascending: false });
   expect(queryObj.limit).toHaveBeenCalledWith(100);
-  expect(queryObj.eq).toHaveBeenCalledWith('table_name', 'produits');
-  expect(queryObj.gte).toHaveBeenCalledWith('changed_at', '2024-01-01');
-  expect(queryObj.lte).toHaveBeenCalledWith('changed_at', '2024-01-31');
+  expect(queryObj.eq).toHaveBeenCalledWith('table_modifiee', 'produits');
+  expect(queryObj.gte).toHaveBeenCalledWith('date_action', '2024-01-01');
+  expect(queryObj.lte).toHaveBeenCalledWith('date_action', '2024-01-31');
 });
 
 test('fetchEntries returns empty array on error', async () => {


### PR DESCRIPTION
## Summary
- create `journal_audit` table with triggers in Ajout.sql
- implement audit log fetching using new column names
- display logs in `AuditTrail.jsx`
- add `/audit` route and sidebar menu
- update tests for new audit fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687baa9af3c4832db8ad603f28553843