### PR TITLE
Fix auth context unification

### DIFF
--- a/src/components/DeleteAccountButton.jsx
+++ b/src/components/DeleteAccountButton.jsx
@@ -2,7 +2,7 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { useRGPD } from "@/hooks/useRGPD";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import toast from "react-hot-toast";
 
 export default function DeleteAccountButton() {

--- a/src/components/ResetAuthButton.jsx
+++ b/src/components/ResetAuthButton.jsx
@@ -1,4 +1,4 @@
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export default function ResetAuthButton({ className = "" }) {
   const { resetAuth } = useAuth() || {};

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { Link, useLocation } from "react-router-dom";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 import MamaLogo from "@/components/ui/MamaLogo";
 

--- a/src/components/parametrage/ParamAccess.jsx
+++ b/src/components/parametrage/ParamAccess.jsx
@@ -4,7 +4,7 @@ import { useRoles } from "@/hooks/useRoles";
 import { Button } from "@/components/ui/button";
 import TableContainer from "@/components/ui/TableContainer";
 import { useEffect } from "react";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { Toaster, toast } from "react-hot-toast";
 
 export default function ParamAccess() {

--- a/src/components/parametrage/ParamCostCenters.jsx
+++ b/src/components/parametrage/ParamCostCenters.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useCostCenters } from "@/hooks/useCostCenters";
 import { useState, useEffect, useRef } from "react";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { Button } from "@/components/ui/button";
 import TableContainer from "@/components/ui/TableContainer";
 import { Toaster, toast } from "react-hot-toast";

--- a/src/components/parametrage/ParamFamilles.jsx
+++ b/src/components/parametrage/ParamFamilles.jsx
@@ -3,7 +3,7 @@ import { useFamilles } from "@/hooks/useFamilles";
 import { Button } from "@/components/ui/button";
 import TableContainer from "@/components/ui/TableContainer";
 import { useState, useEffect } from "react";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { Toaster, toast } from "react-hot-toast";
 import { saveAs } from "file-saver";
 import * as XLSX from "xlsx";

--- a/src/components/parametrage/ParamMama.jsx
+++ b/src/components/parametrage/ParamMama.jsx
@@ -2,7 +2,7 @@
 import { useMama } from "@/hooks/useMama";
 import { Button } from "@/components/ui/button";
 import { useState, useEffect } from "react";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { Toaster, toast } from "react-hot-toast";
 
 export default function ParamMama() {

--- a/src/components/parametrage/ParamRoles.jsx
+++ b/src/components/parametrage/ParamRoles.jsx
@@ -3,7 +3,7 @@ import { useRoles } from "@/hooks/useRoles";
 import { Button } from "@/components/ui/button";
 import TableContainer from "@/components/ui/TableContainer";
 import { useState, useEffect } from "react";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { Toaster, toast } from "react-hot-toast";
 
 export default function ParamRoles() {

--- a/src/components/parametrage/ParamUnites.jsx
+++ b/src/components/parametrage/ParamUnites.jsx
@@ -3,7 +3,7 @@ import { useUnites } from "@/hooks/useUnites";
 import { Button } from "@/components/ui/button";
 import TableContainer from "@/components/ui/TableContainer";
 import { useState, useEffect } from "react";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { Toaster, toast } from "react-hot-toast";
 import { saveAs } from "file-saver";
 import * as XLSX from "xlsx";

--- a/src/components/parametrage/UtilisateurRow.jsx
+++ b/src/components/parametrage/UtilisateurRow.jsx
@@ -1,5 +1,5 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { useState } from "react";
 import toast from "react-hot-toast";
 import { supabase } from "@/lib/supabase";

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -192,6 +192,7 @@ export const AuthProvider = ({ children }) => {
   }, [userData, pathname, navigate]);
 
   const login = async ({ email, password }) => {
+    if (import.meta.env.DEV) console.log('login', email);
     const { data, error } = await loginUser(email, password);
     if (error) {
       toast.error(error.message || "Erreur");
@@ -241,6 +242,7 @@ export const AuthProvider = ({ children }) => {
   };
 
   const logout = async () => {
+    if (import.meta.env.DEV) console.log('logout');
     await supabase.auth.signOut();
     setSession(null);
     setUserData(null);

--- a/src/context/HelpProvider.jsx
+++ b/src/context/HelpProvider.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { createContext, useContext, useEffect, useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 const HelpContext = createContext();
 

--- a/src/context/MultiMamaContext.jsx
+++ b/src/context/MultiMamaContext.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { createContext, useContext, useEffect, useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import toast from "react-hot-toast";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 

--- a/src/context/ThemeProvider.jsx
+++ b/src/context/ThemeProvider.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { createContext, useContext, useEffect } from "react";
 import useMamaSettings from "@/hooks/useMamaSettings";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 const ThemeContext = createContext({});
 

--- a/src/hooks/useAchats.js
+++ b/src/hooks/useAchats.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export function useAchats() {
   const { mama_id } = useAuth();

--- a/src/hooks/useAlerts.js
+++ b/src/hooks/useAlerts.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export function useAlerts() {
   const { mama_id } = useAuth();

--- a/src/hooks/useAnalyse.js
+++ b/src/hooks/useAnalyse.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export function useAnalyse() {
   const { mama_id } = useAuth();

--- a/src/hooks/useAnalytique.js
+++ b/src/hooks/useAnalytique.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export function useAnalytique() {
   const { mama_id } = useAuth();

--- a/src/hooks/useApiKeys.js
+++ b/src/hooks/useApiKeys.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback } from 'react';
 import { supabase } from '@/lib/supabase';
-import { useAuth } from '@/context/AuthContext';
+import useAuth from '@/hooks/useAuth';
 
 export function useApiKeys() {
   const { mama_id, user_id } = useAuth();

--- a/src/hooks/useAuditLog.js
+++ b/src/hooks/useAuditLog.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export function useAuditLog() {
   const { mama_id, user } = useAuth();

--- a/src/hooks/useAuditTrail.js
+++ b/src/hooks/useAuditTrail.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export function useAuditTrail() {
   const { mama_id } = useAuth();

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -4,6 +4,7 @@ import { AuthContext } from "@/context/AuthContext";
 
 export default function useAuth() {
   const ctx = useContext(AuthContext) || {};
+  if (import.meta.env.DEV) console.log('useAuth hook', ctx);
   const loading = ctx.loading ?? ctx.isLoading;
   return {
     session: ctx.session,
@@ -22,5 +23,8 @@ export default function useAuth() {
     getAuthorizedModules: ctx.getAuthorizedModules,
     error: ctx.error,
     resetAuth: ctx.resetAuth,
+    login: ctx.login,
+    signup: ctx.signup,
+    logout: ctx.logout,
   };
 }

--- a/src/hooks/useBonsLivraison.js
+++ b/src/hooks/useBonsLivraison.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export function useBonsLivraison() {
   const { mama_id } = useAuth();

--- a/src/hooks/useCarte.js
+++ b/src/hooks/useCarte.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export function useCarte() {
   const { mama_id } = useAuth();

--- a/src/hooks/useCommandes.js
+++ b/src/hooks/useCommandes.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export function useCommandes() {
   const { mama_id } = useAuth();

--- a/src/hooks/useComparatif.js
+++ b/src/hooks/useComparatif.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useEffect, useCallback } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 /**
  * Hook retournant le comparatif des prix par fournisseur pour un produit donné.

--- a/src/hooks/useConsentements.js
+++ b/src/hooks/useConsentements.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { createClient } from "@/lib/supabaseClient";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export default function useConsentements() {
   const { userData } = useAuth();

--- a/src/hooks/useCostCenterMonthlyStats.js
+++ b/src/hooks/useCostCenterMonthlyStats.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export function useCostCenterMonthlyStats() {
   const { mama_id } = useAuth();

--- a/src/hooks/useCostCenterStats.js
+++ b/src/hooks/useCostCenterStats.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export function useCostCenterStats() {
   const { mama_id } = useAuth();

--- a/src/hooks/useCostCenters.js
+++ b/src/hooks/useCostCenters.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { useAuditLog } from "@/hooks/useAuditLog";
 import * as XLSX from "xlsx";
 import { saveAs } from "file-saver";

--- a/src/hooks/useDashboard.js
+++ b/src/hooks/useDashboard.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import * as XLSX from "xlsx";
 import { saveAs } from "file-saver";
 

--- a/src/hooks/useDashboardStats.js
+++ b/src/hooks/useDashboardStats.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useRef, useEffect, useCallback } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 /**
  * options: {

--- a/src/hooks/useDashboards.js
+++ b/src/hooks/useDashboards.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export function useDashboards() {
   const { user_id, mama_id } = useAuth();

--- a/src/hooks/useDocuments.js
+++ b/src/hooks/useDocuments.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { uploadFile, deleteFile, pathFromUrl } from "@/hooks/useStorage";
 
 export function useDocuments() {

--- a/src/hooks/useEcartsInventaire.js
+++ b/src/hooks/useEcartsInventaire.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export function useEcartsInventaire() {
   const { mama_id } = useAuth();

--- a/src/hooks/useEnrichedProducts.js
+++ b/src/hooks/useEnrichedProducts.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export function useEnrichedProducts() {
   const { mama_id } = useAuth();

--- a/src/hooks/useExport.js
+++ b/src/hooks/useExport.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from 'react';
 import { supabase } from '@/lib/supabase';
-import { useAuth } from '@/context/AuthContext';
+import useAuth from '@/hooks/useAuth';
 import {
   exportToPDF,
   exportToExcel,

--- a/src/hooks/useExportCompta.js
+++ b/src/hooks/useExportCompta.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from 'react';
 import { supabase } from '@/lib/supabase';
-import { useAuth } from '@/context/AuthContext';
+import useAuth from '@/hooks/useAuth';
 import { exportToCSV } from '@/lib/export/exportHelpers';
 import toast from 'react-hot-toast';
 

--- a/src/hooks/useFactures.js
+++ b/src/hooks/useFactures.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export function useFactures() {
   const { mama_id } = useAuth();

--- a/src/hooks/useFacturesAutocomplete.js
+++ b/src/hooks/useFacturesAutocomplete.js
@@ -1,6 +1,6 @@
 import { useState, useCallback } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export function useFacturesAutocomplete() {
   const { mama_id } = useAuth();

--- a/src/hooks/useFamilles.js
+++ b/src/hooks/useFamilles.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import * as XLSX from "xlsx";
 import { saveAs } from "file-saver";
 

--- a/src/hooks/useFeedback.js
+++ b/src/hooks/useFeedback.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export function useFeedback() {
   const { mama_id, user_id } = useAuth();

--- a/src/hooks/useFicheCoutHistory.js
+++ b/src/hooks/useFicheCoutHistory.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export function useFicheCoutHistory() {
   const { mama_id } = useAuth();

--- a/src/hooks/useFiches.js
+++ b/src/hooks/useFiches.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import * as XLSX from "xlsx";
 import { saveAs } from "file-saver";
 import jsPDF from "jspdf";

--- a/src/hooks/useFichesAutocomplete.js
+++ b/src/hooks/useFichesAutocomplete.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export function useFichesAutocomplete() {
   const { mama_id } = useAuth();

--- a/src/hooks/useFichesTechniques.js
+++ b/src/hooks/useFichesTechniques.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export function useFichesTechniques() {
   const { mama_id } = useAuth();

--- a/src/hooks/useFournisseurAPI.js
+++ b/src/hooks/useFournisseurAPI.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import toast from "react-hot-toast";
 
 export function useFournisseurAPI() {

--- a/src/hooks/useFournisseurApiConfig.js
+++ b/src/hooks/useFournisseurApiConfig.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from 'react';
 import { supabase } from '@/lib/supabase';
-import { useAuth } from '@/context/AuthContext';
+import useAuth from '@/hooks/useAuth';
 import toast from 'react-hot-toast';
 
 export function useFournisseurApiConfig() {

--- a/src/hooks/useFournisseurNotes.js
+++ b/src/hooks/useFournisseurNotes.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export function useFournisseurNotes() {
   const { mama_id } = useAuth();

--- a/src/hooks/useFournisseurStats.js
+++ b/src/hooks/useFournisseurStats.js
@@ -2,7 +2,7 @@
 // src/hooks/useFournisseurStats.js
 
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 // Stats d’évolution d’achats (tous fournisseurs ou par fournisseur)
 export function useFournisseurStats() {

--- a/src/hooks/useFournisseurs.js
+++ b/src/hooks/useFournisseurs.js
@@ -2,7 +2,7 @@
 // src/hooks/useFournisseurs.js
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import * as XLSX from "xlsx";
 import { saveAs } from "file-saver";
 import { toast } from "react-hot-toast";

--- a/src/hooks/useFournisseursAutocomplete.js
+++ b/src/hooks/useFournisseursAutocomplete.js
@@ -1,6 +1,6 @@
 import { useState, useCallback } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export function useFournisseursAutocomplete() {
   const { mama_id } = useAuth();

--- a/src/hooks/useFournisseursInactifs.js
+++ b/src/hooks/useFournisseursInactifs.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export function useFournisseursInactifs() {
   const { mama_id } = useAuth();

--- a/src/hooks/useGadgets.js
+++ b/src/hooks/useGadgets.js
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react';
 import { supabase } from '@/lib/supabase';
-import { useAuth } from '@/context/AuthContext';
+import useAuth from '@/hooks/useAuth';
 
 export function useGadgets() {
   const { mama_id, user_id } = useAuth();

--- a/src/hooks/useGlobalSearch.js
+++ b/src/hooks/useGlobalSearch.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback } from 'react';
 import { supabase } from '@/lib/supabase';
-import { useAuth } from '@/context/AuthContext';
+import useAuth from '@/hooks/useAuth';
 
 export function useGlobalSearch() {
   const { mama_id } = useAuth();

--- a/src/hooks/useGraphiquesMultiZone.js
+++ b/src/hooks/useGraphiquesMultiZone.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export function useGraphiquesMultiZone() {
   const { mama_id } = useAuth();

--- a/src/hooks/useInventaireLignes.js
+++ b/src/hooks/useInventaireLignes.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export function useInventaireLignes() {
   const { mama_id } = useAuth();

--- a/src/hooks/useInventaireZones.js
+++ b/src/hooks/useInventaireZones.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { toast } from "react-hot-toast";
 
 export function useInventaireZones() {

--- a/src/hooks/useInventaires.js
+++ b/src/hooks/useInventaires.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export function useInventaires() {
   const { mama_id } = useAuth();

--- a/src/hooks/useInvoiceItems.js
+++ b/src/hooks/useInvoiceItems.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 // Hook managing invoice line items (facture_lignes)
 export function useInvoiceItems() {

--- a/src/hooks/useInvoices.js
+++ b/src/hooks/useInvoices.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import * as XLSX from "xlsx";
 import { saveAs } from "file-saver";
 

--- a/src/hooks/useLogs.js
+++ b/src/hooks/useLogs.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import * as XLSX from "xlsx";
 import { saveAs } from "file-saver";
 

--- a/src/hooks/useMama.js
+++ b/src/hooks/useMama.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export function useMama() {
   const { mama_id } = useAuth();

--- a/src/hooks/useMamaSettings.js
+++ b/src/hooks/useMamaSettings.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 const defaults = {
   logo_url: "",

--- a/src/hooks/useMamas.js
+++ b/src/hooks/useMamas.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import * as XLSX from "xlsx";
 import { saveAs } from "file-saver";
 

--- a/src/hooks/useMenuDuJour.js
+++ b/src/hooks/useMenuDuJour.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { useAuditLog } from "@/hooks/useAuditLog";
 import * as XLSX from "xlsx";
 import { saveAs } from "file-saver";

--- a/src/hooks/useMenuEngineering.js
+++ b/src/hooks/useMenuEngineering.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback } from 'react'
 import { supabase } from '@/lib/supabase'
-import { useAuth } from '@/context/AuthContext'
+import useAuth from '@/hooks/useAuth'
 
 export function useMenuEngineering() {
   const { mama_id } = useAuth()

--- a/src/hooks/useMenus.js
+++ b/src/hooks/useMenus.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { useAuditLog } from "@/hooks/useAuditLog";
 import * as XLSX from "xlsx";
 import { saveAs } from "file-saver";

--- a/src/hooks/useMouvementCostCenters.js
+++ b/src/hooks/useMouvementCostCenters.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { useAuditLog } from "@/hooks/useAuditLog";
 
 export function useMouvementCostCenters() {

--- a/src/hooks/useMouvements.js
+++ b/src/hooks/useMouvements.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export function useMouvements() {
   const { mama_id, user_id } = useAuth();

--- a/src/hooks/useMouvementsStock.js
+++ b/src/hooks/useMouvementsStock.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import * as XLSX from "xlsx";
 import { saveAs } from "file-saver";
 

--- a/src/hooks/useNotifications.js
+++ b/src/hooks/useNotifications.js
@@ -2,7 +2,7 @@
 import { useState, useCallback } from "react";
 import toast from "react-hot-toast";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export default function useNotifications() {
   const { mama_id, user_id } = useAuth();

--- a/src/hooks/useOnboarding.js
+++ b/src/hooks/useOnboarding.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useEffect } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export function useOnboarding() {
   const { mama_id, user } = useAuth();

--- a/src/hooks/usePerformanceFiches.js
+++ b/src/hooks/usePerformanceFiches.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from 'react';
 import { supabase } from '@/lib/supabase';
-import { useAuth } from '@/context/AuthContext';
+import useAuth from '@/hooks/useAuth';
 
 export default function usePerformanceFiches() {
   const { mama_id } = useAuth();

--- a/src/hooks/usePermissions.js
+++ b/src/hooks/usePermissions.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import * as XLSX from "xlsx";
 import { saveAs } from "file-saver";
 

--- a/src/hooks/usePertes.js
+++ b/src/hooks/usePertes.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { useAuditLog } from "@/hooks/useAuditLog";
 
 export function usePertes() {

--- a/src/hooks/usePlanning.js
+++ b/src/hooks/usePlanning.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export function usePlanning() {
   const { mama_id } = useAuth();

--- a/src/hooks/usePriceTrends.js
+++ b/src/hooks/usePriceTrends.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from 'react';
 import { supabase } from '@/lib/supabase';
-import { useAuth } from '@/context/AuthContext';
+import useAuth from '@/hooks/useAuth';
 
 export function usePriceTrends(productIdInitial) {
   const { mama_id } = useAuth();

--- a/src/hooks/useProducts.js
+++ b/src/hooks/useProducts.js
@@ -2,7 +2,7 @@
 // src/hooks/useProducts.js
 import { useState, useCallback } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import * as XLSX from "xlsx";
 import { saveAs } from "file-saver";
 import { toast } from "react-hot-toast";

--- a/src/hooks/useProduitsAutocomplete.js
+++ b/src/hooks/useProduitsAutocomplete.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export function useProduitsAutocomplete() {
   const { mama_id } = useAuth();

--- a/src/hooks/useProduitsInventaire.js
+++ b/src/hooks/useProduitsInventaire.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback } from 'react';
 import { supabase } from '@/lib/supabase';
-import { useAuth } from '@/context/AuthContext';
+import useAuth from '@/hooks/useAuth';
 
 export function useProduitsInventaire() {
   const { mama_id } = useAuth();

--- a/src/hooks/usePromotions.js
+++ b/src/hooks/usePromotions.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export function usePromotions() {
   const { mama_id } = useAuth();

--- a/src/hooks/useRGPD.js
+++ b/src/hooks/useRGPD.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export function useRGPD() {
   const { user_id, mama_id, role } = useAuth();

--- a/src/hooks/useRecommendations.js
+++ b/src/hooks/useRecommendations.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useEffect } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export async function getRecommendations(user_id, mama_id) {
   if (!mama_id) return [];

--- a/src/hooks/useReporting.js
+++ b/src/hooks/useReporting.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export function useReporting() {
   const { mama_id } = useAuth();

--- a/src/hooks/useRequisitions.js
+++ b/src/hooks/useRequisitions.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 // src/hooks/useRequisitions.js
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export function useRequisitions() {
   const { mama_id, user_id } = useAuth();

--- a/src/hooks/useRoles.js
+++ b/src/hooks/useRoles.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import * as XLSX from "xlsx";
 import { saveAs } from "file-saver";
 import { exportToCSV } from "@/lib/export/exportHelpers";

--- a/src/hooks/useSignalements.js
+++ b/src/hooks/useSignalements.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export function useSignalements() {
   const { mama_id, user_id, loading: authLoading } = useAuth();

--- a/src/hooks/useSimulation.js
+++ b/src/hooks/useSimulation.js
@@ -2,7 +2,7 @@
 // src/hooks/useSimulation.js
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export const useSimulation = () => {
   const { mama_id } = useAuth();

--- a/src/hooks/useStats.js
+++ b/src/hooks/useStats.js
@@ -2,7 +2,7 @@
 // src/hooks/useStats.js
 import { useState, useEffect, useCallback } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export function useStats() {
   const { mama_id } = useAuth();

--- a/src/hooks/useStock.js
+++ b/src/hooks/useStock.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export function useStock() {
   const { mama_id, user_id } = useAuth();

--- a/src/hooks/useStockRequisitionne.js
+++ b/src/hooks/useStockRequisitionne.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useEffect } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export function useStockRequisitionne() {
   const { mama_id } = useAuth();

--- a/src/hooks/useSupplierProducts.js
+++ b/src/hooks/useSupplierProducts.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 export function useSupplierProducts() {
   const { mama_id } = useAuth();
   const [cache, setCache] = useState({});

--- a/src/hooks/useSuppliers.js
+++ b/src/hooks/useSuppliers.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 // Hook principal pour tout accès/fonction fournisseur
 export function useSuppliers() {

--- a/src/hooks/useTaches.js
+++ b/src/hooks/useTaches.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export function useTaches() {
   const { mama_id, user_id } = useAuth();

--- a/src/hooks/useTasks.js
+++ b/src/hooks/useTasks.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export function useTasks() {
   const { mama_id } = useAuth();

--- a/src/hooks/useTopProducts.js
+++ b/src/hooks/useTopProducts.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { supabase } from '@/lib/supabase';
-import { useAuth } from '@/context/AuthContext';
+import useAuth from '@/hooks/useAuth';
 
 export function useTopProducts() {
   const { mama_id } = useAuth();

--- a/src/hooks/useTransferts.js
+++ b/src/hooks/useTransferts.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export function useTransferts() {
   const { mama_id, user_id } = useAuth();

--- a/src/hooks/useUnites.js
+++ b/src/hooks/useUnites.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import * as XLSX from "xlsx";
 import { saveAs } from "file-saver";
 

--- a/src/hooks/useUsageStats.js
+++ b/src/hooks/useUsageStats.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export function useUsageStats() {
   const { mama_id } = useAuth();

--- a/src/hooks/useUtilisateurs.js
+++ b/src/hooks/useUtilisateurs.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import * as XLSX from "xlsx";
 import { saveAs } from "file-saver";
 import { exportToCSV } from "@/lib/export/exportHelpers";

--- a/src/hooks/useValidations.js
+++ b/src/hooks/useValidations.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export function useValidations() {
   const { mama_id, user } = useAuth();

--- a/src/hooks/useZones.js
+++ b/src/hooks/useZones.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from 'react';
 import { supabase } from '@/lib/supabase';
-import { useAuth } from '@/context/AuthContext';
+import useAuth from '@/hooks/useAuth';
 import { toast } from 'react-hot-toast';
 
 export function useZones() {

--- a/src/layout/Navbar.jsx
+++ b/src/layout/Navbar.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useEffect } from "react";
 import { useTranslation } from 'react-i18next';
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { useGlobalSearch } from "@/hooks/useGlobalSearch";
 import LanguageSelector from "@/components/ui/LanguageSelector";
 

--- a/src/layout/Sidebar.jsx
+++ b/src/layout/Sidebar.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { Link, useLocation } from "react-router-dom";
 import { routePreloadMap } from "@/router";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import toast from "react-hot-toast";
 import {
   Boxes,

--- a/src/pages/Alertes.jsx
+++ b/src/pages/Alertes.jsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from "react";
 import { useAlerts } from "@/hooks/useAlerts";
 import { useProducts } from "@/hooks/useProducts";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { Button } from "@/components/ui/button";
 import PrimaryButton from "@/components/ui/PrimaryButton";
 import SecondaryButton from "@/components/ui/SecondaryButton";

--- a/src/pages/AuditTrail.jsx
+++ b/src/pages/AuditTrail.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState } from "react";
 import { useAuditTrail } from "@/hooks/useAuditTrail";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { Button } from "@/components/ui/button";
 import PrimaryButton from "@/components/ui/PrimaryButton";
 import { Input } from "@/components/ui/input";

--- a/src/pages/BarManager.jsx
+++ b/src/pages/BarManager.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useEffect } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import toast, { Toaster } from "react-hot-toast";
 import * as XLSX from "xlsx";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";

--- a/src/pages/CartePlats.jsx
+++ b/src/pages/CartePlats.jsx
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useEffect } from "react";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { supabase } from "@/lib/supabase";
 import { Toaster } from "react-hot-toast";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";

--- a/src/pages/Consolidation.jsx
+++ b/src/pages/Consolidation.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect } from "react";
 import { useConsolidation } from "@/hooks/useConsolidation";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { Toaster } from "react-hot-toast";
 import { Button } from "@/components/ui/button";
 import TableContainer from "@/components/ui/TableContainer";

--- a/src/pages/Feedback.jsx
+++ b/src/pages/Feedback.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState } from "react";
 import { useFeedback } from "@/hooks/useFeedback";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { Button } from "@/components/ui/button";
 import PrimaryButton from "@/components/ui/PrimaryButton";
 import { Input } from "@/components/ui/input";

--- a/src/pages/Journal.jsx
+++ b/src/pages/Journal.jsx
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState } from "react";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { useLogs } from "@/hooks/useLogs";
 import { Button } from "@/components/ui/button";
 import PrimaryButton from "@/components/ui/PrimaryButton";

--- a/src/pages/Logs.jsx
+++ b/src/pages/Logs.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState } from "react";
 import { useLogs } from "@/hooks/useLogs";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { Button } from "@/components/ui/button";
 import PrimaryButton from "@/components/ui/PrimaryButton";
 import { Input } from "@/components/ui/input";

--- a/src/pages/MenuEngineering.jsx
+++ b/src/pages/MenuEngineering.jsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react'
 import { useMenuEngineering } from '@/hooks/useMenuEngineering'
 import { Toaster, toast } from 'react-hot-toast'
 import { Button } from '@/components/ui/button'
-import { useAuth } from '@/context/AuthContext'
+import useAuth from '@/hooks/useAuth'
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner'
 import {
   ResponsiveContainer,

--- a/src/pages/Pertes.jsx
+++ b/src/pages/Pertes.jsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from "react";
 import { usePertes } from "@/hooks/usePertes";
 import { useProducts } from "@/hooks/useProducts";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { Button } from "@/components/ui/button";
 import PrimaryButton from "@/components/ui/PrimaryButton";
 import { Input } from "@/components/ui/input";

--- a/src/pages/Stock.jsx
+++ b/src/pages/Stock.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState } from "react";
 import { useStock } from "@/hooks/useStock";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import StockMouvementForm from "@/components/stock/StockMouvementForm";
 import StockDetail from "@/components/stock/StockDetail";
 import { Button } from "@/components/ui/button";

--- a/src/pages/Transferts.jsx
+++ b/src/pages/Transferts.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useEffect } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import toast, { Toaster } from "react-hot-toast";
 import * as XLSX from "xlsx";
 import jsPDF from "jspdf";

--- a/src/pages/Utilisateurs.jsx
+++ b/src/pages/Utilisateurs.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState } from "react";
 import { useUtilisateurs } from "@/hooks/useUtilisateurs";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import UtilisateurForm from "@/components/utilisateurs/UtilisateurForm";
 import UtilisateurDetail from "@/components/utilisateurs/UtilisateurDetail";
 import { Button } from "@/components/ui/button";

--- a/src/pages/Validations.jsx
+++ b/src/pages/Validations.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState } from "react";
 import { useValidations } from "@/hooks/useValidations";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { Button } from "@/components/ui/button";
 import { Toaster, toast } from "react-hot-toast";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";

--- a/src/pages/analytique/AnalytiqueDashboard.jsx
+++ b/src/pages/analytique/AnalytiqueDashboard.jsx
@@ -5,7 +5,7 @@ import { Toaster } from "react-hot-toast";
 import * as XLSX from "xlsx";
 import { Button } from "@/components/ui/button";
 import GlassCard from "@/components/ui/GlassCard";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { useCostCenters } from "@/hooks/useCostCenters";
 import { useFamilles } from "@/hooks/useFamilles";
 import { useAnalytique } from "@/hooks/useAnalytique";

--- a/src/pages/auth/CreateMama.jsx
+++ b/src/pages/auth/CreateMama.jsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import PageWrapper from "@/components/ui/PageWrapper";
 import GlassCard from "@/components/ui/GlassCard";
 import MamaLogo from "@/components/ui/MamaLogo";

--- a/src/pages/auth/Logout.jsx
+++ b/src/pages/auth/Logout.jsx
@@ -1,19 +1,20 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect } from "react";
-import { supabase } from "@/lib/supabase";
 import { useNavigate } from "react-router-dom";
 import { toast } from "react-hot-toast";
+import useAuth from "@/hooks/useAuth";
 import PageWrapper from "@/components/ui/PageWrapper";
 import GlassCard from "@/components/ui/GlassCard";
 
 export default function Logout() {
   const navigate = useNavigate();
+  const { logout } = useAuth();
   useEffect(() => {
-    supabase.auth.signOut().then(() => {
+    logout().then(() => {
       toast.success("Déconnecté");
       navigate("/login");
     });
-  }, [navigate]);
+  }, [logout, navigate]);
   return (
     <PageWrapper>
       <GlassCard className="text-center">Déconnexion…</GlassCard>

--- a/src/pages/carte/Carte.jsx
+++ b/src/pages/carte/Carte.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useEffect } from "react";
 import { Navigate, Link } from "react-router-dom";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { useCarte } from "@/hooks/useCarte";
 import { useFamilles } from "@/hooks/useFamilles";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";

--- a/src/pages/catalogue/CatalogueSyncViewer.jsx
+++ b/src/pages/catalogue/CatalogueSyncViewer.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { Button } from "@/components/ui/button";
 import TableContainer from "@/components/ui/TableContainer";
 import toast from "react-hot-toast";

--- a/src/pages/commandes/CommandesEnvoyees.jsx
+++ b/src/pages/commandes/CommandesEnvoyees.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { Button } from "@/components/ui/button";
 import { useFournisseurAPI } from "@/hooks/useFournisseurAPI";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";

--- a/src/pages/costboisson/CostBoisson.jsx
+++ b/src/pages/costboisson/CostBoisson.jsx
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useEffect } from "react";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { supabase } from "@/lib/supabase";
 import { Button } from "@/components/ui/button";
 import toast, { Toaster } from "react-hot-toast";

--- a/src/pages/debug/AccessExample.jsx
+++ b/src/pages/debug/AccessExample.jsx
@@ -1,4 +1,4 @@
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 import GlassCard from "@/components/ui/GlassCard";
 

--- a/src/pages/debug/Debug.jsx
+++ b/src/pages/debug/Debug.jsx
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import React from "react";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 import GlassCard from "@/components/ui/GlassCard";
 

--- a/src/pages/debug/DebugUser.jsx
+++ b/src/pages/debug/DebugUser.jsx
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 // src/pages/debug/DebugUser.jsx
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 import GlassCard from "@/components/ui/GlassCard";
 

--- a/src/pages/documents/Documents.jsx
+++ b/src/pages/documents/Documents.jsx
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState } from "react";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { useDocuments } from "@/hooks/useDocuments";
 import DocumentForm from "./DocumentForm.jsx";
 import DocumentPreview from "@/components/documents/DocumentPreview";

--- a/src/pages/ecarts/Ecarts.jsx
+++ b/src/pages/ecarts/Ecarts.jsx
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEcartsInventaire } from "@/hooks/useEcartsInventaire";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";

--- a/src/pages/factures/Factures.jsx
+++ b/src/pages/factures/Factures.jsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from "react";
 import { useFactures } from "@/hooks/useFactures";
 import { useSuppliers } from "@/hooks/useSuppliers";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { useFacturesAutocomplete } from "@/hooks/useFacturesAutocomplete";
 import FactureForm from "./FactureForm.jsx";
 import FactureDetail from "./FactureDetail.jsx";

--- a/src/pages/fiches/FicheDetail.jsx
+++ b/src/pages/fiches/FicheDetail.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState } from "react";
 import { useParams, Navigate } from "react-router-dom";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { Button } from "@/components/ui/button";
 import * as XLSX from "xlsx";
 import jsPDF from "jspdf";

--- a/src/pages/fiches/FicheForm.jsx
+++ b/src/pages/fiches/FicheForm.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useEffect } from "react";
 import { Navigate } from "react-router-dom";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { useFiches } from "@/hooks/useFiches";
 import { useProducts } from "@/hooks/useProducts";
 import { useFamilles } from "@/hooks/useFamilles";

--- a/src/pages/fiches/Fiches.jsx
+++ b/src/pages/fiches/Fiches.jsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from "react";
 import { Navigate } from "react-router-dom";
 import { useFiches } from "@/hooks/useFiches";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import FicheForm from "./FicheForm.jsx";
 import FicheDetail from "./FicheDetail.jsx";
 import { Button } from "@/components/ui/button";

--- a/src/pages/fournisseurs/ApiFournisseurs.jsx
+++ b/src/pages/fournisseurs/ApiFournisseurs.jsx
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState } from "react";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { useFournisseurApiConfig } from "@/hooks/useFournisseurApiConfig";
 import { Link } from "react-router-dom";
 import TableContainer from "@/components/ui/TableContainer";

--- a/src/pages/fournisseurs/FournisseurApiSettingsForm.jsx
+++ b/src/pages/fournisseurs/FournisseurApiSettingsForm.jsx
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState } from "react";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { Button } from "@/components/ui/button";
 import PrimaryButton from "@/components/ui/PrimaryButton";
 import { Input } from "@/components/ui/input";

--- a/src/pages/fournisseurs/FournisseurDetail.jsx
+++ b/src/pages/fournisseurs/FournisseurDetail.jsx
@@ -6,7 +6,7 @@ import { useSupplierProducts } from "@/hooks/useSupplierProducts";
 import { useInvoices } from "@/hooks/useInvoices";
 import { useFournisseurs } from "@/hooks/useFournisseurs";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 import { ResponsiveContainer, LineChart, Line, BarChart, Bar, XAxis, YAxis, Tooltip, Legend } from "recharts";
 import { Button } from "@/components/ui/button";

--- a/src/pages/fournisseurs/comparatif/ComparatifPrix.jsx
+++ b/src/pages/fournisseurs/comparatif/ComparatifPrix.jsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import PrixFournisseurs from "./PrixFournisseurs";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 import { Select } from "@/components/ui/select";
 

--- a/src/pages/inventaire/EcartInventaire.jsx
+++ b/src/pages/inventaire/EcartInventaire.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useEffect, useCallback } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import TableContainer from "@/components/ui/TableContainer";
 import InputField from "@/components/ui/InputField";
 

--- a/src/pages/menus/MenuDuJour.jsx
+++ b/src/pages/menus/MenuDuJour.jsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from "react";
 import { useMenuDuJour } from "@/hooks/useMenuDuJour";
 import { useFiches } from "@/hooks/useFiches";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import MenuDuJourForm from "./MenuDuJourForm.jsx";
 import MenuDuJourDetail from "./MenuDuJourDetail.jsx";
 import { Button } from "@/components/ui/button";

--- a/src/pages/menus/MenuPDF.jsx
+++ b/src/pages/menus/MenuPDF.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export default function MenuPDF({ id }) {
   const { mama_id } = useAuth();

--- a/src/pages/menus/Menus.jsx
+++ b/src/pages/menus/Menus.jsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from "react";
 import { useMenus } from "@/hooks/useMenus";
 import { useFiches } from "@/hooks/useFiches";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import MenuForm from "./MenuForm.jsx";
 import MenuDetail from "./MenuDetail.jsx";
 import { Button } from "@/components/ui/button";

--- a/src/pages/mobile/MobileInventaire.jsx
+++ b/src/pages/mobile/MobileInventaire.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { useInventaires } from "@/hooks/useInventaires";
 import { LiquidBackground, TouchLight } from "@/components/LiquidBackground";
 import GlassCard from "@/components/ui/GlassCard";

--- a/src/pages/mobile/MobileMouvement.jsx
+++ b/src/pages/mobile/MobileMouvement.jsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from "react";
 import { supabase } from "@/lib/supabase";
 import { toast } from "react-toastify";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { LiquidBackground, TouchLight } from "@/components/LiquidBackground";
 import GlassCard from "@/components/ui/GlassCard";
 

--- a/src/pages/mobile/MobileRequisition.jsx
+++ b/src/pages/mobile/MobileRequisition.jsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from "react";
 import { supabase } from "@/lib/supabase";
 import { toast } from "react-toastify";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { LiquidBackground, TouchLight } from "@/components/LiquidBackground";
 import GlassCard from "@/components/ui/GlassCard";
 

--- a/src/pages/parametrage/AccessRights.jsx
+++ b/src/pages/parametrage/AccessRights.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect } from "react";
 import { useUtilisateurs } from "@/hooks/useUtilisateurs";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { MODULES } from "@/config/modules";
 import { toast, Toaster } from "react-hot-toast";
 import TableContainer from "@/components/ui/TableContainer";

--- a/src/pages/parametrage/CentreCoutForm.jsx
+++ b/src/pages/parametrage/CentreCoutForm.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import PrimaryButton from "@/components/ui/PrimaryButton";
 import SecondaryButton from "@/components/ui/SecondaryButton";
 import { Input } from "@/components/ui/input";

--- a/src/pages/parametrage/ExportUserData.jsx
+++ b/src/pages/parametrage/ExportUserData.jsx
@@ -2,7 +2,7 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import toast, { Toaster } from "react-hot-toast";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { useRGPD } from "@/hooks/useRGPD";
 
 export default function ExportUserData({ userId = null }) {

--- a/src/pages/parametrage/InvitationsEnAttente.jsx
+++ b/src/pages/parametrage/InvitationsEnAttente.jsx
@@ -2,7 +2,7 @@
 import { useState, useEffect } from "react";
 import { supabase } from "@/lib/supabase";
 import { Button } from "@/components/ui/button";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import toast, { Toaster } from "react-hot-toast";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 

--- a/src/pages/parametrage/InviteUser.jsx
+++ b/src/pages/parametrage/InviteUser.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useEffect } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import PrimaryButton from "@/components/ui/PrimaryButton";
 import SecondaryButton from "@/components/ui/SecondaryButton";
 import { Input } from "@/components/ui/input";

--- a/src/pages/parametrage/MamaForm.jsx
+++ b/src/pages/parametrage/MamaForm.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import PrimaryButton from "@/components/ui/PrimaryButton";
 import SecondaryButton from "@/components/ui/SecondaryButton";
 import { Input } from "@/components/ui/input";

--- a/src/pages/parametrage/MamaSettingsForm.jsx
+++ b/src/pages/parametrage/MamaSettingsForm.jsx
@@ -5,7 +5,7 @@ import PrimaryButton from "@/components/ui/PrimaryButton";
 import { Input } from "@/components/ui/input";
 import useMamaSettings from "@/hooks/useMamaSettings";
 import { uploadFile, deleteFile, pathFromUrl } from "@/hooks/useStorage";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export default function MamaSettingsForm() {
   const { mama_id } = useAuth();

--- a/src/pages/parametrage/Mamas.jsx
+++ b/src/pages/parametrage/Mamas.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useEffect } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { Button } from "@/components/ui/button";
 import TableContainer from "@/components/ui/TableContainer";
 import {

--- a/src/pages/parametrage/Parametrage.jsx
+++ b/src/pages/parametrage/Parametrage.jsx
@@ -7,7 +7,7 @@ import ParamAccess from "@/components/parametrage/ParamAccess";
 import ParamMama from "@/components/parametrage/ParamMama";
 import ParamCostCenters from "@/components/parametrage/ParamCostCenters";
 import ParamSecurity from "@/components/parametrage/ParamSecurity";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export default function Parametrage() {
   const { isAuthenticated } = useAuth();

--- a/src/pages/parametrage/Permissions.jsx
+++ b/src/pages/parametrage/Permissions.jsx
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useEffect } from "react";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { supabase } from "@/lib/supabase";
 import { Button } from "@/components/ui/button";
 import {

--- a/src/pages/parametrage/PermissionsAdmin.jsx
+++ b/src/pages/parametrage/PermissionsAdmin.jsx
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useEffect } from "react";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { supabase } from "@/lib/supabase";
 import { Button } from "@/components/ui/button";
 import {

--- a/src/pages/parametrage/PermissionsForm.jsx
+++ b/src/pages/parametrage/PermissionsForm.jsx
@@ -3,7 +3,7 @@ import { useState, useEffect } from "react";
 import { supabase } from "@/lib/supabase";
 import { Button } from "@/components/ui/button";
 import toast, { Toaster } from "react-hot-toast";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { MODULES as MODULE_LIST } from "@/config/modules";
 
 const MODULES = MODULE_LIST.map(m => ({ nom: m.label, cle: m.key }));

--- a/src/pages/parametrage/RGPDConsentForm.jsx
+++ b/src/pages/parametrage/RGPDConsentForm.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import PrimaryButton from "@/components/ui/PrimaryButton";
 import toast, { Toaster } from "react-hot-toast";
 

--- a/src/pages/parametrage/RoleForm.jsx
+++ b/src/pages/parametrage/RoleForm.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import PrimaryButton from "@/components/ui/PrimaryButton";

--- a/src/pages/parametrage/Roles.jsx
+++ b/src/pages/parametrage/Roles.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useEffect } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import toast, { Toaster } from "react-hot-toast";
 import { Button } from "@/components/ui/button";
 import TableContainer from "@/components/ui/TableContainer";

--- a/src/pages/parametrage/UtilisateurForm.jsx
+++ b/src/pages/parametrage/UtilisateurForm.jsx
@@ -3,7 +3,7 @@ import { useState, useEffect } from "react";
 import { useUtilisateurs } from "@/hooks/useUtilisateurs";
 import { useRoles } from "@/hooks/useRoles";
 import { useMamas } from "@/hooks/useMamas";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { Input } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
 import { Label } from "@/components/ui/label";

--- a/src/pages/parametrage/Utilisateurs.jsx
+++ b/src/pages/parametrage/Utilisateurs.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState } from "react";
 import { useUtilisateurs } from "@/hooks/useUtilisateurs";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { useRoles } from "@/hooks/useRoles";
 import { useMamas } from "@/hooks/useMamas";
 import UtilisateurForm from "./UtilisateurForm";

--- a/src/pages/planning/SimulationPlanner.jsx
+++ b/src/pages/planning/SimulationPlanner.jsx
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState } from "react";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { useMenus } from "@/hooks/useMenus";
 import { useSimulation } from "@/hooks/useSimulation";
 import SimulationDetailsModal from "@/components/simulation/SimulationDetailsModal";

--- a/src/pages/promotions/Promotions.jsx
+++ b/src/pages/promotions/Promotions.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState } from "react";
 import { usePromotions } from "@/hooks/usePromotions";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { Button } from "@/components/ui/button";
 import TableContainer from "@/components/ui/TableContainer";
 import { Toaster, toast } from "react-hot-toast";

--- a/src/pages/reporting/Reporting.jsx
+++ b/src/pages/reporting/Reporting.jsx
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState } from "react";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { useReporting } from "@/hooks/useReporting";
 import StatCard from "@/components/ui/StatCard";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";

--- a/src/pages/requisitions/RequisitionDetail.jsx
+++ b/src/pages/requisitions/RequisitionDetail.jsx
@@ -2,7 +2,7 @@
 import { useParams } from "react-router-dom";
 import { useRequisitions } from "@/hooks/useRequisitions";
 import { useEffect, useState } from "react";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 import GlassCard from "@/components/ui/GlassCard";
 

--- a/src/pages/requisitions/RequisitionForm.jsx
+++ b/src/pages/requisitions/RequisitionForm.jsx
@@ -4,7 +4,7 @@ import { useNavigate } from "react-router-dom";
 import { useRequisitions } from "@/hooks/useRequisitions";
 import { useProducts } from "@/hooks/useProducts";
 import { useZones } from "@/hooks/useZones";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { supabase } from "@/lib/supabase";
 import { Toaster, toast } from "react-hot-toast";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";

--- a/src/pages/requisitions/Requisitions.jsx
+++ b/src/pages/requisitions/Requisitions.jsx
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useEffect } from "react";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { useZones } from "@/hooks/useZones";
 import { useRequisitions } from "@/hooks/useRequisitions";
 import toast, { Toaster } from "react-hot-toast";

--- a/src/pages/signalements/SignalementForm.jsx
+++ b/src/pages/signalements/SignalementForm.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { useSignalements } from "@/hooks/useSignalements";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import toast from "react-hot-toast";
 
 export default function SignalementForm({ onCreated }) {

--- a/src/pages/signalements/Signalements.jsx
+++ b/src/pages/signalements/Signalements.jsx
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useSignalements } from "@/hooks/useSignalements";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 import GlassCard from "@/components/ui/GlassCard";
 

--- a/src/pages/simulation/Simulation.jsx
+++ b/src/pages/simulation/Simulation.jsx
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useSignalements } from "@/hooks/useSignalements";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 import GlassCard from "@/components/ui/GlassCard";
 

--- a/src/pages/simulation/SimulationForm.jsx
+++ b/src/pages/simulation/SimulationForm.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import toast from "react-hot-toast";
 
 export default function SimulationForm({ addRecipe, setPrix }) {

--- a/src/pages/stats/StatsAdvanced.jsx
+++ b/src/pages/stats/StatsAdvanced.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState } from "react";
 import { useAdvancedStats } from "@/hooks/useAdvancedStats";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip, Legend } from "recharts";
 import { Toaster } from "react-hot-toast";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";

--- a/src/pages/stats/StatsConsolidation.jsx
+++ b/src/pages/stats/StatsConsolidation.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect } from "react";
 import { useConsolidatedStats } from "@/hooks/useConsolidatedStats";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { Toaster } from "react-hot-toast";
 import { Button } from "@/components/ui/button";
 import TableContainer from "@/components/ui/TableContainer";

--- a/src/pages/stats/StatsCostCenters.jsx
+++ b/src/pages/stats/StatsCostCenters.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useEffect } from "react";
 import { useCostCenterStats } from "@/hooks/useCostCenterStats";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { Toaster } from "react-hot-toast";
 import { Button } from "@/components/ui/button";
 import TableContainer from "@/components/ui/TableContainer";

--- a/src/pages/stats/StatsCostCentersPivot.jsx
+++ b/src/pages/stats/StatsCostCentersPivot.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState } from "react";
 import { useCostCenterMonthlyStats } from "@/hooks/useCostCenterMonthlyStats";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { Toaster } from "react-hot-toast";
 import { Button } from "@/components/ui/button";
 import TableContainer from "@/components/ui/TableContainer";

--- a/src/pages/stats/StatsFiches.jsx
+++ b/src/pages/stats/StatsFiches.jsx
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useEffect } from "react";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { supabase } from "@/lib/supabase";
 import toast, { Toaster } from "react-hot-toast";
 import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Legend, LineChart, Line } from "recharts";

--- a/src/pages/stats/StatsStock.jsx
+++ b/src/pages/stats/StatsStock.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState } from "react";
 import { useDashboardStats } from "@/hooks/useDashboardStats";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { Toaster } from "react-hot-toast";
 import { Button } from "@/components/ui/button";
 import TableContainer from "@/components/ui/TableContainer";

--- a/src/pages/stock/Transferts.jsx
+++ b/src/pages/stock/Transferts.jsx
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useEffect } from "react";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { useTransferts } from "@/hooks/useTransferts";
 import { useProducts } from "@/hooks/useProducts";
 import { useZones } from "@/hooks/useZones";

--- a/src/pages/supervision/GroupeParamForm.jsx
+++ b/src/pages/supervision/GroupeParamForm.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { Button } from "@/components/ui/button";
 import GlassCard from "@/components/ui/GlassCard";
 import toast from "react-hot-toast";

--- a/src/pages/taches/Alertes.jsx
+++ b/src/pages/taches/Alertes.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 import TableContainer from "@/components/ui/TableContainer";
 

--- a/src/pages/taches/TacheDetail.jsx
+++ b/src/pages/taches/TacheDetail.jsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { useTasks } from "@/hooks/useTasks";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import TacheForm from "@/components/taches/TacheForm";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 

--- a/test/ComparatifPrix.test.jsx
+++ b/test/ComparatifPrix.test.jsx
@@ -3,8 +3,8 @@ import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { vi, beforeEach } from 'vitest';
 
-vi.mock('@/context/AuthContext', () => ({
-  useAuth: () => ({ mama_id: 1 }),
+vi.mock('@/hooks/useAuth', () => ({
+  default: () => ({ mama_id: 1 }),
 }));
 
 const orderMock = vi.fn();

--- a/test/Feedback.test.jsx
+++ b/test/Feedback.test.jsx
@@ -7,8 +7,8 @@ let hook;
 vi.mock('@/hooks/useFeedback', () => ({
   useFeedback: () => hook,
 }));
-vi.mock('@/context/AuthContext', () => ({
-  useAuth: () => ({ mama_id: '1', loading: false }),
+vi.mock('@/hooks/useAuth', () => ({
+  default: () => ({ mama_id: '1', loading: false }),
 }));
 
 import Feedback from '@/pages/Feedback.jsx';

--- a/test/FournisseurApiConfigs.test.jsx
+++ b/test/FournisseurApiConfigs.test.jsx
@@ -8,7 +8,7 @@ let hook;
 vi.mock('@/hooks/useFournisseurApiConfig', () => ({
   useFournisseurApiConfig: () => hook,
 }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1' }) }));
 
 import ApiFournisseurs from '@/pages/fournisseurs/ApiFournisseurs.jsx';
 

--- a/test/FournisseurApiSettingsForm.test.jsx
+++ b/test/FournisseurApiSettingsForm.test.jsx
@@ -13,7 +13,7 @@ const upsertMock = vi.fn(() => ({ select: selectAfterUpsert }));
 const fromMock = vi.fn(() => ({ select: selectMock, upsert: upsertMock }));
 
 vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1' }) }));
 
 let FournisseurApiSettingsForm;
 

--- a/test/ImportFactures.test.jsx
+++ b/test/ImportFactures.test.jsx
@@ -7,8 +7,8 @@ let hook;
 vi.mock('@/hooks/useInvoiceImport', () => ({
   useInvoiceImport: () => hook,
 }));
-vi.mock('@/context/AuthContext', () => ({
-  useAuth: () => ({ mama_id: '1', loading: false }),
+vi.mock('@/hooks/useAuth', () => ({
+  default: () => ({ mama_id: '1', loading: false }),
 }));
 
 import ImportFactures from '@/pages/factures/ImportFactures.jsx';

--- a/test/Planning.test.jsx
+++ b/test/Planning.test.jsx
@@ -8,8 +8,8 @@ let hook;
 vi.mock('@/hooks/usePlanning', () => ({
   usePlanning: () => hook,
 }));
-vi.mock('@/context/AuthContext', () => ({
-  useAuth: () => ({ mama_id: '1' }),
+vi.mock('@/hooks/useAuth', () => ({
+  default: () => ({ mama_id: '1' }),
 }));
 vi.mock('@/hooks/useProducts', () => ({
   useProducts: () => ({ products: [{ id: 'p1', nom: 'Prod' }], fetchProducts: vi.fn() }),

--- a/test/duplicateProduct.test.js
+++ b/test/duplicateProduct.test.js
@@ -19,7 +19,7 @@ function setup(initial = []) {
   };
   fromMock = vi.fn(() => query);
   vi.mock('@/lib/supabase', () => ({ supabase: { from: (...args) => fromMock(...args) } }), { overwrite: true });
-  vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
+  vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1' }) }));
 }
 
 let useProducts;

--- a/test/router.test.jsx
+++ b/test/router.test.jsx
@@ -15,8 +15,8 @@ const authState = {
   pending: false,
   userData: null,
 };
-vi.mock('@/context/AuthContext', () => ({
-  useAuth: () => authState
+vi.mock('@/hooks/useAuth', () => ({
+  default: () => authState
 }));
 vi.mock('@/hooks/useAuth', () => ({
   default: () => authState

--- a/test/useAlerts.test.js
+++ b/test/useAlerts.test.js
@@ -14,7 +14,7 @@ const queryObj = {
 };
 const fromMock = vi.fn(() => queryObj);
 vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1' }) }));
 
 let useAlerts;
 

--- a/test/useAuditLog.test.js
+++ b/test/useAuditLog.test.js
@@ -6,7 +6,7 @@ const insertMock = vi.fn(() => Promise.resolve({ error: null }));
 const fromMock = vi.fn(() => ({ insert: insertMock }));
 
 vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock }, }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1', user: { id: 'u1' } }) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1', user: { id: 'u1' } }) }));
 
 let useAuditLog;
 

--- a/test/useAuditTrail.test.js
+++ b/test/useAuditTrail.test.js
@@ -13,7 +13,7 @@ const queryObj = {
 };
 const fromMock = vi.fn(() => queryObj);
 vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: '1' }) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: '1' }) }));
 
 let useAuditTrail;
 

--- a/test/useAuthHook.test.jsx
+++ b/test/useAuthHook.test.jsx
@@ -1,0 +1,21 @@
+import { renderHook } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { vi, expect, test } from 'vitest';
+import { AuthProvider } from '../src/context/AuthContext.jsx';
+import useAuth from '../src/hooks/useAuth.js';
+
+vi.mock('../src/lib/supabase.js', () => ({
+  supabase: { auth: { getSession: vi.fn(() => ({ data: { session: null }, error: null })), onAuthStateChange: vi.fn(() => ({ data: { subscription: { unsubscribe: vi.fn() } } })), signOut: vi.fn(() => Promise.resolve({ error: null })) } }
+}));
+
+vi.mock('../src/lib/loginUser.js', () => ({ login: vi.fn(() => Promise.resolve({ data: {} })) }));
+
+test('login is available via useAuth', () => {
+  const wrapper = ({ children }) => (
+    <MemoryRouter>
+      <AuthProvider>{children}</AuthProvider>
+    </MemoryRouter>
+  );
+  const { result } = renderHook(() => useAuth(), { wrapper });
+  expect(typeof result.current.login).toBe('function');
+});

--- a/test/useCostCenterMonthlyStats.test.js
+++ b/test/useCostCenterMonthlyStats.test.js
@@ -13,7 +13,7 @@ const selectMock = vi.fn(() => queryObj);
 const fromMock = vi.fn(() => ({ select: selectMock }));
 
 vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1' }) }));
 
 let useCostCenterMonthlyStats;
 

--- a/test/useCostCenterStats.test.js
+++ b/test/useCostCenterStats.test.js
@@ -7,7 +7,7 @@ const rpcMock = vi.fn(() => Promise.resolve({ data: [], error: null }));
 vi.mock('@/lib/supabase', () => ({
   supabase: { rpc: rpcMock }
 }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1' }) }));
 
 let useCostCenterStats;
 

--- a/test/useCostCenters.test.js
+++ b/test/useCostCenters.test.js
@@ -9,7 +9,7 @@ const selectMock = vi.fn(() => ({ eq: eqMock, order: orderMock }));
 const fromMock = vi.fn(() => ({ select: selectMock }));
 
 vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1' }) }));
 const sheetToJson = vi.fn(() => [{ nom: 'Food' }]);
 let readMock = vi.fn(() => ({ SheetNames: ['CostCenters'], Sheets: { CostCenters: {} } }));
 vi.mock('xlsx', () => ({ read: (...args) => readMock(...args), utils: { sheet_to_json: sheetToJson } }), { virtual: true });

--- a/test/useDashboard.test.js
+++ b/test/useDashboard.test.js
@@ -7,7 +7,7 @@ const selectMock = vi.fn(() => ({ eq: eqMock }));
 const fromMock = vi.fn(() => ({ select: selectMock }));
 const rpcMock = vi.fn(() => Promise.resolve({ data: [], error: null }));
 vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock, rpc: rpcMock } }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1', loading: false }) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1', loading: false }) }));
 
 let useDashboard;
 

--- a/test/useDocuments.test.js
+++ b/test/useDocuments.test.js
@@ -14,7 +14,7 @@ const queryObj = {
 };
 const fromMock = vi.fn(() => queryObj);
 vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1' }) }));
 vi.mock('@/hooks/useStorage', () => ({
   uploadFile: vi.fn(() => '/f'),
   deleteFile: vi.fn(),

--- a/test/useExport.test.js
+++ b/test/useExport.test.js
@@ -11,7 +11,7 @@ const queryObj = {
 };
 const fromMock = vi.fn(() => queryObj);
 vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1' }) }));
 
 const pdfMock = vi.fn();
 const excelMock = vi.fn();

--- a/test/useFactures.test.js
+++ b/test/useFactures.test.js
@@ -16,7 +16,7 @@ const query = {
 const fromMock = vi.fn(() => query);
 const rpcMock = vi.fn(() => ({ data: null, error: null }));
 vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock, rpc: rpcMock } }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1' }) }));
 
 let useFactures;
 

--- a/test/useFacturesAutocomplete.test.js
+++ b/test/useFacturesAutocomplete.test.js
@@ -10,7 +10,7 @@ const selectMock = vi.fn(() => ({ eq: eqMock, ilike: ilikeMock, order: orderMock
 const fromMock = vi.fn(() => ({ select: selectMock }));
 
 vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1' }) }));
 
 let useFacturesAutocomplete;
 

--- a/test/useFichesAutocomplete.test.js
+++ b/test/useFichesAutocomplete.test.js
@@ -11,7 +11,7 @@ const selectMock = vi.fn(() => ({ eq: eqMock, ilike: ilikeMock, neq: neqMock, or
 const fromMock = vi.fn(() => ({ select: selectMock }));
 
 vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1' }) }));
 
 let useFichesAutocomplete;
 

--- a/test/useFournisseurAPI.test.js
+++ b/test/useFournisseurAPI.test.js
@@ -27,7 +27,7 @@ updEqIdMock.mockReturnValue({ eq: updEqMamaMock });
 const fromMock = vi.fn();
 
 vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1' }) }));
 
 vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ json: () => Promise.resolve({}) })));
 

--- a/test/useFournisseurApiConfig.test.js
+++ b/test/useFournisseurApiConfig.test.js
@@ -14,7 +14,7 @@ const queryObj = {
 
 const fromMock = vi.fn(() => queryObj);
 vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1' }) }));
 
 let useFournisseurApiConfig;
 

--- a/test/useFournisseurs.test.js
+++ b/test/useFournisseurs.test.js
@@ -28,7 +28,7 @@ const fromMock = vi.fn((table) => {
 });
 
 vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1' }) }));
 
 let useFournisseurs;
 

--- a/test/useFournisseursAutocomplete.test.js
+++ b/test/useFournisseursAutocomplete.test.js
@@ -4,13 +4,13 @@ import { vi, beforeEach, test, expect } from 'vitest';
 
 const limitMock = vi.fn(() => Promise.resolve({ data: [], error: null }));
 const orderMock = vi.fn(() => ({ limit: limitMock }));
-const orMock = vi.fn(() => ({ order: orderMock, limit: limitMock }));
-const eqMock = vi.fn(() => ({ or: orMock, order: orderMock, limit: limitMock }));
-const selectMock = vi.fn(() => ({ eq: eqMock, or: orMock, order: orderMock, limit: limitMock }));
+const ilikeMock = vi.fn(() => ({ order: orderMock, limit: limitMock }));
+const eqMock = vi.fn(() => ({ ilike: ilikeMock, order: orderMock, limit: limitMock }));
+const selectMock = vi.fn(() => ({ eq: eqMock, ilike: ilikeMock, order: orderMock, limit: limitMock }));
 const fromMock = vi.fn(() => ({ select: selectMock }));
 
 vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1' }) }));
 
 let useFournisseursAutocomplete;
 
@@ -19,7 +19,7 @@ beforeEach(async () => {
   fromMock.mockClear();
   selectMock.mockClear();
   eqMock.mockClear();
-  orMock.mockClear();
+  ilikeMock.mockClear();
 });
 
 test('searchFournisseurs filters by mama_id and query', async () => {
@@ -30,5 +30,5 @@ test('searchFournisseurs filters by mama_id and query', async () => {
   expect(fromMock).toHaveBeenCalledWith('fournisseurs');
   expect(selectMock).toHaveBeenCalledWith('id, nom');
   expect(eqMock).toHaveBeenCalledWith('mama_id', 'm1');
-  expect(orMock).toHaveBeenCalledWith('nom.ilike.%paris%');
+  expect(ilikeMock).toHaveBeenCalledWith('nom', '%paris%');
 });

--- a/test/useFournisseursInactifs.test.js
+++ b/test/useFournisseursInactifs.test.js
@@ -9,7 +9,7 @@ const queryObj = {
 const fromMock = vi.fn(() => queryObj);
 
 vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1' }) }));
 
 let useFournisseursInactifs;
 

--- a/test/useGlobalSearch.test.js
+++ b/test/useGlobalSearch.test.js
@@ -7,7 +7,7 @@ const fourQuery = { ilike: vi.fn(() => fourQuery), eq: vi.fn(() => fourQuery), s
 const fromMock = vi.fn(source => ({ select: source === 'produits' ? prodQuery.select : fourQuery.select }));
 
 vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1' }) }));
 
 let useGlobalSearch;
 

--- a/test/useHelpArticles.test.js
+++ b/test/useHelpArticles.test.js
@@ -13,7 +13,7 @@ const query = {
 };
 const fromMock = vi.fn(() => query);
 vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({}) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({}) }));
 
 let useHelpArticles;
 

--- a/test/useInventaireLignes.test.js
+++ b/test/useInventaireLignes.test.js
@@ -16,7 +16,7 @@ const query = {
 };
 const fromMock = vi.fn(() => query);
 vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1' }) }));
 
 let useInventaireLignes;
 

--- a/test/useInvoiceItems.test.js
+++ b/test/useInvoiceItems.test.js
@@ -14,7 +14,7 @@ const query = {
 const fromMock = vi.fn(() => query);
 
 vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1' }) }));
 
 let useInvoiceItems;
 

--- a/test/useInvoices.test.js
+++ b/test/useInvoices.test.js
@@ -7,7 +7,7 @@ const queryChain = { select: vi.fn(() => queryChain), eq: vi.fn(() => queryChain
 const fromMock = vi.fn(() => queryChain);
 
 vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1' }) }));
 
 let useInvoices;
 

--- a/test/useLogs.test.js
+++ b/test/useLogs.test.js
@@ -14,7 +14,7 @@ const fromMock = vi.fn(() => ({ select: selectMock }));
 
 vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
 const authMock = vi.fn(() => ({ mama_id: 'm1' }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: authMock }));
+vi.mock('@/hooks/useAuth', () => ({ default: authMock }));
 vi.mock('file-saver', () => ({ saveAs: vi.fn() }));
 vi.mock('xlsx', () => ({ utils: { book_new: vi.fn(() => ({})), book_append_sheet: vi.fn(), json_to_sheet: vi.fn(() => ({})) }, write: vi.fn(() => new ArrayBuffer(10)) }));
 

--- a/test/useMenuDuJour.test.js
+++ b/test/useMenuDuJour.test.js
@@ -12,7 +12,7 @@ const selectMock = vi.fn(() => ({ eq: eqMock, ilike: ilikeMock, gte: gteMock, lt
 const fromMock = vi.fn(() => ({ select: selectMock }));
 
 vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1' }) }));
 
 let useMenuDuJour;
 

--- a/test/useMenuEngineering.test.js
+++ b/test/useMenuEngineering.test.js
@@ -14,7 +14,7 @@ const query = {
 const fromMock = vi.fn(() => query)
 vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }))
 const authMock = vi.fn(() => ({ mama_id: 'm1' }))
-vi.mock('@/context/AuthContext', () => ({ useAuth: authMock }))
+vi.mock('@/hooks/useAuth', () => ({ default: authMock }))
 
 let useMenuEngineering
 

--- a/test/useMenus.test.js
+++ b/test/useMenus.test.js
@@ -23,7 +23,7 @@ const removeChannelMock = vi.fn();
 vi.mock('@/lib/supabase', () => ({
   supabase: { from: fromMock, channel: channelMock, removeChannel: removeChannelMock },
 }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1' }) }));
 
 let useMenus;
 

--- a/test/useMouvements.test.js
+++ b/test/useMouvements.test.js
@@ -13,7 +13,7 @@ const query = {
 };
 const fromMock = vi.fn(() => query);
 vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1', user_id: 'u1' }) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1', user_id: 'u1' }) }));
 
 let useMouvements;
 

--- a/test/useNotifications.test.js
+++ b/test/useNotifications.test.js
@@ -25,7 +25,7 @@ const removeChannelMock = vi.fn();
 vi.mock('@/lib/supabase', () => ({
   supabase: { from: fromMock, rpc: rpcMock, channel: channelMock, removeChannel: removeChannelMock },
 }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1', user_id: 'u1' }) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1', user_id: 'u1' }) }));
 
 let useNotifications;
 

--- a/test/useOnboarding.test.js
+++ b/test/useOnboarding.test.js
@@ -11,7 +11,7 @@ const queryObj = {
 };
 const fromMock = vi.fn(() => queryObj);
 vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1', user: { id: 'u1' } }) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1', user: { id: 'u1' } }) }));
 
 let useOnboarding;
 

--- a/test/usePertes.test.js
+++ b/test/usePertes.test.js
@@ -10,7 +10,7 @@ const selectMock = vi.fn(() => ({ eq: eqMock, gte: gteMock, lte: lteMock, order:
 const fromMock = vi.fn(() => ({ select: selectMock }));
 
 vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1' }) }));
 vi.mock('@/hooks/useAuditLog', () => ({ useAuditLog: () => ({ log: vi.fn() }) }));
 
 let usePertes;

--- a/test/usePlanning.test.js
+++ b/test/usePlanning.test.js
@@ -13,7 +13,7 @@ const queryObj = {
 queryObj.then = (fn) => Promise.resolve(fn({ data: [], error: null }));
 const fromMock = vi.fn(() => queryObj);
 vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1' }) }));
 
 let usePlanning;
 

--- a/test/usePriceTrends.test.jsx
+++ b/test/usePriceTrends.test.jsx
@@ -3,8 +3,8 @@ import { renderHook, act } from '@testing-library/react';
 vi.mock('@/lib/supabase', () => ({
   supabase: { from: vi.fn() }
 }));
-vi.mock('@/context/AuthContext', () => ({
-  useAuth: () => ({ mama_id: 'm1' })
+vi.mock('@/hooks/useAuth', () => ({
+  default: () => ({ mama_id: 'm1' })
 }));
 import { usePriceTrends } from '@/hooks/usePriceTrends';
 import { supabase } from '@/lib/supabase';

--- a/test/useProductsPrices.test.js
+++ b/test/useProductsPrices.test.js
@@ -8,7 +8,7 @@ const selectMock = vi.fn(() => ({
 const fromMock = vi.fn(() => ({ select: selectMock }));
 
 vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1' }) }));
 
 let useProducts;
 

--- a/test/useProductsView.test.js
+++ b/test/useProductsView.test.js
@@ -9,7 +9,7 @@ const selectMock = vi.fn(() => ({ eq: eqMock, order: orderMock1, range: rangeMoc
 const fromMock = vi.fn(() => ({ select: selectMock }));
 
 vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1' }) }));
 
 let useProducts;
 

--- a/test/useProduitsAutocomplete.test.js
+++ b/test/useProduitsAutocomplete.test.js
@@ -10,7 +10,7 @@ const selectMock = vi.fn(() => ({ eq: eqMock, ilike: ilikeMock, order: orderMock
 const fromMock = vi.fn(() => ({ select: selectMock }));
 
 vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1' }) }));
 
 let useProduitsAutocomplete;
 

--- a/test/useProduitsInventaire.test.js
+++ b/test/useProduitsInventaire.test.js
@@ -9,7 +9,7 @@ const selectMock = vi.fn(() => ({ eq: eqMock, ilike: ilikeMock, order: orderMock
 const fromMock = vi.fn(() => ({ select: selectMock }));
 
 vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1' }) }));
 
 let useProduitsInventaire;
 

--- a/test/usePromotions.test.js
+++ b/test/usePromotions.test.js
@@ -14,7 +14,7 @@ const query = {
 };
 const fromMock = vi.fn(() => query);
 vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1' }) }));
 
 let usePromotions;
 

--- a/test/useRequisitions.test.js
+++ b/test/useRequisitions.test.js
@@ -16,7 +16,7 @@ const query = {
 };
 const fromMock = vi.fn(() => query);
 vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1', user_id: 'u1' }) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1', user_id: 'u1' }) }));
 
 let useRequisitions;
 

--- a/test/useSimulation.test.js
+++ b/test/useSimulation.test.js
@@ -10,7 +10,7 @@ const query = {
 const fromMock = vi.fn(() => query);
 
 vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1' }) }));
 
 let useSimulation;
 

--- a/test/useStockRequisitionne.test.js
+++ b/test/useStockRequisitionne.test.js
@@ -7,7 +7,7 @@ const queryObj = {
 };
 const fromMock = vi.fn(() => queryObj);
 vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1' }) }));
 
 let useStockRequisitionne;
 

--- a/test/useSupplierProducts.test.js
+++ b/test/useSupplierProducts.test.js
@@ -9,7 +9,7 @@ const selectMock = vi.fn(() => ({ eq: eq1Mock }));
 const fromMock = vi.fn(() => ({ select: selectMock }));
 
 vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1' }) }));
 
 let useSupplierProducts;
 beforeEach(async () => {

--- a/test/useTaches.test.js
+++ b/test/useTaches.test.js
@@ -14,7 +14,7 @@ const query = {
 };
 const fromMock = vi.fn(() => query);
 vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1', user_id: 'u1' }) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1', user_id: 'u1' }) }));
 
 let useTaches;
 

--- a/test/useTasks.test.js
+++ b/test/useTasks.test.js
@@ -9,7 +9,7 @@ const selectMock = vi.fn(() => queryChain);
 const fromMock = vi.fn(() => ({ select: selectMock }));
 
 vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1' }) }));
 
 let useTasks;
 

--- a/test/useTopProducts.test.js
+++ b/test/useTopProducts.test.js
@@ -4,7 +4,7 @@ import { vi, beforeEach, test, expect } from 'vitest';
 
 const rpcMock = vi.fn(() => Promise.resolve({ data: [{ id: 'p1' }], error: null }));
 vi.mock('@/lib/supabase', () => ({ supabase: { rpc: rpcMock } }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1' }) }));
 
 let useTopProducts;
 

--- a/test/useUtilisateurs.test.js
+++ b/test/useUtilisateurs.test.js
@@ -18,7 +18,7 @@ const csvMock = vi.fn();
 vi.mock('@/lib/export/exportHelpers', () => ({ exportToCSV: csvMock }));
 
 const authMock = vi.fn(() => ({ mama_id: 'm1', role: 'admin' }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: authMock }));
+vi.mock('@/hooks/useAuth', () => ({ default: authMock }));
 
 let useUtilisateurs;
 

--- a/test/useValidations.test.js
+++ b/test/useValidations.test.js
@@ -12,7 +12,7 @@ const queryObj = {
 };
 const fromMock = vi.fn(() => queryObj);
 vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1', user: { id: 'u1' } }) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1', user: { id: 'u1' } }) }));
 
 let useValidations;
 

--- a/test/useZones.test.js
+++ b/test/useZones.test.js
@@ -13,7 +13,7 @@ const queryObj = {
 };
 const fromMock = vi.fn(() => queryObj);
 vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1' }) }));
 vi.mock('react-hot-toast', () => ({ toast: { error: vi.fn() } }));
 
 let useZones;

--- a/test/visual_update.test.js
+++ b/test/visual_update.test.js
@@ -8,7 +8,7 @@ beforeAll(() => {
   fs.writeFileSync('test_visual_update.log', '');
 });
 
-vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1' }) }));
 
 let fromMock;
 let data = {};


### PR DESCRIPTION
## Summary
- clean up imports to always use the `useAuth` hook
- log hook usage for easier debugging
- expose login/logout/signup functions through `useAuth`
- add debug logs inside auth provider
- update pages and components to rely on the hook
- adjust tests to mock `@/hooks/useAuth`
- add new `useAuthHook` unit test

## Testing
- `npx -y vitest run test/useFournisseursAutocomplete.test.js`
- `npx -y vitest run` *(fails: Missing Supabase credentials, various test failures)*

------
https://chatgpt.com/codex/tasks/task_e_687faa49efb0832dbaeb3634cb53200f