### PR TITLE
Fix access control handling

### DIFF
--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "@/context/AuthContext";
-import { hasAccess } from "@/lib/utils";
+import { hasAccess } from "@/lib/access";
 import LoadingScreen from "@/components/ui/LoadingScreen";
 
 export default function ProtectedRoute({ children, accessKey }) {
@@ -16,7 +16,10 @@ export default function ProtectedRoute({ children, accessKey }) {
       return;
     }
 
-    if (accessKey && !hasAccess(accessKey, userData.access_rights)) {
+    if (
+      accessKey &&
+      !hasAccess(userData.access_rights, accessKey, "peut_voir", userData.role === "superadmin")
+    ) {
       navigate("/unauthorized", { replace: true });
     }
   }, [session, userData, pending, accessKey, navigate]);

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -1,18 +1,16 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { Link, useLocation } from "react-router-dom";
 import { useAuth } from "@/context/AuthContext";
-import { normalizeRights } from "@/lib/access";
-import { hasAccess } from "@/lib/utils";
+
 import MamaLogo from "@/components/ui/MamaLogo";
 
 export default function Sidebar() {
-  const { access_rights, role, loading } = useAuth();
+  const { access_rights, role, loading, hasAccess } = useAuth();
   const { pathname } = useLocation();
 
   if (loading || access_rights === null) return null;
   const showAll = role === "superadmin";
-  const rights = normalizeRights(access_rights);
-  const has = (key) => showAll || hasAccess(key, rights);
+  const has = (key) => showAll || hasAccess(key, "peut_voir");
   const canAnalyse = has("analyse");
 
   return (

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -18,6 +18,8 @@ export default function useAuth() {
     pending: ctx.pending,
     isAuthenticated: ctx.isAuthenticated,
     isSuperadmin: ctx.isSuperadmin,
+    hasAccess: ctx.hasAccess,
+    getAuthorizedModules: ctx.getAuthorizedModules,
     error: ctx.error,
   };
 }

--- a/src/layout/Sidebar.jsx
+++ b/src/layout/Sidebar.jsx
@@ -1,7 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { Link, useLocation } from "react-router-dom";
 import { useAuth } from "@/context/AuthContext";
-import { normalizeRights } from "@/lib/access";
 import toast from "react-hot-toast";
 import {
   Boxes,
@@ -40,6 +39,7 @@ export default function Sidebar() {
     logout,
     session,
     isSuperadmin,
+    hasAccess,
   } = useAuth();
   const { pathname } = useLocation();
   if (import.meta.env.DEV) {
@@ -50,8 +50,8 @@ export default function Sidebar() {
     return null;
   }
 
-  const rights = normalizeRights(access_rights);
-  const peutVoir = (module) => isSuperadmin || rights.includes(module);
+  const peutVoir = (module) =>
+    isSuperadmin || hasAccess(module, "peut_voir");
 
   const Item = ({ to, icon, label }) => (
     <Link

--- a/src/lib/access.js
+++ b/src/lib/access.js
@@ -8,7 +8,18 @@ export function normalizeRights(rights) {
   return [];
 }
 
-export function hasAccess(rights, key, isSuperadmin = false) {
-  if (!key) return false;
-  return isSuperadmin || normalizeRights(rights).includes(key);
+export function hasAccess(accessRights, module, right = "peut_voir", isSuperadmin = false) {
+  if (!module) return false;
+  if (isSuperadmin) return true;
+  if (!accessRights || typeof accessRights !== "object") return false;
+  const mod = accessRights[module];
+  if (!mod || typeof mod !== "object") return false;
+  return mod[right] === true;
+}
+
+export function getAuthorizedModules(accessRights, right = "peut_voir") {
+  if (!accessRights || typeof accessRights !== "object") return [];
+  return Object.entries(accessRights)
+    .filter(([, v]) => v && v[right] === true)
+    .map(([k]) => k);
 }

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,8 +1,6 @@
 export function hasAccess(module, access_rights) {
-  if (!access_rights) return false;
-  if (Array.isArray(access_rights)) return access_rights.includes(module);
-  if (typeof access_rights === "object") {
-    return Boolean(access_rights[module]);
-  }
-  return false;
+  if (!access_rights || typeof access_rights !== "object") return false;
+  const mod = access_rights[module];
+  if (!mod || typeof mod !== "object") return false;
+  return mod.peut_voir === true || mod === true;
 }

--- a/src/pages/auth/Login.jsx
+++ b/src/pages/auth/Login.jsx
@@ -19,7 +19,7 @@ export default function Login() {
   const navigate = useNavigate();
   const { pathname } = useLocation();
 
-  const { session, userData, loading: authLoading } = useAuth();
+  const { session, userData, loading: authLoading, getAuthorizedModules } = useAuth();
 
 
   // Redirection après authentification une fois les données chargées
@@ -33,9 +33,7 @@ export default function Login() {
       navigate("/blocked");
       return;
     }
-    const rights = Array.isArray(userData.access_rights)
-      ? userData.access_rights
-      : [];
+    const rights = getAuthorizedModules();
     if (rights.length === 0 && pathname !== "/unauthorized") {
       navigate("/unauthorized");
       return;


### PR DESCRIPTION
## Summary
- update helper `lib/access.js` with new `hasAccess` and `getAuthorizedModules`
- expose these helpers through `AuthContext`
- use new access logic in sidebar, login page and protected routes
- sign out blocked users and log user data for debugging

## Testing
- `npx vitest run` *(fails: Missing Supabase credentials)*

------
https://chatgpt.com/codex/tasks/task_e_687caf1ee4ac832db63ac248483a4e17