### PR TITLE
Liste des demandes de stock

### DIFF
--- a/src/components/requisitions/RequisitionRow.jsx
+++ b/src/components/requisitions/RequisitionRow.jsx
@@ -1,0 +1,12 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+export default function RequisitionRow({ requisition }) {
+  return (
+    <tr>
+      <td className="p-2 text-center">
+        {new Date(requisition.date_requisition).toLocaleDateString('fr-FR')}
+      </td>
+      <td className="p-2 text-center">{requisition.produit_nom}</td>
+      <td className="p-2 text-right">{requisition.quantite}</td>
+    </tr>
+  );
+}

--- a/src/hooks/useRequisitions.js
+++ b/src/hooks/useRequisitions.js
@@ -6,6 +6,23 @@ import useAuth from "@/hooks/useAuth";
 export function useRequisitions() {
   const { mama_id, user_id } = useAuth();
 
+  async function fetchRequisitions({ search = "", page = 1, limit = 20 } = {}) {
+    if (!mama_id) return { data: [], count: 0 };
+    let query = supabase
+      .from("v_requisitions")
+      .select("*", { count: "exact" })
+      .eq("mama_id", mama_id)
+      .order("date_requisition", { ascending: false })
+      .range((page - 1) * limit, page * limit - 1);
+    if (search) query = query.ilike("produit_nom", `%${search}%`);
+    const { data, count, error } = await query;
+    if (error) {
+      console.error("❌ Erreur fetchRequisitions:", error.message);
+      return { data: [], count: 0 };
+    }
+    return { data: data || [], count: count || 0 };
+  }
+
   async function getRequisitions({ zone = "", statut = "", debut = "", fin = "", page = 1, limit = 10 } = {}) {
     if (!mama_id) return { data: [], count: 0 };
     let query = supabase
@@ -103,6 +120,7 @@ export function useRequisitions() {
   }
 
   return {
+    fetchRequisitions,
     getRequisitions,
     getRequisitionById,
     createRequisition,

--- a/src/pages/stock/Requisitions.jsx
+++ b/src/pages/stock/Requisitions.jsx
@@ -1,0 +1,85 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { useEffect, useState } from "react";
+import { useRequisitions } from "@/hooks/useRequisitions";
+import useAuth from "@/hooks/useAuth";
+import TableContainer from "@/components/ui/TableContainer";
+import { Button } from "@/components/ui/button";
+import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import RequisitionRow from "@/components/requisitions/RequisitionRow";
+
+const PAGE_SIZE = 20;
+
+export default function RequisitionsPage() {
+  const { fetchRequisitions } = useRequisitions();
+  const { mama_id, loading: authLoading } = useAuth();
+  const [items, setItems] = useState([]);
+  const [search, setSearch] = useState("");
+  const [page, setPage] = useState(1);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!mama_id || authLoading) return;
+    (async () => {
+      setLoading(true);
+      const { data, count } = await fetchRequisitions({ search, page, limit: PAGE_SIZE });
+      setItems(data);
+      setTotal(count);
+      setLoading(false);
+    })();
+  }, [mama_id, authLoading, search, page, fetchRequisitions]);
+
+  const pageCount = Math.ceil(total / PAGE_SIZE) || 1;
+
+  if (authLoading || loading) {
+    return <LoadingSpinner message="Chargement..." />;
+  }
+
+  return (
+    <div className="p-6 max-w-3xl mx-auto">
+      <h1 className="text-xl font-bold text-mamastock-gold mb-4">Demandes de stock</h1>
+      <div className="flex flex-wrap gap-4 items-center mb-4">
+        <input
+          type="search"
+          value={search}
+          onChange={e => { setSearch(e.target.value); setPage(1); }}
+          className="input"
+          placeholder="Recherche produit"
+        />
+      </div>
+      <TableContainer>
+        <table className="min-w-full text-sm text-center">
+          <thead>
+            <tr>
+              <th className="p-2">Date de réquisition</th>
+              <th className="p-2">Nom du produit</th>
+              <th className="p-2">Quantité demandée</th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.map(r => (
+              <RequisitionRow key={r.id} requisition={r} />
+            ))}
+          </tbody>
+        </table>
+      </TableContainer>
+      <div className="flex justify-center gap-2 mt-4">
+        <Button
+          variant="outline"
+          disabled={page <= 1}
+          onClick={() => setPage(p => Math.max(1, p - 1))}
+        >
+          Précédent
+        </Button>
+        <span className="px-2">Page {page} / {pageCount}</span>
+        <Button
+          variant="outline"
+          disabled={page >= pageCount}
+          onClick={() => setPage(p => Math.min(pageCount, p + 1))}
+        >
+          Suivant
+        </Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- vue `v_requisitions` handled in hook
- nouveau tableau `Requisitions.jsx`
- ligne affichée par `RequisitionRow`

## Testing
- `npm run lint`
- `npm test` *(échoue : 15 failed, 94 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688252b1c3bc832d91580384dc307e6f