### PR TITLE
Update utilisateurs module

### DIFF
--- a/src/components/utilisateurs/UtilisateurDetail.jsx
+++ b/src/components/utilisateurs/UtilisateurDetail.jsx
@@ -14,6 +14,14 @@ export default function UtilisateurDetail({ utilisateur, onClose }) {
         <h2 className="font-bold text-xl mb-4">{utilisateur.nom || utilisateur.email}</h2>
         <div><b>Rôle :</b> {utilisateur.role}</div>
         <div><b>Actif :</b> {utilisateur.actif ? "Oui" : "Non"}</div>
+        {utilisateur.access_rights && (
+          <div>
+            <b>Droits :</b>
+            <pre className="text-xs whitespace-pre-wrap max-h-40 overflow-auto bg-black/20 p-2 rounded">
+              {JSON.stringify(utilisateur.access_rights, null, 2)}
+            </pre>
+          </div>
+        )}
         <div>
           <b>Historique :</b>
           <ul className="list-disc pl-6">

--- a/src/pages/parametrage/UtilisateurForm.jsx
+++ b/src/pages/parametrage/UtilisateurForm.jsx
@@ -11,6 +11,7 @@ import { Label } from "@/components/ui/label";
 import PrimaryButton from "@/components/ui/PrimaryButton";
 import SecondaryButton from "@/components/ui/SecondaryButton";
 import toast from "react-hot-toast";
+import { MODULES } from "@/config/modules";
 
 export default function UtilisateurForm({ utilisateur, onClose }) {
   const { addUser, updateUser } = useUtilisateurs();
@@ -22,6 +23,9 @@ export default function UtilisateurForm({ utilisateur, onClose }) {
   const [roleId, setRoleId] = useState(utilisateur?.role_id || "");
   const [mama, setMama] = useState(utilisateur?.mama_id || myMama);
   const [actif, setActif] = useState(utilisateur?.actif ?? true);
+  const [rightsText, setRightsText] = useState(
+    JSON.stringify(utilisateur?.access_rights || {}, null, 2)
+  );
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
@@ -41,6 +45,13 @@ export default function UtilisateurForm({ utilisateur, onClose }) {
       role_id: roleId,
       actif,
       mama_id: mama,
+      access_rights: (() => {
+        try {
+          return JSON.parse(rightsText || "{}") || {};
+        } catch {
+          return {};
+        }
+      })(),
     };
     try {
       if (utilisateur?.id) {
@@ -119,6 +130,14 @@ export default function UtilisateurForm({ utilisateur, onClose }) {
         <input id="actif" type="checkbox" checked={actif} onChange={e => setActif(e.target.checked)} />
         <Label htmlFor="actif" className="!mb-0">Actif</Label>
       </label>
+      <Label htmlFor="rights">Droits personnalisés (JSON)</Label>
+      <textarea
+        id="rights"
+        className="input w-full font-mono mb-2"
+        value={rightsText}
+        onChange={e => setRightsText(e.target.value)}
+        rows={MODULES.length / 2}
+      />
       <div className="flex gap-2 mt-4">
         <PrimaryButton type="submit" disabled={loading}>{utilisateur ? "Modifier" : "Ajouter"}</PrimaryButton>
         <SecondaryButton type="button" onClick={onClose}>Annuler</SecondaryButton>

--- a/src/pages/parametrage/Utilisateurs.jsx
+++ b/src/pages/parametrage/Utilisateurs.jsx
@@ -18,9 +18,10 @@ const PAGE_SIZE = 50;
 export default function Utilisateurs() {
   const {
     users,
+    loading,
+    error,
     fetchUsers,
     toggleUserActive,
-    deleteUser,
     exportUsersToExcel,
     exportUsersToCSV,
   } = useUtilisateurs();
@@ -83,13 +84,6 @@ export default function Utilisateurs() {
     toast.success(u.actif ? "Utilisateur désactivé" : "Utilisateur réactivé");
   };
 
-  const handleDelete = async (u) => {
-    if (window.confirm(`Supprimer l'utilisateur ${u.nom} ?`)) {
-      await deleteUser(u.id);
-      await refreshList();
-      toast.success("Utilisateur supprimé.");
-    }
-  };
 
   return (
     <div className="p-6 container mx-auto text-shadow">
@@ -156,6 +150,10 @@ export default function Utilisateurs() {
         <Button variant="outline" onClick={() => exportUsersToExcel(filtres)}>Export Excel</Button>
         <Button variant="outline" onClick={() => exportUsersToCSV(filtres)}>Export CSV</Button>
       </div>
+      {error && (
+        <div className="text-red-500 mb-2">{error.message}</div>
+      )}
+      {loading && <LoadingSpinner message="Chargement..." />}
       <TableContainer className="mb-4">
         <Motion.table
           initial={{ opacity: 0 }}
@@ -183,9 +181,15 @@ export default function Utilisateurs() {
                 setShowForm(true);
               }}
               onToggleActive={() => handleToggleActive(u)}
-              onDelete={() => handleDelete(u)}
             />
           ))}
+          {paged.length === 0 && (
+            <tr>
+              <td colSpan={6} className="py-4 text-center text-gray-400">
+                Aucun utilisateur.
+              </td>
+            </tr>
+          )}
         </tbody>
         </Motion.table>
       </TableContainer>


### PR DESCRIPTION
## Summary
- enhance `useUtilisateurs` hook with view usage, role loading and upsert
- expose access rights editing in `UtilisateurForm`
- show user rights in detail modal
- improve list page with loading/error states and hide deletion
- adjust tests for new upsert logic

## Testing
- `npx vitest run` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68825110da44832d9fe54f77cd80ba96