### PR TITLE
Fix front-end fields for fournisseur

### DIFF
--- a/src/components/gadgets/GadgetProduitsUtilises.jsx
+++ b/src/components/gadgets/GadgetProduitsUtilises.jsx
@@ -21,7 +21,7 @@ export default function GadgetProduitsUtilises() {
           <li key={p.id} className="flex items-center justify-between">
             <div className="flex items-center gap-2">
               <img
-                src={p.photo_url || "/icons/icon-128x128.png"}
+                src={p.image || "/icons/icon-128x128.png"} // ✅ Correction Codex
                 alt={p.nom}
                 className="w-6 h-6 rounded object-cover"
               />

--- a/src/components/produits/ProduitForm.jsx
+++ b/src/components/produits/ProduitForm.jsx
@@ -22,8 +22,8 @@ export default function ProduitForm({ produit, familles = [], unites = [], onSuc
   const [nom, setNom] = useState(produit?.nom || "");
   const [familleId, setFamilleId] = useState(produit?.famille_id || "");
   const [uniteId, setUniteId] = useState(produit?.unite_id || "");
-  // Utilise la colonne main_supplier_id définie dans le schéma SQL
-  const [mainSupplierId, setMainSupplierId] = useState(produit?.main_supplier_id || "");
+  // Utilise la colonne fournisseur_id définie dans le schéma SQL // ✅ Correction Codex
+  const [fournisseurId, setFournisseurId] = useState(produit?.fournisseur_id || ""); // ✅ Correction Codex
   const [stock_reel, setStockReel] = useState(produit?.stock_reel || 0);
   const [stock_min, setStockMin] = useState(produit?.stock_min || 0);
   const [actif, setActif] = useState(produit?.actif ?? true);
@@ -47,7 +47,7 @@ export default function ProduitForm({ produit, familles = [], unites = [], onSuc
       setNom(produit.nom || "");
       setFamilleId(produit.famille_id || "");
       setUniteId(produit.unite_id || "");
-      setMainSupplierId(produit.main_supplier_id || "");
+      setFournisseurId(produit.fournisseur_id || ""); // ✅ Correction Codex
       setStockReel(produit.stock_reel || 0);
       setStockMin(produit.stock_min || 0);
       setActif(produit.actif ?? true);
@@ -73,7 +73,7 @@ export default function ProduitForm({ produit, familles = [], unites = [], onSuc
       nom,
       famille_id: familleId || null,
       unite_id: uniteId || null,
-      main_supplier_id: mainSupplierId || null,
+      fournisseur_id: fournisseurId || null, // ✅ Correction Codex
       stock_reel: Number(stock_reel),
       stock_min: Number(stock_min),
       actif,
@@ -160,8 +160,8 @@ export default function ProduitForm({ produit, familles = [], unites = [], onSuc
         <label className="block text-sm mb-1 font-medium" htmlFor="prod-supplier">Fournisseur principal</label>
         <Select
           id="prod-supplier"
-          value={mainSupplierId}
-          onChange={e => setMainSupplierId(e.target.value)}
+          value={fournisseurId} // ✅ Correction Codex
+          onChange={e => setFournisseurId(e.target.value)} // ✅ Correction Codex
           className="w-full"
         >
           <option value="">Aucun</option>

--- a/src/components/produits/ProduitRow.jsx
+++ b/src/components/produits/ProduitRow.jsx
@@ -16,7 +16,7 @@ export default function ProduitRow({
       <td>{produit.pmp != null ? Number(produit.pmp).toFixed(2) : '-'}</td>
       <td>{produit.stock_theorique}</td>
       <td>{produit.stock_min}</td>
-      <td>{produit.main_supplier?.nom || "-"}</td>
+      <td>{produit.fournisseur?.nom || "-"}</td> // ✅ Correction Codex
       <td>
         {produit.dernier_prix != null
           ? Number(produit.dernier_prix).toFixed(2)

--- a/src/hooks/gadgets/useProduitsUtilises.js
+++ b/src/hooks/gadgets/useProduitsUtilises.js
@@ -15,7 +15,7 @@ export default function useProduitsUtilises() {
     start.setDate(start.getDate() - 30);
     const { data, error } = await supabase
       .from('requisitions')
-      .select(`quantite, date_requisition, produit:produit_id(id, nom, photo_url)`)
+      .select(`quantite, date_requisition, produit:produit_id(id, nom, image)`)
       .eq('mama_id', mama_id)
       .gte('date_requisition', start.toISOString().slice(0, 10));
     setLoading(false);
@@ -28,7 +28,7 @@ export default function useProduitsUtilises() {
     (data || []).forEach((r) => {
       const id = r.produit?.id;
       if (!totals[id]) {
-        totals[id] = { id, nom: r.produit?.nom, photo_url: r.produit?.photo_url, total: 0 };
+        totals[id] = { id, nom: r.produit?.nom, image: r.produit?.image, total: 0 }; // ✅ Correction Codex
       }
       totals[id].total += Number(r.quantite || 0);
     });

--- a/src/hooks/useProducts.js
+++ b/src/hooks/useProducts.js
@@ -29,14 +29,14 @@ export function useProducts() {
     let query = supabase
       .from("produits")
       .select(
-        "*, famille:familles(nom), unite:unites(nom), main_supplier:fournisseurs(id, nom)",
+        "*, famille:familles(nom), unite:unites(nom), fournisseur:fournisseurs(id, nom)", // ✅ Correction Codex
         { count: "exact" }
       )
       .eq("mama_id", mama_id);
 
     if (search) {
       query = query.or(
-        `nom.ilike.%${search}%,main_supplier.nom.ilike.%${search}%`
+        `nom.ilike.%${search}%,fournisseur.nom.ilike.%${search}%` // ✅ Correction Codex
       );
     }
     if (famille) query = query.eq("famille_id", famille);
@@ -84,10 +84,10 @@ export function useProducts() {
     if (!mama_id) return { error: "Aucun mama_id" };
     setLoading(true);
     setError(null);
-    const { main_supplier_id, ...rest } = product || {};
+    const { fournisseur_id, ...rest } = product || {}; // ✅ Correction Codex
     const payload = {
       ...rest,
-      main_supplier_id: main_supplier_id ?? null,
+      fournisseur_id: fournisseur_id ?? null, // ✅ Correction Codex
       mama_id,
     };
     const { error } = await supabase.from("produits").insert([payload]);
@@ -103,10 +103,10 @@ export function useProducts() {
     if (!mama_id) return { error: "Aucun mama_id" };
     setLoading(true);
     setError(null);
-    const { main_supplier_id, ...rest } = updateFields || {};
+    const { fournisseur_id, ...rest } = updateFields || {}; // ✅ Correction Codex
     const payload = { ...rest };
-    if (main_supplier_id !== undefined) {
-      payload.main_supplier_id = main_supplier_id;
+    if (fournisseur_id !== undefined) {
+      payload.fournisseur_id = fournisseur_id; // ✅ Correction Codex
     }
     const { error } = await supabase
       .from("produits")
@@ -127,7 +127,7 @@ export function useProducts() {
     const {
       famille_id,
       unite_id,
-      main_supplier_id,
+      fournisseur_id, // ✅ Correction Codex
       stock_reel,
       stock_min,
       actif,
@@ -139,7 +139,7 @@ export function useProducts() {
       nom: `${orig.nom} (copie)`,
       famille_id,
       unite_id,
-      main_supplier_id,
+      fournisseur_id, // ✅ Correction Codex
       stock_reel,
       stock_min,
       actif,
@@ -227,7 +227,7 @@ export function useProducts() {
       stock_reel: p.stock_reel,
       stock_min: p.stock_min,
       dernier_prix: p.dernier_prix,
-      main_supplier: p.main_supplier?.nom || "",
+      fournisseur: p.fournisseur?.nom || "", // ✅ Correction Codex
       actif: p.actif,
       mama_id: p.mama_id,
     }));

--- a/src/hooks/useRequisitions.js
+++ b/src/hooks/useRequisitions.js
@@ -49,7 +49,7 @@ export function useRequisitions() {
     const { data, error } = await supabase
       .from("requisitions")
       .select(
-        "*, lignes:requisition_lignes(*, produit:produits(id, nom, photo_url))"
+        "*, lignes:requisition_lignes(*, produit:produits(id, nom, image))" // ✅ Correction Codex
       )
       .eq("id", id)
       .eq("mama_id", mama_id)

--- a/src/pages/produits/ProduitDetail.jsx
+++ b/src/pages/produits/ProduitDetail.jsx
@@ -54,7 +54,7 @@ export default function ProduitDetailPage() {
                 history.map((h, i) => (
                   <tr key={i}>
                     <td>{h.created_at?.slice(0, 10) || '-'}</td>
-                    <td>{h.supplier?.nom || '-'}</td>
+                    <td>{h.fournisseur?.nom || '-'} </td> // ✅ Correction Codex
                     <td>{h.prix_achat ?? '-'}</td>
                     <td>{h.derniere_livraison?.slice(0, 10) || '-'}</td>
                   </tr>

--- a/src/pages/requisitions/RequisitionDetail.jsx
+++ b/src/pages/requisitions/RequisitionDetail.jsx
@@ -43,9 +43,9 @@ function RequisitionDetailPage() {
           <ul className="list-disc ml-5 space-y-1">
             {(requisition.lignes || []).map((l) => (
               <li key={l.id} className="flex items-center gap-2">
-                {l.produit?.photo_url ? (
+                {l.produit?.image ? ( // ✅ Correction Codex
                   <img
-                    src={l.produit.photo_url}
+                    src={l.produit.image}
                     alt={l.produit.nom}
                     className="w-6 h-6 rounded object-cover"
                   />


### PR DESCRIPTION
## Summary
- replace old `photo_url` and `main_supplier_id` fields with new `image` and `fournisseur_id`
- update product forms and listing components
- fix queries for requisitions and dashboard gadgets
- adjust product history page

## Testing
- `npx vitest run` *(fails: Need to install packages)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68825d455f7c832d9c9f1029c7c954bf