### PR TITLE
Improve auth session handling

### DIFF
--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -15,10 +15,7 @@ export default function ProtectedRoute({ children, accessKey }) {
       return;
     }
 
-    if (
-      accessKey &&
-      !hasAccess(userData.access_rights, accessKey, "peut_voir", userData.role === "superadmin")
-    ) {
+    if (accessKey && !hasAccess(accessKey, "peut_voir")) {
       navigate("/unauthorized", { replace: true });
     }
   }, [session, userData, pending, loading, accessKey, navigate, hasAccess]);


### PR DESCRIPTION
## Summary
- refresh user lookup using email fallback
- redirect to login when session goes away
- add debug log for auth state
- fix ProtectedRoute call to hasAccess

## Testing
- `npx vitest run` *(fails: 10 failed, 98 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687fb75c9994832dbfd225d09892b3f0