### PR TITLE
Fix product supplier relation

### DIFF
--- a/src/components/produits/ProduitForm.jsx
+++ b/src/components/produits/ProduitForm.jsx
@@ -22,7 +22,7 @@ export default function ProduitForm({ produit, familles = [], unites = [], onSuc
   const [familleId, setFamilleId] = useState(produit?.famille_id || "");
   const [uniteId, setUniteId] = useState(produit?.unite_id || "");
   const [fournisseurId, setFournisseurId] = useState(
-    produit?.fournisseur_principal_id || ""
+    produit?.fournisseur_id || ""
   );
   const [stock_reel, setStockReel] = useState(produit?.stock_reel || 0);
   const [stock_min, setStockMin] = useState(produit?.stock_min || 0);
@@ -45,7 +45,7 @@ export default function ProduitForm({ produit, familles = [], unites = [], onSuc
       setNom(produit.nom || "");
       setFamilleId(produit.famille_id || "");
       setUniteId(produit.unite_id || "");
-      setFournisseurId(produit.fournisseur_principal_id || "");
+      setFournisseurId(produit.fournisseur_id || "");
       setStockReel(produit.stock_reel || 0);
       setStockMin(produit.stock_min || 0);
       setActif(produit.actif ?? true);
@@ -70,7 +70,7 @@ export default function ProduitForm({ produit, familles = [], unites = [], onSuc
       nom,
       famille_id: familleId || null,
       unite_id: uniteId || null,
-      fournisseur_principal_id: fournisseurId || null,
+      fournisseur_id: fournisseurId || null,
       stock_reel: Number(stock_reel),
       stock_min: Number(stock_min),
       actif,

--- a/src/hooks/useProducts.js
+++ b/src/hooks/useProducts.js
@@ -30,7 +30,7 @@ export function useProducts() {
     let query = supabase
       .from("produits")
       .select(
-        "*, famille:familles(nom), unite:unites(nom), fournisseur:fournisseurs!fournisseur_principal_id(id, nom)",
+        "*, famille:familles(nom), unite:unites(nom), fournisseur:fournisseurs!fournisseur_id(id, nom)",
         { count: "exact" }
       )
       .eq("mama_id", mama_id);
@@ -86,10 +86,10 @@ export function useProducts() {
     if (!mama_id) return { error: "Aucun mama_id" };
     setLoading(true);
     setError(null);
-    const { fournisseur_principal_id, ...rest } = product || {};
+    const { fournisseur_id, ...rest } = product || {};
     const payload = {
       ...rest,
-      fournisseur_principal_id: fournisseur_principal_id ?? null,
+      fournisseur_id: fournisseur_id ?? null,
       mama_id,
     };
     const { error } = await supabase.from("produits").insert([payload]);
@@ -105,10 +105,10 @@ export function useProducts() {
     if (!mama_id) return { error: "Aucun mama_id" };
     setLoading(true);
     setError(null);
-    const { fournisseur_principal_id, ...rest } = updateFields || {};
+    const { fournisseur_id, ...rest } = updateFields || {};
     const payload = { ...rest };
-    if (fournisseur_principal_id !== undefined) {
-      payload.fournisseur_principal_id = fournisseur_principal_id;
+    if (fournisseur_id !== undefined) {
+      payload.fournisseur_id = fournisseur_id;
     }
     const { error } = await supabase
       .from("produits")
@@ -129,7 +129,7 @@ export function useProducts() {
     const {
       famille_id,
       unite_id,
-      fournisseur_principal_id,
+      fournisseur_id,
       stock_reel,
       stock_min,
       actif,
@@ -140,7 +140,7 @@ export function useProducts() {
       nom: `${orig.nom} (copie)`,
       famille_id,
       unite_id,
-      fournisseur_principal_id,
+      fournisseur_id,
       stock_reel,
       stock_min,
       actif,
@@ -219,7 +219,7 @@ export function useProducts() {
       const { data, error } = await supabase
         .from("produits")
         .select(
-          "*, fournisseur:fournisseurs!fournisseur_principal_id(id, nom), famille:familles(nom), unite:unites(nom)"
+          "*, fournisseur:fournisseurs!fournisseur_id(id, nom), famille:familles(nom), unite:unites(nom)"
         )
         .eq("id", id)
         .eq("mama_id", mama_id)
@@ -248,7 +248,7 @@ export function useProducts() {
       stock_min: p.stock_min,
       dernier_prix: p.dernier_prix,
       fournisseur: p.fournisseur?.nom || "",
-      fournisseur_principal_id: p.fournisseur_principal_id || "",
+      fournisseur_id: p.fournisseur_id || "",
       actif: p.actif,
     }));
     const wb = XLSX.utils.book_new();

--- a/src/pages/produits/Produits.jsx
+++ b/src/pages/produits/Produits.jsx
@@ -94,7 +94,7 @@ export default function Produits() {
           nom: row.nom,
           famille_id: famMap[row.famille?.toLowerCase().trim()] || null,
           unite_id: uniteMap[row.unite?.toLowerCase().trim()] || null,
-          fournisseur_principal_id:
+          fournisseur_id:
             fournisseurMap[row.fournisseur?.toLowerCase().trim()] || null,
           stock_reel: Number(row.stock_reel) || 0,
           stock_min: Number(row.stock_min) || 0,


### PR DESCRIPTION
## Summary
- use `fournisseur_id` in products hooks and forms
- map supplier when importing products

## Testing
- `npm run lint`
- `npm test` *(fails: Missing Supabase credentials)*

------
https://chatgpt.com/codex/tasks/task_e_688b293eac0c832d9b6bae895512bc3a