### PR TITLE
Update dashboard hooks for new Supabase views

### DIFF
--- a/src/hooks/gadgets/useAchatsMensuels.js
+++ b/src/hooks/gadgets/useAchatsMensuels.js
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { supabase } from '@/lib/supabase';
 import { useAuth } from '@/context/AuthContext';
 
-export default function useEvolutionAchats() {
+export default function useAchatsMensuels() {
   const { mama_id } = useAuth();
   const [data, setData] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -13,14 +13,10 @@ export default function useEvolutionAchats() {
 
     const fetchData = async () => {
       setLoading(true);
-      const start = new Date();
-      start.setMonth(start.getMonth() - 12);
-      const filterDate = new Date(start.getFullYear(), start.getMonth(), 1).toISOString();
       const { data, error } = await supabase
-        .from('v_evolution_achats')
-        .select('mama_id, mois, montant_total')
+        .from('v_achats_mensuels')
+        .select('mama_id, mois, montant_total, nombre_achats')
         .eq('mama_id', mama_id)
-        .gte('mois', filterDate)
         .order('mois', { ascending: true });
 
       if (error) {

--- a/src/hooks/gadgets/useTopFournisseurs.js
+++ b/src/hooks/gadgets/useTopFournisseurs.js
@@ -1,53 +1,37 @@
-import { useState, useEffect, useCallback } from 'react';
-import useSupabaseClient from '@/hooks/useSupabaseClient';
-import useAuth from '@/hooks/useAuth';
+import { useEffect, useState } from 'react';
+import { supabase } from '@/lib/supabase';
+import { useAuth } from '@/context/AuthContext';
 
 export default function useTopFournisseurs() {
-  const supabase = useSupabaseClient();
   const { mama_id } = useAuth();
   const [data, setData] = useState([]);
-  const [loading, setLoading] = useState(false);
-
-  const fetchData = useCallback(async () => {
-    if (!mama_id) return [];
-    setLoading(true);
-    const start = new Date();
-    start.setDate(1);
-    const end = new Date(start);
-    end.setMonth(start.getMonth() + 1);
-    const { data, error, status } = await supabase
-      .from('v_top_fournisseurs')
-      .select('fournisseur_id, montant') // ✅ Correction Codex
-      .eq('mama_id', mama_id)
-      .order('montant', { ascending: false })
-      .limit(3);
-    if (error) {
-      console.warn('useTopFournisseurs', { status, error, data }); // ✅ Correction Codex
-      setData([]);
-      setLoading(false);
-      return [];
-    }
-    const ids = (data || []).map((r) => r.fournisseur_id);
-    const { data: names } = await supabase
-      .from('fournisseurs')
-      .select('id, nom')
-      .eq('mama_id', mama_id)
-      .in('id', ids);
-    const nameMap = Object.fromEntries((names || []).map((n) => [n.id, n.nom]));
-    const list = (data || []).map((row) => ({
-      id: row.fournisseur_id,
-      nom: nameMap[row.fournisseur_id] || '',
-      total: Number(row.montant || 0),
-    })); // ✅ Correction Codex
-    setLoading(false);
-    setData(list);
-    if (import.meta.env.DEV) console.log('Chargement dashboard terminé');
-    return list;
-  }, [mama_id, supabase]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
 
   useEffect(() => {
-    fetchData();
-  }, [fetchData]);
+    if (!mama_id) return;
 
-  return { data, loading, refresh: fetchData };
+    const fetchData = async () => {
+      setLoading(true);
+      const { data, error } = await supabase
+        .from('v_top_fournisseurs')
+        .select(
+          'fournisseur_id, fournisseur, montant_total, nombre_achats, mama_id'
+        )
+        .eq('mama_id', mama_id);
+
+      if (error) {
+        setError(error);
+        setData([]);
+      } else {
+        setData(data || []);
+      }
+
+      setLoading(false);
+    };
+
+    fetchData();
+  }, [mama_id]);
+
+  return { data, loading, error };
 }


### PR DESCRIPTION
## Summary
- adjust hooks to use updated views
- add new `useAchatsMensuels` hook
- query supabase with mama filters and return error state

## Testing
- `npm test` *(fails: missing Supabase credentials and other environment issues)*

------
https://chatgpt.com/codex/tasks/task_e_68838d8136e8832d9767d006c3cebd1a