### PR TITLE
Update product list with supplier info

### DIFF
--- a/src/hooks/useProducts.js
+++ b/src/hooks/useProducts.js
@@ -34,7 +34,11 @@ export function useProducts() {
       )
       .eq("mama_id", mama_id);
 
-    if (search) query = query.ilike("nom", `%${search}%`);
+    if (search) {
+      query = query.or(
+        `nom.ilike.%${search}%,main_supplier.nom.ilike.%${search}%`
+      );
+    }
     if (famille) query = query.eq("famille_id", famille);
     if (typeof actif === "boolean") query = query.eq("actif", actif);
 
@@ -219,8 +223,11 @@ export function useProducts() {
       allergenes: p.allergenes,
       image: p.image,
       pmp: p.pmp,
+      stock_theorique: p.stock_theorique,
       stock_reel: p.stock_reel,
       stock_min: p.stock_min,
+      dernier_prix: p.dernier_prix,
+      main_supplier: p.main_supplier?.nom || "",
       actif: p.actif,
       mama_id: p.mama_id,
     }));

--- a/src/pages/produits/Produits.jsx
+++ b/src/pages/produits/Produits.jsx
@@ -145,8 +145,10 @@ export default function Produits() {
               <th className="cursor-pointer" onClick={() => toggleSort("famille")}>Famille{renderArrow("famille")}</th>
               <th>Unité</th>
               <th className="cursor-pointer" onClick={() => toggleSort("pmp")}>PMP (€){renderArrow("pmp")}</th>
-              <th className="cursor-pointer" onClick={() => toggleSort("stock_reel")}>Stock{renderArrow("stock_reel")}</th>
+              <th className="cursor-pointer" onClick={() => toggleSort("stock_theorique")}>Stock théorique{renderArrow("stock_theorique")}</th>
               <th className="cursor-pointer" onClick={() => toggleSort("stock_min")}>Min{renderArrow("stock_min")}</th>
+              <th>Fournisseur</th>
+              <th className="cursor-pointer" onClick={() => toggleSort("dernier_prix")}>Dernier prix (€){renderArrow("dernier_prix")}</th>
               <th>Actif</th>
               <th>Actions</th>
             </tr>
@@ -154,7 +156,7 @@ export default function Produits() {
           <tbody>
           {products.length === 0 ? (
             <tr>
-              <td colSpan={8} className="py-4 text-muted-foreground">
+              <td colSpan={10} className="py-4 text-muted-foreground">
                 Aucun produit trouvé
               </td>
             </tr>
@@ -165,8 +167,10 @@ export default function Produits() {
                   <td>{p.famille}</td>
                   <td>{p.unite}</td>
                   <td>{p.pmp}</td>
-                  <td>{p.stock_reel}</td>
+                  <td>{p.stock_theorique}</td>
                   <td>{p.stock_min}</td>
+                  <td>{p.main_supplier?.nom || "-"}</td>
+                  <td>{p.dernier_prix ?? "-"}</td>
                   <td>{p.actif ? "✅" : "❌"}</td>
                   <td>
                     <Button size="sm" variant="outline" onClick={() => { setSelectedProduct(p); setShowForm(true); }}>


### PR DESCRIPTION
## Summary
- search products by supplier name
- export product data with supplier & last price
- show theoretical stock, supplier and last price in product list

## Testing
- `npm test` *(fails: 8 failed, 97 passed)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687f4a666358832d974b0e29be3559c4