### PR TITLE
Update facture module

### DIFF
--- a/db/Ajout.sql
+++ b/db/Ajout.sql
@@ -1,0 +1,35 @@
+-- Mise à jour module Factures
+-- Calcul automatique des totaux à chaque modification de ligne
+create or replace function update_facture_totals() returns trigger as $$
+begin
+  update factures
+  set total_ht = coalesce((select sum(quantite * prix_unitaire) from facture_lignes where facture_id = coalesce(new.facture_id, old.facture_id) and actif = true),0),
+      total_tva = coalesce((select sum(quantite * prix_unitaire * coalesce(tva,0)/100) from facture_lignes where facture_id = coalesce(new.facture_id, old.facture_id) and actif = true),0),
+      total_ttc = coalesce((select sum(quantite * prix_unitaire * (1 + coalesce(tva,0)/100)) from facture_lignes where facture_id = coalesce(new.facture_id, old.facture_id) and actif = true),0),
+      montant_total = coalesce((select sum(quantite * prix_unitaire * (1 + coalesce(tva,0)/100)) from facture_lignes where facture_id = coalesce(new.facture_id, old.facture_id) and actif = true),0)
+  where id = coalesce(new.facture_id, old.facture_id);
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger trg_facture_lignes_totals
+  after insert or update or delete on facture_lignes
+  for each row execute procedure update_facture_totals();
+
+-- Historique des achats
+create or replace function insert_achat_from_facture_line() returns trigger as $$
+begin
+  if tg_op = 'INSERT' then
+    insert into achats(mama_id, produit_id, supplier_id, prix, quantite, date_achat)
+    values(new.mama_id, new.produit_id,
+           (select fournisseur_id from factures where id = new.facture_id),
+           new.prix_unitaire, new.quantite,
+           (select date_facture from factures where id = new.facture_id));
+  end if;
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger trg_facture_lignes_achats
+  after insert on facture_lignes
+  for each row execute procedure insert_achat_from_facture_line();

--- a/src/hooks/useFacturesAutocomplete.js
+++ b/src/hooks/useFacturesAutocomplete.js
@@ -14,12 +14,12 @@ export function useFacturesAutocomplete() {
     setError(null);
     let q = supabase
       .from("factures")
-      .select("id, numero, date, fournisseurs(nom)")
+      .select("id, numero, date_facture, fournisseurs(nom)")
       .eq("mama_id", mama_id);
     if (query) {
       q = q.ilike("numero", `%${query}%`);
     }
-    q = q.order("date", { ascending: false }).limit(10);
+    q = q.order("date_facture", { ascending: false }).limit(10);
     const { data, error } = await q;
     setLoading(false);
     if (error) {

--- a/src/pages/factures/FactureForm.jsx
+++ b/src/pages/factures/FactureForm.jsx
@@ -21,7 +21,7 @@ export default function FactureForm({ facture, suppliers = [], onClose }) {
   const [fournisseur_id, setFournisseurId] = useState(facture?.fournisseur_id || "");
   const [fournisseurName, setFournisseurName] = useState("");
   const [numero, setNumero] = useState(facture?.numero || "");
-  const [statut, setStatut] = useState(facture?.statut || "en attente");
+  const [statut, setStatut] = useState(facture?.statut || "brouillon");
   const [lignes, setLignes] = useState(
     facture?.lignes?.map(l => ({
       ...l,
@@ -93,7 +93,7 @@ export default function FactureForm({ facture, suppliers = [], onClose }) {
       for (const ligne of lignes) {
         if (ligne.produit_id) {
           const { produit_nom: _unused, ...rest } = ligne;
-          await addLigneFacture(fid, { ...rest, prix: ligne.prix_unitaire, fournisseur_id });
+          await addLigneFacture(fid, { ...rest, fournisseur_id });
         }
       }
       await calculateTotals(fid);
@@ -209,9 +209,13 @@ export default function FactureForm({ facture, suppliers = [], onClose }) {
         value={statut}
         onChange={e => setStatut(e.target.value)}
       >
+        <option value="brouillon">Brouillon</option>
         <option value="en attente">En attente</option>
+        <option value="validée">Validée</option>
         <option value="payée">Payée</option>
         <option value="refusée">Refusée</option>
+        <option value="annulée">Annulée</option>
+        <option value="archivée">Archivée</option>
       </select>
       <label>
         Justificatif PDF : <input type="file" accept="application/pdf,image/*" onChange={e => setFile(e.target.files[0])} />

--- a/src/pages/factures/Factures.jsx
+++ b/src/pages/factures/Factures.jsx
@@ -15,9 +15,13 @@ import * as XLSX from "xlsx";
 import { motion as Motion } from "framer-motion";
 
 const STATUTS = {
+  brouillon: "badge",
   "en attente": "badge badge-user",
-  "payée": "badge badge-admin",
-  "refusée": "badge badge-superadmin"
+  validée: "badge badge-admin",
+  payée: "badge badge-admin",
+  refusée: "badge badge-superadmin",
+  annulée: "badge badge-superadmin",
+  archivée: "badge"
 };
 
 export default function Factures() {
@@ -68,7 +72,7 @@ export default function Factures() {
 
   // Suppression avec confirmation
   const handleDelete = async (facture) => {
-    if (window.confirm(`Supprimer la facture n°${facture.id} ?`)) {
+    if (window.confirm(`Archiver la facture n°${facture.id} ?`)) {
       setLoading(true);
       await deleteFacture(facture.id);
       await getFactures({
@@ -81,7 +85,7 @@ export default function Factures() {
         pageSize,
       });
       setLoading(false);
-      toast.success("Facture supprimée.");
+      toast.success("Facture archivée.");
     }
   };
 
@@ -110,9 +114,9 @@ export default function Factures() {
         </select>
         <select className="input" value={statutFilter} onChange={e => setStatutFilter(e.target.value)}>
           <option value="">Tous statuts</option>
-          <option value="en attente">En attente</option>
-          <option value="payée">Payée</option>
-          <option value="refusée">Refusée</option>
+          {Object.keys(STATUTS).map(s => (
+            <option key={s} value={s}>{s}</option>
+          ))}
         </select>
         <input
           type="month"
@@ -205,7 +209,7 @@ export default function Factures() {
                   onClick={() => handleDelete(facture)}
                   disabled={loading}
                 >
-                  Supprimer
+                  Archiver
                 </Button>
               </td>
             </tr>

--- a/test/useFacturesAutocomplete.test.js
+++ b/test/useFacturesAutocomplete.test.js
@@ -28,7 +28,7 @@ test('searchFactures filters by mama_id and query', async () => {
     await result.current.searchFactures('FA');
   });
   expect(fromMock).toHaveBeenCalledWith('factures');
-  expect(selectMock).toHaveBeenCalledWith('id, numero, date, fournisseurs(nom)');
+  expect(selectMock).toHaveBeenCalledWith('id, numero, date_facture, fournisseurs(nom)');
   expect(eqMock).toHaveBeenCalledWith('mama_id', 'm1');
   expect(ilikeMock).toHaveBeenCalledWith('numero', '%FA%');
 });


### PR DESCRIPTION
## Summary
- extend facture statuses and support soft delete
- fix addLigneFacture to use prix_unitaire, total and achats
- correct calculateTotals logic
- adjust autocomplete query
- update forms and list filters for new statuses
- add SQL trigger helpers for totals and achats
- update failing unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e159c3df4832d870fe88ef58a1f2f