### PR TITLE
Add advanced analytics module

### DIFF
--- a/db/TABLE.txt
+++ b/db/TABLE.txt
@@ -528,6 +528,10 @@
 | public       | v_ecarts_inventaire                      | stock_reel                | numeric                  | YES         | null               |
 | public       | v_ecarts_inventaire                      | ecart                     | numeric                  | YES         | null               |
 | public       | v_ecarts_inventaire                      | motif                     | text                     | YES         | null               |
+| public       | v_evolution_achats                       | mama_id          | uuid                     | YES         | null               |
+| public       | v_evolution_achats                       | produit_id       | uuid                     | YES         | null               |
+| public       | v_evolution_achats                       | mois             | text                     | YES         | null               |
+| public       | v_evolution_achats                       | montant          | numeric                  | YES         | null               |
 | public       | v_fournisseurs_inactifs                  | mama_id                   | uuid                     | YES         | null               |
 | public       | v_fournisseurs_inactifs                  | fournisseur_id            | uuid                     | YES         | null               |
 | public       | v_fournisseurs_inactifs                  | nom                       | text                     | YES         | null               |
@@ -1282,3 +1286,11 @@ END;
 | taches              | trg_set_updated_at_taches              | BEFORE        | UPDATE             | EXECUTE FUNCTION set_updated_at()             |
 | ventes_fiches_carte | trg_set_updated_at_ventes_fiches_carte | BEFORE        | UPDATE             | EXECUTE FUNCTION set_updated_at()             |
 
+| v_evolution_achats                      |  SELECT f.mama_id,
+    fl.produit_id,
+    to_char(date_trunc('month', f.date_facture), 'YYYY-MM') AS mois,
+    sum(fl.prix_unitaire * fl.quantite) AS montant
+   FROM (facture_lignes fl
+     JOIN factures f ON ((fl.facture_id = f.id)))
+  WHERE ((fl.actif = true) AND (f.actif = true))
+  GROUP BY f.mama_id, fl.produit_id, to_char(date_trunc('month', f.date_facture), 'YYYY-MM');

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -11,6 +11,8 @@ export default function Sidebar() {
   const showAll = role === "superadmin";
   const rights = Array.isArray(access_rights) ? access_rights : [];
   const has = (key) => showAll || rights.includes(key);
+  const canAnalyse =
+    showAll || rights.includes("analyse") || access_rights?.analyse?.peut_voir;
 
   return (
     <aside className="w-64 bg-glass border border-white/10 backdrop-blur-xl text-white p-4 h-screen shadow-md text-shadow">
@@ -61,16 +63,16 @@ export default function Sidebar() {
           </details>
         )}
 
-        {(has("documents") || has("analyse") || has("menu_engineering")) && (
+        {(has("documents") || canAnalyse || has("menu_engineering")) && (
           <details open={pathname.startsWith("/documents") || pathname.startsWith("/analyse") || pathname.startsWith("/engineering") || pathname.startsWith("/menu-engineering")}>
             <summary className="cursor-pointer">Documents / Analyse</summary>
             <div className="ml-4 flex flex-col gap-1 mt-1">
               {has("documents") && <Link to="/documents">Documents</Link>}
-              {has("analyse") && <Link to="/analyse">Analyse</Link>}
+              {canAnalyse && <Link to="/analyse">Analyse</Link>}
               {has("menu_engineering") && (
                 <Link to="/menu-engineering">Menu Engineering</Link>
               )}
-              {has("analyse") && <Link to="/engineering">Engineering</Link>}
+              {canAnalyse && <Link to="/engineering">Engineering</Link>}
             </div>
           </details>
         )}

--- a/src/hooks/useAnalyse.js
+++ b/src/hooks/useAnalyse.js
@@ -1,0 +1,79 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/context/AuthContext";
+
+export function useAnalyse() {
+  const { mama_id } = useAuth();
+
+  const applyPeriode = (query, { debut, fin } = {}) => {
+    if (debut) query = query.gte("mois", debut);
+    if (fin) query = query.lte("mois", fin);
+    return query;
+  };
+
+  async function getMonthlyPurchases(filters = {}) {
+    if (!mama_id) return [];
+    let query = supabase
+      .from("v_monthly_purchases")
+      .select("mois, total")
+      .eq("mama_id", mama_id)
+      .order("mois", { ascending: true });
+    query = applyPeriode(query, filters);
+    const { data, error } = await query;
+    if (error) {
+      console.error("getMonthlyPurchases", error);
+      return [];
+    }
+    return data || [];
+  }
+
+  async function getEvolutionAchats(filters = {}) {
+    if (!mama_id) return [];
+    let query = supabase
+      .from("v_evolution_achats")
+      .select("mois, montant")
+      .eq("mama_id", mama_id)
+      .order("mois", { ascending: true });
+    if (filters.produit_id) query = query.eq("produit_id", filters.produit_id);
+    query = applyPeriode(query, filters);
+    const { data, error } = await query;
+    if (error) {
+      console.error("getEvolutionAchats", error);
+      return [];
+    }
+    return data || [];
+  }
+
+  async function getPmp() {
+    if (!mama_id) return [];
+    const { data, error } = await supabase
+      .from("v_pmp")
+      .select("*")
+      .eq("mama_id", mama_id);
+    if (error) {
+      console.error("getPmp", error);
+      return [];
+    }
+    return data || [];
+  }
+
+  async function getEcartsInventaire(filters = {}) {
+    if (!mama_id) return [];
+    let query = supabase
+      .from("v_ecarts_inventaire")
+      .select("date, ecart")
+      .eq("mama_id", mama_id)
+      .order("date", { ascending: true });
+    if (filters.produit_id) query = query.eq("produit_id", filters.produit_id);
+    const { data, error } = await query;
+    if (error) {
+      console.error("getEcartsInventaire", error);
+      return [];
+    }
+    return data || [];
+  }
+
+  return { getMonthlyPurchases, getEvolutionAchats, getPmp, getEcartsInventaire };
+}
+
+export default useAnalyse;

--- a/src/pages/analyse/Analyse.jsx
+++ b/src/pages/analyse/Analyse.jsx
@@ -1,4 +1,89 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { useEffect, useState } from "react";
+import { Navigate } from "react-router-dom";
+import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip, BarChart, Bar } from "recharts";
+import { useAuth } from "@/hooks/useAuth";
+import { useAnalyse } from "@/hooks/useAnalyse";
+import { useProduitsAutocomplete } from "@/hooks/useProduitsAutocomplete";
+import GlassCard from "@/components/ui/GlassCard";
+import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+
 export default function Analyse() {
-  return <div>Page Analyse (en construction)</div>;
+  const { isAuthenticated, loading: authLoading, access_rights } = useAuth();
+  const { getMonthlyPurchases, getEvolutionAchats } = useAnalyse();
+  const { results, searchProduits } = useProduitsAutocomplete();
+  const [filters, setFilters] = useState({ produit_id: "", debut: "", fin: "" });
+  const [monthly, setMonthly] = useState([]);
+  const [evolution, setEvolution] = useState([]);
+
+  useEffect(() => { searchProduits(); }, [searchProduits]);
+
+  useEffect(() => {
+    if (!isAuthenticated || authLoading) return;
+    getMonthlyPurchases({ debut: filters.debut, fin: filters.fin }).then(setMonthly);
+    if (filters.produit_id) {
+      getEvolutionAchats({ produit_id: filters.produit_id, debut: filters.debut, fin: filters.fin }).then(setEvolution);
+    } else {
+      setEvolution([]);
+    }
+  }, [isAuthenticated, authLoading, filters, getMonthlyPurchases, getEvolutionAchats]);
+
+  if (authLoading) return <LoadingSpinner message="Chargement..." />;
+  if (!access_rights?.analyse?.peut_voir) return <Navigate to="/unauthorized" replace />;
+
+  return (
+    <div className="p-6 space-y-6">
+      <h1 className="text-2xl font-bold">Analyse avancée</h1>
+      <div className="flex flex-wrap gap-2">
+        <input type="month" className="input" value={filters.debut} onChange={e => setFilters(f => ({ ...f, debut: e.target.value }))} />
+        <input type="month" className="input" value={filters.fin} onChange={e => setFilters(f => ({ ...f, fin: e.target.value }))} />
+        <select className="input" value={filters.produit_id} onChange={e => setFilters(f => ({ ...f, produit_id: e.target.value }))}>
+          <option value="">Tous produits</option>
+          {results.map(p => (
+            <option key={p.id} value={p.id}>{p.nom}</option>
+          ))}
+        </select>
+      </div>
+      <GlassCard>
+        <h2 className="font-semibold mb-2">Achats mensuels</h2>
+        <ResponsiveContainer width="100%" height={300}>
+          <LineChart data={monthly}>
+            <XAxis dataKey="mois" />
+            <YAxis />
+            <Tooltip />
+            <Line type="monotone" dataKey="total" stroke="#bfa14d" />
+          </LineChart>
+        </ResponsiveContainer>
+        <table className="table-auto mt-4 text-sm w-full">
+          <thead>
+            <tr>
+              <th className="px-2 py-1 text-left">Mois</th>
+              <th className="px-2 py-1 text-right">Total €</th>
+            </tr>
+          </thead>
+          <tbody>
+            {monthly.map(row => (
+              <tr key={row.mois}>
+                <td className="px-2 py-1">{row.mois}</td>
+                <td className="px-2 py-1 text-right">{Number(row.total).toFixed(2)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </GlassCard>
+      {evolution.length > 0 && (
+        <GlassCard>
+          <h2 className="font-semibold mb-2">Évolution des achats du produit</h2>
+          <ResponsiveContainer width="100%" height={300}>
+            <BarChart data={evolution}>
+              <XAxis dataKey="mois" />
+              <YAxis />
+              <Tooltip />
+              <Bar dataKey="montant" fill="#8884d8" />
+            </BarChart>
+          </ResponsiveContainer>
+        </GlassCard>
+      )}
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- define analytic SQL views in `Ajout.sql`
- register `v_evolution_achats` view in `TABLE.txt`
- implement `useAnalyse` hook for analytics queries
- build `/analyse` page with charts and tables
- show analyse menu item using new access rights

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687baf42ebb8832db994cc9fe3336b1f