### PR TITLE
Update menu du jour module

### DIFF
--- a/src/hooks/useMenuDuJour.js
+++ b/src/hooks/useMenuDuJour.js
@@ -1,32 +1,137 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { useMenus } from "@/hooks/useMenus";
+import { useState } from "react";
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/context/AuthContext";
+import { useAuditLog } from "@/hooks/useAuditLog";
+import * as XLSX from "xlsx";
+import { saveAs } from "file-saver";
 
 export function useMenuDuJour() {
-  const {
-    menus,
-    total,
-    loading,
-    error,
-    getMenus,
-    createMenu,
-    updateMenu,
-    deleteMenu,
-    toggleMenuActive,
-    exportMenusToExcel,
-    importMenusFromExcel,
-  } = useMenus();
+  const { mama_id } = useAuth();
+  const { log } = useAuditLog();
+  const [menusDuJour, setMenus] = useState([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  async function fetchMenusDuJour({ search = "", date = "", actif = null, offset = 0, limit = 50 } = {}) {
+    if (!mama_id) return [];
+    setLoading(true);
+    setError(null);
+    let query = supabase
+      .from("menus_jour")
+      .select(
+        "*, fiches:menus_jour_fiches(fiche_id, quantite, fiche:fiches_techniques(id, nom, cout_par_portion))",
+        { count: "exact" }
+      )
+      .eq("mama_id", mama_id);
+    if (search) query = query.ilike("nom", `%${search}%`);
+    if (date) query = query.eq("date", date);
+    if (typeof actif === "boolean") query = query.eq("actif", actif);
+    const { data, count, error } = await query
+      .order("date", { ascending: false })
+      .range(offset, offset + limit - 1);
+    const withCost = Array.isArray(data)
+      ? data.map((m) => {
+          const cost = (m.fiches || []).reduce(
+            (s, f) => s + (Number(f.quantite || 1) * (Number(f.fiche?.cout_par_portion) || 0)),
+            0
+          );
+          return {
+            ...m,
+            cout_total: cost,
+            marge: m.prix_vente_ttc ? ((Number(m.prix_vente_ttc) - cost) / Number(m.prix_vente_ttc)) * 100 : null,
+          };
+        })
+      : [];
+    setMenus(withCost);
+    setTotal(typeof count === "number" ? count : withCost.length);
+    setLoading(false);
+    if (error) setError(error);
+    return withCost;
+  }
+
+  async function addMenuDuJour(menu) {
+    if (!mama_id) return { error: "Aucun mama_id" };
+    const { fiches = [], ...entete } = menu;
+    setLoading(true);
+    setError(null);
+    const { data, error } = await supabase
+      .from("menus_jour")
+      .insert([{ ...entete, mama_id }])
+      .select("id")
+      .single();
+    if (!error && data?.id && fiches.length) {
+      const toInsert = fiches.map((fiche_id) => ({ menu_jour_id: data.id, fiche_id, mama_id }));
+      await supabase.from("menus_jour_fiches").insert(toInsert);
+    }
+    setLoading(false);
+    if (error) setError(error); else await log("Ajout menu du jour", { id: data?.id, ...entete });
+    await fetchMenusDuJour();
+    return data;
+  }
+
+  async function editMenuDuJour(id, menu) {
+    if (!mama_id) return { error: "Aucun mama_id" };
+    const { fiches = [], ...entete } = menu;
+    setLoading(true);
+    setError(null);
+    const { error: err } = await supabase
+      .from("menus_jour")
+      .update(entete)
+      .eq("id", id)
+      .eq("mama_id", mama_id);
+    if (!err) {
+      await supabase.from("menus_jour_fiches").delete().eq("menu_jour_id", id).eq("mama_id", mama_id);
+      if (fiches.length) {
+        const toInsert = fiches.map((fiche_id) => ({ menu_jour_id: id, fiche_id, mama_id }));
+        await supabase.from("menus_jour_fiches").insert(toInsert);
+      }
+    }
+    setLoading(false);
+    if (err) setError(err); else await log("Modification menu du jour", { id, ...entete });
+    await fetchMenusDuJour();
+  }
+
+  async function deleteMenuDuJour(id) {
+    if (!mama_id) return;
+    setLoading(true);
+    setError(null);
+    const { error } = await supabase
+      .from("menus_jour")
+      .update({ actif: false })
+      .eq("id", id)
+      .eq("mama_id", mama_id);
+    setLoading(false);
+    if (error) setError(error); else await log("Suppression menu du jour", { id });
+    await fetchMenusDuJour();
+  }
+
+  function exportMenusDuJourToExcel() {
+    const datas = (menusDuJour || []).map((m) => ({
+      id: m.id,
+      nom: m.nom,
+      date: m.date,
+      prix_vente_ttc: m.prix_vente_ttc,
+      cout_total: m.cout_total,
+      marge: m.marge,
+      fiches: (m.fiches || []).map((f) => f.fiche?.nom).join(", "),
+    }));
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, XLSX.utils.json_to_sheet(datas), "MenusJour");
+    const buf = XLSX.write(wb, { bookType: "xlsx", type: "array" });
+    saveAs(new Blob([buf]), "menus_jour.xlsx");
+  }
 
   return {
-    menusDuJour: menus,
+    menusDuJour,
     total,
     loading,
     error,
-    fetchMenusDuJour: getMenus,
-    addMenuDuJour: createMenu,
-    editMenuDuJour: updateMenu,
-    deleteMenuDuJour: deleteMenu,
-    toggleMenuDuJourActive: toggleMenuActive,
-    exportMenusDuJourToExcel: exportMenusToExcel,
-    importMenusDuJourFromExcel: importMenusFromExcel,
+    fetchMenusDuJour,
+    addMenuDuJour,
+    editMenuDuJour,
+    deleteMenuDuJour,
+    exportMenusDuJourToExcel,
   };
 }

--- a/src/pages/menus/MenuDuJour.jsx
+++ b/src/pages/menus/MenuDuJour.jsx
@@ -8,12 +8,10 @@ import MenuDuJourDetail from "./MenuDuJourDetail.jsx";
 import { Button } from "@/components/ui/button";
 import TableContainer from "@/components/ui/TableContainer";
 import { Toaster, toast } from "react-hot-toast";
-import { saveAs } from "file-saver";
-import * as XLSX from "xlsx";
 import { motion as Motion } from "framer-motion";
 
 export default function MenuDuJour() {
-  const { menusDuJour, fetchMenusDuJour, deleteMenuDuJour } = useMenuDuJour();
+  const { menusDuJour, fetchMenusDuJour, deleteMenuDuJour, exportMenusDuJourToExcel } = useMenuDuJour();
   const { fiches, fetchFiches } = useFiches();
   const { mama_id, loading: authLoading } = useAuth();
   const [showForm, setShowForm] = useState(false);
@@ -35,14 +33,7 @@ export default function MenuDuJour() {
   );
 
   const exportExcel = () => {
-    const wb = XLSX.utils.book_new();
-    const ws = XLSX.utils.json_to_sheet(menusDuJour.map(m => ({
-      ...m,
-      fiches: m.fiches?.map(f => f.nom).join(", ")
-    })));
-    XLSX.utils.book_append_sheet(wb, ws, "MenusDuJour");
-    const buf = XLSX.write(wb, { bookType: "xlsx", type: "array" });
-    saveAs(new Blob([buf]), "menus_du_jour.xlsx");
+    exportMenusDuJourToExcel();
   };
 
   const handleDelete = async (menu) => {
@@ -82,6 +73,8 @@ export default function MenuDuJour() {
             <th className="px-4 py-2">Date</th>
             <th className="px-4 py-2">Nom</th>
             <th className="px-4 py-2">Fiches</th>
+            <th className="px-4 py-2">Coût</th>
+            <th className="px-4 py-2">Marge</th>
             <th className="px-4 py-2">Actions</th>
           </tr>
         </thead>
@@ -101,6 +94,8 @@ export default function MenuDuJour() {
               <td className="border px-4 py-2">
                 {menu.fiches?.map(f => f.nom).join(", ")}
               </td>
+              <td className="border px-4 py-2">{menu.cout_total?.toFixed(2)} €</td>
+              <td className="border px-4 py-2">{menu.marge != null ? `${menu.marge.toFixed(1)}%` : '-'}</td>
               <td className="border px-4 py-2">
                 <Button
                   size="sm"

--- a/src/pages/menus/MenuDuJourDetail.jsx
+++ b/src/pages/menus/MenuDuJourDetail.jsx
@@ -37,6 +37,10 @@ export default function MenuDuJourDetail({ menu, onClose }) {
             {menu.fiches?.map((f, i) => <li key={i}>{f.nom}</li>)}
           </ul>
         </div>
+        <div><b>Coût total :</b> {menu.cout_total?.toFixed(2)} €</div>
+        {menu.marge != null && (
+          <div><b>Marge :</b> {menu.marge.toFixed(1)}%</div>
+        )}
         <div>
           <b>Document :</b> {menu.document ?
             <a href={menu.document} target="_blank" rel="noopener noreferrer" className="text-blue-700 underline">Voir document</a> :

--- a/src/pages/menus/MenuDuJourForm.jsx
+++ b/src/pages/menus/MenuDuJourForm.jsx
@@ -9,12 +9,18 @@ export default function MenuDuJourForm({ menu, fiches = [], onClose }) {
   const { addMenuDuJour, editMenuDuJour } = useMenuDuJour();
   const [nom, setNom] = useState(menu?.nom || "");
   const [date, setDate] = useState(menu?.date || "");
+  const [prixVente, setPrixVente] = useState(menu?.prix_vente_ttc || 0);
+  const [tva, setTva] = useState(menu?.tva || 5.5);
   const [selectedFiches, setSelectedFiches] = useState(
     menu?.fiches?.map(f => f.fiche_id) || []
   );
   const [file, setFile] = useState(null);
   const [fileUrl, setFileUrl] = useState(menu?.document || "");
   const [loading, setLoading] = useState(false);
+
+  const selectedObjects = fiches.filter(f => selectedFiches.includes(f.id));
+  const coutTotal = selectedObjects.reduce((sum, f) => sum + (Number(f.cout_total) || 0), 0);
+  const marge = prixVente > 0 ? ((prixVente - coutTotal) / prixVente) * 100 : 0;
 
   const handleSelectFiche = id => {
     setSelectedFiches(selectedFiches.includes(id)
@@ -50,7 +56,9 @@ export default function MenuDuJourForm({ menu, fiches = [], onClose }) {
       nom,
       date,
       fiches: selectedFiches,
-      document: fileUrl || menu?.document
+      document: fileUrl || menu?.document,
+      prix_vente_ttc: prixVente || null,
+      tva: tva || null
     };
     try {
       if (menu?.id) {
@@ -89,6 +97,26 @@ export default function MenuDuJourForm({ menu, fiches = [], onClose }) {
         onChange={e => setDate(e.target.value)}
         required
       />
+      <div className="flex gap-2 mb-2">
+        <input
+          type="number"
+          className="input"
+          placeholder="Prix vente TTC"
+          min={0}
+          step="0.01"
+          value={prixVente}
+          onChange={e => setPrixVente(Number(e.target.value))}
+        />
+        <input
+          type="number"
+          className="input"
+          placeholder="TVA %"
+          min={0}
+          step="0.1"
+          value={tva}
+          onChange={e => setTva(Number(e.target.value))}
+        />
+      </div>
       <div className="mb-4">
         <label className="block font-semibold mb-2">Fiches du menu :</label>
         <div className="max-h-48 overflow-auto border border-borderGlass rounded p-2 bg-glass backdrop-blur">
@@ -119,6 +147,12 @@ export default function MenuDuJourForm({ menu, fiches = [], onClose }) {
           </a>
         )}
       </label>
+      <div className="my-2 flex gap-4">
+        <div><b>Coût total :</b> {coutTotal.toFixed(2)} €</div>
+        {prixVente > 0 && (
+          <div><b>Marge :</b> {marge.toFixed(1)}%</div>
+        )}
+      </div>
       <div className="flex gap-2 mt-4">
         <Button type="submit" disabled={loading}>{menu ? "Modifier" : "Ajouter"}</Button>
         <Button variant="outline" type="button" onClick={onClose}>Annuler</Button>

--- a/test/useMenuDuJour.test.js
+++ b/test/useMenuDuJour.test.js
@@ -30,8 +30,8 @@ test('fetchMenusDuJour retrieves menus', async () => {
   await act(async () => {
     await result.current.fetchMenusDuJour();
   });
-  expect(fromMock).toHaveBeenCalledWith('menus');
-  expect(selectMock).toHaveBeenCalledWith('*, fiches:menu_fiches(fiche_id, fiche: fiches(id, nom))', { count: 'exact' });
+  expect(fromMock).toHaveBeenCalledWith('menus_jour');
+  expect(selectMock).toHaveBeenCalledWith('*, fiches:menus_jour_fiches(fiche_id, quantite, fiche:fiches_techniques(id, nom, cout_par_portion))', { count: 'exact' });
   expect(eqMock).toHaveBeenCalledWith('mama_id', 'm1');
   expect(orderMock).toHaveBeenCalledWith('date', { ascending: false });
   expect(rangeMock).toHaveBeenCalledWith(0, 49);


### PR DESCRIPTION
## Summary
- add `menus_jour` and `menus_jour_fiches` SQL tables with RLS
- implement dedicated `useMenuDuJour` hook
- extend menu du jour forms with pricing and cost
- display cost and margin in menu du jour pages
- adjust tests for new table names

## Testing
- `npm test` *(fails: Missing Supabase credentials and other test errors)*

------
https://chatgpt.com/codex/tasks/task_e_687e39778570832daf763141f19b95de