### PR TITLE
Fix auth and navigation issues

### DIFF
--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -1,6 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { Navigate, useLocation } from "react-router-dom";
 import useAuth from "@/hooks/useAuth";
+import { normalizeRights } from "@/lib/access";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 import useConsentements from "@/hooks/useConsentements";
 
@@ -75,13 +76,10 @@ export default function ProtectedRoute({ children, accessKey }) {
   // Vérifie les droits si une clé est fournie
   if (accessKey) {
     const required = Array.isArray(accessKey) ? accessKey : [accessKey];
-    const hasRight = (key) =>
-      isSuperadmin ||
-      (Array.isArray(access_rights) && access_rights.includes(key)) ||
-      access_rights?.[key]?.peut_voir === true;
+    const rights = normalizeRights(access_rights);
+    const hasRight = (key) => isSuperadmin || rights.includes(key);
 
-    const isAllowed =
-      hasRight("parametrage") || required.some((k) => hasRight(k));
+    const isAllowed = hasRight("parametrage") || required.some((k) => hasRight(k));
 
     if (!isAllowed && location.pathname !== "/unauthorized") {
       return <Navigate to="/unauthorized" replace />;

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -1,6 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { Link, useLocation } from "react-router-dom";
 import { useAuth } from "@/context/AuthContext";
+import { normalizeRights } from "@/lib/access";
 import MamaLogo from "@/components/ui/MamaLogo";
 
 export default function Sidebar() {
@@ -9,13 +10,8 @@ export default function Sidebar() {
 
   if (loading || access_rights === null) return null;
   const showAll = role === "superadmin";
-  const rights = Array.isArray(access_rights)
-    ? access_rights
-    : Object.entries(access_rights || {})
-        .filter(([, v]) => v?.peut_voir)
-        .map(([k]) => k);
-  const has = (key) =>
-    showAll || rights.includes(key) || access_rights?.[key]?.peut_voir === true;
+  const rights = normalizeRights(access_rights);
+  const has = (key) => showAll || rights.includes(key);
   const canAnalyse = has("analyse");
 
   return (

--- a/src/layout/Layout.jsx
+++ b/src/layout/Layout.jsx
@@ -3,6 +3,7 @@ import { Outlet, useLocation, Link } from "react-router-dom";
 import { useState, useEffect } from "react";
 import Sidebar from "@/layout/Sidebar";
 import useAuth from "@/hooks/useAuth";
+import useNotifications from "@/hooks/useNotifications";
 import { Badge } from "@/components/ui/badge";
 import { Bell } from "lucide-react";
 import toast from "react-hot-toast";
@@ -26,19 +27,8 @@ export default function Layout() {
     loading,
     logout,
   } = useAuth();
-  const placeholder = () => ({
-    fetchUnreadCount: async () => 0,
-    subscribeToNotifications: () => () => {},
-  });
-  const [useNotif, setUseNotif] = useState(() => placeholder);
-  const { fetchUnreadCount, subscribeToNotifications } = useNotif();
+  const { fetchUnreadCount, subscribeToNotifications } = useNotifications();
   const [unread, setUnread] = useState(0);
-
-  useEffect(() => {
-    import("@/hooks/useNotifications").then((mod) => {
-      setUseNotif(() => mod.default);
-    });
-  }, []);
 
   useEffect(() => {
     fetchUnreadCount().then(setUnread);

--- a/src/layout/Sidebar.jsx
+++ b/src/layout/Sidebar.jsx
@@ -1,6 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { Link, useLocation } from "react-router-dom";
 import { useAuth } from "@/context/AuthContext";
+import { normalizeRights } from "@/lib/access";
 import toast from "react-hot-toast";
 import {
   Boxes,
@@ -49,10 +50,8 @@ export default function Sidebar() {
     return null;
   }
 
-  const peutVoir = (module) =>
-    isSuperadmin ||
-    (Array.isArray(access_rights) && access_rights.includes(module)) ||
-    access_rights?.[module]?.peut_voir === true;
+  const rights = normalizeRights(access_rights);
+  const peutVoir = (module) => isSuperadmin || rights.includes(module);
 
   const Item = ({ to, icon, label }) => (
     <Link

--- a/src/lib/access.js
+++ b/src/lib/access.js
@@ -1,0 +1,14 @@
+export function normalizeRights(rights) {
+  if (Array.isArray(rights)) return rights;
+  if (rights && typeof rights === "object") {
+    return Object.entries(rights)
+      .filter(([, v]) => v === true || v?.peut_voir === true)
+      .map(([k]) => k);
+  }
+  return [];
+}
+
+export function hasAccess(rights, key, isSuperadmin = false) {
+  if (!key) return false;
+  return isSuperadmin || normalizeRights(rights).includes(key);
+}


### PR DESCRIPTION
## Summary
- normalize access rights when loading user data
- expose `hasAccess` helper in auth context
- simplify layout notifications hook usage
- fix access checks in sidebar and protected route
- share `normalizeRights` helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c9e5d9274832daa5c2baaff253935