### PR TITLE
Améliore gestion utilisateurs et RLS

### DIFF
--- a/db/Ajout.sql
+++ b/db/Ajout.sql
@@ -151,3 +151,11 @@ SELECT
 FROM requisitions r
 JOIN produits p ON p.id = r.produit_id;
 
+
+-- Politiques RLS pour la table utilisateurs
+ALTER TABLE utilisateurs ENABLE ROW LEVEL SECURITY;
+CREATE POLICY IF NOT EXISTS utilisateurs_select ON utilisateurs FOR SELECT USING (mama_id = current_user_mama_id());
+CREATE POLICY IF NOT EXISTS utilisateurs_insert ON utilisateurs FOR INSERT WITH CHECK (mama_id = current_user_mama_id());
+CREATE POLICY IF NOT EXISTS utilisateurs_update ON utilisateurs FOR UPDATE USING (mama_id = current_user_mama_id()) WITH CHECK (mama_id = current_user_mama_id());
+CREATE POLICY IF NOT EXISTS utilisateurs_delete ON utilisateurs FOR DELETE USING (mama_id = current_user_mama_id());
+

--- a/src/components/parametrage/UtilisateurRow.jsx
+++ b/src/components/parametrage/UtilisateurRow.jsx
@@ -38,7 +38,8 @@ export default function UtilisateurRow({
   return (
     <>
       <tr className={utilisateur.actif ? "" : "opacity-60"}>
-        <td>{utilisateur.nom || utilisateur.email}</td>
+        <td>{utilisateur.nom}</td>
+        <td>{utilisateur.email}</td>
         <td>
           <span className={
             utilisateur.role === "superadmin"
@@ -50,7 +51,8 @@ export default function UtilisateurRow({
             {utilisateur.role}
           </span>
         </td>
-        <td>{utilisateur.mama_id}</td>
+        <td>{utilisateur.mamaNom || utilisateur.mama_id}</td>
+        <td>{utilisateur.actif ? "Oui" : "Non"}</td>
         <td>
           {canEdit && (
             <>
@@ -81,7 +83,7 @@ export default function UtilisateurRow({
       </tr>
       {showHistory && (
         <tr>
-          <td colSpan={4} className="bg-glass border border-borderGlass backdrop-blur">
+          <td colSpan={6} className="bg-glass border border-borderGlass backdrop-blur">
             <div>
               <b>Connexions récentes :</b>
               <ul>

--- a/src/pages/parametrage/UtilisateurForm.jsx
+++ b/src/pages/parametrage/UtilisateurForm.jsx
@@ -18,6 +18,7 @@ export default function UtilisateurForm({ utilisateur, onClose }) {
   const { mamas, fetchMamas } = useMamas();
   const { mama_id: myMama, role: myRole, loading: authLoading } = useAuth();
   const [nom, setNom] = useState(utilisateur?.nom || "");
+  const [email, setEmail] = useState(utilisateur?.email || "");
   const [roleId, setRoleId] = useState(utilisateur?.role_id || "");
   const [mama, setMama] = useState(utilisateur?.mama_id || myMama);
   const [actif, setActif] = useState(utilisateur?.actif ?? true);
@@ -36,6 +37,7 @@ export default function UtilisateurForm({ utilisateur, onClose }) {
     setLoading(true);
     const data = {
       nom,
+      email,
       role_id: roleId,
       actif,
       mama_id: mama,
@@ -73,6 +75,16 @@ export default function UtilisateurForm({ utilisateur, onClose }) {
         onChange={e => setNom(e.target.value)}
         required
       />
+      <Label htmlFor="email">Email</Label>
+      <Input
+        id="email"
+        className="mb-2"
+        type="email"
+        value={email}
+        onChange={e => setEmail(e.target.value)}
+        required
+        readOnly={!!utilisateur?.id}
+      />
       <Label htmlFor="role">Rôle</Label>
       <Select
         id="role"
@@ -81,9 +93,11 @@ export default function UtilisateurForm({ utilisateur, onClose }) {
         onChange={e => setRoleId(e.target.value)}
         required
       >
-        {roles.map(r => (
-          <option key={r.id} value={r.id}>{r.nom}</option>
-        ))}
+        {roles
+          .filter(r => myRole === "superadmin" || r.nom !== "superadmin")
+          .map(r => (
+            <option key={r.id} value={r.id}>{r.nom}</option>
+          ))}
       </Select>
       {myRole === "superadmin" && (
         <>

--- a/src/pages/parametrage/Utilisateurs.jsx
+++ b/src/pages/parametrage/Utilisateurs.jsx
@@ -62,12 +62,15 @@ export default function Utilisateurs() {
     role: roles.find(r => r.id === u.role_id)?.nom || u.role?.nom || "",
   }));
   const filtres = mapped.filter(u =>
-    (!search || u.nom?.toLowerCase().includes(search.toLowerCase())) &&
+    (!search ||
+      u.nom?.toLowerCase().includes(search.toLowerCase()) ||
+      u.email?.toLowerCase().includes(search.toLowerCase())) &&
     (actifFilter === "all" || (actifFilter === "true" ? u.actif : !u.actif)) &&
     (roleFilter === "all" || u.roleNom === roleFilter)
   ).sort((a, b) => {
     if (sortBy === "mama") return a.mamaNom.localeCompare(b.mamaNom);
     if (sortBy === "role") return a.roleNom.localeCompare(b.roleNom);
+    if (sortBy === "email") return (a.email || "").localeCompare(b.email || "");
     return a.nom.localeCompare(b.nom);
   });
   const nbPages = Math.ceil(filtres.length / PAGE_SIZE);
@@ -148,6 +151,7 @@ export default function Utilisateurs() {
           <option value="nom">Tri nom</option>
           <option value="mama">Tri Mama</option>
           <option value="role">Tri rôle</option>
+          <option value="email">Tri email</option>
         </select>
         <Button variant="outline" onClick={() => exportUsersToExcel(filtres)}>Export Excel</Button>
         <Button variant="outline" onClick={() => exportUsersToCSV(filtres)}>Export CSV</Button>
@@ -161,6 +165,7 @@ export default function Utilisateurs() {
         <thead>
           <tr>
             <th className="px-4 py-2">Nom</th>
+            <th className="px-4 py-2">Email</th>
             <th className="px-4 py-2">Rôle</th>
             <th className="px-4 py-2">Mama</th>
             <th className="px-4 py-2">Actif</th>


### PR DESCRIPTION
## Summary
- expose email/role id when fetching utilisateurs
- inject role rights on create/update and forbid superadmin role
- add email field to user form
- show email column in users list
- enable RLS policies for `utilisateurs` table

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_688248a68bd4832dad206334a8d094be