### PR TITLE
Fix dashboard hooks with new Supabase views

### DIFF
--- a/db/Ajout.sql
+++ b/db/Ajout.sql
@@ -159,3 +159,15 @@ CREATE POLICY IF NOT EXISTS utilisateurs_insert ON utilisateurs FOR INSERT WITH 
 CREATE POLICY IF NOT EXISTS utilisateurs_update ON utilisateurs FOR UPDATE USING (mama_id = current_user_mama_id()) WITH CHECK (mama_id = current_user_mama_id());
 CREATE POLICY IF NOT EXISTS utilisateurs_delete ON utilisateurs FOR DELETE USING (mama_id = current_user_mama_id());
 
+-- Vue d'évolution des achats (par mois)
+DROP VIEW IF EXISTS v_evolution_achats;
+CREATE VIEW v_evolution_achats AS
+SELECT
+  a.mama_id,
+  date_trunc('month', a.date_achat)::date AS mois,
+  SUM(a.prix * a.quantite) AS montant
+FROM achats a
+WHERE a.actif IS TRUE
+GROUP BY a.mama_id, mois
+ORDER BY mois;
+

--- a/src/hooks/gadgets/useDerniersAcces.js
+++ b/src/hooks/gadgets/useDerniersAcces.js
@@ -14,7 +14,7 @@ export default function useDerniersAcces() {
     const { data, error } = await supabase
       .from('logs_securite')
       .select(
-        'user_id, created_at, utilisateur:utilisateurs(email, auth_id)'
+        'utilisateur_id, created_at, utilisateur:utilisateurs!logs_securite_utilisateur_id_fkey(email, auth_id)'
       )
       .eq('mama_id', mama_id)
       .order('created_at', { ascending: false })
@@ -28,10 +28,10 @@ export default function useDerniersAcces() {
     const seen = {};
     const list = [];
     for (const row of data || []) {
-      if (!row.user_id || seen[row.user_id]) continue;
-      seen[row.user_id] = true;
+      if (!row.utilisateur_id || seen[row.utilisateur_id]) continue;
+      seen[row.utilisateur_id] = true;
       list.push({
-        id: row.user_id,
+        id: row.utilisateur_id,
         email: row.utilisateur?.email,
         date: row.created_at,
       });

--- a/src/hooks/gadgets/useEvolutionAchats.js
+++ b/src/hooks/gadgets/useEvolutionAchats.js
@@ -15,7 +15,7 @@ export default function useEvolutionAchats() {
     start.setMonth(start.getMonth() - 12);
     const { data, error } = await supabase
       .from('v_evolution_achats')
-      .select('mois, montant')
+      .select('mama_id, mois, montant')
       .eq('mama_id', mama_id)
       .gte('mois', start.toISOString().slice(0, 7))
       .order('mois', { ascending: true });

--- a/src/hooks/gadgets/useTopFournisseurs.js
+++ b/src/hooks/gadgets/useTopFournisseurs.js
@@ -16,34 +16,22 @@ export default function useTopFournisseurs() {
     const end = new Date(start);
     end.setMonth(start.getMonth() + 1);
     const { data, error } = await supabase
-      .from('achats')
-      .select(
-        'prix, quantite, supplier_id, fournisseurs(id, nom)'
-      )
+      .from('v_top_fournisseurs')
+      .select('fournisseur_id, montant, fournisseurs(id, nom)')
       .eq('mama_id', mama_id)
-      .gte('date_achat', start.toISOString().slice(0, 10))
-      .lt('date_achat', end.toISOString().slice(0, 10));
+      .order('montant', { ascending: false })
+      .limit(3);
     setLoading(false);
     if (error) {
       console.error(error);
       setData([]);
       return [];
     }
-    const totals = {};
-    (data || []).forEach((a) => {
-      const id = a.supplier_id;
-      if (!totals[id]) {
-        totals[id] = {
-          id,
-          nom: a.fournisseurs?.nom,
-          total: 0,
-        };
-      }
-      totals[id].total += Number(a.prix || 0) * Number(a.quantite || 1);
-    });
-    const list = Object.values(totals)
-      .sort((a, b) => b.total - a.total)
-      .slice(0, 3);
+    const list = (data || []).map((row) => ({
+      id: row.fournisseur_id,
+      nom: row.fournisseurs?.nom,
+      total: Number(row.montant || 0),
+    }));
     setData(list);
     if (import.meta.env.DEV) console.log('Chargement dashboard terminé');
     return list;

--- a/src/hooks/useAchats.js
+++ b/src/hooks/useAchats.js
@@ -23,7 +23,7 @@ export function useAchats() {
       .eq("mama_id", mama_id)
       .order("date_achat", { ascending: false })
       .range((page - 1) * pageSize, page * pageSize - 1);
-    if (fournisseur) q = q.eq("supplier_id", fournisseur);
+    if (fournisseur) q = q.eq("fournisseur_id", fournisseur);
     if (produit) q = q.eq("produit_id", produit);
     if (actif !== null) q = q.eq("actif", actif);
     if (debut) q = q.gte("date_achat", debut);

--- a/src/hooks/useAnalyse.js
+++ b/src/hooks/useAnalyse.js
@@ -14,7 +14,7 @@ export function useAnalyse() {
   async function getMonthlyPurchases(filters = {}) {
     if (!mama_id) return [];
     let query = supabase
-      .from("v_monthly_purchases")
+      .from("v_achats_mensuels")
       .select("mois, total")
       .eq("mama_id", mama_id)
       .order("mois", { ascending: true });
@@ -31,10 +31,9 @@ export function useAnalyse() {
     if (!mama_id) return [];
     let query = supabase
       .from("v_evolution_achats")
-      .select("mois, montant")
+      .select("mama_id, mois, montant")
       .eq("mama_id", mama_id)
       .order("mois", { ascending: true });
-    if (filters.produit_id) query = query.eq("produit_id", filters.produit_id);
     query = applyPeriode(query, filters);
     const { data, error } = await query;
     if (error) {

--- a/src/hooks/useFactures.js
+++ b/src/hooks/useFactures.js
@@ -198,7 +198,7 @@ export function useFactures() {
         .insert([
           {
             produit_id,
-            supplier_id: fournisseur_id,
+            fournisseur_id,
             mama_id,
             prix: prix_unitaire,
             quantite,

--- a/src/hooks/useReporting.js
+++ b/src/hooks/useReporting.js
@@ -29,7 +29,7 @@ export function useReporting() {
     let query;
     switch (type) {
       case 'achats':
-        query = supabase.from('v_monthly_purchases').select('*').eq('mama_id', mama_id);
+        query = supabase.from('v_achats_mensuels').select('*').eq('mama_id', mama_id);
         query = applyFilters(query, filters);
         break;
       case 'pmp':

--- a/src/pages/achats/AchatForm.jsx
+++ b/src/pages/achats/AchatForm.jsx
@@ -18,7 +18,7 @@ export default function AchatForm({ achat, suppliers = [], onClose }) {
   const [date_achat, setDateAchat] = useState(achat?.date_achat || "");
   const [produit_id, setProduitId] = useState(achat?.produit_id || "");
   const [produitNom, setProduitNom] = useState("");
-  const [supplier_id, setSupplierId] = useState(achat?.supplier_id || "");
+  const [fournisseur_id, setFournisseurId] = useState(achat?.fournisseur_id || "");
   const [quantite, setQuantite] = useState(achat?.quantite || 1);
   const [prix, setPrix] = useState(achat?.prix || 0);
   const [loading, setLoading] = useState(false);
@@ -33,10 +33,10 @@ export default function AchatForm({ achat, suppliers = [], onClose }) {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    if (!produit_id || !supplier_id) return toast.error("Produit et fournisseur requis");
+    if (!produit_id || !fournisseur_id) return toast.error("Produit et fournisseur requis");
     setLoading(true);
     try {
-      const payload = { produit_id, supplier_id, quantite, prix, date_achat };
+      const payload = { produit_id, fournisseur_id, quantite, prix, date_achat };
       if (achat?.id) {
         await updateAchat(achat.id, payload);
         toast.success("Achat modifié");
@@ -67,7 +67,7 @@ export default function AchatForm({ achat, suppliers = [], onClose }) {
             }}
             options={produitOptions.map(p => p.nom)}
           />
-          <select className="input" value={supplier_id} onChange={e => setSupplierId(e.target.value)} required>
+          <select className="input" value={fournisseur_id} onChange={e => setFournisseurId(e.target.value)} required>
             <option value="">Fournisseur</option>
             {suppliers.map(s => <option key={s.id} value={s.id}>{s.nom}</option>)}
           </select>


### PR DESCRIPTION
## Summary
- adapt `useEvolutionAchats` to new view columns
- fetch top suppliers from `v_top_fournisseurs`
- fix last access query with explicit user relation
- update hooks to use French view names
- rename supplier_id usages to fournisseur_id
- add SQL view definition for `v_evolution_achats`

## Testing
- `npm run lint`
- `npm test` *(fails: Missing Supabase credentials and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6882587c46a0832da370065dc3355102