### PR TITLE
Stabilise auth flow

### DIFF
--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -14,10 +14,13 @@ export default function ProtectedRoute({ children, accessKey }) {
   const navigate = useNavigate();
 
   useEffect(() => {
-    // on patiente tant que userData n'est pas chargé pour éviter
-    // une redirection prématurée si le rôle est encore null
-    // (le rôle est parfois chargé avec un léger délai via Supabase)
-    if (!session || !userData || pending || loading) return;
+    // On patiente tant que les données ne sont pas chargées
+    if (!session || pending || loading) return;
+
+    if (!userData) {
+      navigate('/unauthorized', { replace: true });
+      return;
+    }
 
     if (userData.actif === false) {
       navigate("/blocked", { replace: true });
@@ -38,6 +41,12 @@ export default function ProtectedRoute({ children, accessKey }) {
       navigate("/unauthorized", { replace: true });
     }
   }, [session, userData, pending, loading, accessKey, navigate, hasAccess]);
-  if (!session || pending || loading || !userData) return <LoadingScreen />;
+
+  if (!session && !loading && !pending) {
+    navigate('/login', { replace: true });
+    return null;
+  }
+  if (!session || pending || loading) return <LoadingScreen />;
+  if (!userData) return <LoadingScreen />;
   return children;
 }

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -9,10 +9,10 @@ import { Badge } from "@/components/ui/badge";
 import MamaLogo from "@/components/ui/MamaLogo";
 
 export default function Sidebar() {
-  const { access_rights, isSuperadmin, loading, hasAccess } = useAuth();
+  const { access_rights, isSuperadmin, loading, pending, hasAccess } = useAuth();
   const { pathname } = useLocation();
 
-  if (loading || access_rights === null) return null;
+  if (loading || pending || access_rights === null) return null;
   const has = (key) => isSuperadmin || hasAccess(key, "peut_voir");
   const canAnalyse = has("analyse");
 

--- a/src/components/produits/ProduitForm.jsx
+++ b/src/components/produits/ProduitForm.jsx
@@ -28,7 +28,7 @@ export default function ProduitForm({ produit, familles = [], unites = [], onSuc
   const [actif, setActif] = useState(produit?.actif ?? true);
   const [code, setCode] = useState(produit?.code || "");
   const [allergenes, setAllergenes] = useState(produit?.allergenes || "");
-  const [image, setImage] = useState(null); // ✅ Correction Codex
+  const [_image, setImage] = useState(null); // ✅ Correction Codex
   const [errors, setErrors] = useState({});
 
   const { addProduct, updateProduct, loading } = useProducts();

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -76,17 +76,25 @@ export const AuthProvider = ({ children }) => {
 
       if (!data && !error) {
         console.warn("user not loaded", userId);
+        setError("Utilisateur introuvable");
+        setUserData(null);
         return;
       }
 
       if (error) {
         if (error.message && error.message.includes("column")) {
-          console.error("fetchUserData column error", error.message); // ✅ Correction Codex
+          console.error("fetchUserData column error", error.message);
           setError(error.message);
           setUserData(null);
           return;
         }
         throw error;
+      }
+
+      if (!data) {
+        setError("Utilisateur introuvable");
+        setUserData(null);
+        return;
       }
 
       if (import.meta.env.DEV) console.log("fetchUserData result", data);
@@ -262,15 +270,15 @@ export const AuthProvider = ({ children }) => {
     navigate("/login");
   };
 
+  const isSuperadmin = checkAccess(userData?.access_rights, 'superadmin', 'peut_voir');
+
   const hasAccess = (module, droit = "peut_voir") => {
-    return checkAccess(userData?.access_rights, module, droit, false);
+    return checkAccess(userData?.access_rights, module, droit, isSuperadmin);
   };
 
   const getAuthorizedModules = (droit = "peut_voir") => {
     return listModules(userData?.access_rights, droit);
   };
-
-  const isSuperadmin = checkAccess(userData?.access_rights, 'superadmin', 'peut_voir');
   const isAdmin =
     isSuperadmin || checkAccess(userData?.access_rights, 'admin', 'peut_voir');
 

--- a/src/hooks/useAccess.js
+++ b/src/hooks/useAccess.js
@@ -1,0 +1,9 @@
+import useAuth from './useAuth';
+
+export default function useAccess(module, right = 'peut_voir') {
+  const { hasAccess, loading, pending, isSuperadmin } = useAuth();
+  const allowed = module ? hasAccess(module, right) : false;
+  const ready = !loading && !pending;
+  return { allowed: isSuperadmin || allowed, loading: !ready };
+}
+

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -10,34 +10,34 @@ export function useAuth() {
       "useAuth n’est pas correctement initialisé (provider absent ou mal injecté) !"
     );
   }
-  const loading = ctx.loading ?? ctx.isLoading;
+  const loading = ctx.loading ?? ctx.isLoading ?? false;
   const roleName =
     ctx.role ??
     ctx.userData?.roleData?.nom ??
     ctx.roleData?.nom ??
     null;
   const rights = ctx.access_rights ?? ctx.userData?.access_rights ?? {};
-  const mamaId = ctx.userData?.mama_id ?? ctx.mama_id ?? null; // ✅ Correction Codex
+  const mamaId = ctx.userData?.mama_id ?? ctx.mama_id ?? null;
   return {
-    session: ctx.session,
-    userData: ctx.userData,
+    session: ctx.session ?? null,
+    userData: ctx.userData ?? null,
     user_id: ctx.user_id ?? ctx.session?.user?.id ?? null,
     mama_id: mamaId,
-    nom: ctx.userData?.nom ?? ctx.nom,
+    nom: ctx.userData?.nom ?? ctx.nom ?? null,
     access_rights: rights,
     role: roleName,
     roleData: ctx.userData?.roleData ?? ctx.roleData ?? null,
-    email: ctx.userData?.email ?? ctx.email,
-    actif: ctx.userData?.actif ?? ctx.actif,
-    isSuperadmin: ctx.isSuperadmin,
-    isAdmin: ctx.isAdmin,
+    email: ctx.userData?.email ?? ctx.email ?? null,
+    actif: ctx.userData?.actif ?? ctx.actif ?? null,
+    isSuperadmin: ctx.isSuperadmin ?? false,
+    isAdmin: ctx.isAdmin ?? false,
     loading,
-    pending: ctx.pending,
-    isAuthenticated: ctx.isAuthenticated,
-    hasAccess: ctx.hasAccess,
-    getAuthorizedModules: ctx.getAuthorizedModules,
-    error: ctx.error,
-    resetAuth: ctx.resetAuth,
+    pending: ctx.pending ?? false,
+    isAuthenticated: ctx.isAuthenticated ?? !!ctx.session?.user?.id,
+    hasAccess: ctx.hasAccess ?? (() => false),
+    getAuthorizedModules: ctx.getAuthorizedModules ?? (() => []),
+    error: ctx.error ?? null,
+    resetAuth: ctx.resetAuth ?? (() => {}),
     login: ctx.login,
     signup: ctx.signup,
     logout: ctx.logout,

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -161,10 +161,11 @@ function RootRoute() {
   const { session, loading, pending, userData, error } = useAuth();
   if (loading || pending) return <LoadingSpinner message="Chargement..." />;
   if (error) {
-    console.error('Auth error', error); // ✅ Correction Codex
+    console.error('Auth error', error);
     return <Navigate to="/login" replace />;
   }
-  if (session && session.user && userData && userData.actif !== false) {
+  if (session && userData) {
+    if (userData.actif === false) return <Navigate to="/blocked" replace />;
     return <Navigate to="/dashboard" replace />;
   }
   return <Navigate to="/accueil" replace />;

--- a/test/authRole.test.jsx
+++ b/test/authRole.test.jsx
@@ -36,7 +36,7 @@ test('access rights are loaded from supabase', async () => {
 });
 
 test('user not found keeps userData null', async () => {
-  maybeSingle.mockResolvedValueOnce({ data: null, error: null });
+  maybeUser.mockResolvedValueOnce({ data: null, error: null });
   const wrapper = ({ children }) => (
     <MemoryRouter>
       <AuthProvider>{children}</AuthProvider>


### PR DESCRIPTION
## Summary
- fix user data loading in AuthContext
- return stable values from `useAuth`
- add `useAccess` helper
- improve `ProtectedRoute` and router root behavior
- gate sidebar until auth ready
- address eslint warnings and tests

## Testing
- `npm run lint`
- `npm test` *(fails: Missing Supabase credentials and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6884a22bf6f8832dbaf33aec770c278c