### PR TITLE
Add justificatif column

### DIFF
--- a/db/Ajout.sql
+++ b/db/Ajout.sql
@@ -1,3 +1,6 @@
 -- Ajouts complémentaires pour le back-end Supabase
 -- Ajout colonne manquante pour stocker la configuration du tableau de bord
 ALTER TABLE tableaux_de_bord ADD COLUMN IF NOT EXISTS liste_gadgets_json jsonb DEFAULT '[]'::jsonb;
+
+-- Ajout colonne justificatif pour stocker l'URL de la pièce jointe de facture
+ALTER TABLE factures ADD COLUMN IF NOT EXISTS justificatif text;


### PR DESCRIPTION
## Summary
- add justificatif column in Ajout.sql

## Testing
- `npm run lint`
- `npm test` *(fails: see logs)*

------
https://chatgpt.com/codex/tasks/task_e_687f4d00e2b8832d82f7b9553b47b717