### PR TITLE
Fix autocomplete insert with id references

### DIFF
--- a/src/components/produits/ProduitForm.jsx
+++ b/src/components/produits/ProduitForm.jsx
@@ -122,7 +122,7 @@ export default function ProduitForm({ produit, familles = [], unites = [], onSuc
                 onAddOption={async val => {
                   const { data, error } = await addFamille(val);
                   if (error) toast.error(error.message || error);
-                  else return { id: data.id, label: data.nom };
+                  else return { id: data.id, nom: data.nom };
                 }}
                 required
               />
@@ -137,7 +137,7 @@ export default function ProduitForm({ produit, familles = [], unites = [], onSuc
                 onAddOption={async val => {
                   const { data, error } = await addUnite(val);
                   if (error) toast.error(error.message || error);
-                  else return { id: data.id, label: data.nom };
+                  else return { id: data.id, nom: data.nom };
                 }}
                 required
               />

--- a/src/components/ui/AutoCompleteField.jsx
+++ b/src/components/ui/AutoCompleteField.jsx
@@ -47,7 +47,7 @@ export default function AutoCompleteField({
       const res = await onAddOption(inputValue);
       if (res && res.id) {
         onChange(res.id);
-        setInputValue(res.label || inputValue);
+        setInputValue(res.nom || inputValue);
       }
       setShowAdd(false);
     }

--- a/src/hooks/useFamilles.js
+++ b/src/hooks/useFamilles.js
@@ -63,7 +63,7 @@ export function useFamilles() {
     const { data, error } = await supabase
       .from("familles")
       .insert([{ nom, mama_id }])
-      .select()
+      .select("id, nom")
       .single();
     setLoading(false);
     if (error) {

--- a/src/hooks/useUnites.js
+++ b/src/hooks/useUnites.js
@@ -62,7 +62,7 @@ export function useUnites() {
     const { data, error } = await supabase
       .from("unites")
       .insert([{ nom, mama_id }])
-      .select()
+      .select("id, nom")
       .single();
     setLoading(false);
     if (error) {


### PR DESCRIPTION
## Summary
- use ids when creating new familles or unites
- return { id, nom } after inserting autocomplete values
- update ProduitForm to store ids

## Testing
- `npx vitest run` *(fails: Cannot find package 'vite')*
- `npm run test:e2e` *(skipped: Playwright browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688ba7abbdd4832d8ea1baccc7364ea9