### PR TITLE
Add contextual help module

### DIFF
--- a/db/Ajout.sql
+++ b/db/Ajout.sql
@@ -20,8 +20,11 @@ update documents
       titre = coalesce(titre, nom),
       nom = coalesce(nom, split_part(coalesce(url, chemin), '/', -1));
 
--- Table help_articles : aucune modification necessaire, on conserve
--- les colonnes `titre` et `contenu` deja utilisees par le front-end
+-- Table help_articles : ajout des colonnes pour l'aide contextuelle
+alter table if exists help_articles
+  add column if not exists categorie text,
+  add column if not exists lien_page text,
+  add column if not exists mama_id uuid;
 
 -- Table mamas : ajout des colonnes de parametrage utilisees par le front
 alter table if exists mamas

--- a/src/hooks/useAide.js
+++ b/src/hooks/useAide.js
@@ -1,0 +1,112 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { useState, useCallback } from 'react';
+import { supabase } from '@/lib/supabase';
+import useAuth from '@/hooks/useAuth';
+
+export function useAide() {
+  const { mama_id } = useAuth();
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const fetchArticles = useCallback(
+    async (filters = {}) => {
+      if (!mama_id) return [];
+      setLoading(true);
+      setError(null);
+      let query = supabase
+        .from('help_articles')
+        .select('*')
+        .eq('mama_id', mama_id)
+        .order('created_at', { ascending: false });
+      if (filters.categorie) query = query.eq('categorie', filters.categorie);
+      if (filters.lien_page) query = query.eq('lien_page', filters.lien_page);
+      if (filters.search) query = query.ilike('titre', `%${filters.search}%`);
+      const { data, error } = await query;
+      setLoading(false);
+      if (error) {
+        setError(error.message || error);
+        setItems([]);
+        return [];
+      }
+      setItems(Array.isArray(data) ? data : []);
+      return data || [];
+    },
+    [mama_id]
+  );
+
+  const addArticle = useCallback(
+    async (values) => {
+      if (!mama_id) return { error: 'missing mama_id' };
+      setLoading(true);
+      setError(null);
+      const { data, error } = await supabase
+        .from('help_articles')
+        .insert([{ ...values, mama_id }])
+        .select()
+        .single();
+      setLoading(false);
+      if (error) {
+        setError(error.message || error);
+        return { error };
+      }
+      setItems((arr) => [data, ...arr]);
+      return { data };
+    },
+    [mama_id]
+  );
+
+  const updateArticle = useCallback(
+    async (id, values) => {
+      if (!mama_id || !id) return { error: 'missing id' };
+      setLoading(true);
+      setError(null);
+      const { data, error } = await supabase
+        .from('help_articles')
+        .update(values)
+        .eq('id', id)
+        .eq('mama_id', mama_id)
+        .select()
+        .single();
+      setLoading(false);
+      if (error) {
+        setError(error.message || error);
+        return { error };
+      }
+      setItems((arr) => arr.map((a) => (a.id === id ? data : a)));
+      return { data };
+    },
+    [mama_id]
+  );
+
+  const deleteArticle = useCallback(
+    async (id) => {
+      if (!mama_id || !id) return { error: 'missing id' };
+      setLoading(true);
+      setError(null);
+      const { error } = await supabase
+        .from('help_articles')
+        .delete()
+        .eq('id', id)
+        .eq('mama_id', mama_id);
+      setLoading(false);
+      if (error) {
+        setError(error.message || error);
+        return { error };
+      }
+      setItems((arr) => arr.filter((a) => a.id !== id));
+      return { success: true };
+    },
+    [mama_id]
+  );
+
+  return {
+    items,
+    loading,
+    error,
+    fetchArticles,
+    addArticle,
+    updateArticle,
+    deleteArticle,
+  };
+}

--- a/src/pages/AideContextuelle.jsx
+++ b/src/pages/AideContextuelle.jsx
@@ -1,3 +1,3 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import HelpCenter from './HelpCenter';
-export default HelpCenter;
+import Aide from './aide/Aide.jsx';
+export default Aide;

--- a/src/pages/aide/Aide.jsx
+++ b/src/pages/aide/Aide.jsx
@@ -1,0 +1,105 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { useEffect, useState } from 'react';
+import { useAide } from '@/hooks/useAide';
+import useAuth from '@/hooks/useAuth';
+import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
+import GlassCard from '@/components/ui/GlassCard';
+import { Button } from '@/components/ui/button';
+import AideForm from './AideForm.jsx';
+
+export default function Aide() {
+  const { access_rights, isSuperadmin, mama_id, loading: authLoading } = useAuth();
+  const { items, fetchArticles, loading, error } = useAide();
+  const [search, setSearch] = useState('');
+  const [categorieFilter, setCategorieFilter] = useState('');
+  const [pageFilter, setPageFilter] = useState('');
+  const [editing, setEditing] = useState(null);
+
+  useEffect(() => {
+    if (!authLoading && mama_id) {
+      fetchArticles({
+        search,
+        categorie: categorieFilter || undefined,
+        lien_page: pageFilter || undefined,
+      });
+    }
+  }, [authLoading, mama_id, search, categorieFilter, pageFilter, fetchArticles]);
+
+  const categories = [...new Set(items.map((a) => a.categorie).filter(Boolean))];
+  const pages = [...new Set(items.map((a) => a.lien_page).filter(Boolean))];
+  const canEdit = isSuperadmin || access_rights?.aide?.peut_modifier;
+
+  if (authLoading) return <LoadingSpinner message="Chargement..." />;
+
+  return (
+    <div className="p-6 space-y-6 container mx-auto">
+      <h1 className="text-2xl font-bold">Aide</h1>
+      <div className="flex flex-wrap gap-2 items-end">
+        <input
+          className="input"
+          placeholder="Recherche"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        <select
+          className="input"
+          value={categorieFilter}
+          onChange={(e) => setCategorieFilter(e.target.value)}
+        >
+          <option value="">Toutes catégories</option>
+          {categories.map((c) => (
+            <option key={c} value={c}>
+              {c}
+            </option>
+          ))}
+        </select>
+        <select
+          className="input"
+          value={pageFilter}
+          onChange={(e) => setPageFilter(e.target.value)}
+        >
+          <option value="">Toutes pages</option>
+          {pages.map((p) => (
+            <option key={p} value={p}>
+              {p}
+            </option>
+          ))}
+        </select>
+        {canEdit && (
+          <Button onClick={() => setEditing({})}>Nouvel article</Button>
+        )}
+      </div>
+      {loading && <LoadingSpinner message="Chargement..." />}
+      {error && <div className="text-red-600">{error}</div>}
+      <ul className="space-y-4">
+        {items.map((a) => (
+          <li key={a.id} className="list-none">
+            <GlassCard>
+              <h2 className="font-semibold text-lg mb-2">{a.titre}</h2>
+              <p className="whitespace-pre-line text-sm mb-2">{a.contenu}</p>
+              {canEdit && (
+                <Button size="sm" variant="outline" onClick={() => setEditing(a)}>
+                  Éditer
+                </Button>
+              )}
+            </GlassCard>
+          </li>
+        ))}
+      </ul>
+      {editing && (
+        <AideForm
+          article={editing.id ? editing : null}
+          onClose={() => setEditing(null)}
+          onSaved={() => {
+            setEditing(null);
+            fetchArticles({
+              search,
+              categorie: categorieFilter || undefined,
+              lien_page: pageFilter || undefined,
+            });
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/pages/aide/AideForm.jsx
+++ b/src/pages/aide/AideForm.jsx
@@ -1,0 +1,89 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { useState } from 'react';
+import ModalGlass from '@/components/ui/ModalGlass';
+import { Button } from '@/components/ui/button';
+import { useAide } from '@/hooks/useAide';
+import { Toaster, toast } from 'react-hot-toast';
+
+export default function AideForm({ article, onClose, onSaved }) {
+  const isEdit = !!article?.id;
+  const { addArticle, updateArticle } = useAide();
+  const [values, setValues] = useState({
+    titre: article?.titre || '',
+    contenu: article?.contenu || '',
+    categorie: article?.categorie || '',
+    lien_page: article?.lien_page || '',
+  });
+  const [saving, setSaving] = useState(false);
+
+  const handleChange = (e) => {
+    setValues((v) => ({ ...v, [e.target.name]: e.target.value }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (saving) return;
+    setSaving(true);
+    let res;
+    if (isEdit) {
+      res = await updateArticle(article.id, values);
+    } else {
+      res = await addArticle(values);
+    }
+    if (res?.error) {
+      toast.error(res.error.message || res.error);
+    } else {
+      toast.success('Article enregistré');
+      onSaved?.(res.data);
+      onClose?.();
+    }
+    setSaving(false);
+  };
+
+  return (
+    <ModalGlass open={true} onClose={onClose}>
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <Toaster />
+        <h3 className="text-lg font-semibold mb-2">
+          {isEdit ? "Modifier l'article" : 'Nouvel article'}
+        </h3>
+        <input
+          className="input input-bordered w-full"
+          name="titre"
+          placeholder="Titre"
+          value={values.titre}
+          onChange={handleChange}
+          required
+        />
+        <input
+          className="input input-bordered w-full"
+          name="categorie"
+          placeholder="Catégorie"
+          value={values.categorie}
+          onChange={handleChange}
+        />
+        <input
+          className="input input-bordered w-full"
+          name="lien_page"
+          placeholder="Page liée"
+          value={values.lien_page}
+          onChange={handleChange}
+        />
+        <textarea
+          className="input input-bordered w-full h-32"
+          name="contenu"
+          placeholder="Contenu"
+          value={values.contenu}
+          onChange={handleChange}
+          required
+        />
+        <div className="flex gap-2 pt-2">
+          <Button type="submit" disabled={saving}>Enregistrer</Button>
+          <Button type="button" onClick={onClose} disabled={saving} className="bg-transparent border border-white">
+            Annuler
+          </Button>
+        </div>
+      </form>
+    </ModalGlass>
+  );
+}


### PR DESCRIPTION
## Summary
- extend database script to add help_articles columns
- add `useAide` hook for filtered contextual help queries
- build Aide page with search, filters and edit options
- add AideForm modal for admins
- export new page through `AideContextuelle.jsx`

## Testing
- `npx vitest run` *(fails: `npm ERR! canceled`)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687bc16c4680832da96bca0ad0fb977c