### PR TITLE
Fix ProtectedRoute access checks

### DIFF
--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -11,19 +11,17 @@ import PageSkeleton from "@/components/ui/PageSkeleton";
 export default function ProtectedRoute({ moduleKey, children }) {
   const { session, loading, userData } = useAuth();
 
-  if (loading || !session || !userData) {
+  // Wait for session and user data to be fully loaded
+  if (loading || !session || !userData || !userData.access_rights) {
     return <PageSkeleton />;
   }
 
-  if (userData.actif === false) {
-    return <Navigate to="/unauthorized" />;
-  }
+  const access = userData.access_rights || {};
+  const hasAccess = access[moduleKey]?.peut_voir === true;
 
-  const rights = userData.access_rights || {};
-  const hasAccess =
-    rights[moduleKey]?.peut_voir === true || rights[moduleKey] === true;
-
-  if (!hasAccess) {
+  if (!userData.actif || !hasAccess) {
+    console.warn("🔒 ACCESS DENIED for moduleKey:", moduleKey);
+    console.warn("🔒 access_rights:", access);
     return <Navigate to="/unauthorized" />;
   }
 

--- a/src/layout/Layout.jsx
+++ b/src/layout/Layout.jsx
@@ -44,6 +44,7 @@ export default function Layout() {
       mama_id,
       access_rights,
     });
+    console.log("\uD83E\uDDE0 moduleKey access_rights", userData?.access_rights);
   }
 
   if (pathname === "/login" || pathname === "/unauthorized") return <Outlet />;


### PR DESCRIPTION
## Summary
- ensure `ProtectedRoute` waits for auth data before redirecting
- log access rights for debugging
- add temporary rights log in `Layout`

## Testing
- `npm install`
- `npm test` *(fails: Missing Supabase credentials)*

------
https://chatgpt.com/codex/tasks/task_e_688b230f1dc8832dba327ed0e424c92a