### PR TITLE
Add document module support

### DIFF
--- a/db/Ajout.sql
+++ b/db/Ajout.sql
@@ -4,6 +4,9 @@
 alter table if exists documents
   add column if not exists nom text,
   add column if not exists url text,
+  add column if not exists titre text,
+  add column if not exists fichier_url text,
+  add column if not exists commentaire text,
   add column if not exists taille numeric,
   add column if not exists categorie text,
   add column if not exists entite_liee_type text,
@@ -13,6 +16,8 @@ alter table if exists documents
 
 update documents
   set url = coalesce(url, chemin),
+      fichier_url = coalesce(fichier_url, coalesce(url, chemin)),
+      titre = coalesce(titre, nom),
       nom = coalesce(nom, split_part(coalesce(url, chemin), '/', -1));
 
 -- Table help_articles : aucune modification necessaire, on conserve

--- a/src/pages/documents/DocumentForm.jsx
+++ b/src/pages/documents/DocumentForm.jsx
@@ -1,0 +1,53 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+
+export default function DocumentForm({ onUploaded, entiteType = "", entiteId = null, categories = [] }) {
+  const [file, setFile] = useState(null);
+  const [titre, setTitre] = useState("");
+  const [commentaire, setCommentaire] = useState("");
+  const [categorie, setCategorie] = useState("");
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!file) return;
+    await onUploaded?.(file, {
+      titre,
+      commentaire,
+      categorie,
+      entite_liee_type: entiteType,
+      entite_liee_id: entiteId,
+    });
+    setFile(null);
+    setTitre("");
+    setCommentaire("");
+    setCategorie("");
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2">
+      <input type="file" className="input w-full" onChange={(e) => setFile(e.target.files?.[0] || null)} required />
+      <input
+        className="input w-full"
+        placeholder="Titre"
+        value={titre}
+        onChange={(e) => setTitre(e.target.value)}
+      />
+      <textarea
+        className="input w-full"
+        placeholder="Commentaire"
+        value={commentaire}
+        onChange={(e) => setCommentaire(e.target.value)}
+      />
+      <select className="input w-full" value={categorie} onChange={(e) => setCategorie(e.target.value)}>
+        <option value="">Catégorie</option>
+        {categories.map((c) => (
+          <option key={c} value={c}>
+            {c}
+          </option>
+        ))}
+      </select>
+      <Button type="submit">Uploader</Button>
+    </form>
+  );
+}

--- a/src/pages/documents/Documents.jsx
+++ b/src/pages/documents/Documents.jsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from "react";
 import { useAuth } from "@/context/AuthContext";
 import { useDocuments } from "@/hooks/useDocuments";
-import DocumentUpload from "@/components/documents/DocumentUpload";
+import DocumentForm from "./DocumentForm.jsx";
 import DocumentPreview from "@/components/documents/DocumentPreview";
 import TableContainer from "@/components/ui/TableContainer";
 import { Button } from "@/components/ui/button";
@@ -12,12 +12,19 @@ export default function Documents() {
   const { documents, listDocuments, uploadDocument, deleteDocument } = useDocuments();
   const [showUpload, setShowUpload] = useState(false);
   const [preview, setPreview] = useState(null);
+  const [search, setSearch] = useState("");
+  const [typeFilter, setTypeFilter] = useState("");
+  const [categorieFilter, setCategorieFilter] = useState("");
 
   useEffect(() => {
     if (!authLoading && mama_id) {
-      listDocuments();
+      listDocuments({
+        search,
+        type: typeFilter || undefined,
+        categorie: categorieFilter || undefined,
+      });
     }
-  }, [authLoading, mama_id, listDocuments]);
+  }, [authLoading, mama_id, listDocuments, search, typeFilter, categorieFilter]);
 
   const handleUploaded = async (file, meta) => {
     await uploadDocument(file, meta);
@@ -38,12 +45,32 @@ export default function Documents() {
       </div>
       {showUpload && (
         <div className="mb-4">
-          <DocumentUpload
+          <DocumentForm
             onUploaded={handleUploaded}
             categories={["Contrat fournisseur", "Spécification produit"]}
           />
         </div>
       )}
+      <div className="flex flex-wrap gap-2 mb-4">
+        <input
+          className="input"
+          placeholder="Recherche"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        <input
+          className="input"
+          placeholder="Type"
+          value={typeFilter}
+          onChange={(e) => setTypeFilter(e.target.value)}
+        />
+        <input
+          className="input"
+          placeholder="Catégorie"
+          value={categorieFilter}
+          onChange={(e) => setCategorieFilter(e.target.value)}
+        />
+      </div>
       <TableContainer>
         <table className="min-w-full text-sm">
           <thead>
@@ -59,7 +86,7 @@ export default function Documents() {
           <tbody>
             {documents.map((doc) => (
               <tr key={doc.id}>
-                <td className="p-2">{doc.nom}</td>
+                <td className="p-2">{doc.titre || doc.nom}</td>
                 <td className="p-2">
                   {doc.categorie && (
                     <span className="bg-blue-800/50 text-white px-2 py-0.5 rounded-full text-xs">

--- a/test/useDocuments.test.js
+++ b/test/useDocuments.test.js
@@ -7,6 +7,7 @@ const queryObj = {
   order: vi.fn(() => queryObj),
   eq: vi.fn(() => queryObj),
   ilike: vi.fn(() => queryObj),
+  or: vi.fn(() => queryObj),
   insert: vi.fn(() => queryObj),
   delete: vi.fn(() => queryObj),
   single: vi.fn(() => Promise.resolve({ data: { url: '/f' }, error: null })),
@@ -35,7 +36,7 @@ test('listDocuments queries documents with search', async () => {
   expect(fromMock).toHaveBeenCalledWith('documents');
   expect(queryObj.select).toHaveBeenCalledWith('*');
   expect(queryObj.eq).toHaveBeenCalledWith('mama_id', 'm1');
-  expect(queryObj.ilike).toHaveBeenCalledWith('nom', '%foo%');
+  expect(queryObj.or).toHaveBeenCalledWith('nom.ilike.%foo%,titre.ilike.%foo%');
 });
 
 test('uploadDocument inserts row with metadata', async () => {


### PR DESCRIPTION
## Summary
- extend `documents` SQL table
- create document upload form
- list & filter documents
- support title/comment/file url in docs hook
- update documents hook tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687bbce75f2c832da8be4421381ec9d2