### PR TITLE
Fix AuthContext role fetching

### DIFF
--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -13,7 +13,7 @@ export function useAuth() {
   const loading = ctx.loading ?? ctx.isLoading;
   const roleName =
     ctx.role ??
-    ctx.userData?.role?.nom ??
+    ctx.userData?.roleData?.nom ??
     ctx.roleData?.nom ??
     null;
   return {
@@ -24,7 +24,7 @@ export function useAuth() {
     nom: ctx.userData?.nom ?? ctx.nom,
     access_rights: ctx.userData?.access_rights ?? ctx.access_rights ?? {},
     role: roleName,
-    roleData: ctx.userData?.role ?? ctx.roleData ?? null,
+    roleData: ctx.userData?.roleData ?? ctx.roleData ?? null,
     email: ctx.userData?.email ?? ctx.email,
     actif: ctx.userData?.actif ?? ctx.actif,
     isSuperadmin: ctx.isSuperadmin,

--- a/test/authRole.test.jsx
+++ b/test/authRole.test.jsx
@@ -8,13 +8,14 @@ import useAuth from '../src/hooks/useAuth.js';
 const getSession = vi.fn(() => Promise.resolve({ data: { session: { user: { id: 'u1', email: 'u@x.com' } } }, error: null }));
 const onAuthStateChange = vi.fn(() => ({ data: { subscription: { unsubscribe: vi.fn() } } }));
 const signOut = vi.fn(() => Promise.resolve({ error: null }));
-const maybeSingle = vi.fn(() => Promise.resolve({ data: { id: '1', mama_id: 1, access_rights: {} }, error: null }));
+const maybeUser = vi.fn(() => Promise.resolve({ data: { id: '1', mama_id: 1, role_id: 'r1', access_rights: {} }, error: null }));
+const maybeRole = vi.fn(() => Promise.resolve({ data: { id: 'r1', nom: 'admin', access_rights: {} }, error: null }));
 const accessSelect = vi.fn(() => ({ eq: vi.fn(() => Promise.resolve({ data: [] })) }));
 const from = vi.fn((table) => {
   if (table === 'access_rights') {
     return { select: accessSelect };
   }
-  return { select: () => ({ eq: () => ({ maybeSingle }) }) };
+  return { select: () => ({ eq: () => ({ maybeSingle: table === 'roles' ? maybeRole : maybeUser }) }) };
 });
 
 vi.mock('../src/lib/supabase.js', () => ({

--- a/test/useAuthRole.test.jsx
+++ b/test/useAuthRole.test.jsx
@@ -8,8 +8,15 @@ import useAuth from '../src/hooks/useAuth.js';
 const getSession = vi.fn(() => Promise.resolve({ data: { session: { user: { id: 'u1', email: 'u@x.com' } } }, error: null }));
 const onAuthStateChange = vi.fn(() => ({ data: { subscription: { unsubscribe: vi.fn() } } }));
 const signOut = vi.fn(() => Promise.resolve({ error: null }));
-const maybeSingle = vi.fn(() => Promise.resolve({ data: { id: '1', nom: 'User', mama_id: 1, role_id: 'r1', access_rights: {}, role: { id: 'r1', nom: 'superadmin', access_rights: {} } }, error: null }));
-const from = vi.fn(() => ({ select: () => ({ eq: () => ({ maybeSingle }) }) }));
+const maybeUser = vi.fn(() => Promise.resolve({ data: { id: '1', nom: 'User', mama_id: 1, role_id: 'r1', access_rights: {} }, error: null }));
+const maybeRole = vi.fn(() => Promise.resolve({ data: { id: 'r1', nom: 'superadmin', access_rights: {} }, error: null }));
+const from = vi.fn((table) => ({
+  select: () => ({
+    eq: () => ({
+      maybeSingle: table === 'roles' ? maybeRole : maybeUser,
+    }),
+  }),
+}));
 
 vi.mock('../src/lib/supabase.js', () => ({
   supabase: { auth: { getSession, onAuthStateChange, signOut }, from }


### PR DESCRIPTION
## Summary
- fetch role_id first then load role from roles table
- expose role name via `roleData` in auth provider and hook
- update tests to match new calls

## Testing
- `npm test` *(fails: Missing Supabase credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68849c3c4344832d93a3e211f72f129a