### PR TITLE
Add customizable dashboard gadgets

### DIFF
--- a/db/Ajout.sql
+++ b/db/Ajout.sql
@@ -653,3 +653,25 @@ create table if not exists notification_preferences (
   updated_at timestamptz default now()
 );
 create unique index if not exists uniq_notif_prefs_user on notification_preferences(utilisateur_id, mama_id);
+-- Module Tableau de bord gadgets personnalisable
+create table if not exists gadgets (
+  id uuid primary key default gen_random_uuid(),
+  type text,
+  nom text,
+  configuration_json jsonb,
+  mama_id uuid references mamas(id),
+  actif boolean default true,
+  created_at timestamptz default now()
+);
+create index if not exists idx_gadgets_mama_id on gadgets(mama_id);
+create index if not exists idx_gadgets_actif on gadgets(actif);
+
+create table if not exists tableaux_de_bord (
+  id uuid primary key default gen_random_uuid(),
+  utilisateur_id uuid references utilisateurs(id),
+  liste_gadgets_json jsonb,
+  mama_id uuid references mamas(id),
+  created_at timestamptz default now()
+);
+create unique index if not exists uniq_tableaux_de_bord_user on tableaux_de_bord(utilisateur_id, mama_id);
+create index if not exists idx_tableaux_de_bord_mama_id on tableaux_de_bord(mama_id);

--- a/src/components/dashboard/GadgetConfigForm.jsx
+++ b/src/components/dashboard/GadgetConfigForm.jsx
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+import { useGadgets } from '@/hooks/useGadgets';
+import InputField from '@/components/ui/InputField';
+import { Button } from '@/components/ui/button';
+import { toast } from 'react-hot-toast';
+
+export default function GadgetConfigForm({ gadget, onSave, onCancel }) {
+  const editing = !!gadget;
+  const [nom, setNom] = useState(gadget?.nom || '');
+  const [type, setType] = useState(gadget?.type || 'indicator');
+  const [config, setConfig] = useState(
+    JSON.stringify(gadget?.configuration_json || {}, null, 2)
+  );
+  const { addGadget, updateGadget } = useGadgets();
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    let json;
+    try {
+      json = config ? JSON.parse(config) : {};
+    } catch {
+      toast.error('JSON invalide');
+      return;
+    }
+    if (editing) {
+      await updateGadget(gadget.id, {
+        nom,
+        type,
+        configuration_json: json,
+      });
+    } else {
+      await addGadget({ nom, type, configuration_json: json });
+    }
+    onSave?.();
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <InputField label="Nom" value={nom} onChange={(e) => setNom(e.target.value)} required />
+      <div>
+        <label className="block text-sm text-white mb-1">Type</label>
+        <select className="input w-full" value={type} onChange={(e) => setType(e.target.value)}>
+          <option value="indicator">Indicateur</option>
+          <option value="line">Line</option>
+          <option value="bar">Bar</option>
+          <option value="pie">Pie</option>
+          <option value="list">Liste</option>
+        </select>
+      </div>
+      <div>
+        <label className="block text-sm text-white mb-1">Configuration (JSON)</label>
+        <textarea
+          className="input w-full font-mono"
+          rows="4"
+          value={config}
+          onChange={(e) => setConfig(e.target.value)}
+        />
+      </div>
+      <div className="flex justify-end gap-2">
+        <Button type="button" onClick={onCancel}>Annuler</Button>
+        <Button type="submit">{editing ? 'Enregistrer' : 'Ajouter'}</Button>
+      </div>
+    </form>
+  );
+}

--- a/src/hooks/useGadgets.js
+++ b/src/hooks/useGadgets.js
@@ -1,0 +1,124 @@
+import { useState, useCallback } from 'react';
+import { supabase } from '@/lib/supabase';
+import { useAuth } from '@/context/AuthContext';
+
+export function useGadgets() {
+  const { mama_id, user_id } = useAuth();
+  const [gadgets, setGadgets] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const fetchGadgets = useCallback(async () => {
+    if (!mama_id || !user_id) return [];
+    setLoading(true);
+    setError(null);
+    const { data, error } = await supabase
+      .from('tableaux_de_bord')
+      .select('liste_gadgets_json')
+      .eq('utilisateur_id', user_id)
+      .eq('mama_id', mama_id)
+      .single();
+    setLoading(false);
+    if (error) {
+      setError(error.message || error);
+      setGadgets([]);
+      return [];
+    }
+    const list = data?.liste_gadgets_json || [];
+    setGadgets(list);
+    return list;
+  }, [mama_id, user_id]);
+
+  const saveGadgets = useCallback(
+    async (list) => {
+      if (!mama_id || !user_id) return null;
+      setLoading(true);
+      setError(null);
+      const { error } = await supabase
+        .from('tableaux_de_bord')
+        .upsert(
+          { utilisateur_id: user_id, mama_id, liste_gadgets_json: list },
+          { onConflict: 'utilisateur_id,mama_id' }
+        );
+      setLoading(false);
+      if (error) {
+        setError(error.message || error);
+        return null;
+      }
+      setGadgets(list);
+      return list;
+    },
+    [mama_id, user_id]
+  );
+
+  const addGadget = useCallback(
+    async (gadget) => {
+      if (!mama_id) return null;
+      setLoading(true);
+      setError(null);
+      const { data, error } = await supabase
+        .from('gadgets')
+        .insert([{ ...gadget, mama_id }])
+        .select()
+        .single();
+      setLoading(false);
+      if (error) {
+        setError(error.message || error);
+        return null;
+      }
+      return data;
+    },
+    [mama_id]
+  );
+
+  const updateGadget = useCallback(
+    async (id, values) => {
+      if (!id || !mama_id) return null;
+      setLoading(true);
+      setError(null);
+      const { data, error } = await supabase
+        .from('gadgets')
+        .update(values)
+        .eq('id', id)
+        .eq('mama_id', mama_id)
+        .select()
+        .single();
+      setLoading(false);
+      if (error) {
+        setError(error.message || error);
+        return null;
+      }
+      return data;
+    },
+    [mama_id]
+  );
+
+  const deleteGadget = useCallback(
+    async (id) => {
+      if (!id || !mama_id) return;
+      setLoading(true);
+      setError(null);
+      const { error } = await supabase
+        .from('gadgets')
+        .delete()
+        .eq('id', id)
+        .eq('mama_id', mama_id);
+      setLoading(false);
+      if (error) {
+        setError(error.message || error);
+      }
+    },
+    [mama_id]
+  );
+
+  return {
+    gadgets,
+    loading,
+    error,
+    fetchGadgets,
+    saveGadgets,
+    addGadget,
+    updateGadget,
+    deleteGadget,
+  };
+}

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,22 +1,52 @@
-// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { useAuth } from "@/context/AuthContext";
-import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
-import GlassCard from "@/components/ui/GlassCard";
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite.
+import { useEffect, useState } from 'react';
+import { Reorder } from 'framer-motion';
+import { useAuth } from '@/context/AuthContext';
+import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
+import GlassCard from '@/components/ui/GlassCard';
+import { Button } from '@/components/ui/button';
+import { useGadgets } from '@/hooks/useGadgets';
+import GadgetConfigForm from '@/components/dashboard/GadgetConfigForm';
+import WidgetRenderer from '@/components/dashboard/WidgetRenderer';
 
 export default function Dashboard() {
-  const { session, userData, loading } = useAuth();
-  const user = session?.user;
+  const { loading: authLoading } = useAuth();
+  const { gadgets, loading, fetchGadgets, saveGadgets } = useGadgets();
+  const [ordered, setOrdered] = useState([]);
+  const [showForm, setShowForm] = useState(false);
 
-  if (loading || !user || !userData) {
-    return <LoadingSpinner message="Chargement..." />;
-  }
+  useEffect(() => {
+    fetchGadgets();
+  }, [fetchGadgets]);
+
+  useEffect(() => {
+    setOrdered(gadgets);
+  }, [gadgets]);
+
+  if (authLoading || loading) return <LoadingSpinner message="Chargement..." />;
+
+  const saveOrder = async () => {
+    await saveGadgets(ordered);
+  };
 
   return (
-    <div className="p-6 flex justify-center">
-      <GlassCard className="w-full max-w-md text-center">
-        <h1 className="text-2xl font-bold mb-2">Bienvenue sur MamaStock</h1>
-        <p>Connecté avec : {user.email}</p>
-      </GlassCard>
+    <div className="p-6 space-y-4">
+      {showForm && (
+        <GlassCard className="p-4 max-w-lg mx-auto">
+          <GadgetConfigForm onSave={() => { setShowForm(false); fetchGadgets(); }} onCancel={() => setShowForm(false)} />
+        </GlassCard>
+      )}
+      <Reorder.Group axis="y" values={ordered} onReorder={setOrdered} className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {ordered.map((g, idx) => (
+          <Reorder.Item key={idx} value={g} className="bg-glass border border-borderGlass rounded-xl p-4">
+            <WidgetRenderer config={g.configuration_json} />
+          </Reorder.Item>
+        ))}
+      </Reorder.Group>
+      <div className="flex gap-2">
+        <Button onClick={() => setShowForm(true)}>Ajouter un gadget</Button>
+        <Button onClick={saveOrder}>Enregistrer</Button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- support gadgets and dashboards tables in Ajout.sql
- add hook for fetching/updating gadgets
- add gadget config form component
- implement drag & drop gadgets dashboard

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687bca3ee760832dab5ef26b684e07c8