### PR TITLE
Amélioration module Tâches

### DIFF
--- a/db/Ajout.sql
+++ b/db/Ajout.sql
@@ -474,3 +474,43 @@ drop policy if exists menus_jour_fiches_all on menus_jour_fiches;
 create policy menus_jour_fiches_all on menus_jour_fiches
   for all using (mama_id = current_user_mama_id())
   with check (mama_id = current_user_mama_id());
+-- Module Taches : liaison utilisateurs et RLS
+alter table if exists taches
+  add column if not exists utilisateur_id uuid references utilisateurs(id);
+create index if not exists idx_taches_utilisateur_id on taches(utilisateur_id);
+
+create table if not exists tache_assignations (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid not null references mamas(id),
+  tache_id uuid not null references taches(id),
+  utilisateur_id uuid not null references utilisateurs(id),
+  statut text default 'a_faire',
+  commentaire text,
+  date_realisation timestamp with time zone,
+  created_at timestamp with time zone default now(),
+  updated_at timestamp with time zone default now(),
+  actif boolean default true
+);
+create index if not exists idx_tache_assignations_mama_id on tache_assignations(mama_id);
+create index if not exists idx_tache_assignations_tache_id on tache_assignations(tache_id);
+
+alter table if exists taches enable row level security;
+alter table if exists taches force row level security;
+drop policy if exists taches_all on taches;
+create policy taches_all on taches
+  for all using (mama_id = current_user_mama_id())
+  with check (mama_id = current_user_mama_id());
+
+alter table if exists tache_assignations enable row level security;
+alter table if exists tache_assignations force row level security;
+drop policy if exists tache_assignations_all on tache_assignations;
+create policy tache_assignations_all on tache_assignations
+  for all using (mama_id = current_user_mama_id())
+  with check (mama_id = current_user_mama_id());
+
+alter table if exists tache_instances enable row level security;
+alter table if exists tache_instances force row level security;
+drop policy if exists tache_instances_all on tache_instances;
+create policy tache_instances_all on tache_instances
+  for all using (mama_id = current_user_mama_id())
+  with check (mama_id = current_user_mama_id());

--- a/src/components/taches/TachesKanban.jsx
+++ b/src/components/taches/TachesKanban.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+export default function TachesKanban({ taches = [] }) {
+  const cols = ['a_faire', 'en_cours', 'terminee'];
+  const labels = {
+    a_faire: 'À faire',
+    en_cours: 'En cours',
+    terminee: 'Terminée',
+  };
+  return (
+    <div className="flex gap-4">
+      {cols.map(col => (
+        <div key={col} className="flex-1 bg-white/10 p-2 rounded">
+          <h3 className="font-bold mb-2 text-center">{labels[col]}</h3>
+          <ul className="space-y-2">
+            {taches.filter(t => t.statut === col).map(t => (
+              <li key={t.id} className="bg-white/5 rounded p-2 text-sm">
+                {t.titre}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/hooks/useTaches.js
+++ b/src/hooks/useTaches.js
@@ -21,6 +21,7 @@ export function useTaches() {
     if (filters.statut) query = query.eq("statut", filters.statut);
     if (filters.priorite) query = query.eq("priorite", filters.priorite);
     if (filters.assigne) query = query.contains("assignes", [filters.assigne]);
+    if (filters.utilisateur_id) query = query.eq("utilisateur_id", filters.utilisateur_id);
     if (filters.start) query = query.gte("date_debut", filters.start);
     if (filters.end) query = query.lte("date_echeance", filters.end);
     const { data, error } = await query;
@@ -55,7 +56,11 @@ export function useTaches() {
         date_echeance: computeDue(values),
         mama_id,
         created_by: user_id,
+        utilisateur_id: values.utilisateur_id || user_id,
       };
+      if (!payload.assignes || payload.assignes.length === 0) {
+        payload.assignes = [user_id];
+      }
       const { error } = await supabase.from("taches").insert([payload]);
       setLoading(false);
       if (error) {
@@ -73,6 +78,9 @@ export function useTaches() {
       setLoading(true);
       setError(null);
       const payload = { ...values, date_echeance: computeDue(values), updated_at: new Date().toISOString() };
+      if (!payload.assignes || payload.assignes.length === 0) {
+        payload.assignes = [user_id];
+      }
       const { error } = await supabase
         .from("taches")
         .update(payload)

--- a/src/pages/taches/TacheForm.jsx
+++ b/src/pages/taches/TacheForm.jsx
@@ -14,6 +14,7 @@ export default function TacheForm({ task }) {
     titre: task?.titre || "",
     description: task?.description || "",
     assignes: task?.assignes || [],
+    utilisateur_id: task?.utilisateur_id || "",
     date_debut: task?.date_debut || "",
     delai_jours: task?.delai_jours || "",
     date_echeance: task?.date_echeance || "",
@@ -107,6 +108,15 @@ export default function TacheForm({ task }) {
       <label className="block">
         <span>Assignés</span>
         <select multiple name="assignes" value={form.assignes} onChange={handleChange} className="input w-full">
+          {users.map(u => (
+            <option key={u.id} value={u.id}>{u.nom}</option>
+          ))}
+        </select>
+      </label>
+      <label className="block">
+        <span>Responsable</span>
+        <select name="utilisateur_id" value={form.utilisateur_id} onChange={handleChange} className="input w-full">
+          <option value="">--</option>
           {users.map(u => (
             <option key={u.id} value={u.id}>{u.nom}</option>
           ))}

--- a/src/pages/taches/Taches.jsx
+++ b/src/pages/taches/Taches.jsx
@@ -6,11 +6,14 @@ import { useUtilisateurs } from "@/hooks/useUtilisateurs";
 import { Button } from "@/components/ui/button";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 import TableContainer from "@/components/ui/TableContainer";
+import TachesKanban from "@/components/taches/TachesKanban";
 
 export default function Taches() {
-  const { taches, loading, error, getTaches } = useTaches();
+  const { taches, loading, error, getTaches, createTache } = useTaches();
   const { users, fetchUsers } = useUtilisateurs();
   const [filters, setFilters] = useState({ statut: "", priorite: "", assigne: "", start: "", end: "" });
+  const [view, setView] = useState('table');
+  const [quick, setQuick] = useState({ titre: '', date_echeance: '' });
 
   useEffect(() => {
     fetchUsers({ actif: true });
@@ -21,13 +24,30 @@ export default function Taches() {
   }, [getTaches, filters]);
 
   const handleChange = e => setFilters(f => ({ ...f, [e.target.name]: e.target.value }));
+  const handleQuickChange = e => setQuick(q => ({ ...q, [e.target.name]: e.target.value }));
+  const handleQuickSubmit = async e => {
+    e.preventDefault();
+    if (!quick.titre.trim()) return;
+    await createTache(quick);
+    setQuick({ titre: '', date_echeance: '' });
+  };
 
   return (
     <div className="p-6 text-sm">
       <div className="flex justify-between items-center mb-4">
         <h1 className="text-2xl font-bold">Tâches planifiées</h1>
-        <Link to="/taches/new" className="btn">Créer une tâche</Link>
+        <div className="flex gap-2">
+          <Button onClick={() => setView(v => (v === 'table' ? 'kanban' : 'table'))}>
+            {view === 'table' ? 'Vue Kanban' : 'Vue liste'}
+          </Button>
+          <Link to="/taches/new" className="btn">Créer une tâche</Link>
+        </div>
       </div>
+      <form onSubmit={handleQuickSubmit} className="flex gap-2 mb-4">
+        <input className="input flex-1" name="titre" value={quick.titre} onChange={handleQuickChange} placeholder="Nouvelle tâche" required />
+        <input type="date" className="input" name="date_echeance" value={quick.date_echeance} onChange={handleQuickChange} />
+        <Button type="submit">Ajouter</Button>
+      </form>
       <div className="flex flex-wrap gap-2 mb-4">
         <select name="statut" value={filters.statut} onChange={handleChange} className="input">
           <option value="">-- Statut --</option>
@@ -53,37 +73,41 @@ export default function Taches() {
       </div>
       {loading && <LoadingSpinner message="Chargement..." />}
       {error && <div className="text-red-600">{error}</div>}
-      <TableContainer>
-      <table className="min-w-full text-white">
-        <thead>
-          <tr>
-            <th className="px-2 py-1">Statut</th>
-            <th className="px-2 py-1">Titre</th>
-            <th className="px-2 py-1">Début</th>
-            <th className="px-2 py-1">Échéance</th>
-            <th className="px-2 py-1">Assignés</th>
-            <th className="px-2 py-1">Récurrence</th>
-          </tr>
-        </thead>
-        <tbody>
-          {taches.map(t => (
-            <tr key={t.id} className="border-t">
-              <td className="px-2 py-1">{t.statut}</td>
-              <td className="px-2 py-1">{t.titre}</td>
-              <td className="px-2 py-1">{t.date_debut}</td>
-              <td className="px-2 py-1">{t.date_echeance}</td>
-              <td className="px-2 py-1">{(t.assignes || []).length}</td>
-              <td className="px-2 py-1">{t.recurrente ? t.frequence : ""}</td>
-            </tr>
-          ))}
-          {taches.length === 0 && !loading && (
-            <tr>
-              <td colSpan="6" className="py-4 text-center text-gray-500">Aucune tâche</td>
-            </tr>
-          )}
-        </tbody>
-      </table>
-      </TableContainer>
+      {view === 'table' ? (
+        <TableContainer>
+          <table className="min-w-full text-white">
+            <thead>
+              <tr>
+                <th className="px-2 py-1">Statut</th>
+                <th className="px-2 py-1">Titre</th>
+                <th className="px-2 py-1">Début</th>
+                <th className="px-2 py-1">Échéance</th>
+                <th className="px-2 py-1">Assignés</th>
+                <th className="px-2 py-1">Récurrence</th>
+              </tr>
+            </thead>
+            <tbody>
+              {taches.map(t => (
+                <tr key={t.id} className="border-t">
+                  <td className="px-2 py-1">{t.statut}</td>
+                  <td className="px-2 py-1">{t.titre}</td>
+                  <td className="px-2 py-1">{t.date_debut}</td>
+                  <td className="px-2 py-1">{t.date_echeance}</td>
+                  <td className="px-2 py-1">{(t.assignes || []).length}</td>
+                  <td className="px-2 py-1">{t.recurrente ? t.frequence : ''}</td>
+                </tr>
+              ))}
+              {taches.length === 0 && !loading && (
+                <tr>
+                  <td colSpan="6" className="py-4 text-center text-gray-500">Aucune tâche</td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </TableContainer>
+      ) : (
+        <TachesKanban taches={taches} />
+      )}
     </div>
   );
 }

--- a/test/useTaches.test.js
+++ b/test/useTaches.test.js
@@ -49,4 +49,6 @@ test('createTache injects ids and computes due date', async () => {
   expect(inserted.mama_id).toBe('m1');
   expect(inserted.created_by).toBe('u1');
   expect(inserted.date_echeance).toBe('2025-05-04');
+  expect(inserted.utilisateur_id).toBe('u1');
+  expect(inserted.assignes).toEqual(['u1']);
 });


### PR DESCRIPTION
## Summary
- liaison utilisateur pour les tâches et politiques RLS
- ajout table `tache_assignations`
- hooks taches enrichis (assignation par défaut, filtre utilisateur)
- formulaire avec champ responsable
- vue tableau/kanban avec saisie rapide
- mise à jour des tests

## Testing
- `npm install`
- `npm test` *(échoue : Missing Supabase credentials)*

------
https://chatgpt.com/codex/tasks/task_e_687e3bc4f5f4832db1bafb4eee6f2492