### PR TITLE
Add logs security module

### DIFF
--- a/db/Ajout.sql
+++ b/db/Ajout.sql
@@ -675,3 +675,38 @@ create table if not exists tableaux_de_bord (
 );
 create unique index if not exists uniq_tableaux_de_bord_user on tableaux_de_bord(utilisateur_id, mama_id);
 create index if not exists idx_tableaux_de_bord_mama_id on tableaux_de_bord(mama_id);
+
+-- Journaux utilisateur (logs activite)
+create table if not exists journaux_utilisateur (
+  id uuid primary key default gen_random_uuid(),
+  utilisateur_id uuid references utilisateurs(id),
+  action text,
+  page text,
+  ip text,
+  date_action timestamptz default now(),
+  mama_id uuid references mamas(id)
+);
+create index if not exists idx_journaux_utilisateur_mama on journaux_utilisateur(mama_id);
+alter table if exists journaux_utilisateur
+  add column if not exists utilisateur_id uuid references utilisateurs(id),
+  add column if not exists page text,
+  add column if not exists ip text,
+  add column if not exists date_action timestamptz;
+
+-- Logs securite
+create table if not exists logs_securite (
+  id uuid primary key default gen_random_uuid(),
+  type_evenement text,
+  details jsonb,
+  date_evenement timestamptz default now(),
+  niveau_criticite text,
+  utilisateur_id uuid references utilisateurs(id),
+  mama_id uuid references mamas(id)
+);
+create index if not exists idx_logs_securite_mama on logs_securite(mama_id);
+alter table if exists logs_securite
+  add column if not exists type_evenement text,
+  add column if not exists details jsonb,
+  add column if not exists date_evenement timestamptz,
+  add column if not exists niveau_criticite text,
+  add column if not exists utilisateur_id uuid references utilisateurs(id);

--- a/src/hooks/useLogs.js
+++ b/src/hooks/useLogs.js
@@ -11,13 +11,67 @@ export function useLogs() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
 
-  async function fetchLogs({ search = "", startDate = null, endDate = null, page = 1, limit = 100 } = {}) {
+  async function fetchLogs({
+    search = "",
+    startDate = null,
+    endDate = null,
+    page = 1,
+    limit = 100,
+    ip = null,
+    utilisateur = null,
+    date = null,
+    type = null,
+  } = {}) {
     if (!mama_id) {
-      // Skip querying when authentication hasn't provided a mama id yet
       return [];
     }
     setLoading(true);
     setError(null);
+
+    if (ip || utilisateur || date || type) {
+      let q1 = supabase
+        .from("journaux_utilisateur")
+        .select(
+          "id, utilisateur_id, action, page, ip, date_action, mama_id, utilisateurs:utilisateur_id(nom)"
+        )
+        .eq("mama_id", mama_id)
+        .order("date_action", { ascending: false });
+      if (ip) q1 = q1.eq("ip", ip);
+      if (utilisateur) q1 = q1.eq("utilisateur_id", utilisateur);
+      if (date) q1 = q1.gte("date_action", date).lt("date_action", date + "T23:59:59");
+      if (type) q1 = q1.ilike("action", `%${type}%`);
+
+      let q2 = supabase
+        .from("logs_securite")
+        .select(
+          "id, type_evenement, details, date_evenement, niveau_criticite, ip, utilisateur_id, mama_id, utilisateurs:utilisateur_id(nom)"
+        )
+        .eq("mama_id", mama_id)
+        .order("date_evenement", { ascending: false });
+      if (ip) q2 = q2.eq("ip", ip);
+      if (utilisateur) q2 = q2.eq("utilisateur_id", utilisateur);
+      if (date) q2 = q2.gte("date_evenement", date).lt("date_evenement", date + "T23:59:59");
+      if (type) q2 = q2.ilike("type_evenement", `%${type}%`);
+
+      const [{ data: d1, error: e1 }, { data: d2, error: e2 }] = await Promise.all([q1, q2]);
+      setLoading(false);
+      if (e1 || e2) {
+        setError(e1 || e2);
+        setLogs([]);
+        return [];
+      }
+      const rows = [];
+      (d1 || []).forEach((l) => rows.push({ ...l, source: "activite" }));
+      (d2 || []).forEach((l) => rows.push({ ...l, source: "securite" }));
+      rows.sort(
+        (a, b) =>
+          new Date(b.date_action || b.date_evenement).getTime() -
+          new Date(a.date_action || a.date_evenement).getTime()
+      );
+      setLogs(rows);
+      return rows;
+    }
+
     let query = supabase
       .from("journaux_utilisateur")
       .select("*, utilisateurs:done_by(nom)")
@@ -39,10 +93,11 @@ export function useLogs() {
   }
 
   function exportLogsToExcel() {
-    const rows = (logs || []).map(l => ({
-      date: l.created_at,
-      action: l.action,
-      utilisateur: l.utilisateurs?.nom || l.done_by,
+    const rows = (logs || []).map((l) => ({
+      date: l.date_action || l.date_evenement || l.created_at,
+      action: l.action || l.type_evenement,
+      ip: l.ip || "",
+      utilisateur: l.utilisateurs?.nom || l.utilisateur_id || l.done_by,
     }));
     const wb = XLSX.utils.book_new();
     XLSX.utils.book_append_sheet(wb, XLSX.utils.json_to_sheet(rows), "Logs");

--- a/src/layout/Sidebar.jsx
+++ b/src/layout/Sidebar.jsx
@@ -152,6 +152,7 @@ export default function Sidebar() {
       title: "Audit",
       items: [
         { module: "audit", to: "/audit", label: "Audit", icon: <History size={16} /> },
+        { module: "logs", to: "/logs", label: "Logs", icon: <History size={16} /> },
       ],
     },
     {

--- a/src/pages/Logs.jsx
+++ b/src/pages/Logs.jsx
@@ -1,0 +1,73 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { useEffect, useState } from "react";
+import { useLogs } from "@/hooks/useLogs";
+import { useAuth } from "@/context/AuthContext";
+import { Button } from "@/components/ui/button";
+import TableContainer from "@/components/ui/TableContainer";
+import { Toaster } from "react-hot-toast";
+import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+
+export default function Logs() {
+  const { mama_id, loading: authLoading } = useAuth();
+  const { logs, fetchLogs, loading, error } = useLogs();
+  const [ip, setIp] = useState("");
+  const [utilisateur, setUtilisateur] = useState("");
+  const [date, setDate] = useState("");
+  const [type, setType] = useState("");
+
+  useEffect(() => {
+    if (!authLoading && mama_id) fetchLogs();
+  }, [authLoading, mama_id, fetchLogs]);
+
+  if (authLoading) return <LoadingSpinner message="Chargement..." />;
+  if (!mama_id) return null;
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    await fetchLogs({ ip: ip || undefined, utilisateur: utilisateur || undefined, date: date || undefined, type: type || undefined });
+  };
+
+  return (
+    <div className="p-6 container mx-auto space-y-4 text-sm">
+      <Toaster position="top-right" />
+      <h1 className="text-2xl font-bold">Logs sécurité & activité</h1>
+      <form onSubmit={handleSubmit} className="flex gap-2 flex-wrap items-end">
+        <input className="input" placeholder="IP" value={ip} onChange={(e) => setIp(e.target.value)} />
+        <input className="input" placeholder="Utilisateur id" value={utilisateur} onChange={(e) => setUtilisateur(e.target.value)} />
+        <input type="date" className="input" value={date} onChange={(e) => setDate(e.target.value)} />
+        <input className="input" placeholder="Type" value={type} onChange={(e) => setType(e.target.value)} />
+        <Button type="submit">Filtrer</Button>
+      </form>
+      {loading ? (
+        <LoadingSpinner message="Chargement..." />
+      ) : error ? (
+        <div className="text-red-600">{error.message || error}</div>
+      ) : (
+        <TableContainer>
+          <table className="min-w-full text-xs">
+            <thead>
+              <tr>
+                <th className="px-2 py-1">Date</th>
+                <th className="px-2 py-1">Type</th>
+                <th className="px-2 py-1">IP</th>
+                <th className="px-2 py-1">Utilisateur</th>
+                <th className="px-2 py-1">Détails</th>
+              </tr>
+            </thead>
+            <tbody>
+              {logs.map((l) => (
+                <tr key={l.id + (l.source || "")} className="align-top">
+                  <td className="border px-2 py-1 whitespace-nowrap">{new Date(l.date_action || l.date_evenement || l.created_at).toLocaleString()}</td>
+                  <td className="border px-2 py-1">{l.action || l.type_evenement}</td>
+                  <td className="border px-2 py-1">{l.ip || ""}</td>
+                  <td className="border px-2 py-1">{l.utilisateurs?.nom || l.utilisateur_id}</td>
+                  <td className="border px-2 py-1 font-mono break-all">{JSON.stringify(l.details || l.description || {})}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </TableContainer>
+      )}
+    </div>
+  );
+}

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -76,6 +76,7 @@ const Consolidation = lazy(() => import("@/pages/Consolidation.jsx"));
 const CreateMama = lazy(() => import("@/pages/auth/CreateMama.jsx"));
 const Feedback = lazy(() => import("@/pages/Feedback.jsx"));
 const AuditTrail = lazy(() => import("@/pages/AuditTrail.jsx"));
+const Logs = lazy(() => import("@/pages/Logs.jsx"));
 const Consentements = lazy(() => import("@/pages/Consentements.jsx"));
 const Requisitions = lazy(() => import("@/pages/requisitions/Requisitions.jsx"));
 const RequisitionForm = lazy(() => import("@/pages/requisitions/RequisitionForm.jsx"));
@@ -381,6 +382,10 @@ export default function Router() {
           <Route
             path="/feedback"
             element={<ProtectedRoute accessKey="feedback"><Feedback /></ProtectedRoute>}
+          />
+          <Route
+            path="/logs"
+            element={<ProtectedRoute accessKey="logs"><Logs /></ProtectedRoute>}
           />
           <Route
             path="/audit"


### PR DESCRIPTION
## Summary
- extend Ajout.sql with tables for journaux_utilisateur and logs_securite
- implement new hooks/useLogs.js for unified logs
- add Logs page with filters
- register /logs route and sidebar entry

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687bd41932f4832d84b93465efa4a162