### PR TITLE
Fix user management role loading

### DIFF
--- a/src/components/utilisateurs/UtilisateurForm.jsx
+++ b/src/components/utilisateurs/UtilisateurForm.jsx
@@ -1,26 +1,28 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useUtilisateurs } from "@/hooks/useUtilisateurs";
-import { Button } from "@/components/ui/button";
+import { useRoles } from "@/hooks/useRoles";
+import useAuth from "@/hooks/useAuth";
 import PrimaryButton from "@/components/ui/PrimaryButton";
 import SecondaryButton from "@/components/ui/SecondaryButton";
 import { Input } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
 import toast from "react-hot-toast";
 
-const ROLES = [
-  { value: "superadmin", label: "Superadmin" },
-  { value: "admin", label: "Admin" },
-  { value: "user", label: "Utilisateur" },
-];
-
 export default function UtilisateurForm({ utilisateur, onClose }) {
   const { addUser, updateUser } = useUtilisateurs();
+  const { roles, fetchRoles } = useRoles();
+  const { mama_id } = useAuth();
   const [nom, setNom] = useState(utilisateur?.nom || "");
-  const [role, setRole] = useState(utilisateur?.role || "user");
+  const [email, setEmail] = useState(utilisateur?.email || "");
+  const [roleId, setRoleId] = useState(utilisateur?.role_id || "");
   const [actif, setActif] = useState(utilisateur?.actif ?? true);
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    fetchRoles();
+  }, [fetchRoles]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -28,8 +30,10 @@ export default function UtilisateurForm({ utilisateur, onClose }) {
     setLoading(true);
     const data = {
       nom,
-      role,
+      email,
+      role_id: roleId,
       actif,
+      mama_id,
       ...(password && { password }),
     };
     try {
@@ -64,14 +68,22 @@ export default function UtilisateurForm({ utilisateur, onClose }) {
         placeholder="Nom"
         required
       />
+      <Input
+        className="mb-2"
+        type="email"
+        value={email}
+        onChange={e => setEmail(e.target.value)}
+        placeholder="Email"
+        required
+      />
       <Select
         className="mb-2"
-        value={role}
-        onChange={e => setRole(e.target.value)}
+        value={roleId}
+        onChange={e => setRoleId(e.target.value)}
         required
       >
-        {ROLES.map(r => (
-          <option key={r.value} value={r.value}>{r.label}</option>
+        {roles.map(r => (
+          <option key={r.id} value={r.id}>{r.nom}</option>
         ))}
       </Select>
       <label className="flex items-center gap-2 mb-2">

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -68,7 +68,7 @@ export const AuthProvider = ({ children }) => {
       .from("utilisateurs")
       .select(
         `id, nom, mama_id, email, actif, access_rights, role_id, auth_id,
-        role:roles!fk_utilisateurs_role_id(id, nom, access_rights)`
+        role:roles!fk_utilisateurs_role_id(nom, access_rights)`
       )
       .eq("auth_id", userId)
       .maybeSingle();
@@ -78,7 +78,7 @@ export const AuthProvider = ({ children }) => {
         .from("utilisateurs")
         .select(
           `id, nom, mama_id, email, actif, access_rights, role_id, auth_id,
-          role:roles!fk_utilisateurs_role_id(id, nom, access_rights)`
+          role:roles!fk_utilisateurs_role_id(nom, access_rights)`
         )
         .eq("email", email)
         .maybeSingle();

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -15,6 +15,7 @@ export function useAuth() {
   return {
     session: ctx.session,
     userData: ctx.userData,
+    user_id: ctx.user_id ?? ctx.session?.user?.id ?? null,
     mama_id: ctx.userData?.mama_id ?? ctx.mama_id ?? null,
     nom: ctx.userData?.nom ?? ctx.nom,
     access_rights: ctx.userData?.access_rights ?? ctx.access_rights ?? {},

--- a/src/hooks/useUtilisateurs.js
+++ b/src/hooks/useUtilisateurs.js
@@ -20,7 +20,7 @@ export function useUtilisateurs() {
     let query = supabase
       .from("utilisateurs")
       .select(
-        `id, nom, email, auth_id, role_id, actif, mama_id, access_rights, role:roles!fk_utilisateurs_role_id(id, nom)`
+        `id, nom, email, auth_id, role_id, actif, mama_id, access_rights, role:roles!fk_utilisateurs_role_id(nom, access_rights)`
       )
       .order("nom", { ascending: true });
 
@@ -41,6 +41,9 @@ export function useUtilisateurs() {
     const targetMama = isSuperadmin ? user.mama_id : mama_id;
     if (!targetMama) return { error: "Aucun mama_id" };
     if (!user.role_id) return { error: "Rôle manquant" };
+    if (!user.email) return { error: "Email manquant" };
+    if (user.actif === undefined) user.actif = true;
+    if (user.auth_id === undefined) user.auth_id = null;
     setLoading(true);
     setError(null);
     // charge les droits associés au rôle
@@ -68,6 +71,11 @@ export function useUtilisateurs() {
     if (!mama_id && !isSuperadmin) return { error: "Aucun mama_id" };
     setLoading(true);
     setError(null);
+    if (updateFields.email !== undefined && !updateFields.email) {
+      setLoading(false);
+      return { error: "Email manquant" };
+    }
+    if (updateFields.auth_id === undefined) updateFields.auth_id = null;
     let rights = null;
     if (updateFields.role_id) {
       const { data: roleData } = await supabase

--- a/src/pages/Utilisateurs.jsx
+++ b/src/pages/Utilisateurs.jsx
@@ -29,7 +29,9 @@ export default function Utilisateurs() {
   }, [authLoading, mama_id, fetchUsers]);
 
   const filtres = users.filter(u =>
-    (!search || u.nom?.toLowerCase().includes(search.toLowerCase())) &&
+    (!search ||
+      u.nom?.toLowerCase().includes(search.toLowerCase()) ||
+      u.email?.toLowerCase().includes(search.toLowerCase())) &&
     (actifFilter === "all" || (actifFilter === "true" ? u.actif : !u.actif))
   );
   const nbPages = Math.ceil(filtres.length / PAGE_SIZE);
@@ -106,7 +108,7 @@ export default function Utilisateurs() {
                   {u.nom}
                 </Button>
               </td>
-              <td className="border px-4 py-2">{u.role}</td>
+              <td className="border px-4 py-2">{u.role?.nom || u.role}</td>
               <td className="border px-4 py-2">
                 <span className={u.actif ? "badge badge-admin" : "badge badge-user"}>
                   {u.actif ? "Actif" : "Inactif"}


### PR DESCRIPTION
## Summary
- join roles table when loading users in AuthContext and hooks
- expose `user_id` from `useAuth`
- validate user fields in user hooks
- search users by email too and display role name correctly
- refactor UtilisateurForm to load roles from Supabase

## Testing
- `npm run lint`
- `npm test` *(fails: Missing Supabase credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68824b695c34832dac0c1eaf9efaf2a7