### PR TITLE
Fix user role handling in frontend auth flow

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -55,13 +55,25 @@ export function AuthProvider({ children }) {
       return;
     }
 
+    const roleName = data.role?.nom ?? data.role;
+    if (!roleName) {
+      toast.error(
+        "Erreur de permission : rôle utilisateur non trouvé. Merci de contacter l’administrateur."
+      );
+      setUserData(null);
+      fetchingRef.current = false;
+      await supabase.auth.signOut().catch(() => {});
+      navigate("/no-role");
+      return;
+    }
+
     lastUserIdRef.current = userId;
     setError(null);
     setUserData({
       ...data,
       auth_id: userId,
       email,
-      role: data.role?.nom ?? data.role,
+      role: roleName,
       access_rights: data.access_rights || null,
     });
     if (!data.mama_id) console.warn("missing mama_id for user", userId);

--- a/src/layout/Sidebar.jsx
+++ b/src/layout/Sidebar.jsx
@@ -50,6 +50,15 @@ export default function Sidebar() {
   if (loading || !user || !access_rights) {
     return null;
   }
+  if (!role) {
+    return (
+      <aside className="w-64 p-4 text-white">
+        <p className="text-red-400 text-sm">
+          Erreur de permission : rôle utilisateur non trouvé. Merci de contacter l’administrateur.
+        </p>
+      </aside>
+    );
+  }
 
   const peutVoir = (module) =>
     isSuperadmin || hasAccess(module, "peut_voir");

--- a/src/pages/auth/RoleError.jsx
+++ b/src/pages/auth/RoleError.jsx
@@ -1,0 +1,17 @@
+import { useNavigate } from "react-router-dom";
+import GlassCard from "@/components/ui/GlassCard";
+import PageWrapper from "@/components/ui/PageWrapper";
+import PrimaryButton from "@/components/ui/PrimaryButton";
+
+export default function RoleError() {
+  const navigate = useNavigate();
+  return (
+    <PageWrapper>
+      <GlassCard className="flex flex-col items-center text-center gap-4">
+        <h1 className="text-3xl font-bold text-gold">Erreur de permission</h1>
+        <p>rôle utilisateur non trouvé. Merci de contacter l’administrateur.</p>
+        <PrimaryButton onClick={() => navigate("/login")}>Se reconnecter</PrimaryButton>
+      </GlassCard>
+    </PageWrapper>
+  );
+}

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -14,6 +14,7 @@ import Login from "@/pages/auth/Login";
 import Unauthorized from "@/pages/auth/Unauthorized";
 import Pending from "@/pages/auth/Pending";
 import Blocked from "@/pages/auth/Blocked";
+import RoleError from "@/pages/auth/RoleError";
 import AuthDebug from "@/pages/debug/AuthDebug";
 import NotFound from "@/pages/NotFound";
 import ProtectedRoute from "@/components/ProtectedRoute";
@@ -177,6 +178,7 @@ export default function Router() {
         <Route path="/onboarding" element={<Onboarding />} />
         <Route path="/create-mama" element={<CreateMama />} />
         <Route path="/pending" element={<Pending />} />
+        <Route path="/no-role" element={<RoleError />} />
         <Route path="/unauthorized" element={<Unauthorized />} />
         <Route path="/blocked" element={<Blocked />} />
         <Route path="/rgpd" element={<Rgpd />} />

--- a/test/authRole.test.jsx
+++ b/test/authRole.test.jsx
@@ -1,0 +1,40 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { vi } from 'vitest';
+import { AuthProvider, useAuth } from '../src/context/AuthContext.jsx';
+
+const getSession = vi.fn(() => Promise.resolve({ data: { session: { user: { id: 'u1', email: 'u@x.com' } } }, error: null }));
+const onAuthStateChange = vi.fn(() => ({ data: { subscription: { unsubscribe: vi.fn() } } }));
+const signOut = vi.fn(() => Promise.resolve({ error: null }));
+const maybeSingle = vi.fn(() => Promise.resolve({ data: { id: '1', mama_id: 1, role_id: 1, role: { nom: 'admin' }, access_rights: {} }, error: null }));
+const from = vi.fn(() => ({ select: () => ({ eq: () => ({ maybeSingle }) }) }));
+
+vi.mock('../src/lib/supabase.js', () => ({
+  supabase: { auth: { getSession, onAuthStateChange, signOut }, from }
+}));
+
+vi.mock('../src/lib/loginUser.js', () => ({ login: vi.fn() }));
+
+test('role is loaded from supabase', async () => {
+  const wrapper = ({ children }) => (
+    <MemoryRouter>
+      <AuthProvider>{children}</AuthProvider>
+    </MemoryRouter>
+  );
+  const { result } = renderHook(() => useAuth(), { wrapper });
+  await waitFor(() => result.current.role !== undefined);
+  expect(result.current.role).toBe('admin');
+});
+
+test('logout when role missing', async () => {
+  maybeSingle.mockResolvedValueOnce({ data: { id: '1', mama_id: 1, role_id: 1, role: null, access_rights: {} }, error: null });
+  const wrapper = ({ children }) => (
+    <MemoryRouter>
+      <AuthProvider>{children}</AuthProvider>
+    </MemoryRouter>
+  );
+  renderHook(() => useAuth(), { wrapper });
+  await waitFor(() => signOut.mock.calls.length > 0);
+  expect(signOut).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- ensure role is fetched with roles table join
- prevent login when role missing and show dedicated page
- display error in sidebar when role undefined
- add `/no-role` route
- test role retrieval logic

## Testing
- `npm test` *(fails: Missing Supabase credentials and other test errors)*

------
https://chatgpt.com/codex/tasks/task_e_687f528e3180832db497f2bc02581a65