### PR TITLE
Add RGPD consent module

### DIFF
--- a/db/Ajout.sql
+++ b/db/Ajout.sql
@@ -602,3 +602,20 @@ join factures f on f.id = fl.facture_id
 where f.actif = true
   and fl.actif = true
 group by f.mama_id, fl.produit_id, to_char(date_trunc('month', f.date_facture), 'YYYY-MM');
+
+-- Table consentements_utilisateur pour RGPD
+create table if not exists consentements_utilisateur (
+  id uuid primary key default gen_random_uuid(),
+  utilisateur_id uuid references utilisateurs(id),
+  mama_id uuid references mamas(id),
+  type_consentement text,
+  donne boolean,
+  date_consentement timestamptz default now()
+);
+
+alter table if exists consentements_utilisateur
+  rename column if exists user_id to utilisateur_id;
+alter table if exists consentements_utilisateur
+  rename column if exists consentement to donne;
+alter table if exists consentements_utilisateur
+  add column if not exists type_consentement text;

--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -2,6 +2,7 @@
 import { Navigate, useLocation } from "react-router-dom";
 import useAuth from "@/hooks/useAuth";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import useConsentements from "@/hooks/useConsentements";
 
 export default function ProtectedRoute({ children, accessKey }) {
   const {
@@ -14,6 +15,11 @@ export default function ProtectedRoute({ children, accessKey }) {
     isAuthenticated,
     error,
   } = useAuth();
+  const {
+    consentements,
+    loaded: consentLoaded,
+    fetchConsentements,
+  } = useConsentements();
   const location = useLocation();
   if (import.meta.env.DEV) {
     console.log("ProtectedRoute", {
@@ -27,6 +33,10 @@ export default function ProtectedRoute({ children, accessKey }) {
   if (error) {
     console.error("Auth error:", error);
     return <div className="text-red-500 p-4">{error}</div>;
+  }
+
+  if (userData && !consentLoaded) {
+    fetchConsentements();
   }
 
   if (loading || access_rights === null)
@@ -44,6 +54,14 @@ export default function ProtectedRoute({ children, accessKey }) {
     if (location.pathname !== "/unauthorized")
       return <Navigate to="/unauthorized" replace />;
     return null;
+  }
+
+  if (
+    consentLoaded &&
+    consentements.length === 0 &&
+    location.pathname !== "/consentements"
+  ) {
+    return <Navigate to="/consentements" replace />;
   }
 
   if ((userData.role == null || userData.mama_id == null) &&

--- a/src/hooks/useConsentements.js
+++ b/src/hooks/useConsentements.js
@@ -1,0 +1,69 @@
+import { useState } from "react";
+import { getSupabaseClient } from "@/api/shared/supabaseClient.js";
+import { useAuth } from "@/context/AuthContext";
+
+export function useConsentements() {
+  const { user_id, mama_id } = useAuth();
+  const [consentements, setConsentements] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [loaded, setLoaded] = useState(false);
+
+  async function fetchConsentements() {
+    if (!user_id || !mama_id) return [];
+    setLoading(true);
+    const supabase = getSupabaseClient();
+    const { data, error } = await supabase
+      .from("consentements_utilisateur")
+      .select("*")
+      .eq("utilisateur_id", user_id)
+      .eq("mama_id", mama_id)
+      .order("date_consentement", { ascending: false });
+    setLoading(false);
+    if (error) {
+      setError(error);
+      setLoaded(true);
+      return [];
+    }
+    setConsentements(Array.isArray(data) ? data : []);
+    setLoaded(true);
+    return data || [];
+  }
+
+  async function enregistrerConsentement(type_consentement, donne) {
+    if (!user_id || !mama_id) return { error: "no user" };
+    setLoading(true);
+    const supabase = getSupabaseClient();
+    const { data, error } = await supabase
+      .from("consentements_utilisateur")
+      .insert([
+        {
+          utilisateur_id: user_id,
+          mama_id,
+          type_consentement,
+          donne,
+          date_consentement: new Date().toISOString(),
+        },
+      ])
+      .select()
+      .single();
+    setLoading(false);
+    if (error) {
+      setError(error);
+      return { error };
+    }
+    await fetchConsentements();
+    return { data };
+  }
+
+  return {
+    consentements,
+    loading,
+    error,
+    loaded,
+    fetchConsentements,
+    enregistrerConsentement,
+  };
+}
+
+export default useConsentements;

--- a/src/layout/Sidebar.jsx
+++ b/src/layout/Sidebar.jsx
@@ -145,6 +145,7 @@ export default function Sidebar() {
         { module: "settings", to: "/parametrage/settings", label: "Autres", icon: <Settings size={16} /> },
         { module: "zones_stock", to: "/parametrage/zones-stock", label: "Zones de stock", icon: <Boxes size={16} /> },
         { module: "licences", to: "/parametrage/licences", label: "Licences", icon: <Key size={16} /> },
+        { module: "parametrage", to: "/consentements", label: "Consentements", icon: <CheckSquare size={16} /> },
       ],
     },
     {

--- a/src/pages/Consentements.jsx
+++ b/src/pages/Consentements.jsx
@@ -1,0 +1,45 @@
+import { useEffect } from "react";
+import useConsentements from "@/hooks/useConsentements";
+import RGPDConsentForm from "@/pages/parametrage/RGPDConsentForm.jsx";
+
+export default function Consentements() {
+  const { consentements, fetchConsentements } = useConsentements();
+
+  useEffect(() => {
+    fetchConsentements();
+  }, []);
+
+  return (
+    <div className="p-6 max-w-2xl mx-auto space-y-6">
+      <h1 className="text-xl font-bold">Historique des consentements</h1>
+      <table className="w-full text-sm">
+        <thead>
+          <tr>
+            <th className="p-2 text-left">Date</th>
+            <th className="p-2 text-left">Type</th>
+            <th className="p-2 text-left">Donné</th>
+          </tr>
+        </thead>
+        <tbody>
+          {consentements.map(c => (
+            <tr key={c.id} className="border-b last:border-none">
+              <td className="p-2">
+                {new Date(c.date_consentement).toLocaleString()}
+              </td>
+              <td className="p-2">{c.type_consentement || "-"}</td>
+              <td className="p-2">{c.donne ? "Oui" : "Non"}</td>
+            </tr>
+          ))}
+          {consentements.length === 0 && (
+            <tr>
+              <td colSpan="3" className="p-2 text-center text-gray-500">
+                Aucun consentement enregistré
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+      {consentements.length === 0 && <RGPDConsentForm />}
+    </div>
+  );
+}

--- a/src/pages/parametrage/RGPDConsentForm.jsx
+++ b/src/pages/parametrage/RGPDConsentForm.jsx
@@ -17,9 +17,10 @@ export default function RGPDConsentForm() {
     e.preventDefault();
     if (loading) return;
     const payload = {
-      user_id,
+      utilisateur_id: user_id,
       mama_id,
-      consentement: values.cookies && values.interne && values.tiers,
+      type_consentement: "global",
+      donne: values.cookies && values.interne && values.tiers,
       date_consentement: new Date().toISOString(),
     };
     try {

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -76,6 +76,7 @@ const Consolidation = lazy(() => import("@/pages/Consolidation.jsx"));
 const CreateMama = lazy(() => import("@/pages/auth/CreateMama.jsx"));
 const Feedback = lazy(() => import("@/pages/Feedback.jsx"));
 const AuditTrail = lazy(() => import("@/pages/AuditTrail.jsx"));
+const Consentements = lazy(() => import("@/pages/Consentements.jsx"));
 const Requisitions = lazy(() => import("@/pages/requisitions/Requisitions.jsx"));
 const RequisitionForm = lazy(() => import("@/pages/requisitions/RequisitionForm.jsx"));
 const RequisitionDetail = lazy(() => import("@/pages/requisitions/RequisitionDetail.jsx"));
@@ -368,6 +369,10 @@ export default function Router() {
           <Route
             path="/parametrage/access"
             element={<ProtectedRoute accessKey="access"><AccessRights /></ProtectedRoute>}
+          />
+          <Route
+            path="/consentements"
+            element={<ProtectedRoute accessKey="parametrage"><Consentements /></ProtectedRoute>}
           />
           <Route
             path="/aide"


### PR DESCRIPTION
## Summary
- create SQL for `consentements_utilisateur`
- add RGPD consent hook and consent page
- update protected route to force consent on first login
- show consent history and form
- wire page into sidebar and router

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687bb1e35d7c832da47f78ddaf1b4bbc