### PR TITLE
Fix AuthContext exports and login redirect logic

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -12,9 +12,9 @@ import {
 import toast from "react-hot-toast";
 
 // eslint-disable-next-line react-refresh/only-export-components
-export const AuthContext = createContext();
+export const AuthContext = createContext(null);
 
-export function AuthProvider({ children }) {
+export const AuthProvider = ({ children }) => {
   const [session, setSession] = useState(null);
   const [userData, setUserData] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -37,7 +37,7 @@ export function AuthProvider({ children }) {
     const { data, error } = await supabase
       .from("utilisateurs")
       .select(
-        "id, mama_id, role_id, role:roles(id, nom, access_rights), role, access_rights, actif, email"
+        "id, mama_id, role_id, role:roles(nom), role, access_rights, actif, email"
       )
       .eq("auth_id", userId)
       .maybeSingle();
@@ -246,9 +246,11 @@ export function AuthProvider({ children }) {
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
-}
+};
 
 // eslint-disable-next-line react-refresh/only-export-components
 export function useAuth() {
   return useContext(AuthContext) || {};
 }
+
+export default AuthProvider;

--- a/src/layout/Layout.jsx
+++ b/src/layout/Layout.jsx
@@ -53,6 +53,15 @@ export default function Layout() {
   if (!session || !userData)
     return <LoadingSpinner message="Chargement utilisateur..." />;
 
+  if (!role) {
+    return (
+      <div className="p-4 text-red-400">
+        Erreur de permission : rôle utilisateur non trouvé. Merci de contacter
+        l’administrateur.
+      </div>
+    );
+  }
+
   const user = session.user;
 
   return (

--- a/src/pages/auth/Login.jsx
+++ b/src/pages/auth/Login.jsx
@@ -9,6 +9,7 @@ import GlassCard from "@/components/ui/GlassCard";
 import PageWrapper from "@/components/ui/PageWrapper";
 import PreviewBanner from "@/components/ui/PreviewBanner";
 import PrimaryButton from "@/components/ui/PrimaryButton";
+import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 import { login as loginUser } from "../../lib/loginUser";
 
 export default function Login() {
@@ -19,7 +20,16 @@ export default function Login() {
   const navigate = useNavigate();
   const { pathname } = useLocation();
 
-  const { session, userData, loading: authLoading, getAuthorizedModules } = useAuth();
+  const {
+    session,
+    userData,
+    loading: authLoading,
+    getAuthorizedModules,
+  } = useAuth();
+
+  if (authLoading || (session && !userData)) {
+    return <LoadingSpinner message="Chargement..." />;
+  }
 
 
   // Redirection après authentification une fois les données chargées
@@ -28,6 +38,13 @@ export default function Login() {
     if (redirectedRef.current) return;
     if (!session || authLoading) return;
     if (!userData) return;
+    if (!userData.role) {
+      toast.error(
+        "Erreur de permission – rôle utilisateur non trouvé. Merci de contacter l’administrateur."
+      );
+      navigate("/login");
+      return;
+    }
     redirectedRef.current = true;
     if (userData.actif === false && pathname !== "/blocked") {
       navigate("/blocked");
@@ -40,7 +57,7 @@ export default function Login() {
     }
     toast.success(`Bienvenue ${session.user.email}`);
     if (pathname !== "/dashboard") navigate("/dashboard");
-  }, [session, userData, authLoading, navigate, pathname]);
+  }, [session, userData, authLoading, navigate, pathname, getAuthorizedModules]);
 
   const handleLogin = async (e) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- clean up AuthContext exports for fast refresh compatibility
- fetch user role correctly and expose default export
- show loading spinner while waiting for auth on login page
- handle missing role on login redirect
- warn in layout if role is missing

## Testing
- `npm test` *(fails: Missing Supabase credentials)*

------
https://chatgpt.com/codex/tasks/task_e_687f6a7087a8832d8fe8fa8b5ef576f6