### PR TITLE
Refactor ProduitForm with liquid glass design

### DIFF
--- a/src/components/produits/ProduitForm.jsx
+++ b/src/components/produits/ProduitForm.jsx
@@ -9,9 +9,9 @@ import { toast } from "react-hot-toast";
 import AutoCompleteField from "@/components/ui/AutoCompleteField";
 import { Input } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
-import PrimaryButton from "@/components/ui/PrimaryButton";
 import SecondaryButton from "@/components/ui/SecondaryButton";
 import GlassCard from "@/components/ui/GlassCard";
+import { Card, CardContent } from "@/components/ui/card";
 
 export default function ProduitForm({ produit, familles = [], unites = [], onSuccess, onClose }) {
   const editing = !!produit;
@@ -22,9 +22,7 @@ export default function ProduitForm({ produit, familles = [], unites = [], onSuc
   const [nom, setNom] = useState(produit?.nom || "");
   const [familleId, setFamilleId] = useState(produit?.famille_id || "");
   const [uniteId, setUniteId] = useState(produit?.unite_id || "");
-  const [fournisseurId, setFournisseurId] = useState(
-    produit?.fournisseur_id || ""
-  );
+  const [fournisseurId, setFournisseurId] = useState(produit?.fournisseur_id || "");
   const [stock_reel, setStockReel] = useState(produit?.stock_reel || 0);
   const [stock_min, setStockMin] = useState(produit?.stock_min || 0);
   const [actif, setActif] = useState(produit?.actif ?? true);
@@ -78,147 +76,149 @@ export default function ProduitForm({ produit, familles = [], unites = [], onSuc
       code,
       allergenes,
     };
+    let toastId;
     try {
       setSaving(true);
+      toastId = toast.loading(editing ? "Mise à jour..." : "Enregistrement...");
       if (editing) {
         const res = await updateProduct(produit.id, newProd, { refresh: false });
         if (res?.error) throw res.error;
-        toast.success("Produit mis à jour !");
+        toast.success("Produit mis à jour !", { id: toastId });
       } else {
         const res = await addProduct(newProd, { refresh: false });
         if (res?.error) throw res.error;
-        toast.success("Produit ajouté !");
+        toast.success("Produit ajouté !", { id: toastId });
       }
       onSuccess?.();
       onClose?.();
     } catch (err) {
       console.error("Erreur enregistrement produit:", err);
-      toast.error("Erreur lors de l'enregistrement.");
+      toast.error("Erreur lors de l'enregistrement.", { id: toastId });
     } finally {
       setSaving(false);
     }
   };
 
-
   return (
-    <GlassCard title={editing ? "Éditer le produit" : "Nouveau produit"}>
-      <form onSubmit={handleSubmit} className="space-y-4">
-      <div>
-        <label className="block text-sm mb-1 font-medium" htmlFor="prod-nom">Nom</label>
-        <Input
-          id="prod-nom"
-          value={nom}
-          onChange={e => setNom(e.target.value)}
-          required
-        />
-        {errors.nom && <p className="text-red-500 text-sm">{errors.nom}</p>}
-      </div>
-      <AutoCompleteField
-        label="Famille"
-        value={familleId}
-        onChange={setFamilleId}
-        options={[...famillesHook, ...familles].map(f => ({ value: f.id, label: f.nom }))}
-        onAddOption={async val => {
-          const { data, error } = await addFamille(val);
-          if (error) toast.error(error.message || error);
-          else return { id: data.id, label: data.nom };
-        }}
-        required
-      />
-      {errors.famille && <p className="text-red-500 text-sm">{errors.famille}</p>}
-      <AutoCompleteField
-        label="Unité"
-        value={uniteId}
-        onChange={setUniteId}
-        options={[...unitesHook, ...unites].map(u => ({ value: u.id, label: u.nom }))}
-        onAddOption={async val => {
-          const { data, error } = await addUnite(val);
-          if (error) toast.error(error.message || error);
-          else return { id: data.id, label: data.nom };
-        }}
-        required
-      />
-      {errors.unite && <p className="text-red-500 text-sm">{errors.unite}</p>}
-      <div>
-        <label className="block text-sm mb-1 font-medium" htmlFor="prod-fournisseur">Fournisseur</label>
-        <Select
-          id="prod-fournisseur"
-          value={fournisseurId}
-          onChange={e => setFournisseurId(e.target.value)}
-          className="w-full"
-        >
-          <option value="">Aucun</option>
-          {fournisseurs.map(f => (
-            <option key={f.id} value={f.id}>{f.nom}</option>
-          ))}
-        </Select>
-      </div>
-      <div>
-        <label htmlFor="prod-code" className="block text-sm mb-1 font-medium">Code interne</label>
-        <Input id="prod-code" value={code} onChange={e => setCode(e.target.value)} />
-      </div>
-      <div>
-        <label htmlFor="prod-allerg" className="block text-sm mb-1 font-medium">Allergènes</label>
-        <Input
-          id="prod-allerg"
-          value={allergenes}
-          onChange={e => setAllergenes(e.target.value)}
-          placeholder="Ex: gluten, lait"
-        />
-      </div>
-      <div>
-        <label className="block text-sm mb-1 font-medium">Photo</label>
-        <input id="prod-photo" type="file" accept="image/*" disabled />
-      </div>
-      {editing && (
-        <div>
-          <label className="block text-sm mb-1 font-medium">PMP (€)</label>
-          <Input
-            type="number"
-            className="w-28"
-            value={produit?.pmp || 0}
-            readOnly
-            disabled
-          />
-        </div>
-      )}
-      <div>
-        <label className="block text-sm mb-1 font-medium">Stock réel</label>
-        <Input
-          type="number"
-          className="w-28"
-          value={stock_reel}
-          onChange={e => setStockReel(e.target.value)}
-          min={0}
-        />
-      </div>
-      <div>
-        <label htmlFor="prod-min" className="block text-sm mb-1 font-medium">Stock minimum</label>
-        <Input
-          id="prod-min"
-          type="number"
-          className="w-28"
-          value={stock_min}
-          onChange={e => setStockMin(e.target.value)}
-          min={0}
-        />
-      </div>
-      <div className="flex items-center gap-2">
-        <input
-          type="checkbox"
-          checked={actif}
-          onChange={e => setActif(e.target.checked)}
-          id="prod-actif"
-        />
-        <label htmlFor="prod-actif" className="text-sm">Produit actif</label>
-      </div>
-      <div className="flex gap-2 justify-end mt-4">
-        <SecondaryButton type="button" onClick={onClose}>Annuler</SecondaryButton>
-        <PrimaryButton type="submit" disabled={loading || saving} className="flex items-center gap-2">
-          {(loading || saving) && <span className="loader-glass" />}
-          {editing ? "Enregistrer" : "Créer"}
-        </PrimaryButton>
-      </div>
+    <GlassCard className="max-w-2xl">
+      <h2 className="text-xl font-bold text-white mb-4">Créer ou modifier un produit</h2>
+      <form onSubmit={handleSubmit} className="space-y-6">
+        {/* Bloc 1: Informations générales */}
+        <Card className="bg-white/10 backdrop-blur-lg border border-white/20 rounded-2xl shadow-lg text-white">
+          <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="md:col-span-2">
+              <label htmlFor="prod-nom" className="text-white text-sm font-semibold mb-1 block">
+                Nom *
+              </label>
+              <Input id="prod-nom" value={nom} onChange={e => setNom(e.target.value)} required />
+              {errors.nom && <p className="text-red-500 text-sm">{errors.nom}</p>}
+            </div>
+            <div>
+              <AutoCompleteField
+                label="Famille"
+                value={familleId}
+                onChange={setFamilleId}
+                options={[...famillesHook, ...familles].map(f => ({ value: f.id, label: f.nom }))}
+                onAddOption={async val => {
+                  const { data, error } = await addFamille(val);
+                  if (error) toast.error(error.message || error);
+                  else return { id: data.id, label: data.nom };
+                }}
+                required
+              />
+              {errors.famille && <p className="text-red-500 text-sm">{errors.famille}</p>}
+            </div>
+            <div>
+              <AutoCompleteField
+                label="Unité"
+                value={uniteId}
+                onChange={setUniteId}
+                options={[...unitesHook, ...unites].map(u => ({ value: u.id, label: u.nom }))}
+                onAddOption={async val => {
+                  const { data, error } = await addUnite(val);
+                  if (error) toast.error(error.message || error);
+                  else return { id: data.id, label: data.nom };
+                }}
+                required
+              />
+              {errors.unite && <p className="text-red-500 text-sm">{errors.unite}</p>}
+            </div>
+            <div>
+              <label htmlFor="prod-code" className="text-white text-sm font-semibold mb-1 block">
+                Code interne
+              </label>
+              <Input id="prod-code" value={code} onChange={e => setCode(e.target.value)} />
+            </div>
+            <div>
+              <label htmlFor="prod-allerg" className="text-white text-sm font-semibold mb-1 block">
+                Allergènes
+              </label>
+              <Input id="prod-allerg" value={allergenes} onChange={e => setAllergenes(e.target.value)} placeholder="Ex: gluten, lait" />
+            </div>
+            <div className="md:col-span-2">
+              <label className="text-white text-sm font-semibold mb-1 block">Photo</label>
+              <input id="prod-photo" type="file" accept="image/*" disabled className="w-full text-white/70" />
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Bloc 2: Stock & prix */}
+        <Card className="bg-white/10 backdrop-blur-lg border border-white/20 rounded-2xl shadow-lg text-white">
+          <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {editing && (
+              <div>
+                <label className="text-white text-sm font-semibold mb-1 block">PMP (€)</label>
+                <Input type="number" className="w-full" value={produit?.pmp || 0} readOnly disabled />
+              </div>
+            )}
+            <div>
+              <label className="text-white text-sm font-semibold mb-1 block">Stock réel</label>
+              <Input type="number" value={stock_reel} onChange={e => setStockReel(e.target.value)} min={0} />
+            </div>
+            <div>
+              <label htmlFor="prod-min" className="text-white text-sm font-semibold mb-1 block">
+                Stock minimum
+              </label>
+              <Input id="prod-min" type="number" value={stock_min} onChange={e => setStockMin(e.target.value)} min={0} />
+            </div>
+            <label className="flex items-center gap-2 md:col-span-2">
+              <input type="checkbox" checked={actif} onChange={e => setActif(e.target.checked)} id="prod-actif" className="accent-white" />
+              Produit actif
+            </label>
+          </CardContent>
+        </Card>
+
+        {/* Bloc 3: Fournisseurs */}
+        <Card className="bg-white/10 backdrop-blur-lg border border-white/20 rounded-2xl shadow-lg text-white">
+          <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="md:col-span-2">
+              <label htmlFor="prod-fournisseur" className="text-white text-sm font-semibold mb-1 block">
+                Fournisseur principal
+              </label>
+              <Select id="prod-fournisseur" value={fournisseurId} onChange={e => setFournisseurId(e.target.value)} className="w-full">
+                <option value="">Aucun</option>
+                {fournisseurs.map(f => (
+                  <option key={f.id} value={f.id}>{f.nom}</option>
+                ))}
+              </Select>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Bloc 4: Actions */}
+        <Card className="bg-white/10 backdrop-blur-lg border border-white/20 rounded-2xl shadow-lg text-white">
+          <CardContent className="flex justify-end gap-2">
+            <SecondaryButton type="button" onClick={onClose}>Annuler</SecondaryButton>
+            <button
+              type="submit"
+              disabled={loading || saving}
+              className="bg-white/20 hover:bg-white/30 text-white font-bold py-2 px-4 rounded-xl backdrop-blur flex items-center gap-2"
+            >
+              {(loading || saving) && <span className="loader-glass" />}
+              {editing ? "Enregistrer" : "Créer"}
+            </button>
+          </CardContent>
+        </Card>
       </form>
     </GlassCard>
   );


### PR DESCRIPTION
## Summary
- restyle `ProduitForm` with liquid glass cards
- organize fields into logical blocks using `Card` components
- add user feedback via toast.loading during save
- tweak submit button style for clarity

## Testing
- `npx vitest run` *(fails: Cannot find package 'vite')*

------
https://chatgpt.com/codex/tasks/task_e_688b88283620832d92d0efb2f57eb878