### PR TITLE
Improve fiches techniques module

### DIFF
--- a/db/Ajout.sql
+++ b/db/Ajout.sql
@@ -33,3 +33,9 @@ $$ language plpgsql;
 create trigger trg_facture_lignes_achats
   after insert on facture_lignes
   for each row execute procedure insert_achat_from_facture_line();
+
+-- Module fiches techniques : support des sous-fiches
+alter table if exists fiche_lignes
+  add column if not exists sous_fiche_id uuid references fiches_techniques(id);
+create index if not exists idx_fiche_lignes_sous_fiche_id
+  on fiche_lignes(sous_fiche_id);

--- a/src/hooks/useFichesAutocomplete.js
+++ b/src/hooks/useFichesAutocomplete.js
@@ -14,7 +14,7 @@ export function useFichesAutocomplete() {
     setLoading(true);
     setError(null);
     let q = supabase
-      .from("fiches")
+      .from("fiches_techniques")
       .select("id, nom, cout_par_portion, actif")
       .eq("mama_id", mama_id)
       .eq("actif", true);

--- a/src/pages/fiches/FicheDetail.jsx
+++ b/src/pages/fiches/FicheDetail.jsx
@@ -41,10 +41,14 @@ export default function FicheDetail({ fiche: ficheProp, onClose }) {
 
   function exportExcel() {
     const rows = fiche.lignes?.map(l => ({
-      Produit: l.product?.nom,
+      Produit: l.produit?.nom || l.sous_fiche?.nom,
       Quantite: l.quantite,
-      Unite: l.product?.unite,
-      Cout: l.product?.pmp ? (l.product.pmp * l.quantite).toFixed(2) : "",
+      Unite: l.produit?.unite || (l.sous_fiche ? "portion" : ""),
+      Cout: l.produit?.pmp
+        ? (l.produit.pmp * l.quantite).toFixed(2)
+        : l.sous_fiche?.cout_par_portion
+          ? (l.sous_fiche.cout_par_portion * l.quantite).toFixed(2)
+          : "",
     })) || [];
     const wb = XLSX.utils.book_new();
     XLSX.utils.book_append_sheet(wb, XLSX.utils.json_to_sheet(rows), "Fiche");
@@ -55,10 +59,14 @@ export default function FicheDetail({ fiche: ficheProp, onClose }) {
     const doc = new jsPDF();
     doc.text(fiche.nom, 10, 10);
     const rows = fiche.lignes?.map(l => [
-      l.product?.nom,
+      l.produit?.nom || l.sous_fiche?.nom,
       l.quantite,
-      l.product?.unite || "",
-      l.product?.pmp ? (l.product.pmp * l.quantite).toFixed(2) : "",
+      l.produit?.unite || (l.sous_fiche ? "portion" : ""),
+      l.produit?.pmp
+        ? (l.produit.pmp * l.quantite).toFixed(2)
+        : l.sous_fiche?.cout_par_portion
+          ? (l.sous_fiche.cout_par_portion * l.quantite).toFixed(2)
+          : "",
     ]) || [];
     doc.autoTable({
       head: [["Produit", "Quantité", "Unité", "Coût"]],
@@ -94,7 +102,14 @@ export default function FicheDetail({ fiche: ficheProp, onClose }) {
           <ul className="list-disc pl-6">
             {fiche.lignes?.map((l, i) => (
               <li key={i}>
-                {l.product?.nom} — {l.quantite} {l.product?.unite} — {l.product?.pmp ? (l.product.pmp * l.quantite).toFixed(2) : "-"} €
+                {l.produit?.nom || l.sous_fiche?.nom} — {l.quantite}{" "}
+                {l.produit?.unite || (l.sous_fiche ? "portion" : "")} —{" "}
+                {l.produit?.pmp
+                  ? (l.produit.pmp * l.quantite).toFixed(2)
+                  : l.sous_fiche?.cout_par_portion
+                    ? (l.sous_fiche.cout_par_portion * l.quantite).toFixed(2)
+                    : "-"}
+                {" €"}
               </li>
             ))}
           </ul>


### PR DESCRIPTION
## Summary
- fix fiche autocomplete source table
- correct product references in fiche detail view
- enhance fiche hooks for filters and duplication
- add filters and duplication on fiches list
- support sous-fiches in SQL

## Testing
- `npm run lint`
- `npm test` *(fails: Missing Supabase credentials, searchFiches expectation)*

------
https://chatgpt.com/codex/tasks/task_e_687e185d2edc832db1e21b0390f039f1