### PR TITLE
Fix auth session handling

### DIFF
--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -1,15 +1,14 @@
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { useAuth } from "@/context/AuthContext";
-import { hasAccess } from "@/lib/access";
+import useAuth from "@/hooks/useAuth";
 import LoadingScreen from "@/components/ui/LoadingScreen";
 
 export default function ProtectedRoute({ children, accessKey }) {
-  const { session, userData, pending } = useAuth();
+  const { session, userData, pending, loading, hasAccess } = useAuth();
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (!session || !userData || pending) return;
+    if (!session || !userData || pending || loading) return;
 
     if (userData.actif === false) {
       navigate("/blocked", { replace: true });
@@ -22,8 +21,7 @@ export default function ProtectedRoute({ children, accessKey }) {
     ) {
       navigate("/unauthorized", { replace: true });
     }
-  }, [session, userData, pending, accessKey, navigate]);
-
-  if (!session || pending || !userData) return <LoadingScreen />;
+  }, [session, userData, pending, loading, accessKey, navigate, hasAccess]);
+  if (!session || pending || loading || !userData) return <LoadingScreen />;
   return children;
 }

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -123,18 +123,25 @@ export const AuthProvider = ({ children }) => {
 
   async function loadSession() {
     setLoading(true);
-    const { data, error } = await supabase.auth.getSession();
-    if (error) {
-      console.warn("loadSession error", error.message);
-      setError(error.message);
-      if (/invalid.*token/i.test(error.message)) {
-        purgeLocalAuth();
+    try {
+      const { data, error } = await supabase.auth.getSession();
+      if (error) {
+        console.warn("loadSession error", error.message);
+        setError(error.message);
+        if (/invalid.*token/i.test(error.message)) {
+          purgeLocalAuth();
+        }
       }
+      const current = data?.session ?? null;
+      if (import.meta.env.DEV) console.log("loadSession", current?.user?.id);
+      sessionLoadedRef.current = true;
+      setSession(current);
+    } catch (e) {
+      console.error("loadSession failure", e);
+      setError(e.message || "loadSession error");
+    } finally {
+      setLoading(false);
     }
-    const current = data?.session ?? null;
-    if (import.meta.env.DEV) console.log("loadSession", current?.user?.id);
-    sessionLoadedRef.current = true;
-    setSession(current);
   }
 
   useEffect(() => {

--- a/src/layout/Layout.jsx
+++ b/src/layout/Layout.jsx
@@ -25,6 +25,7 @@ export default function Layout() {
     mama_id,
     access_rights,
     loading,
+    pending,
     logout,
   } = useAuth();
   const { fetchUnreadCount, subscribeToNotifications } = useNotifications();
@@ -49,7 +50,7 @@ export default function Layout() {
 
   if (pathname === "/login" || pathname === "/unauthorized") return <Outlet />;
 
-  if (loading) return <LoadingSpinner message="Chargement..." />;
+  if (loading || pending) return <LoadingSpinner message="Chargement..." />;
   if (!session || !userData)
     return <LoadingSpinner message="Chargement utilisateur..." />;
 

--- a/src/pages/auth/Login.jsx
+++ b/src/pages/auth/Login.jsx
@@ -2,16 +2,15 @@
 import React, { useState, useEffect, useRef } from "react";
 import { useNavigate, useLocation, Link } from "react-router-dom";
 import MamaLogo from "@/components/ui/MamaLogo";
-import useAuth from "@/hooks/useAuth";
 import ResetAuthButton from "@/components/ResetAuthButton";
 import toast from "react-hot-toast";
+import useAuth from "@/hooks/useAuth";
 import useFormErrors from "@/hooks/useFormErrors";
 import GlassCard from "@/components/ui/GlassCard";
 import PageWrapper from "@/components/ui/PageWrapper";
 import PreviewBanner from "@/components/ui/PreviewBanner";
 import PrimaryButton from "@/components/ui/PrimaryButton";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
-import { login as loginUser } from "../../lib/loginUser";
 
 export default function Login() {
   const [email, setEmail] = useState("");
@@ -26,6 +25,7 @@ export default function Login() {
     userData,
     loading: authLoading,
     getAuthorizedModules,
+    login,
     error: authError,
     resetAuth,
   } = useAuth();
@@ -70,14 +70,13 @@ export default function Login() {
 
     setLoading(true);
     try {
-      const { data, error } = await loginUser(email.trim(), password);
+      const { data, error } = await login({ email: email.trim(), password });
       if (error) {
         console.error(error);
         setError("password", error.message || error);
         toast.error(error.message || "Échec de la connexion");
         return;
       }
-
       if (data) {
         toast.success("Connexion réussie");
         // redirection handled once user data is loaded


### PR DESCRIPTION
## Summary
- stabilize session retrieval in `AuthContext`
- use context login inside login page
- wait for auth loading in protected route
- handle pending state in layout

## Testing
- `npm test` *(fails: Missing Supabase credentials)*

------
https://chatgpt.com/codex/tasks/task_e_687f906f1a40832db83e1c0ab59d055b