### PR TITLE
Switch to access_rights auth

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -248,6 +248,9 @@ export const AuthProvider = ({ children }) => {
     return listModules(userData?.access_rights, droit);
   };
 
+  const isSuperadmin = hasAccess(userData?.access_rights, 'superadmin', 'peut_voir', false);
+  const isAdmin = isSuperadmin || hasAccess(userData?.access_rights, 'admin', 'peut_voir', false);
+
   const value = {
     /** Direct session object returned by Supabase */
     session,
@@ -266,6 +269,8 @@ export const AuthProvider = ({ children }) => {
     pending: !!session && !userData,
     email: userData?.email,
     actif: userData?.actif,
+    isSuperadmin,
+    isAdmin,
     hasAccess,
     getAuthorizedModules,
     login,

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -2,7 +2,7 @@
 import { useContext } from "react";
 import { AuthContext } from "@/context/AuthContext";
 
-export default function useAuth() {
+export function useAuth() {
   const ctx = useContext(AuthContext) || {};
   if (import.meta.env.DEV) console.log('useAuth hook', ctx);
   if (!ctx || typeof ctx.login !== 'function') {
@@ -19,6 +19,8 @@ export default function useAuth() {
     access_rights: ctx.userData?.access_rights ?? ctx.access_rights,
     email: ctx.userData?.email ?? ctx.email,
     actif: ctx.userData?.actif ?? ctx.actif,
+    isSuperadmin: ctx.isSuperadmin,
+    isAdmin: ctx.isAdmin,
     loading,
     pending: ctx.pending,
     isAuthenticated: ctx.isAuthenticated,
@@ -31,3 +33,5 @@ export default function useAuth() {
     logout: ctx.logout,
   };
 }
+
+export default useAuth;

--- a/src/pages/factures/FactureForm.jsx
+++ b/src/pages/factures/FactureForm.jsx
@@ -254,7 +254,6 @@ export default function FactureForm({ facture, suppliers = [], onClose }) {
             Voir
           </a>
         )}
-      </label>
       {ocrText && (
         <div className="text-xs text-gray-600 whitespace-pre-wrap mt-2 border rounded p-2 max-h-32 overflow-auto">
           {ocrText}

--- a/src/pages/parametrage/UtilisateurForm.jsx
+++ b/src/pages/parametrage/UtilisateurForm.jsx
@@ -83,18 +83,20 @@ export default function UtilisateurForm({ utilisateur, onClose }) {
         ))}
       </Select>
       {myRole === "superadmin" && (
-        <Label htmlFor="mama">Établissement</Label>
-        <Select
-          id="mama"
-          className="mb-2"
-          value={mama}
-          onChange={e => setMama(e.target.value)}
-          required
-        >
-          {mamas.map(m => (
-            <option key={m.id} value={m.id}>{m.nom}</option>
-          ))}
-        </Select>
+        <>
+          <Label htmlFor="mama">Établissement</Label>
+          <Select
+            id="mama"
+            className="mb-2"
+            value={mama}
+            onChange={e => setMama(e.target.value)}
+            required
+          >
+            {mamas.map(m => (
+              <option key={m.id} value={m.id}>{m.nom}</option>
+            ))}
+          </Select>
+        </>
       )}
       <label className="flex items-center gap-2 mb-2">
         <input id="actif" type="checkbox" checked={actif} onChange={e => setActif(e.target.checked)} />

--- a/src/pages/requisitions/RequisitionForm.jsx
+++ b/src/pages/requisitions/RequisitionForm.jsx
@@ -189,7 +189,7 @@ function RequisitionFormPage() {
         </div>
 
         <div className="text-right">
-          <PrimaryButton type="submit" disabled={submitting}">
+          <PrimaryButton type="submit" disabled={submitting}>
             Enregistrer
           </PrimaryButton>
         </div>

--- a/test/authRole.test.jsx
+++ b/test/authRole.test.jsx
@@ -8,7 +8,7 @@ import useAuth from '../src/hooks/useAuth.js';
 const getSession = vi.fn(() => Promise.resolve({ data: { session: { user: { id: 'u1', email: 'u@x.com' } } }, error: null }));
 const onAuthStateChange = vi.fn(() => ({ data: { subscription: { unsubscribe: vi.fn() } } }));
 const signOut = vi.fn(() => Promise.resolve({ error: null }));
-const maybeSingle = vi.fn(() => Promise.resolve({ data: { id: '1', mama_id: 1, role_id: 1, role: { id: 'r1', nom: 'admin', access_rights: {} }, access_rights: {} }, error: null }));
+const maybeSingle = vi.fn(() => Promise.resolve({ data: { id: '1', mama_id: 1, access_rights: {} }, error: null }));
 const accessSelect = vi.fn(() => ({ eq: vi.fn(() => Promise.resolve({ data: [] })) }));
 const from = vi.fn((table) => {
   if (table === 'access_rights') {
@@ -23,25 +23,25 @@ vi.mock('../src/lib/supabase.js', () => ({
 
 vi.mock('../src/lib/loginUser.js', () => ({ login: vi.fn() }));
 
-test('role is loaded from supabase', async () => {
+test('access rights are loaded from supabase', async () => {
   const wrapper = ({ children }) => (
     <MemoryRouter>
       <AuthProvider>{children}</AuthProvider>
     </MemoryRouter>
   );
   const { result } = renderHook(() => useAuth(), { wrapper });
-  await waitFor(() => result.current.role !== undefined);
-  expect(result.current.role).toBe('admin');
+  await waitFor(() => result.current.access_rights !== null);
+  expect(result.current.access_rights).toEqual({});
 });
 
-test('logout when role missing', async () => {
-  maybeSingle.mockResolvedValueOnce({ data: { id: '1', mama_id: 1, role_id: 1, role: null, access_rights: {} }, error: null });
+test('user not found keeps userData null', async () => {
+  maybeSingle.mockResolvedValueOnce({ data: null, error: null });
   const wrapper = ({ children }) => (
     <MemoryRouter>
       <AuthProvider>{children}</AuthProvider>
     </MemoryRouter>
   );
-  renderHook(() => useAuth(), { wrapper });
-  await waitFor(() => signOut.mock.calls.length > 0);
-  expect(signOut).toHaveBeenCalled();
+  const { result } = renderHook(() => useAuth(), { wrapper });
+  await waitFor(() => result.current.userData === null);
+  expect(signOut).not.toHaveBeenCalled();
 });


### PR DESCRIPTION
## Summary
- rely on `access_rights` when loading the current user
- expose `isSuperadmin` and `isAdmin` through `useAuth`
- refactor `useUtilisateurs` to remove role usage
- fix small markup issues spotted by lint
- update related unit tests

## Testing
- `npm run lint`
- `npm test` *(fails: missing Supabase credentials and other test errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687fc3ac9890832d9287996ec02c7cf4