### PR TITLE
Align front views with Supabase

### DIFF
--- a/db/Ajout.sql
+++ b/db/Ajout.sql
@@ -464,6 +464,15 @@ join requisitions on requisitions.id = requisition_lignes.requisition_id
 where requisitions.actif is true
 group by produit_id, mama_id;
 
+-- Vue cumulée des stocks théoriques par produit
+create or replace view v_stocks as
+select s.mama_id,
+       s.produit_id,
+       sum(s.quantite) as stock
+from stocks s
+where s.actif is true
+group by s.mama_id, s.produit_id;
+
 -- Module Planning prévisionnel
 create table if not exists planning_previsionnel (
   id uuid primary key default gen_random_uuid(),
@@ -590,7 +599,7 @@ group by p.mama_id, p.id, p.actif;
 create or replace view v_ecarts_inventaire as
 select i.mama_id,
        l.produit_id,
-       i.date as date,
+       i.date_inventaire as date,
        l.zone_id as zone,
        l.quantite_theorique as stock_theorique,
        l.quantite_reelle as stock_reel,

--- a/src/hooks/useProducts.js
+++ b/src/hooks/useProducts.js
@@ -42,7 +42,22 @@ export function useProducts() {
     if (typeof actif === "boolean") query = query.eq("actif", actif);
 
     const { data, error, count } = await query;
-    setProducts(Array.isArray(data) ? data : []);
+    const { data: pmpData } = await supabase
+      .from('v_pmp')
+      .select('produit_id, pmp')
+      .eq('mama_id', mama_id);
+    const { data: stockData } = await supabase
+      .from('v_stocks')
+      .select('produit_id, stock')
+      .eq('mama_id', mama_id);
+    const pmpMap = Object.fromEntries((pmpData || []).map(p => [p.produit_id, p.pmp]));
+    const stockMap = Object.fromEntries((stockData || []).map(s => [s.produit_id, s.stock]));
+    const final = (Array.isArray(data) ? data : []).map(p => ({
+      ...p,
+      pmp: pmpMap[p.id] ?? p.pmp,
+      stock_theorique: stockMap[p.id] ?? p.stock_theorique,
+    }));
+    setProducts(final);
     setTotal(count || 0);
     setLoading(false);
     if (error) {

--- a/src/hooks/useProduitsAutocomplete.js
+++ b/src/hooks/useProduitsAutocomplete.js
@@ -15,7 +15,7 @@ export function useProduitsAutocomplete() {
     setError(null);
     let q = supabase
       .from("v_produits_dernier_prix")
-      .select("id, nom, unite, pmp")
+      .select("id, nom, unite")
       .eq("mama_id", mama_id)
       .eq("actif", true);
     if (query) q = q.ilike("nom", `%${query}%`);
@@ -26,8 +26,17 @@ export function useProduitsAutocomplete() {
       setError(error);
       return [];
     }
-    setResults(Array.isArray(data) ? data : []);
-    return data || [];
+    const { data: pmpData } = await supabase
+      .from('v_pmp')
+      .select('produit_id, pmp')
+      .eq('mama_id', mama_id);
+    const pmpMap = Object.fromEntries((pmpData || []).map(p => [p.produit_id, p.pmp]));
+    const final = (Array.isArray(data) ? data : []).map(p => ({
+      ...p,
+      pmp: pmpMap[p.id] ?? 0,
+    }));
+    setResults(final);
+    return final;
   }, [mama_id]);
 
   return { results, loading, error, searchProduits };

--- a/src/hooks/useProduitsInventaire.js
+++ b/src/hooks/useProduitsInventaire.js
@@ -16,7 +16,7 @@ export function useProduitsInventaire() {
       setError(null);
       let query = supabase
         .from('v_produits_dernier_prix')
-        .select('id, nom, unite, pmp, famille, stock_theorique')
+        .select('id, nom, unite, famille')
         .eq('mama_id', mama_id)
         .eq('actif', true);
       if (famille) query = query.ilike('famille', `%${famille}%`);
@@ -27,8 +27,23 @@ export function useProduitsInventaire() {
         setError(error);
         return [];
       }
-      setProduits(Array.isArray(data) ? data : []);
-      return data || [];
+      const { data: pmpData } = await supabase
+        .from('v_pmp')
+        .select('produit_id, pmp')
+        .eq('mama_id', mama_id);
+      const { data: stockData } = await supabase
+        .from('v_stocks')
+        .select('produit_id, stock')
+        .eq('mama_id', mama_id);
+      const pmpMap = Object.fromEntries((pmpData || []).map(p => [p.produit_id, p.pmp]));
+      const stockMap = Object.fromEntries((stockData || []).map(s => [s.produit_id, s.stock]));
+      const final = (Array.isArray(data) ? data : []).map(p => ({
+        ...p,
+        pmp: pmpMap[p.id] ?? 0,
+        stock_theorique: stockMap[p.id] ?? 0,
+      }));
+      setProduits(final);
+      return final;
     },
     [mama_id]
   );

--- a/src/hooks/useStock.js
+++ b/src/hooks/useStock.js
@@ -87,16 +87,16 @@ export function useStock() {
 
   // ----- New helpers for stock module -----
   const getStockTheorique = useCallback(
-      async (produit_id) => {
-        if (!mama_id || !produit_id) return 0;
-        const { data, error } = await supabase
-          .from("produits")
-          .select("stock_theorique")
-          .eq("mama_id", mama_id)
-          .eq("id", produit_id)
-          .single();
+    async (produit_id) => {
+      if (!mama_id || !produit_id) return 0;
+      const { data, error } = await supabase
+        .from("v_stocks")
+        .select("stock")
+        .eq("mama_id", mama_id)
+        .eq("produit_id", produit_id)
+        .single();
       if (error) return 0;
-      return data?.stock_theorique ?? 0;
+      return data?.stock ?? 0;
     },
     [mama_id]
   );

--- a/src/pages/Rgpd.jsx
+++ b/src/pages/Rgpd.jsx
@@ -17,14 +17,6 @@ export default function Rgpd() {
       >
         <GlassCard className="space-y-6 text-white">
           <h1 className="text-3xl font-bold text-center">Données &amp; Confidentialité</h1>
-        <Motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5 }}
-          className="w-full max-w-3xl"
-        >
-          <GlassCard className="space-y-6 text-white">
-            <h1 className="text-3xl font-bold text-center">Données &amp; Confidentialité</h1>
             <Motion.section
               initial={{ opacity: 0, y: 20 }}
               whileInView={{ opacity: 1, y: 0 }}

--- a/src/pages/Transferts.jsx
+++ b/src/pages/Transferts.jsx
@@ -75,7 +75,7 @@ export default function Transferts() {
   const filtered = transferts
     .map((t) => {
       const prod = produits.find((p) => p.id === t.produit_id) || {};
-      const prix = prod.pmp || prod.dernier_prix || 0;
+      const prix = prod.pmp || 0;
       const cout = Math.round(t.quantite * prix * 100) / 100;
       return { ...t, nom: prod.nom || "-", prix, cout };
     })

--- a/src/pages/inventaire/InventaireForm.jsx
+++ b/src/pages/inventaire/InventaireForm.jsx
@@ -37,7 +37,7 @@ export default function InventaireForm() {
 
   const getProduct = id => products.find(p => p.id === id) || {};
   const getTheo = id => Number(getProduct(id).stock_theorique || 0);
-  const getPrice = id => Number(getProduct(id).pmp || getProduct(id).dernier_prix || 0);
+  const getPrice = id => Number(getProduct(id).pmp || 0);
 
   const totalValeur = lignes.reduce((s, l) => s + Number(l.quantite || 0) * getPrice(l.produit_id), 0);
   const totalEcart = lignes.reduce((s, l) => s + (Number(l.quantite || 0) - getTheo(l.produit_id)) * getPrice(l.produit_id), 0);

--- a/test/useProduitsAutocomplete.test.js
+++ b/test/useProduitsAutocomplete.test.js
@@ -28,7 +28,8 @@ test('searchProduits filters by mama_id and query', async () => {
     await result.current.searchProduits('car');
   });
   expect(fromMock).toHaveBeenCalledWith('v_produits_dernier_prix');
-  expect(selectMock).toHaveBeenCalledWith('id, nom, unite, pmp');
+  expect(fromMock).toHaveBeenCalledWith('v_pmp');
+  expect(selectMock).toHaveBeenCalledWith('id, nom, unite');
   expect(eqMock).toHaveBeenCalledWith('mama_id', 'm1');
   expect(ilikeMock).toHaveBeenCalledWith('nom', '%car%');
 });

--- a/test/useProduitsInventaire.test.js
+++ b/test/useProduitsInventaire.test.js
@@ -28,7 +28,9 @@ test('fetchProduits filters by family and search', async () => {
     await result.current.fetchProduits({ famille: 'Viande', search: 'boeuf' });
   });
   expect(fromMock).toHaveBeenCalledWith('v_produits_dernier_prix');
-  expect(selectMock).toHaveBeenCalledWith('id, nom, unite, pmp, famille, stock_theorique');
+  expect(fromMock).toHaveBeenCalledWith('v_pmp');
+  expect(fromMock).toHaveBeenCalledWith('v_stocks');
+  expect(selectMock).toHaveBeenCalledWith('id, nom, unite, famille');
   expect(eqMock).toHaveBeenCalledWith('mama_id', 'm1');
   expect(eqMock).toHaveBeenCalledWith('actif', true);
   expect(ilikeMock).toHaveBeenCalledWith('famille', '%Viande%');


### PR DESCRIPTION
## Summary
- expose new `v_stocks` view and fix `v_ecarts_inventaire` date column
- fetch PMP and stock data from `v_pmp` and `v_stocks`
- update stock and price helpers to rely on those views
- adjust tests for new queries
- fix JSX issue in `Rgpd` page

## Testing
- `npm test` *(fails: Missing Supabase credentials)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687d22b1e3f8832d89b3bb8d6020cccb