### PR TITLE
Improve auth resilience

### DIFF
--- a/src/components/ResetAuthButton.jsx
+++ b/src/components/ResetAuthButton.jsx
@@ -1,0 +1,15 @@
+import { useAuth } from "@/context/AuthContext";
+
+export default function ResetAuthButton({ className = "" }) {
+  const { resetAuth } = useAuth() || {};
+  if (!resetAuth) return null;
+  return (
+    <button
+      type="button"
+      onClick={resetAuth}
+      className={className}
+    >
+      Réinitialiser la connexion
+    </button>
+  );
+}

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -21,5 +21,6 @@ export default function useAuth() {
     hasAccess: ctx.hasAccess,
     getAuthorizedModules: ctx.getAuthorizedModules,
     error: ctx.error,
+    resetAuth: ctx.resetAuth,
   };
 }

--- a/src/pages/auth/Login.jsx
+++ b/src/pages/auth/Login.jsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect, useRef } from "react";
 import { useNavigate, useLocation, Link } from "react-router-dom";
 import MamaLogo from "@/components/ui/MamaLogo";
 import useAuth from "@/hooks/useAuth";
+import ResetAuthButton from "@/components/ResetAuthButton";
 import toast from "react-hot-toast";
 import useFormErrors from "@/hooks/useFormErrors";
 import GlassCard from "@/components/ui/GlassCard";
@@ -25,6 +26,8 @@ export default function Login() {
     userData,
     loading: authLoading,
     getAuthorizedModules,
+    error: authError,
+    resetAuth,
   } = useAuth();
 
   if (authLoading || (session && !userData)) {
@@ -92,6 +95,16 @@ export default function Login() {
   return (
     <PageWrapper>
       <PreviewBanner />
+      {authError && (
+        <div className="text-red-500 text-center mb-2 text-sm">
+          {authError}
+          {resetAuth && (
+            <div className="mt-1">
+              <ResetAuthButton className="underline" />
+            </div>
+          )}
+        </div>
+      )}
       <GlassCard className="flex flex-col items-center">
         <div className="mb-6">
           <MamaLogo width={96} />

--- a/src/pages/debug/AccessExample.jsx
+++ b/src/pages/debug/AccessExample.jsx
@@ -1,0 +1,18 @@
+import { useAuth } from "@/context/AuthContext";
+import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import GlassCard from "@/components/ui/GlassCard";
+
+export default function AccessExample() {
+  const { loading, hasAccess } = useAuth();
+  if (loading) return <LoadingSpinner message="Chargement..." />;
+
+  return (
+    <div className="p-6 flex justify-center">
+      <GlassCard className="w-full max-w-xl text-white text-sm">
+        <h2 className="text-lg font-bold mb-2">Exemple de droits</h2>
+        <p className="mb-2">Accès au module 'factures' : {hasAccess('factures') ? 'oui' : 'non'}</p>
+        <p>Accès au module 'utilisateurs' : {hasAccess('utilisateurs') ? 'oui' : 'non'}</p>
+      </GlassCard>
+    </div>
+  );
+}

--- a/src/pages/debug/AuthDebug.jsx
+++ b/src/pages/debug/AuthDebug.jsx
@@ -2,6 +2,7 @@
 // src/pages/debug/AuthDebug.jsx
 import useAuth from "@/hooks/useAuth";
 import GlassCard from "@/components/ui/GlassCard";
+import ResetAuthButton from "@/components/ResetAuthButton";
 
 export default function AuthDebug() {
   const { session, userData } = useAuth();
@@ -10,6 +11,9 @@ export default function AuthDebug() {
     <div className="p-6 flex justify-center">
       <GlassCard className="w-full max-w-xl overflow-auto text-xs">
         <pre>{JSON.stringify({ session, userData }, null, 2)}</pre>
+        <div className="mt-2">
+          <ResetAuthButton className="underline text-sm" />
+        </div>
       </GlassCard>
     </div>
   );

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -16,6 +16,7 @@ import Pending from "@/pages/auth/Pending";
 import Blocked from "@/pages/auth/Blocked";
 import RoleError from "@/pages/auth/RoleError";
 import AuthDebug from "@/pages/debug/AuthDebug";
+import AccessExample from "@/pages/debug/AccessExample";
 import NotFound from "@/pages/NotFound";
 import ProtectedRoute from "@/components/ProtectedRoute";
 
@@ -487,6 +488,10 @@ export default function Router() {
           <Route
             path="/debug/auth"
             element={<ProtectedRoute accessKey="dashboard"><AuthDebug /></ProtectedRoute>}
+          />
+          <Route
+            path="/debug/access"
+            element={<ProtectedRoute accessKey="dashboard"><AccessExample /></ProtectedRoute>}
           />
           <Route path="*" element={<NotFound />} />
         </Route>


### PR DESCRIPTION
## Summary
- expose `useAuth` function in context and add resetAuth helper
- detect invalid sessions and auto-clean local storage
- add reset auth button component
- wire up reset button in login screen and AuthDebug page
- show rights example and route in debug section

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f6fcf9af0832d98b640022d52c34e