### PR TITLE
Fix role handling and access checks

### DIFF
--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -8,7 +8,7 @@ export default function ProtectedRoute({ children, accessKey }) {
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (!session || !userData || !userData.role || pending || loading) return;
+    if (!session || !userData || pending || loading) return;
 
     if (userData.actif === false) {
       navigate("/blocked", { replace: true });
@@ -28,6 +28,6 @@ export default function ProtectedRoute({ children, accessKey }) {
       navigate("/unauthorized", { replace: true });
     }
   }, [session, userData, pending, loading, accessKey, navigate, hasAccess]);
-  if (!session || pending || loading || !userData || !userData.role) return <LoadingScreen />;
+  if (!session || pending || loading || !userData) return <LoadingScreen />;
   return children;
 }

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -1,16 +1,16 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { Link, useLocation } from "react-router-dom";
 import useAuth from "@/hooks/useAuth";
+import { Badge } from "@/components/ui/badge";
 
 import MamaLogo from "@/components/ui/MamaLogo";
 
 export default function Sidebar() {
-  const { access_rights, role, loading, hasAccess } = useAuth();
+  const { access_rights, role, isSuperadmin, loading, hasAccess } = useAuth();
   const { pathname } = useLocation();
 
   if (loading || access_rights === null) return null;
-  const showAll = role === "superadmin";
-  const has = (key) => showAll || hasAccess(key, "peut_voir");
+  const has = (key) => isSuperadmin || hasAccess(key, "peut_voir");
   const canAnalyse = has("analyse");
 
   return (

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -11,13 +11,15 @@ export function useAuth() {
     );
   }
   const loading = ctx.loading ?? ctx.isLoading;
+  const roleName = ctx.userData?.role?.nom ?? ctx.role?.nom ?? ctx.role ?? null;
   return {
     session: ctx.session,
     userData: ctx.userData,
     mama_id: ctx.userData?.mama_id ?? ctx.mama_id ?? null,
     nom: ctx.userData?.nom ?? ctx.nom,
     access_rights: ctx.userData?.access_rights ?? ctx.access_rights ?? {},
-    role: ctx.userData?.role ?? ctx.role ?? null,
+    role: roleName,
+    roleData: ctx.userData?.role ?? ctx.roleData ?? null,
     email: ctx.userData?.email ?? ctx.email,
     actif: ctx.userData?.actif ?? ctx.actif,
     isSuperadmin: ctx.isSuperadmin,

--- a/src/layout/Navbar.jsx
+++ b/src/layout/Navbar.jsx
@@ -90,7 +90,7 @@ export default function Navbar() {
               {session.user.email}
             </span>
             <span className="text-xs bg-mamastock-gold text-black px-3 py-1 rounded-full capitalize shadow">
-              {role || "chargement..."}
+              {role || '[Rôle inconnu]'}
             </span>
             {mama_id && (
               <span className="text-xs bg-sky-600 text-white px-3 py-1 rounded-full shadow">

--- a/src/layout/Sidebar.jsx
+++ b/src/layout/Sidebar.jsx
@@ -3,6 +3,7 @@ import { Link, useLocation } from "react-router-dom";
 import { routePreloadMap } from "@/router";
 import useAuth from "@/hooks/useAuth";
 import toast from "react-hot-toast";
+import { Badge } from "@/components/ui/badge";
 import {
   Boxes,
   ClipboardList,
@@ -36,6 +37,7 @@ export default function Sidebar() {
     loading,
     user,
     userData,
+    role,
     mama_id,
     logout,
     session,
@@ -46,7 +48,7 @@ export default function Sidebar() {
     console.log("Sidebar", { user, mama_id, access_rights });
   }
 
-  if (loading || !user || !userData || !access_rights || !userData.role) {
+  if (loading || !user || !userData || !access_rights) {
     return null;
   }
 
@@ -205,6 +207,11 @@ export default function Sidebar() {
       {session && (
         <div className="mt-6 border-t border-white/20 pt-4 text-sm flex flex-col gap-2">
           <span>Bienvenue, {userData.nom || user?.email}</span>
+          {role ? (
+            <Badge color="gray">{role}</Badge>
+          ) : (
+            <Badge color="red">[Rôle inconnu]</Badge>
+          )}
           <button
             onClick={() => {
               logout();

--- a/src/lib/roleUtils.js
+++ b/src/lib/roleUtils.js
@@ -1,0 +1,14 @@
+export function extractAccessRightsFromRole(role) {
+  if (!role) return {};
+  const rights = role.access_rights;
+  if (typeof rights === 'string') {
+    try {
+      return JSON.parse(rights) || {};
+    } catch (err) {
+      console.error('Invalid role access_rights JSON', err);
+      return {};
+    }
+  }
+  if (rights && typeof rights === 'object') return rights;
+  return {};
+}

--- a/test/useAuthRole.test.jsx
+++ b/test/useAuthRole.test.jsx
@@ -1,0 +1,30 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { vi } from 'vitest';
+import { AuthProvider } from '../src/context/AuthContext.jsx';
+import useAuth from '../src/hooks/useAuth.js';
+
+const getSession = vi.fn(() => Promise.resolve({ data: { session: { user: { id: 'u1', email: 'u@x.com' } } }, error: null }));
+const onAuthStateChange = vi.fn(() => ({ data: { subscription: { unsubscribe: vi.fn() } } }));
+const signOut = vi.fn(() => Promise.resolve({ error: null }));
+const maybeSingle = vi.fn(() => Promise.resolve({ data: { id: '1', nom: 'User', mama_id: 1, role_id: 'r1', access_rights: {}, role: { id: 'r1', nom: 'superadmin', access_rights: {} } }, error: null }));
+const from = vi.fn(() => ({ select: () => ({ eq: () => ({ maybeSingle }) }) }));
+
+vi.mock('../src/lib/supabase.js', () => ({
+  supabase: { auth: { getSession, onAuthStateChange, signOut }, from }
+}));
+
+vi.mock('../src/lib/loginUser.js', () => ({ login: vi.fn() }));
+
+test('role object is loaded and role name returned', async () => {
+  const wrapper = ({ children }) => (
+    <MemoryRouter>
+      <AuthProvider>{children}</AuthProvider>
+    </MemoryRouter>
+  );
+  const { result } = renderHook(() => useAuth(), { wrapper });
+  await waitFor(() => result.current.userData !== null);
+  expect(result.current.role).toBe('superadmin');
+  expect(result.current.roleData).toEqual({ id: 'r1', nom: 'superadmin', access_rights: {} });
+});


### PR DESCRIPTION
## Summary
- ensure role relation is loaded in `AuthContext` and parse its rights
- expose role name via `useAuth`
- display role badge in sidebar and navbar
- avoid blocking route when role missing
- add helper `extractAccessRightsFromRole`
- add unit test for role loading

## Testing
- `npm test` *(fails: Missing Supabase credentials and other test errors)*

------
https://chatgpt.com/codex/tasks/task_e_6881f692ffec832d858d4db9598f41ae