### PR TITLE
Fix products fetch performance

### DIFF
--- a/src/hooks/useProducts.js
+++ b/src/hooks/useProducts.js
@@ -54,14 +54,13 @@ export function useProducts() {
     query = query.range((page - 1) * limit, page * limit - 1);
 
     const { data, error, count } = await query;
-    const { data: pmpData } = await supabase
-      .from('v_pmp')
-      .select('produit_id, pmp')
-      .eq('mama_id', mama_id);
-    const { data: stockData } = await supabase
-      .from('v_stocks')
-      .select('produit_id, stock')
-      .eq('mama_id', mama_id);
+    const [
+      { data: pmpData },
+      { data: stockData },
+    ] = await Promise.all([
+      supabase.from('v_pmp').select('produit_id, pmp').eq('mama_id', mama_id),
+      supabase.from('v_stocks').select('produit_id, stock').eq('mama_id', mama_id),
+    ]);
     const pmpMap = Object.fromEntries((pmpData || []).map(p => [p.produit_id, p.pmp]));
     const stockMap = Object.fromEntries((stockData || []).map(s => [s.produit_id, s.stock]));
     const final = (Array.isArray(data) ? data : []).map(p => ({


### PR DESCRIPTION
## Summary
- optimize `useProducts` fetch to get PMP and stock in parallel

## Testing
- `npm run lint`
- `npm test` *(fails: Missing Supabase credentials)*

------
https://chatgpt.com/codex/tasks/task_e_688a585e1674832db38bdcc8b04a132b