### PR TITLE
Improve form visibility with GlassCard options

### DIFF
--- a/src/components/help/FeedbackForm.jsx
+++ b/src/components/help/FeedbackForm.jsx
@@ -3,6 +3,8 @@ import { useState } from "react";
 import ModalGlass from "@/components/ui/ModalGlass";
 import { useFeedback } from "@/hooks/useFeedback";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Select } from "@/components/ui/select";
 import { toast } from "react-hot-toast";
 
 export default function FeedbackForm({ open, onOpenChange }) {
@@ -35,34 +37,32 @@ export default function FeedbackForm({ open, onOpenChange }) {
         <h3 className="text-lg font-semibold mb-4">Besoin d'aide ?</h3>
         <form onSubmit={handleSubmit} className="space-y-2">
           <label className="sr-only" htmlFor="module">Module</label>
-          <input
+          <Input
             id="module"
-            className="input input-bordered w-full"
             placeholder="Module"
             value={module}
-            onChange={(e) => setModule(e.target.value)}
+            onChange={e => setModule(e.target.value)}
             required
           />
           <label className="sr-only" htmlFor="message">Message</label>
           <textarea
             id="message"
-            className="input input-bordered w-full h-24"
+            className="w-full p-2 rounded-lg border border-white/20 bg-white/10 dark:bg-[#202638]/50 backdrop-blur text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-white/70 focus:outline-none h-24"
             placeholder="Votre message"
             value={message}
-            onChange={(e) => setMessage(e.target.value)}
+            onChange={e => setMessage(e.target.value)}
             required
           />
           <label className="sr-only" htmlFor="urgence">Urgence</label>
-          <select
+          <Select
             id="urgence"
-            className="input input-bordered w-full"
             value={urgence}
-            onChange={(e) => setUrgence(e.target.value)}
+            onChange={e => setUrgence(e.target.value)}
           >
             <option value="faible">Faible</option>
             <option value="normal">Normal</option>
             <option value="elevee">Élevée</option>
-          </select>
+          </Select>
           <div className="flex gap-2 pt-2">
             <Button type="submit" disabled={sending} className="flex items-center gap-2">
               {sending && <span className="loader-glass" />}Envoyer

--- a/src/components/ui/GlassCard.jsx
+++ b/src/components/ui/GlassCard.jsx
@@ -1,13 +1,37 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import React from 'react';
 
-export function GlassCard({ children, className = '', ...props }) {
+/**
+ * Generic glass style card used across forms.
+ *
+ * @param {object} props
+ * @param {string} [props.title] Optional header title
+ * @param {React.ReactNode} props.children Card content
+ * @param {React.ReactNode} [props.footer] Optional footer element
+ * @param {string} [props.width] Tailwind max-width class (e.g. "max-w-lg")
+ * @param {boolean} [props.dark] Force dark text/background
+ * @param {string} [props.className] Additional classes
+ */
+export function GlassCard({
+  title,
+  children,
+  footer,
+  width = '',
+  dark = false,
+  className = '',
+  ...props
+}) {
+  const colorClasses = dark
+    ? 'bg-[#202638]/60 text-white'
+    : 'bg-white/10 text-gray-900';
   return (
     <div
-      className={`bg-glass border border-borderGlass backdrop-blur rounded-xl p-6 ${className}`}
+      className={`border border-white/30 backdrop-blur-md rounded-2xl shadow-lg p-6 ${colorClasses} ${width} ${className}`}
       {...props}
     >
+      {title && <h2 className="text-xl font-semibold mb-4">{title}</h2>}
       {children}
+      {footer && <div className="mt-4">{footer}</div>}
     </div>
   );
 }

--- a/src/components/ui/InputField.jsx
+++ b/src/components/ui/InputField.jsx
@@ -10,7 +10,7 @@ export default function InputField({
 }) {
   return (
     <div className={`mb-4 ${className}`}>
-      <label className="block text-sm text-white mb-1">{label}</label>
+      <label className="block text-sm text-gray-800 dark:text-white mb-1">{label}</label>
       <input
         value={value}
         onChange={onChange}

--- a/src/components/ui/input.jsx
+++ b/src/components/ui/input.jsx
@@ -19,7 +19,7 @@ export function Input({
       placeholder={placeholder}
       disabled={disabled}
       aria-label={ariaLabel || placeholder || "Champ de saisie"}
-      className={`w-full p-2 rounded-lg border border-white/20 bg-white/10 text-white placeholder-white/70 focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed ${className}`}
+      className={`w-full p-2 rounded-lg border border-white/20 bg-white/10 dark:bg-[#202638]/50 backdrop-blur text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-white/70 focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed ${className}`}
       {...props}
     />
   );

--- a/src/components/ui/select.jsx
+++ b/src/components/ui/select.jsx
@@ -14,7 +14,7 @@ export function Select({
       value={value}
       onChange={onChange}
       aria-label={ariaLabel || "Sélection"}
-      className={`w-full p-2 border border-white/30 rounded-md bg-white/10 text-white backdrop-blur focus:outline-none focus:ring-2 focus:ring-mamastockGold ${className}`}
+      className={`w-full p-2 border border-white/30 rounded-md bg-white/10 dark:bg-[#202638]/50 backdrop-blur text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-mamastockGold ${className}`}
       {...props}
     >
       {children}


### PR DESCRIPTION
## Summary
- update GlassCard to support optional title/footer/dark mode
- tweak input, select and InputField styles for light/dark themes
- refactor FeedbackForm to use updated components

## Testing
- `npm run lint`
- `npm run test` *(fails: 19 failed, 90 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688b3b3bf660832dac143d4243d23927