### PR TITLE
Fix product ordering alias

### DIFF
--- a/src/hooks/useProducts.js
+++ b/src/hooks/useProducts.js
@@ -44,9 +44,11 @@ export function useProducts() {
     if (typeof actif === "boolean") query = query.eq("actif", actif);
 
     if (sortBy === "famille") {
-      query = query.order("nom", { foreignTable: "familles", ascending: order === "asc" });
+      // order by the joined famille alias
+      query = query.order("nom", { foreignTable: "famille", ascending: order === "asc" });
     } else if (sortBy === "unite") {
-      query = query.order("nom", { foreignTable: "unites", ascending: order === "asc" });
+      // order by the joined unite alias
+      query = query.order("nom", { foreignTable: "unite", ascending: order === "asc" });
     } else {
       query = query.order(sortBy, { ascending: order === "asc" });
     }


### PR DESCRIPTION
## Summary
- correct foreign table aliases in useProducts hook for famille and unite sorting

## Testing
- `npm test` *(fails: Missing Supabase credentials)*

------
https://chatgpt.com/codex/tasks/task_e_688a5b040514832d9bd9ed342dd6a14c