### PR TITLE
Fix auth flow and redirection

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -41,6 +41,7 @@ export function AuthProvider({ children }) {
       )
       .eq("auth_id", userId)
       .maybeSingle();
+    if (import.meta.env.DEV) console.log("fetchUserData result", data);
 
     if (error) {
       console.error("Erreur récupération utilisateur:", error);

--- a/src/layout/Sidebar.jsx
+++ b/src/layout/Sidebar.jsx
@@ -35,6 +35,7 @@ export default function Sidebar() {
     access_rights,
     loading,
     user,
+    userData,
     role,
     mama_id,
     logout,
@@ -47,7 +48,7 @@ export default function Sidebar() {
     console.log("Sidebar", { user, role, mama_id, access_rights });
   }
 
-  if (loading || !user || !access_rights) {
+  if (loading || !user || !userData || !access_rights) {
     return null;
   }
   if (!role) {

--- a/src/pages/auth/Login.jsx
+++ b/src/pages/auth/Login.jsx
@@ -62,7 +62,7 @@ export default function Login() {
 
       if (data) {
         toast.success("Connexion réussie");
-        navigate("/");
+        // redirection handled once user data is loaded
       }
     } catch (err) {
       console.error(err);

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -152,9 +152,11 @@ export const routePreloadMap = {
 
 
 function RootRoute() {
-  const { session, loading } = useAuth();
-  if (loading) return <LoadingSpinner message="Chargement..." />;
-  if (session && session.user) return <Navigate to="/dashboard" replace />;
+  const { session, loading, pending, userData } = useAuth();
+  if (loading || pending) return <LoadingSpinner message="Chargement..." />;
+  if (session && session.user && userData && userData.actif !== false) {
+    return <Navigate to="/dashboard" replace />;
+  }
   return <Navigate to="/accueil" replace />;
 }
 

--- a/test/router.test.jsx
+++ b/test/router.test.jsx
@@ -12,6 +12,8 @@ const authState = {
   isAuthenticated: false,
   access_rights: ['dashboard'],
   loading: false,
+  pending: false,
+  userData: null,
 };
 vi.mock('@/context/AuthContext', () => ({
   useAuth: () => authState
@@ -62,13 +64,15 @@ test('root path shows landing when unauthenticated', async () => {
   expect(await screen.findByText(/Simplifiez votre gestion/)).toBeInTheDocument();
 });
 
-test('root path shows landing even when authenticated', async () => {
+test('root path redirects to dashboard when authenticated', async () => {
   authState.isAuthenticated = true;
+  authState.userData = { actif: true };
   render(
     <MemoryRouter initialEntries={["/"]}>
       <RouterConfig />
     </MemoryRouter>
   );
-  expect(await screen.findByText(/Simplifiez votre gestion/)).toBeInTheDocument();
+  expect(await screen.findByText(/Dashboard Stock/)).toBeInTheDocument();
   authState.isAuthenticated = false;
+  authState.userData = null;
 });


### PR DESCRIPTION
## Summary
- log Supabase data before setting userData
- avoid navigating to `/` on login
- check userData before redirecting in RootRoute
- hide Sidebar until user data is loaded
- update router test for new behavior

## Testing
- `npm test` *(fails: Missing Supabase credentials, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687f5b0f6318832da6dd9603172c8113