### PR TITLE
Fix requisitions list with product photos

### DIFF
--- a/db/Ajout.sql
+++ b/db/Ajout.sql
@@ -133,3 +133,20 @@ LEFT JOIN familles f2 ON f2.id = p.famille_id
 LEFT JOIN unites u ON u.id = p.unite_id
 WHERE p.actif = true;
 
+-- Ajout colonne photo_url pour stocker l'URL de la photo produit
+ALTER TABLE produits ADD COLUMN IF NOT EXISTS photo_url text;
+
+-- Vue simplifiée pour les réquisitions avec informations produit
+DROP VIEW IF EXISTS v_requisitions;
+CREATE VIEW v_requisitions AS
+SELECT
+  r.id,
+  r.quantite,
+  r.date_requisition,
+  r.mama_id,
+  r.produit_id,
+  p.nom AS produit_nom,
+  p.photo_url
+FROM requisitions r
+JOIN produits p ON p.id = r.produit_id;
+

--- a/src/components/gadgets/GadgetProduitsUtilises.jsx
+++ b/src/components/gadgets/GadgetProduitsUtilises.jsx
@@ -20,9 +20,11 @@ export default function GadgetProduitsUtilises() {
         {data.map((p) => (
           <li key={p.id} className="flex items-center justify-between">
             <div className="flex items-center gap-2">
-              {p.photo_url && (
-                <img src={p.photo_url} alt={p.nom} className="w-6 h-6 rounded object-cover" />
-              )}
+              <img
+                src={p.photo_url || "/icons/icon-128x128.png"}
+                alt={p.nom}
+                className="w-6 h-6 rounded object-cover"
+              />
               <span>{p.nom}</span>
             </div>
             <span className="font-semibold">{p.total}</span>

--- a/src/hooks/gadgets/useProduitsUtilises.js
+++ b/src/hooks/gadgets/useProduitsUtilises.js
@@ -15,7 +15,7 @@ export default function useProduitsUtilises() {
     start.setDate(start.getDate() - 30);
     const { data, error } = await supabase
       .from('requisitions')
-      .select('quantite, produit:produits(id, nom, photo_url)')
+      .select(`quantite, date_requisition, produit:produits(id, nom, photo_url)`) 
       .eq('mama_id', mama_id)
       .gte('date_requisition', start.toISOString().slice(0, 10));
     setLoading(false);

--- a/src/hooks/useRequisitions.js
+++ b/src/hooks/useRequisitions.js
@@ -31,7 +31,9 @@ export function useRequisitions() {
     if (!id || !mama_id) return null;
     const { data, error } = await supabase
       .from("requisitions")
-      .select("*, lignes:requisition_lignes(*)")
+      .select(
+        "*, lignes:requisition_lignes(*, produit:produits(id, nom, photo_url))"
+      )
       .eq("id", id)
       .eq("mama_id", mama_id)
       .single();

--- a/src/pages/requisitions/RequisitionDetail.jsx
+++ b/src/pages/requisitions/RequisitionDetail.jsx
@@ -40,10 +40,25 @@ function RequisitionDetailPage() {
         </div>
         <div>
           <strong>Lignes :</strong>
-          <ul className="list-disc ml-5">
+          <ul className="list-disc ml-5 space-y-1">
             {(requisition.lignes || []).map((l) => (
-              <li key={l.id}>
-                {l.produit_id} - {l.quantite_demandee} (stock {l.stock_theorique_avant} → {l.stock_theorique_apres})
+              <li key={l.id} className="flex items-center gap-2">
+                {l.produit?.photo_url ? (
+                  <img
+                    src={l.produit.photo_url}
+                    alt={l.produit.nom}
+                    className="w-6 h-6 rounded object-cover"
+                  />
+                ) : (
+                  <img
+                    src="/icons/icon-128x128.png"
+                    alt=""
+                    className="w-6 h-6 rounded object-cover"
+                  />
+                )}
+                <span>
+                  {l.produit?.nom || l.produit_id} - {l.quantite_demandee} (stock {l.stock_theorique_avant} → {l.stock_theorique_apres})
+                </span>
               </li>
             ))}
           </ul>


### PR DESCRIPTION
## Summary
- add `photo_url` column and new `v_requisitions` view
- include product info with photo in requisition details
- show placeholder images when product photo is missing
- expose product photos in gadget and data hook

## Testing
- `npm run lint`
- `npm test` *(fails: Missing Supabase credentials)*

------
https://chatgpt.com/codex/tasks/task_e_6882032771ec832d86b1e88c74e8d759