### PR TITLE
Apply Liquid Glass styling to more layouts

### DIFF
--- a/src/components/CookieConsent.jsx
+++ b/src/components/CookieConsent.jsx
@@ -1,5 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useEffect } from "react";
+import Button from "@/components/ui/button";
+import PrimaryButton from "@/components/ui/PrimaryButton";
 
 export default function CookieConsent() {
   const [visible, setVisible] = useState(false);
@@ -27,12 +29,12 @@ export default function CookieConsent() {
         Nous utilisons des cookies pour améliorer votre expérience et réaliser des statistiques d'utilisation.
       </p>
       <div className="flex gap-2">
-        <button onClick={decline} className="px-4 py-1 rounded bg-white/20 hover:bg-white/30">
+        <Button onClick={decline} className="w-auto px-4 py-2" aria-label="Refuser">
           Refuser
-        </button>
-        <button onClick={accept} className="px-4 py-1 rounded bg-mamastockGold text-black hover:bg-mamastockGoldHover">
+        </Button>
+        <PrimaryButton onClick={accept} className="w-auto px-4 py-2" aria-label="Accepter">
           Accepter
-        </button>
+        </PrimaryButton>
       </div>
     </div>
   );

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -4,7 +4,7 @@ import { watermark } from "@/license";
 
 export default function Footer() {
   return (
-    <footer className="w-full bg-glass backdrop-blur-md border-t border-white/10 text-white/90 text-sm py-4 px-6 flex flex-col sm:flex-row items-center justify-between rounded-t-2xl shadow-lg">
+    <footer className="w-full bg-white/10 backdrop-blur-md border-t border-white/10 text-white/90 text-sm py-4 px-6 flex flex-col sm:flex-row items-center justify-between rounded-t-2xl shadow-lg">
       <span className="font-semibold tracking-wide mb-2 sm:mb-0">MamaStock 2025</span>
       <span className="flex items-center gap-4 flex-wrap">
         <Link to="/rgpd" className="underline hover:text-mamastockGold transition">

--- a/src/components/analytics/CostCenterAllocationModal.jsx
+++ b/src/components/analytics/CostCenterAllocationModal.jsx
@@ -80,7 +80,7 @@ export default function CostCenterAllocationModal({ mouvementId, produitId, open
         <h3 className="font-bold mb-4 text-lg">Ventilation centres de coûts</h3>
         <form onSubmit={handleSubmit} className="space-y-2">
           {suggestions.length > 0 && (
-            <div className="text-xs mb-2 p-2 bg-glass border border-borderGlass backdrop-blur rounded">
+            <div className="text-xs mb-2 p-2 bg-white/10 border border-white/20 backdrop-blur-xl rounded">
               Suggestions:
               <ul className="list-disc list-inside">
                 {suggestions.map(s => (

--- a/src/components/dashboard/DashboardCard.jsx
+++ b/src/components/dashboard/DashboardCard.jsx
@@ -15,7 +15,7 @@ export default function DashboardCard({ title, value, icon, type = "default", pr
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.3 }}
-      className={`bg-glass border border-borderGlass backdrop-blur rounded-2xl shadow-md p-4 flex flex-col items-center min-w-[180px] ${colorClass}`}
+      className={`bg-white/10 border border-white/20 backdrop-blur-xl rounded-2xl shadow-md p-4 flex flex-col items-center min-w-[180px] ${colorClass}`}
     >
       <div className="flex items-center space-x-2">
         {icon && <span className="text-2xl">{icon}</span>}

--- a/src/components/fournisseurs/FournisseurFormModal.jsx
+++ b/src/components/fournisseurs/FournisseurFormModal.jsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button";
 import toast from "react-hot-toast";
 import { motion as Motion } from "framer-motion";
 
-export default function FournisseurFormModal({ fournisseur, onClose, glass }) {
+export default function FournisseurFormModal({ fournisseur, onClose }) {
   const { createFournisseur, updateFournisseur } = useFournisseurs();
   const [form, setForm] = useState({
     nom: fournisseur?.nom || "",
@@ -57,7 +57,7 @@ export default function FournisseurFormModal({ fournisseur, onClose, glass }) {
       animate={{ scale: 1, opacity: 1 }}
       exit={{ scale: 0.98, opacity: 0 }}
       onSubmit={handleSubmit}
-      className={`rounded-xl p-6 space-y-4 ${glass ? "bg-white/80 backdrop-blur-xl shadow-2xl border border-mamastockGold" : "bg-white shadow"} min-w-[340px]`}
+      className="min-w-[340px] space-y-4 bg-white/10 backdrop-blur-xl border border-white/20 rounded-xl shadow-lg p-6 text-white"
    >
       <h3 className="text-xl font-bold mb-2">{fournisseur ? "Modifier" : "Ajouter"} un fournisseur</h3>
       <div>

--- a/src/components/fournisseurs/FournisseurRow.jsx
+++ b/src/components/fournisseurs/FournisseurRow.jsx
@@ -1,4 +1,5 @@
 import { Eye, Edit, Trash2 } from "lucide-react";
+import Button from "@/components/ui/button";
 
 export default function FournisseurRow({ fournisseur, productCount, onDetail, onEdit, onDelete, canEdit }) {
   return (
@@ -9,31 +10,34 @@ export default function FournisseurRow({ fournisseur, productCount, onDetail, on
       <td>{fournisseur.contact?.email}</td>
       <td>{productCount}</td>
       <td className="py-2 px-3">
-        <button
-          className="bg-white/20 hover:bg-white/30 text-white font-semibold px-3 py-1 rounded-xl flex items-center gap-1"
+        <Button
+          className="w-auto flex items-center gap-1"
           onClick={() => onDetail(fournisseur.id)}
+          aria-label="Voir"
         >
           <Eye size={16} />
           <span className="hidden sm:inline">Voir</span>
-        </button>
+        </Button>
       </td>
       <td className="py-2 px-3">
         {canEdit && (
           <div className="flex gap-2">
-            <button
-              className="bg-white/20 hover:bg-white/30 text-white font-semibold px-3 py-1 rounded-xl flex items-center gap-1"
+            <Button
+              className="w-auto flex items-center gap-1"
               onClick={() => onEdit(fournisseur)}
+              aria-label="Modifier"
             >
               <Edit size={16} />
               <span className="hidden sm:inline">Modifier</span>
-            </button>
-            <button
-              className="bg-white/20 hover:bg-white/30 text-white font-semibold px-3 py-1 rounded-xl flex items-center gap-1"
+            </Button>
+            <Button
+              className="w-auto flex items-center gap-1"
               onClick={() => onDelete(fournisseur.id)}
+              aria-label="Désactiver"
             >
               <Trash2 size={16} />
               <span className="hidden sm:inline">Désactiver</span>
-            </button>
+            </Button>
           </div>
         )}
       </td>

--- a/src/components/gadgets/GadgetAlerteStockFaible.jsx
+++ b/src/components/gadgets/GadgetAlerteStockFaible.jsx
@@ -14,7 +14,7 @@ export default function GadgetAlerteStockFaible() {
     );
 
   return (
-    <div className="bg-glass border border-borderGlass backdrop-blur rounded-2xl shadow-md p-4 text-white">
+    <div className="bg-white/10 border border-white/20 backdrop-blur-xl rounded-2xl shadow-md p-4 text-white">
       <h3 className="font-bold mb-2">Alerte stock faible</h3>
       <Motion.ul initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="space-y-2 text-sm">
         {data.map((p) => (

--- a/src/components/gadgets/GadgetBudgetMensuel.jsx
+++ b/src/components/gadgets/GadgetBudgetMensuel.jsx
@@ -16,7 +16,7 @@ export default function GadgetBudgetMensuel() {
   const progress = cible ? Math.min(100, (reel / cible) * 100) : 0;
 
   return (
-    <div className="bg-glass border border-borderGlass backdrop-blur rounded-2xl shadow-md p-4 text-white">
+    <div className="bg-white/10 border border-white/20 backdrop-blur-xl rounded-2xl shadow-md p-4 text-white">
       <h3 className="font-bold mb-2">Budget mensuel</h3>
       <div className="text-sm mb-2">Cible : {cible.toFixed(0)} €</div>
       <div className="text-sm mb-2">Réel : {reel.toFixed(0)} €</div>

--- a/src/components/gadgets/GadgetConsoMoyenne.jsx
+++ b/src/components/gadgets/GadgetConsoMoyenne.jsx
@@ -17,7 +17,7 @@ export default function GadgetConsoMoyenne() {
     <Motion.div
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
-      className="bg-glass border border-borderGlass backdrop-blur rounded-2xl shadow-md p-4 text-center text-white"
+      className="bg-white/10 border border-white/20 backdrop-blur-xl rounded-2xl shadow-md p-4 text-center text-white"
     >
       <h3 className="font-bold mb-2">Consommation moyenne / jour</h3>
       <div className="text-3xl font-extrabold">{avg.toFixed(2)}</div>

--- a/src/components/gadgets/GadgetDerniersAcces.jsx
+++ b/src/components/gadgets/GadgetDerniersAcces.jsx
@@ -14,7 +14,7 @@ export default function GadgetDerniersAcces() {
     );
 
   return (
-    <div className="bg-glass border border-borderGlass backdrop-blur rounded-2xl shadow-md p-4 text-white">
+    <div className="bg-white/10 border border-white/20 backdrop-blur-xl rounded-2xl shadow-md p-4 text-white">
       <h3 className="font-bold mb-2">Derniers accès</h3>
       <Motion.ul initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="space-y-2 text-sm">
         {data.map((u) => (

--- a/src/components/gadgets/GadgetEvolutionAchats.jsx
+++ b/src/components/gadgets/GadgetEvolutionAchats.jsx
@@ -14,7 +14,7 @@ export default function GadgetEvolutionAchats() {
     );
 
   return (
-    <div className="bg-glass border border-borderGlass backdrop-blur rounded-2xl shadow-md p-4 text-white">
+    <div className="bg-white/10 border border-white/20 backdrop-blur-xl rounded-2xl shadow-md p-4 text-white">
       <h3 className="font-bold mb-2">Évolution des achats</h3>
       <ResponsiveContainer width="100%" height={200}>
         <LineChart data={data} margin={{ left: -10, right: 10 }}>

--- a/src/components/gadgets/GadgetProduitsUtilises.jsx
+++ b/src/components/gadgets/GadgetProduitsUtilises.jsx
@@ -14,7 +14,7 @@ export default function GadgetProduitsUtilises() {
     );
 
   return (
-    <div className="bg-glass border border-borderGlass backdrop-blur rounded-2xl shadow-md p-4 text-white">
+    <div className="bg-white/10 border border-white/20 backdrop-blur-xl rounded-2xl shadow-md p-4 text-white">
       <h3 className="font-bold mb-2">Produits les plus utilisés</h3>
       <Motion.ul initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="space-y-2 text-sm">
         {data.map((p) => (

--- a/src/components/gadgets/GadgetTachesUrgentes.jsx
+++ b/src/components/gadgets/GadgetTachesUrgentes.jsx
@@ -14,7 +14,7 @@ export default function GadgetTachesUrgentes() {
     );
 
   return (
-    <div className="bg-glass border border-borderGlass backdrop-blur rounded-2xl shadow-md p-4 text-white">
+    <div className="bg-white/10 border border-white/20 backdrop-blur-xl rounded-2xl shadow-md p-4 text-white">
       <h3 className="font-bold mb-2">Tâches urgentes</h3>
       <Motion.ul initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="space-y-2 text-sm">
         {data.map((t) => (

--- a/src/components/gadgets/GadgetTopFournisseurs.jsx
+++ b/src/components/gadgets/GadgetTopFournisseurs.jsx
@@ -17,7 +17,7 @@ export default function GadgetTopFournisseurs() {
   }
 
   return (
-    <div className="bg-glass border border-borderGlass backdrop-blur rounded-2xl shadow-md p-4 text-white">
+    <div className="bg-white/10 border border-white/20 backdrop-blur-xl rounded-2xl shadow-md p-4 text-white">
       <h3 className="font-bold mb-2">Top fournisseurs du mois</h3>
       <Motion.ul initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="space-y-2 text-sm">
         {data.map((f) => (

--- a/src/components/help/DocumentationPanel.jsx
+++ b/src/components/help/DocumentationPanel.jsx
@@ -20,7 +20,7 @@ export default function DocumentationPanel({ open, onOpenChange }) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogOverlay className="fixed inset-0 bg-black/40" />
-      <DialogContent className="fixed right-0 top-0 bottom-0 w-96 bg-glass border border-borderGlass backdrop-blur p-4 overflow-y-auto">
+      <DialogContent className="fixed right-0 top-0 bottom-0 w-96 bg-white/10 border border-white/20 backdrop-blur-xl p-4 overflow-y-auto">
         <DialogTitle className="font-bold mb-2">Documentation</DialogTitle>
         <DialogDescription className="sr-only">
           Documentation interne

--- a/src/components/help/FeedbackForm.jsx
+++ b/src/components/help/FeedbackForm.jsx
@@ -49,7 +49,7 @@ export default function FeedbackForm({ open, onOpenChange }) {
           <label className="sr-only" htmlFor="message">Message</label>
           <textarea
             id="message"
-            className="w-full px-4 py-2 bg-white/20 text-white placeholder-white/70 rounded-md border border-white/30 backdrop-blur-sm focus:outline-none focus:ring-2 focus:ring-white/50 h-24"
+            className="textarea h-24"
             placeholder="Votre message"
             value={message}
             onChange={e => setMessage(e.target.value)}

--- a/src/components/help/GuidedTour.jsx
+++ b/src/components/help/GuidedTour.jsx
@@ -36,7 +36,7 @@ export default function GuidedTour({ steps = [], module }) {
           initial={{ opacity: 0, scale: 0.8 }}
           animate={{ opacity: 1, scale: 1 }}
           exit={{ opacity: 0 }}
-          className="fixed z-50 bg-glass border border-borderGlass backdrop-blur text-white p-4 rounded-xl shadow-xl"
+          className="fixed z-50 bg-white/10 border border-white/20 backdrop-blur-xl text-white p-4 rounded-xl shadow-xl"
           style={{ top: coords.top, left: coords.left }}
         >
           <p className="mb-2 text-sm">{step.content}</p>

--- a/src/components/ia/RecommandationsBox.jsx
+++ b/src/components/ia/RecommandationsBox.jsx
@@ -28,7 +28,7 @@ export default function RecommandationsBox({ filter }) {
         <div
           key={idx}
           onClick={() => rec.onClick?.(rec) || refresh()}
-          className="flex items-center gap-2 bg-glass border border-borderGlass backdrop-blur rounded-lg p-2 shadow cursor-pointer hover:bg-white/20 text-sm"
+          className="flex items-center gap-2 bg-white/10 border border-white/20 backdrop-blur-xl rounded-lg p-2 shadow cursor-pointer hover:bg-white/20 text-sm"
         >
           <span>{rec.type === 'alert' ? '🔍' : '🧠'}</span>
           <span className="flex-1">{rec.message}</span>

--- a/src/components/inventaires/InventaireDetail.jsx
+++ b/src/components/inventaires/InventaireDetail.jsx
@@ -31,7 +31,7 @@ export default function InventaireDetail({ inventaire, onClose }) {
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
-      <div className="bg-glass border border-borderGlass backdrop-blur rounded-2xl shadow-lg p-8 min-w-[400px] max-w-[95vw] flex flex-col gap-2 relative">
+      <div className="bg-white/10 border border-white/20 backdrop-blur-xl rounded-2xl shadow-lg p-8 min-w-[400px] max-w-[95vw] flex flex-col gap-2 relative">
         <Button variant="outline" className="absolute top-2 right-2" onClick={onClose}>Fermer</Button>
         <h2 className="font-bold text-xl mb-4">{inventaire.reference}</h2>
         <div><b>Date :</b> {inventaire.date_inventaire}</div>
@@ -44,7 +44,7 @@ export default function InventaireDetail({ inventaire, onClose }) {
         </div>
         <div className="my-4">
           <h3 className="font-bold mb-2">Lignes d’inventaire</h3>
-          <table className="min-w-full bg-glass border border-borderGlass rounded backdrop-blur">
+          <table className="min-w-full bg-white/10 border border-white/20 rounded backdrop-blur-xl">
             <thead>
               <tr>
                 <th>Produit</th>
@@ -73,7 +73,7 @@ export default function InventaireDetail({ inventaire, onClose }) {
         </div>
         <div className="my-4">
           <h3 className="font-bold mb-2">Mouvements liés</h3>
-          <table className="min-w-full bg-glass border border-borderGlass rounded backdrop-blur">
+          <table className="min-w-full bg-white/10 border border-white/20 rounded backdrop-blur-xl">
             <thead>
               <tr>
                 <th>Date</th>

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -17,7 +17,7 @@ export default function Sidebar() {
   const canAnalyse = has("analyse");
 
   return (
-    <aside className="w-64 bg-glass border border-white/10 backdrop-blur-xl text-white p-4 h-screen shadow-md text-shadow">
+    <aside className="w-64 bg-white/10 border border-white/10 backdrop-blur-xl text-white p-4 h-screen shadow-md text-shadow">
       <div className="mb-6">
         <MamaLogo width={140} />
       </div>

--- a/src/components/parametrage/UtilisateurRow.jsx
+++ b/src/components/parametrage/UtilisateurRow.jsx
@@ -83,7 +83,7 @@ export default function UtilisateurRow({
       </tr>
       {showHistory && (
         <tr>
-          <td colSpan={6} className="bg-glass border border-borderGlass backdrop-blur">
+          <td colSpan={6} className="bg-white/10 border border-white/20 backdrop-blur-xl">
             <div>
               <b>Connexions récentes :</b>
               <ul>

--- a/src/components/produits/ProduitForm.jsx
+++ b/src/components/produits/ProduitForm.jsx
@@ -10,6 +10,7 @@ import AutoCompleteField from "@/components/ui/AutoCompleteField";
 import { Input } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
 import SecondaryButton from "@/components/ui/SecondaryButton";
+import PrimaryButton from "@/components/ui/PrimaryButton";
 import GlassCard from "@/components/ui/GlassCard";
 import { Card, CardContent } from "@/components/ui/card";
 
@@ -209,14 +210,14 @@ export default function ProduitForm({ produit, familles = [], unites = [], onSuc
         <Card className="bg-white/10 backdrop-blur-lg border border-white/20 rounded-2xl shadow-lg text-white">
           <CardContent className="flex justify-end gap-2">
             <SecondaryButton type="button" onClick={onClose}>Annuler</SecondaryButton>
-            <button
+            <PrimaryButton
               type="submit"
               disabled={loading || saving}
-              className="bg-white/20 hover:bg-white/30 text-white font-bold py-2 px-4 rounded-xl backdrop-blur flex items-center gap-2"
+              className="flex items-center gap-2"
             >
               {(loading || saving) && <span className="loader-glass" />}
               {editing ? "Enregistrer" : "Créer"}
-            </button>
+            </PrimaryButton>
           </CardContent>
         </Card>
       </form>

--- a/src/components/security/TwoFactorSetup.jsx
+++ b/src/components/security/TwoFactorSetup.jsx
@@ -41,7 +41,7 @@ export default function TwoFactorSetup() {
   return (
     <div className="space-y-4">
       {!enabled && secret && (
-        <div className="p-4 bg-glass border border-borderGlass backdrop-blur rounded-2xl shadow">
+        <div className="p-4 bg-white/10 border border-white/20 backdrop-blur-xl rounded-2xl shadow">
           <p>Scannez ce QR code dans votre application d'authentification puis entrez le code :</p>
           {secret && (
             <QRCode value={`otpauth://totp/MamaStock?secret=${secret}`} />

--- a/src/components/stock/StockDetail.jsx
+++ b/src/components/stock/StockDetail.jsx
@@ -27,13 +27,13 @@ export default function StockDetail({ produit, mouvements, onClose }) {
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
-      <div className="bg-glass border border-borderGlass backdrop-blur rounded-2xl shadow-lg p-8 min-w-[400px] max-w-[95vw] flex flex-col gap-2 relative">
+      <div className="bg-white/10 border border-white/20 backdrop-blur-xl rounded-2xl shadow-lg p-8 min-w-[400px] max-w-[95vw] flex flex-col gap-2 relative">
         <Button variant="outline" className="absolute top-2 right-2" onClick={onClose}>Fermer</Button>
         <h2 className="font-bold text-xl mb-4">{produit.nom} — Mouvements</h2>
         <div className="mb-2">Stock réel : {produit.stock_reel} {produit.unite}</div>
         <div className="mb-2">Valorisation : {(produit.pmp * produit.stock_reel).toFixed(2)} €</div>
         <div>
-          <table className="min-w-full bg-glass border border-borderGlass rounded backdrop-blur text-xs">
+          <table className="min-w-full bg-white/10 border border-white/20 rounded backdrop-blur-xl text-xs">
             <thead>
               <tr>
                 <th>Date</th>

--- a/src/components/taches/TacheForm.jsx
+++ b/src/components/taches/TacheForm.jsx
@@ -73,7 +73,7 @@ export default function TacheForm({ task }) {
       <label className="block">
         <span>Description</span>
         <textarea
-          className="w-full px-4 py-2 bg-white/20 text-white placeholder-white/70 rounded-md border border-white/30 backdrop-blur-sm focus:outline-none focus:ring-2 focus:ring-white/50"
+          className="textarea"
           name="description"
           value={form.description}
           onChange={handleChange}

--- a/src/components/ui/AutoCompleteField.jsx
+++ b/src/components/ui/AutoCompleteField.jsx
@@ -62,7 +62,7 @@ export default function AutoCompleteField({
         list={`list-${label}`}
         value={inputValue}
         onChange={handleInputChange}
-        className={`bg-white/70 backdrop-blur text-black rounded-xl shadow-sm border border-white/40 ${isValid ? "border-mamastockGold" : ""}`}
+        className={`${isValid ? "border-mamastockGold" : ""}`}
         aria-label={label}
         aria-autocomplete="list"
         role="combobox"

--- a/src/components/ui/Button.jsx
+++ b/src/components/ui/Button.jsx
@@ -2,7 +2,7 @@
 export function Button({ children, className = '', ...props }) {
   return (
     <button
-      className={`w-full py-2 bg-white/30 text-white font-semibold rounded-md hover:bg-white/40 backdrop-blur focus:outline-none focus:ring-2 focus:ring-white/60 ${className}`}
+      className={`px-4 py-2 rounded-xl font-semibold bg-white/10 hover:bg-white/20 text-white transition-all ${className}`}
       {...props}
     >
       {children}

--- a/src/components/ui/Card.jsx
+++ b/src/components/ui/Card.jsx
@@ -2,7 +2,7 @@
 export function Card({ title, children, className = '' }) {
   return (
     <div
-      className={`bg-glass border border-borderGlass backdrop-blur rounded-2xl shadow-lg ${className}`}
+      className={`bg-white/10 border border-white/20 backdrop-blur-xl rounded-2xl shadow-lg ${className}`}
     >
       {title && <h2 className="text-xl font-bold mb-4 p-6 pb-0">{title}</h2>}
       {children}

--- a/src/components/ui/GlassCard.jsx
+++ b/src/components/ui/GlassCard.jsx
@@ -14,7 +14,7 @@ import React from 'react';
  */
 export function GlassCard({ children, title, footer, className = '', width = 'w-full max-w-lg' }) {
   return (
-    <div className={`relative ${width} rounded-2xl p-6 shadow-xl border border-white/20 bg-white/10 backdrop-blur-md text-white ${className}`}> 
+    <div className={`relative ${width} rounded-xl p-6 shadow-lg border border-white/20 bg-white/10 backdrop-blur-xl text-white ${className}`}>
       {title && <h2 className="text-xl font-semibold mb-4 text-white/90">{title}</h2>}
       <div className="space-y-4">{children}</div>
       {footer && <div className="mt-6">{footer}</div>}

--- a/src/components/ui/PageWrapper.jsx
+++ b/src/components/ui/PageWrapper.jsx
@@ -20,7 +20,7 @@ export default function PageWrapper({ children, className = '', intensity = 1 })
       <WavesBackground className="opacity-40" />
       <MouseLight />
       <TouchLight />
-      <div className={`w-full max-w-md relative z-10 bg-glass border border-borderGlass backdrop-blur p-6 rounded-2xl shadow-lg ${className}`}>{children}</div>
+      <div className={`w-full max-w-md relative z-10 bg-white/10 border border-white/20 backdrop-blur-xl p-6 rounded-2xl shadow-lg ${className}`}>{children}</div>
     </div>
   );
 }

--- a/src/components/ui/PreviewBanner.jsx
+++ b/src/components/ui/PreviewBanner.jsx
@@ -10,7 +10,7 @@ export default function PreviewBanner() {
   params.delete('preview');
   const exitUrl = `${window.location.pathname}?${params.toString()}`.replace(/\?$/, '');
   return (
-    <div className="fixed top-2 left-1/2 -translate-x-1/2 bg-glass backdrop-blur border border-borderGlass text-white px-4 py-1 rounded-xl z-50 text-sm shadow">
+    <div className="fixed top-2 left-1/2 -translate-x-1/2 bg-white/10 backdrop-blur-xl border border-white/20 text-white px-4 py-1 rounded-xl z-50 text-sm shadow">
       Aperçu du thème actif
       {intensity && ` (intensité ${intensity})`} -{' '}
       <Link to={exitUrl} className="underline">Quitter</Link>

--- a/src/components/ui/PrimaryButton.jsx
+++ b/src/components/ui/PrimaryButton.jsx
@@ -2,7 +2,7 @@
 export default function PrimaryButton({ children, className = '', ...props }) {
   return (
     <button
-      className={`w-full py-2 bg-white/30 text-white font-semibold rounded-md hover:bg-white/40 backdrop-blur focus:outline-none focus:ring-2 focus:ring-white/60 ${className}`}
+      className={`px-4 py-2 rounded-xl font-semibold bg-white/10 hover:bg-white/20 text-white transition-all ${className}`}
       {...props}
     >
       {children}

--- a/src/components/ui/SecondaryButton.jsx
+++ b/src/components/ui/SecondaryButton.jsx
@@ -2,7 +2,7 @@
 export default function SecondaryButton({ children, className = '', ...props }) {
   return (
     <button
-      className={`w-full py-2 bg-white/30 text-white font-semibold rounded-md hover:bg-white/40 backdrop-blur focus:outline-none focus:ring-2 focus:ring-white/60 ${className}`}
+      className={`px-4 py-2 rounded-xl font-semibold bg-white/10 hover:bg-white/20 text-white transition-all ${className}`}
       {...props}
     >
       {children}

--- a/src/components/ui/SmartDialog.jsx
+++ b/src/components/ui/SmartDialog.jsx
@@ -33,7 +33,7 @@ export default function SmartDialog({ open, onClose, title, description, childre
                 exit={{ opacity: 0, scale: 0.95 }}
                 transition={{ type: "spring", stiffness: 260, damping: 20 }}
               >
-                <div className="relative bg-glass border border-borderGlass backdrop-blur rounded-2xl shadow-xl p-6 w-full max-w-lg">
+                <div className="relative bg-white/10 border border-white/20 backdrop-blur-xl rounded-2xl shadow-xl p-6 w-full max-w-lg">
                   {title && (
                     <DialogTitle className="text-lg font-semibold mb-4">
                       {title}

--- a/src/components/ui/StatCard.jsx
+++ b/src/components/ui/StatCard.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 export default function StatCard({ label, value, variation = null, icon: Icon }) {
   return (
-    <div className="bg-glass border border-borderGlass backdrop-blur rounded-xl shadow p-4 flex items-center gap-3">
+    <div className="bg-white/10 border border-white/20 backdrop-blur-xl rounded-xl shadow p-4 flex items-center gap-3">
       {Icon && <Icon className="w-5 h-5 text-mamastock-gold" />}
       <div className="flex flex-col">
         <span className="text-xs text-gray-400">{label}</span>

--- a/src/components/ui/TableContainer.jsx
+++ b/src/components/ui/TableContainer.jsx
@@ -4,7 +4,7 @@ import React from "react";
 export default function TableContainer({ className = "", children, ...props }) {
   return (
     <div
-      className={`bg-glass border border-borderGlass backdrop-blur-lg rounded-xl shadow-md overflow-x-auto ${className}`}
+      className={`bg-white/5 text-white border border-white/10 rounded-xl overflow-x-auto ${className}`}
       {...props}
     >
       {children}

--- a/src/components/ui/badge.jsx
+++ b/src/components/ui/badge.jsx
@@ -4,7 +4,7 @@
 export function Badge({ children, color = "gold", className = "", ariaLabel }) {
   const colorClasses = {
     gold: "bg-mamastock-gold text-white",
-    gray: "bg-white/20 text-white backdrop-blur",
+    gray: "bg-white/20 text-white backdrop-blur-xl",
     red: "bg-red-500 text-white",
     green: "bg-green-500 text-white",
     blue: "bg-blue-500 text-white",

--- a/src/components/ui/button.jsx
+++ b/src/components/ui/button.jsx
@@ -2,7 +2,7 @@
 export function Button({ children, className = '', ...props }) {
   return (
     <button
-      className={`w-full py-2 bg-white/30 text-white font-semibold rounded-md hover:bg-white/40 backdrop-blur focus:outline-none focus:ring-2 focus:ring-white/60 ${className}`}
+      className={`px-4 py-2 rounded-xl font-semibold bg-white/10 hover:bg-white/20 text-white transition-all ${className}`}
       {...props}
     >
       {children}

--- a/src/components/ui/card.jsx
+++ b/src/components/ui/card.jsx
@@ -1,9 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 export function Card({ title, children, className = '' }) {
   return (
-    <div
-      className={`bg-glass border border-borderGlass backdrop-blur rounded-2xl shadow-lg ${className}`}
-    >
+    <div className={`bg-white/10 backdrop-blur-xl border border-white/20 rounded-xl shadow-lg text-white ${className}`}>
       {title && <h2 className="text-xl font-bold mb-4 p-6 pb-0">{title}</h2>}
       {children}
     </div>

--- a/src/components/ui/input.jsx
+++ b/src/components/ui/input.jsx
@@ -19,7 +19,7 @@ export function Input({
       placeholder={placeholder}
       disabled={disabled}
       aria-label={ariaLabel || placeholder || "Champ de saisie"}
-      className={`w-full px-4 py-2 bg-white/70 text-black placeholder-black/60 rounded-xl shadow-sm border border-white/40 backdrop-blur focus:outline-none focus:ring-2 focus:ring-mamastockGold disabled:opacity-50 disabled:cursor-not-allowed ${className}`}
+      className={`w-full px-4 py-2 font-semibold text-white placeholder-white/50 bg-white/10 backdrop-blur-xl rounded-xl shadow-lg border border-white/20 focus:outline-none focus:ring-2 focus:ring-white/50 disabled:opacity-50 disabled:cursor-not-allowed ${className}`}
       {...props}
     />
   );

--- a/src/components/ui/select.jsx
+++ b/src/components/ui/select.jsx
@@ -14,7 +14,7 @@ export function Select({
       value={value}
       onChange={onChange}
       aria-label={ariaLabel || "Sélection"}
-      className={`w-full px-4 py-2 bg-white/70 text-black rounded-xl shadow-sm border border-white/40 backdrop-blur focus:outline-none focus:ring-2 focus:ring-mamastockGold ${className}`}
+      className={`w-full px-4 py-2 font-semibold text-white bg-white/10 backdrop-blur-xl rounded-xl shadow-lg border border-white/20 focus:outline-none focus:ring-2 focus:ring-white/50 ${className}`}
       {...props}
     >
       {children}

--- a/src/components/utilisateurs/UtilisateurDetail.jsx
+++ b/src/components/utilisateurs/UtilisateurDetail.jsx
@@ -9,7 +9,7 @@ export default function UtilisateurDetail({ utilisateur, onClose }) {
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
-      <div className="bg-glass border border-borderGlass backdrop-blur rounded-2xl shadow-lg p-8 min-w-[400px] max-w-[95vw] flex flex-col gap-2 relative">
+      <div className="bg-white/10 border border-white/20 backdrop-blur-xl rounded-2xl shadow-lg p-8 min-w-[400px] max-w-[95vw] flex flex-col gap-2 relative">
         <Button variant="outline" className="absolute top-2 right-2" onClick={onClose}>Fermer</Button>
         <h2 className="font-bold text-xl mb-4">{utilisateur.nom || utilisateur.email}</h2>
         <div><b>Rôle :</b> {utilisateur.role}</div>

--- a/src/globals.css
+++ b/src/globals.css
@@ -52,7 +52,7 @@ a:hover {
 /* Buttons pro */
 .btn,
 .btn-primary {
-  @apply px-4 py-2 rounded-xl font-bold bg-white/10 text-white shadow hover:shadow-md transition backdrop-blur-lg;
+  @apply px-4 py-2 rounded-xl font-semibold bg-white/10 text-white hover:bg-white/20 transition-all backdrop-blur-xl;
 }
 .btn-sm {
   @apply px-2 py-1 text-sm;
@@ -69,18 +69,23 @@ a:hover {
   @apply bg-blue-600 text-white;
 }
 .badge-user {
-  @apply bg-white/20 text-white backdrop-blur;
+  @apply bg-white/20 text-white backdrop-blur-xl;
 }
 
 /* Input custom */
 .input {
-  @apply w-full px-4 py-2 bg-white/20 text-white placeholder-white/70 rounded-md border border-white/30 backdrop-blur-sm focus:outline-none focus:ring-2 focus:ring-white/50;
+  @apply w-full px-4 py-2 font-semibold text-white placeholder-white/50 bg-white/10 backdrop-blur-xl rounded-xl shadow-lg border border-white/20 focus:outline-none focus:ring-2 focus:ring-white/50;
 }
 .textarea {
-  @apply w-full px-4 py-2 bg-white/20 text-white placeholder-white/70 rounded-md border border-white/30 backdrop-blur-sm focus:outline-none focus:ring-2 focus:ring-white/50;
+  @apply w-full px-4 py-2 font-semibold text-white placeholder-white/50 bg-white/10 backdrop-blur-xl rounded-xl shadow-lg border border-white/20 focus:outline-none focus:ring-2 focus:ring-white/50;
 }
 .select {
-  @apply w-full px-4 py-2 bg-white/20 text-white placeholder-white/70 rounded-md border border-white/30 backdrop-blur-sm focus:outline-none focus:ring-2 focus:ring-white/50;
+  @apply w-full px-4 py-2 font-semibold text-white placeholder-white/50 bg-white/10 backdrop-blur-xl rounded-xl shadow-lg border border-white/20 focus:outline-none focus:ring-2 focus:ring-white/50;
+}
+
+/* Tables */
+.table-striped tbody tr:nth-child(even) {
+  @apply bg-white/5;
 }
 
 /* Dark mode auto */

--- a/src/layout/Navbar.jsx
+++ b/src/layout/Navbar.jsx
@@ -65,7 +65,7 @@ export default function Navbar() {
             aria-label={t('search')}
           />
           {results.length > 0 && (
-            <div className="absolute z-10 bg-glass backdrop-blur border border-borderGlass text-white w-full shadow-lg mt-1 text-xs rounded">
+            <div className="absolute z-10 bg-white/10 backdrop-blur-xl border border-white/20 text-white w-full shadow-lg mt-1 text-xs rounded">
               {results.map(r => (
                 <div key={r.type + r.id} className="px-2 py-1 border-b last:border-0">
                   {r.type}: {r.nom}

--- a/src/layout/Sidebar.jsx
+++ b/src/layout/Sidebar.jsx
@@ -182,7 +182,7 @@ export default function Sidebar() {
   ];
 
   return (
-    <aside className="w-64 bg-glass border border-white/10 backdrop-blur-xl text-white p-4 h-screen shadow-md text-shadow hidden md:block animate-fade-in-down">
+    <aside className="w-64 bg-white/10 border border-white/10 backdrop-blur-xl text-white p-4 h-screen shadow-md text-shadow hidden md:block animate-fade-in-down">
       <nav className="flex flex-col gap-4 text-sm">
         {peutVoir("dashboard") && (
           <Item to="/dashboard" icon={<Home size={16} />} label="Dashboard" />

--- a/src/layout/ViewerLayout.jsx
+++ b/src/layout/ViewerLayout.jsx
@@ -20,7 +20,7 @@ export default function ViewerLayout({ children }) {
       <TouchLight />
       <Navbar />
       <main className="flex-1 px-4 py-6 flex justify-center items-start overflow-y-auto relative z-10">
-        <div className="w-full max-w-5xl bg-glass backdrop-blur-lg border border-borderGlass rounded-xl shadow-md p-6">
+        <div className="w-full max-w-5xl bg-white/10 backdrop-blur-xl border border-white/20 rounded-xl shadow-md p-6 text-white">
           {children}
         </div>
       </main>

--- a/src/pages/Accueil.jsx
+++ b/src/pages/Accueil.jsx
@@ -43,7 +43,7 @@ export default function Accueil() {
           transition={{ duration: 0.8 }}
           className="w-full max-w-md"
         >
-          <div className="bg-glass border border-borderGlass backdrop-blur-lg rounded-3xl shadow-xl p-6 flex flex-col items-center">
+          <div className="bg-white/10 border border-white/20 backdrop-blur-lg rounded-3xl shadow-xl p-6 flex flex-col items-center">
             <img
               src={logoMamaStock}
               alt="MamaStock"

--- a/src/pages/BarManager.jsx
+++ b/src/pages/BarManager.jsx
@@ -192,7 +192,7 @@ export default function BarManager() {
         <Button onClick={handleExportPDF}>Export PDF</Button>
       </div>
       {/* Stat globales */}
-      <div className="bg-glass backdrop-blur border border-borderGlass rounded-xl shadow p-4 mb-6 flex flex-wrap gap-6">
+      <div className="bg-white/10 backdrop-blur-xl border border-white/20 rounded-xl shadow p-4 mb-6 flex flex-wrap gap-6">
         <div>
           <span className="font-semibold text-blue-700">Ventes totales :</span>
           <span className="font-bold"> {ventesTot} </span>
@@ -216,7 +216,7 @@ export default function BarManager() {
         </div>
       </div>
       {/* Graphe top ventes */}
-      <div className="bg-glass backdrop-blur border border-borderGlass rounded-xl shadow p-4 mb-6">
+      <div className="bg-white/10 backdrop-blur-xl border border-white/20 rounded-xl shadow p-4 mb-6">
         <h2 className="font-bold mb-2">Top 10 ventes (période sélectionnée)</h2>
         <ResponsiveContainer width="100%" height={200}>
           <BarChart data={topVentes}>
@@ -230,7 +230,7 @@ export default function BarManager() {
         </ResponsiveContainer>
       </div>
       {/* Graphe top marges */}
-      <div className="bg-glass backdrop-blur border border-borderGlass rounded-xl shadow p-4 mb-6">
+      <div className="bg-white/10 backdrop-blur-xl border border-white/20 rounded-xl shadow p-4 mb-6">
         <h2 className="font-bold mb-2">Top 10 marges boissons</h2>
         <ResponsiveContainer width="100%" height={200}>
           <BarChart data={topMarge}>
@@ -276,7 +276,7 @@ export default function BarManager() {
                         </Button>
                       </DialogTrigger>
                       <DialogContent
-                        className="bg-glass backdrop-blur-lg border border-borderGlass rounded-xl shadow-lg p-6 max-w-md z-[1000]"
+                        className="bg-white/10 backdrop-blur-lg border border-white/20 rounded-xl shadow-lg p-6 max-w-md z-[1000]"
                       >
                         <h2 className="font-bold text-xl mb-2">{b.nom}</h2>
                         <p>

--- a/src/pages/MenuEngineering.jsx
+++ b/src/pages/MenuEngineering.jsx
@@ -125,7 +125,7 @@ export default function MenuEngineering() {
         </Button>
         <Button variant="outline" onClick={exportPdf}>Export</Button>
       </div>
-      <div id="matrix" className="w-full h-80 bg-glass border border-borderGlass backdrop-blur rounded">
+      <div id="matrix" className="w-full h-80 bg-white/10 border border-white/20 backdrop-blur-xl rounded">
         <ResponsiveContainer width="100%" height="100%">
           <ScatterChart>
             <CartesianGrid />

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -15,7 +15,7 @@ export default function NotFound() {
       <MouseLight />
       <TouchLight />
 
-      <div className="relative z-10 rounded-2xl shadow-2xl bg-glass border border-borderGlass backdrop-blur-xl px-12 py-16 text-center">
+      <div className="relative z-10 rounded-2xl shadow-2xl bg-white/10 backdrop-blur-xl border border-white/20 px-12 py-16 text-center">
         <h1 className="text-6xl font-bold text-mamastockGold mb-4 drop-shadow-md">404</h1>
         <p className="text-xl text-mamastockText mb-6">Page non trouvée</p>
         <Link

--- a/src/pages/Rgpd.jsx
+++ b/src/pages/Rgpd.jsx
@@ -78,7 +78,7 @@ export default function Rgpd() {
               <Motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
                 <Link
                   to="/"
-                  className="inline-block px-6 py-2 rounded-xl bg-glass border border-borderGlass hover:bg-white/20 transition backdrop-blur"
+                  className="inline-block px-6 py-2 rounded-xl bg-white/10 border border-white/20 hover:bg-white/20 transition backdrop-blur-xl"
                 >
                   Retour à l’accueil
                 </Link>

--- a/src/pages/Transferts.jsx
+++ b/src/pages/Transferts.jsx
@@ -346,7 +346,7 @@ export default function Transferts() {
                         Timeline
                       </Button>
                     </DialogTrigger>
-                    <DialogContent className="bg-glass backdrop-blur-lg rounded-xl shadow-lg p-6 max-w-lg">
+                    <DialogContent className="bg-white/10 backdrop-blur-lg rounded-xl shadow-lg p-6 max-w-lg">
                       <h3 className="font-bold mb-2">
                         Timeline transferts : {t.nom}
                       </h3>
@@ -389,7 +389,7 @@ export default function Transferts() {
         open={showCreate}
         onOpenChange={(v) => !v && setShowCreate(false)}
       >
-        <DialogContent className="bg-glass backdrop-blur-lg rounded-xl shadow-lg p-6 max-w-md">
+        <DialogContent className="bg-white/10 backdrop-blur-lg rounded-xl shadow-lg p-6 max-w-md">
           <h2 className="font-bold mb-2">Nouveau transfert de stock</h2>
           <form onSubmit={handleCreateTf} className="space-y-3">
             <div>

--- a/src/pages/aide/AideForm.jsx
+++ b/src/pages/aide/AideForm.jsx
@@ -72,7 +72,7 @@ export default function AideForm({ article, onClose, onSaved }) {
           onChange={handleChange}
         />
         <textarea
-          className="w-full px-4 py-2 bg-white/20 text-white placeholder-white/70 rounded-md border border-white/30 backdrop-blur-sm focus:outline-none focus:ring-2 focus:ring-white/50 h-32"
+          className="textarea h-32"
           name="contenu"
           placeholder="Contenu"
           value={values.contenu}

--- a/src/pages/analyse/MenuEngineering.jsx
+++ b/src/pages/analyse/MenuEngineering.jsx
@@ -41,7 +41,7 @@ export default function MenuEngineering() {
         <Button onClick={() => fetchData(filters)}>Rafraîchir</Button>
         <Button variant="outline" onClick={exportPdf}>Export</Button>
       </div>
-      <div id="matrix" className="w-full h-80 bg-glass border border-borderGlass backdrop-blur rounded">
+      <div id="matrix" className="w-full h-80 bg-white/10 border border-white/20 backdrop-blur-xl rounded">
         <ResponsiveContainer width="100%" height="100%">
           <ScatterChart>
             <CartesianGrid />

--- a/src/pages/auth/CreateMama.jsx
+++ b/src/pages/auth/CreateMama.jsx
@@ -6,6 +6,8 @@ import useAuth from "@/hooks/useAuth";
 import PageWrapper from "@/components/ui/PageWrapper";
 import GlassCard from "@/components/ui/GlassCard";
 import MamaLogo from "@/components/ui/MamaLogo";
+import { Input } from "@/components/ui/input";
+import PrimaryButton from "@/components/ui/PrimaryButton";
 import toast from "react-hot-toast";
 
 export default function CreateMama() {
@@ -33,6 +35,7 @@ export default function CreateMama() {
         .update({ mama_id: mama.id })
         .eq("auth_id", auth_id);
       await refreshUser();
+      toast.success("Établissement créé");
       navigate("/onboarding");
     } catch (err) {
       if (err?.message) toast.error(err.message);
@@ -51,19 +54,17 @@ export default function CreateMama() {
           </div>
           <div>
             <label className="block text-sm text-white mb-1">Nom du restaurant</label>
-            <input
-              className="w-full rounded border border-white/30 bg-white/20 py-2 px-3 text-white placeholder-white/70"
+            <Input
+              className="w-full"
               value={nom}
               onChange={e => setNom(e.target.value)}
               required
+              placeholder="Nom du restaurant"
             />
           </div>
-          <button
-            className="w-full py-2 rounded bg-mamastockGold text-mamastockBg font-semibold hover:bg-mamastockGoldHover transition"
-            disabled={loading}
-          >
+          <PrimaryButton type="submit" className="w-full" disabled={loading}>
             {loading ? "Enregistrement..." : "Valider"}
-          </button>
+          </PrimaryButton>
         </form>
       </GlassCard>
     </PageWrapper>

--- a/src/pages/auth/ResetPassword.jsx
+++ b/src/pages/auth/ResetPassword.jsx
@@ -5,6 +5,7 @@ import logo from "@/assets/logo-mamastock.png";
 import toast, { Toaster } from "react-hot-toast";
 import GlassCard from "@/components/ui/GlassCard";
 import PageWrapper from "@/components/ui/PageWrapper";
+import { Input } from "@/components/ui/input";
 import PrimaryButton from "@/components/ui/PrimaryButton";
 
 export default function ResetPassword() {
@@ -37,8 +38,7 @@ export default function ResetPassword() {
           <p className="text-center">Un email vous a été envoyé si cette adresse est connue.</p>
         ) : (
           <form onSubmit={handleSubmit} className="w-full flex flex-col gap-4">
-            <input
-              className="w-full rounded-xl border border-gold/30 bg-white/70 dark:bg-[#202638]/50 py-2 px-4 text-background dark:text-white placeholder-white/40 focus:outline-none focus:ring-2 focus:ring-gold/30 backdrop-blur transition"
+            <Input
               type="email"
               value={email}
               onChange={e => setEmail(e.target.value)}

--- a/src/pages/auth/UpdatePassword.jsx
+++ b/src/pages/auth/UpdatePassword.jsx
@@ -6,6 +6,7 @@ import logo from "@/assets/logo-mamastock.png";
 import toast, { Toaster } from "react-hot-toast";
 import GlassCard from "@/components/ui/GlassCard";
 import PageWrapper from "@/components/ui/PageWrapper";
+import { Input } from "@/components/ui/input";
 import PrimaryButton from "@/components/ui/PrimaryButton";
 
 export default function UpdatePassword() {
@@ -43,16 +44,14 @@ export default function UpdatePassword() {
           <p className="text-center">{message}</p>
         ) : (
           <form onSubmit={handleUpdate} className="w-full flex flex-col gap-4">
-            <input
-              className="w-full rounded-xl border border-gold/30 bg-white/70 dark:bg-[#202638]/50 py-2 px-4 text-background dark:text-white placeholder-white/40 focus:outline-none focus:ring-2 focus:ring-gold/30 backdrop-blur transition"
+            <Input
               type="password"
               value={password}
               onChange={e => setPassword(e.target.value)}
               placeholder="Nouveau mot de passe"
               required
             />
-            <input
-              className="w-full rounded-xl border border-gold/30 bg-white/70 dark:bg-[#202638]/50 py-2 px-4 text-background dark:text-white placeholder-white/40 focus:outline-none focus:ring-2 focus:ring-gold/30 backdrop-blur transition"
+            <Input
               type="password"
               value={confirm}
               onChange={e => setConfirm(e.target.value)}

--- a/src/pages/bons_livraison/BLDetail.jsx
+++ b/src/pages/bons_livraison/BLDetail.jsx
@@ -24,7 +24,7 @@ export default function BLDetail({ bon: bonProp, onClose }) {
 
   return (
     <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50">
-      <div className="bg-glass backdrop-blur-lg border border-borderGlass rounded-xl shadow-lg p-8 min-w-[400px] max-w-[95vw] flex flex-col gap-2 relative">
+      <div className="bg-white/10 backdrop-blur-lg border border-white/20 rounded-xl shadow-lg p-8 min-w-[400px] max-w-[95vw] flex flex-col gap-2 relative">
         <Button variant="outline" className="absolute top-2 right-2" onClick={onClose}>Fermer</Button>
         <h2 className="font-bold text-xl mb-4">Bon de livraison #{bon.numero_bl}</h2>
         <div><b>Date :</b> {bon.date_reception}</div>

--- a/src/pages/costboisson/CostBoisson.jsx
+++ b/src/pages/costboisson/CostBoisson.jsx
@@ -311,7 +311,7 @@ export default function CostBoissons() {
                           </Button>
                         </DialogTrigger>
                         <DialogContent
-                          className="bg-glass backdrop-blur-lg border border-borderGlass rounded-xl shadow-lg p-6 max-w-md z-[1000]"
+                          className="bg-white/10 backdrop-blur-lg border border-white/20 rounded-xl shadow-lg p-6 max-w-md z-[1000]"
                         >
                           <DialogTitle className="font-bold text-xl mb-2">
                             {b.nom}
@@ -390,7 +390,7 @@ export default function CostBoissons() {
                           <Button variant="ghost" className="text-sm">Voir fiche</Button>
                         </DialogTrigger>
                         <DialogContent
-                          className="bg-glass backdrop-blur-lg border border-borderGlass rounded-xl shadow-lg p-6 max-w-md z-[1000]"
+                          className="bg-white/10 backdrop-blur-lg border border-white/20 rounded-xl shadow-lg p-6 max-w-md z-[1000]"
                         >
                           <DialogTitle className="font-bold text-xl mb-2">
                             {b.nom}

--- a/src/pages/dashboard/DashboardBuilder.jsx
+++ b/src/pages/dashboard/DashboardBuilder.jsx
@@ -90,7 +90,7 @@ export default function DashboardBuilder() {
         className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6"
       >
         {ordered.map((w) => (
-          <Reorder.Item key={w.id} value={w} className="bg-glass backdrop-blur border border-borderGlass rounded-xl p-4 relative">
+          <Reorder.Item key={w.id} value={w} className="bg-white/10 backdrop-blur-xl border border-white/20 rounded-xl p-4 relative">
             <button
               className="absolute top-2 right-2 text-red-600"
               onClick={() => deleteWidget(current.id, w.id)}

--- a/src/pages/debug/Debug.jsx
+++ b/src/pages/debug/Debug.jsx
@@ -28,7 +28,7 @@ export default function Debug() {
           </div>
           <div>
             <strong>Access Rights :</strong>
-            <pre className="bg-glass text-sm border border-borderGlass backdrop-blur rounded p-3 mt-2">
+            <pre className="bg-white/10 text-sm border border-white/20 backdrop-blur-xl rounded p-3 mt-2">
               {JSON.stringify(access_rights, null, 2)}
             </pre>
           </div>

--- a/src/pages/documents/DocumentForm.jsx
+++ b/src/pages/documents/DocumentForm.jsx
@@ -44,7 +44,7 @@ export default function DocumentForm({ onUploaded, entiteType = "", entiteId = n
       />
       <label className="block text-sm mb-1">Commentaire</label>
       <textarea
-        className="w-full px-4 py-2 bg-white/20 text-white placeholder-white/70 rounded-md border border-white/30 backdrop-blur-sm focus:outline-none focus:ring-2 focus:ring-white/50"
+        className="w-full px-4 py-2 font-semibold text-white placeholder-white/50 bg-white/10 backdrop-blur-xl rounded-xl shadow-lg border border-white/20 focus:outline-none focus:ring-2 focus:ring-white/50"
         placeholder="Commentaire"
         value={commentaire}
         onChange={e => setCommentaire(e.target.value)}

--- a/src/pages/factures/FactureDetail.jsx
+++ b/src/pages/factures/FactureDetail.jsx
@@ -69,7 +69,7 @@ export default function FactureDetail({ facture: factureProp, onClose }) {
 
   return (
     <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50">
-      <div className="bg-glass backdrop-blur-lg border border-borderGlass rounded-xl shadow-lg p-8 min-w-[400px] max-w-[95vw] flex flex-col gap-2 relative">
+      <div className="bg-white/10 backdrop-blur-lg border border-white/20 rounded-xl shadow-lg p-8 min-w-[400px] max-w-[95vw] flex flex-col gap-2 relative">
         <Button variant="outline" className="absolute top-2 right-2" onClick={onClose}>Fermer</Button>
         <h2 className="font-bold text-xl mb-4">Détail de la facture #{facture.id}</h2>
         <div><b>Date :</b> {facture.date_facture}</div>
@@ -100,7 +100,7 @@ export default function FactureDetail({ facture: factureProp, onClose }) {
         {produitsFacture.length > 0 && (
           <TableContainer className="mt-4">
             <table className="min-w-full text-sm">
-            <thead className="bg-glass border-b border-borderGlass">
+            <thead className="bg-white/10 border-b border-white/20">
               <tr>
                 <th className="px-2 py-1 border">Produit</th>
                 <th className="px-2 py-1 border">Quantité</th>

--- a/src/pages/factures/FactureForm.jsx
+++ b/src/pages/factures/FactureForm.jsx
@@ -289,7 +289,7 @@ export default function FactureForm({ facture, fournisseurs = [], onClose }) {
           {ocrText}
         </div>
       )}
-      <div className="mt-4 p-2 bg-glass backdrop-blur rounded border border-borderGlass">
+      <div className="mt-4 p-2 bg-white/10 backdrop-blur-xl rounded border border-white/20">
         Total HT: {lignes.reduce((s,l)=>s+l.quantite*l.prix_unitaire,0).toFixed(2)} € - TVA: {lignes.reduce((s,l)=>s+l.quantite*l.prix_unitaire*(l.tva||0)/100,0).toFixed(2)} € - TTC: {(lignes.reduce((s,l)=>s+l.quantite*l.prix_unitaire,0)+lignes.reduce((s,l)=>s+l.quantite*l.prix_unitaire*(l.tva||0)/100,0)).toFixed(2)} €
       </div>
       <div className="flex gap-2 mt-4">

--- a/src/pages/fiches/FicheDetail.jsx
+++ b/src/pages/fiches/FicheDetail.jsx
@@ -82,7 +82,7 @@ export default function FicheDetail({ fiche: ficheProp, onClose }) {
 
   return (
     <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50">
-      <div className="bg-glass backdrop-blur-lg text-white rounded-xl shadow-lg p-8 min-w-[400px] max-w-[95vw] flex flex-col gap-2 relative text-shadow">
+      <div className="bg-white/10 backdrop-blur-lg text-white rounded-xl shadow-lg p-8 min-w-[400px] max-w-[95vw] flex flex-col gap-2 relative text-shadow">
         <Button variant="outline" className="absolute top-2 right-2" onClick={onClose}>Fermer</Button>
         <h2 className="font-bold text-xl mb-4">{fiche.nom}</h2>
         {fiche.famille?.nom && (
@@ -120,7 +120,7 @@ export default function FicheDetail({ fiche: ficheProp, onClose }) {
         </div>
         <div className="mt-6">
           <h3 className="font-semibold mb-2">Analyse rentabilité</h3>
-          <div className="h-32 bg-glass border border-borderGlass backdrop-blur rounded mb-2">
+          <div className="h-32 bg-white/10 border border-white/20 backdrop-blur-xl rounded mb-2">
             <ResponsiveContainer width="100%" height="100%">
               <LineChart data={(history || []).map(h => ({ date: new Date(h.date).toLocaleDateString('fr-FR'), marge: h.prix_vente && h.cout_portion ? ((h.prix_vente - h.cout_portion) / h.prix_vente) * 100 : null }))}>
                 <XAxis dataKey="date" hide />

--- a/src/pages/fournisseurs/FournisseurCreate.jsx
+++ b/src/pages/fournisseurs/FournisseurCreate.jsx
@@ -9,7 +9,7 @@ export default function FournisseurCreate() {
     <div className="relative min-h-screen flex items-center justify-center overflow-hidden p-6 text-white">
       <LiquidBackground showParticles />
       <GlassCard className="relative z-10">
-        <FournisseurFormModal onClose={() => navigate(-1)} glass />
+        <FournisseurFormModal onClose={() => navigate(-1)} />
       </GlassCard>
     </div>
   );

--- a/src/pages/fournisseurs/Fournisseurs.jsx
+++ b/src/pages/fournisseurs/Fournisseurs.jsx
@@ -7,6 +7,7 @@ import { useProduitsFournisseur } from "@/hooks/useProduitsFournisseur";
 import { useProducts } from "@/hooks/useProducts";
 import { useFournisseursInactifs } from "@/hooks/useFournisseursInactifs";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
 import FournisseurRow from "@/components/fournisseurs/FournisseurRow";
 import { Dialog, DialogContent } from "@radix-ui/react-dialog";
 import jsPDF from "jspdf";
@@ -122,7 +123,7 @@ export default function Fournisseurs() {
       <Toaster />
       <h1 className="text-2xl font-bold">Gestion des fournisseurs</h1>
 
-      <Card className="bg-white/10 border border-white/20 shadow-lg backdrop-blur-xl rounded-2xl">
+      <Card>
         <CardHeader className="pb-4">
           <div className="flex flex-wrap gap-4 items-end">
             <div className="relative flex-1">
@@ -148,25 +149,16 @@ export default function Fournisseurs() {
         <CardContent className="pt-4">
           <div className="flex flex-wrap gap-4">
             {canEdit && (
-              <button
-                className="bg-white/20 hover:bg-white/30 text-white font-semibold px-4 py-2 rounded-xl flex items-center"
-                onClick={() => setShowCreate(true)}
-              >
+              <Button className="w-auto flex items-center" onClick={() => setShowCreate(true)}>
                 <PlusCircle className="mr-2" size={18} /> Ajouter fournisseur
-              </button>
+              </Button>
             )}
-            <button
-              className="bg-white/20 hover:bg-white/30 text-white font-semibold px-4 py-2 rounded-xl"
-              onClick={exportFournisseursToExcel}
-            >
+            <Button className="w-auto" onClick={exportFournisseursToExcel}>
               Export Excel
-            </button>
-            <button
-              className="bg-white/20 hover:bg-white/30 text-white font-semibold px-4 py-2 rounded-xl"
-              onClick={exportPDF}
-            >
+            </Button>
+            <Button className="w-auto" onClick={exportPDF}>
               Export PDF
-            </button>
+            </Button>
           </div>
         </CardContent>
       </Card>
@@ -182,7 +174,7 @@ export default function Fournisseurs() {
       )}
       {/* Statistiques générales */}
       <div className="grid md:grid-cols-2 gap-6 mb-10">
-        <Card className="bg-white/10 border border-white/20 shadow-lg backdrop-blur-xl rounded-2xl">
+        <Card>
           <CardHeader>
             <h2 className="font-semibold">Évolution des achats (tous fournisseurs)</h2>
           </CardHeader>
@@ -204,7 +196,7 @@ export default function Fournisseurs() {
             )}
           </CardContent>
         </Card>
-        <Card className="bg-white/10 border border-white/20 shadow-lg backdrop-blur-xl rounded-2xl">
+        <Card>
           <CardHeader>
             <h2 className="font-semibold">Top produits achetés</h2>
           </CardHeader>
@@ -228,13 +220,13 @@ export default function Fournisseurs() {
         </Card>
       </div>
       {/* Tableau fournisseurs */}
-      <Card className="bg-white/10 border border-white/20 shadow-lg backdrop-blur-xl rounded-2xl mb-6">
+      <Card className="mb-6">
         <CardHeader>
           <h2 className="font-semibold">Liste des fournisseurs</h2>
         </CardHeader>
         <CardContent className="pt-2">
-          <div className="overflow-x-auto rounded-xl backdrop-blur">
-            <table className="min-w-full text-sm text-white text-center whitespace-nowrap">
+          <div className="overflow-x-auto rounded-xl backdrop-blur-xl">
+            <table className="min-w-full text-sm text-white text-center whitespace-nowrap table-striped">
               <thead>
                 <tr>
                   <th className="py-2 px-3">Nom</th>
@@ -274,7 +266,7 @@ export default function Fournisseurs() {
               </tbody>
             </table>
           </div>
-          <div className="mt-4 flex gap-2 justify-center">
+          <div className="mt-6 flex gap-4 justify-center">
             {Array.from({ length: Math.max(1, Math.ceil(total / PAGE_SIZE)) }, (_, i) => (
               <button
                 key={i + 1}
@@ -290,7 +282,7 @@ export default function Fournisseurs() {
 
       {/* Modal création/édition */}
       <Dialog open={showCreate || !!editRow} onOpenChange={v => { if (!v) { setShowCreate(false); setEditRow(null); } }}>
-        <DialogContent className="bg-glass backdrop-blur-lg rounded-2xl shadow-xl max-w-lg w-full p-8">
+        <DialogContent className="bg-white/10 backdrop-blur-lg rounded-2xl shadow-xl max-w-lg w-full p-8">
           <FournisseurForm
             fournisseur={editRow}
             saving={saving}
@@ -320,7 +312,7 @@ export default function Fournisseurs() {
 
       {/* Modal détail */}
       <Dialog open={!!selected} onOpenChange={v => !v && setSelected(null)}>
-        <DialogContent className="bg-glass backdrop-blur-lg rounded-2xl shadow-xl max-w-2xl w-full p-10">
+        <DialogContent className="bg-white/10 backdrop-blur-lg rounded-2xl shadow-xl max-w-2xl w-full p-10">
           {selected && <FournisseurDetail id={selected} />}
         </DialogContent>
       </Dialog>

--- a/src/pages/fournisseurs/comparatif/PrixFournisseurs.jsx
+++ b/src/pages/fournisseurs/comparatif/PrixFournisseurs.jsx
@@ -31,7 +31,7 @@ export default function PrixFournisseurs({ produitId }) {
       <GlassCard className="p-4">
         <TableContainer>
           <table className="w-full text-left border-collapse">
-        <thead className="bg-glass border-b border-borderGlass">
+        <thead className="bg-white/10 border-b border-white/20">
           <tr>
             <th className="px-2 py-1">Fournisseur</th>
             <th className="px-2 py-1 text-right">Dernier prix</th>

--- a/src/pages/inventaire/EcartInventaire.jsx
+++ b/src/pages/inventaire/EcartInventaire.jsx
@@ -166,7 +166,7 @@ function EcartInventairePage() {
 
       <TableContainer className="mt-4">
         <table className="w-full text-sm">
-          <thead className="bg-glass border-b border-borderGlass text-white">
+          <thead className="bg-white/10 border-b border-white/20 text-white">
             <tr>
               <th className="p-3 text-left">Date</th>
               <th className="p-3 text-left">Produit</th>

--- a/src/pages/inventaire/InventaireZones.jsx
+++ b/src/pages/inventaire/InventaireZones.jsx
@@ -104,7 +104,7 @@ export default function InventaireZones() {
         </table>
       </TableContainer>
       <Dialog open={!!editZone} onOpenChange={v => !v && setEditZone(null)}>
-      <DialogContent className="bg-glass backdrop-blur-lg text-white rounded-xl shadow-lg p-6 max-w-sm">
+      <DialogContent className="bg-white/10 backdrop-blur-lg text-white rounded-xl shadow-lg p-6 max-w-sm">
         <DialogTitle className="font-bold mb-2">
           {editZone?.id ? "Modifier la zone" : "Nouvelle zone"}
         </DialogTitle>

--- a/src/pages/legal/Contact.jsx
+++ b/src/pages/legal/Contact.jsx
@@ -14,7 +14,7 @@ export default function Contact() {
       </p>
       <Link
         to="/"
-        className="inline-block px-6 py-2 rounded-xl bg-glass border border-borderGlass hover:bg-white/20 transition backdrop-blur"
+        className="inline-block px-6 py-2 rounded-xl bg-white/10 backdrop-blur-xl border border-white/20 hover:bg-white/20 transition"
       >
         Retour à l'accueil
       </Link>

--- a/src/pages/legal/Licence.jsx
+++ b/src/pages/legal/Licence.jsx
@@ -18,7 +18,7 @@ export default function Licence() {
       </p>
       <Link
         to="/"
-        className="inline-block px-6 py-2 rounded-xl bg-glass border border-borderGlass hover:bg-white/20 transition backdrop-blur"
+        className="inline-block px-6 py-2 rounded-xl bg-white/10 backdrop-blur-xl border border-white/20 hover:bg-white/20 transition"
       >
         Retour à l'accueil
       </Link>

--- a/src/pages/menus/MenuDetail.jsx
+++ b/src/pages/menus/MenuDetail.jsx
@@ -33,7 +33,7 @@ export default function MenuDetail({ menu, onClose, onDuplicate }) {
 
   return (
     <div className="fixed inset-0 bg-black/40 backdrop-blur-sm flex items-center justify-center z-50">
-      <div className="bg-glass backdrop-blur-lg border border-borderGlass rounded-xl shadow-lg p-8 min-w-[400px] max-w-[95vw] flex flex-col gap-2 relative">
+      <div className="bg-white/10 backdrop-blur-xl border border-white/20 rounded-xl shadow-lg p-8 min-w-[400px] max-w-[95vw] flex flex-col gap-2 relative text-white">
         <Button variant="outline" className="absolute top-2 right-2" onClick={onClose}>Fermer</Button>
         <h2 className="font-bold text-xl mb-4">{menu.nom}</h2>
         <div><b>Date :</b> {menu.date}</div>

--- a/src/pages/menus/MenuDuJourDetail.jsx
+++ b/src/pages/menus/MenuDuJourDetail.jsx
@@ -27,7 +27,7 @@ export default function MenuDuJourDetail({ menu, onClose }) {
 
   return (
     <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50">
-      <div className="bg-glass border border-borderGlass backdrop-blur rounded-2xl shadow-lg p-8 min-w-[400px] max-w-[95vw] flex flex-col gap-2 relative">
+      <div className="bg-white/10 backdrop-blur-xl border border-white/20 rounded-2xl shadow-lg p-8 min-w-[400px] max-w-[95vw] flex flex-col gap-2 relative text-white">
         <Button variant="outline" className="absolute top-2 right-2" onClick={onClose}>Fermer</Button>
         <h2 className="font-bold text-xl mb-4">{menu.nom}</h2>
         <div><b>Date :</b> {menu.date}</div>

--- a/src/pages/menus/MenuDuJourForm.jsx
+++ b/src/pages/menus/MenuDuJourForm.jsx
@@ -120,7 +120,7 @@ export default function MenuDuJourForm({ menu, fiches = [], onClose }) {
       </div>
       <div className="mb-4">
         <label className="block font-semibold mb-2">Fiches du menu :</label>
-        <div className="max-h-48 overflow-auto border border-borderGlass rounded p-2 bg-glass backdrop-blur">
+        <div className="max-h-48 overflow-auto border border-white/20 rounded p-2 bg-white/10 backdrop-blur-xl text-white">
           {fiches.map(f => (
             <label key={f.id} className="block">
               <input

--- a/src/pages/mouvements/MouvementForm.jsx
+++ b/src/pages/mouvements/MouvementForm.jsx
@@ -114,12 +114,12 @@ export default function MouvementForm({ onClose }) {
           />
         )}
         <textarea
-          className="input mb-2 w-full"
+          className="textarea mb-2 w-full"
           placeholder="Commentaire"
           value={form.commentaire}
           onChange={e => setForm(f => ({ ...f, commentaire: e.target.value }))}
         />
-        <div className="flex gap-2 justify-end mt-4">
+        <div className="flex flex-wrap justify-center gap-4 mt-4">
           <PrimaryButton type="submit" disabled={loading}>
             Valider
           </PrimaryButton>

--- a/src/pages/parametrage/ExportComptaPage.jsx
+++ b/src/pages/parametrage/ExportComptaPage.jsx
@@ -77,7 +77,7 @@ export default function ExportComptaPage() {
       {preview.length > 0 && (
         <TableContainer>
           <table className="min-w-full table-auto text-sm">
-            <thead className="bg-glass border-b border-borderGlass">
+            <thead className="bg-white/10 border-b border-white/20">
               <tr>
                 <th className="px-2 py-1">Date</th>
                 <th className="px-2 py-1">Fournisseur</th>

--- a/src/pages/parametrage/Familles.jsx
+++ b/src/pages/parametrage/Familles.jsx
@@ -96,8 +96,9 @@ export default function Familles() {
         </Button>
       </div>
       {edit && (
-        <div className="modal fixed inset-0 flex items-center justify-center bg-black/50" role="dialog">
-          <div className="bg-white rounded-lg p-4">
+        <div className="fixed inset-0 flex items-center justify-center z-50">
+          <div className="absolute inset-0 bg-black/50" onClick={() => setEdit(null)} />
+          <div className="relative bg-white/10 backdrop-blur-xl border border-white/20 rounded-xl shadow-lg p-6 w-full max-w-md">
             <FamilleForm
               famille={edit}
               onCancel={() => setEdit(null)}

--- a/src/pages/parametrage/InvitationsEnAttente.jsx
+++ b/src/pages/parametrage/InvitationsEnAttente.jsx
@@ -67,7 +67,7 @@ export default function InvitationsEnAttente() {
       <h1 className="text-2xl font-bold text-mamastock-gold mb-4">
         Invitations en attente
       </h1>
-      <div className="bg-glass border border-borderGlass backdrop-blur shadow rounded-xl overflow-x-auto">
+      <div className="bg-white/10 border border-white/20 backdrop-blur-xl shadow rounded-xl overflow-x-auto">
         <table className="min-w-full table-auto text-center">
           <thead>
             <tr>

--- a/src/pages/parametrage/Mamas.jsx
+++ b/src/pages/parametrage/Mamas.jsx
@@ -161,7 +161,7 @@ export default function Mamas() {
         )}
       </TableContainer>
       <Dialog open={!!editMama} onOpenChange={v => !v && setEditMama(null)}>
-        <DialogContent className="bg-glass backdrop-blur-lg text-white rounded-xl shadow-lg p-6 max-w-md">
+        <DialogContent className="bg-white/10 backdrop-blur-lg text-white rounded-xl shadow-lg p-6 max-w-md">
           <DialogTitle className="font-bold mb-2">
             {editMama?.id ? "Modifier l'établissement" : "Nouvel établissement"}
           </DialogTitle>

--- a/src/pages/parametrage/Permissions.jsx
+++ b/src/pages/parametrage/Permissions.jsx
@@ -100,7 +100,7 @@ export default function Permissions() {
         )}
       </TableContainer>
       <Dialog open={!!editRole} onOpenChange={v => !v && setEditRole(null)}>
-        <DialogContent className="bg-glass backdrop-blur-lg border border-borderGlass rounded-xl shadow-lg p-6 max-w-xl">
+        <DialogContent className="bg-white/10 backdrop-blur-lg border border-white/20 rounded-xl shadow-lg p-6 max-w-xl">
           <DialogTitle className="font-bold mb-2">
             {editRole?.id ? "Modifier le rôle" : "Nouveau rôle"}
           </DialogTitle>

--- a/src/pages/parametrage/PermissionsAdmin.jsx
+++ b/src/pages/parametrage/PermissionsAdmin.jsx
@@ -147,7 +147,7 @@ export default function PermissionsAdmin() {
         )}
       </TableContainer>
       <Dialog open={!!editRole} onOpenChange={v => !v && setEditRole(null)}>
-        <DialogContent className="bg-glass backdrop-blur-lg border border-borderGlass rounded-xl shadow-lg p-6 max-w-xl">
+        <DialogContent className="bg-white/10 backdrop-blur-lg border border-white/20 rounded-xl shadow-lg p-6 max-w-xl">
           <DialogTitle className="font-bold mb-2">
             {editRole?.id ? "Modifier le rôle" : "Nouveau rôle"}
           </DialogTitle>

--- a/src/pages/parametrage/Roles.jsx
+++ b/src/pages/parametrage/Roles.jsx
@@ -95,7 +95,7 @@ export default function Roles() {
         </Button>
       </div>
       <TableContainer className="mb-6">
-        <table className="min-w-full table-auto text-center">
+        <table className="min-w-full table-auto text-center table-striped">
           <thead>
             <tr>
               <th className="px-2 py-1">Nom</th>
@@ -142,7 +142,7 @@ export default function Roles() {
                   {(r.access_rights || []).map(k => (
                     <span
                       key={k}
-                      className="inline-block bg-gray-200 text-gray-800 text-xs px-1 mr-1 rounded"
+                      className="inline-block bg-white/20 text-white text-xs px-1 mr-1 rounded"
                     >
                       {k}
                     </span>
@@ -154,7 +154,7 @@ export default function Roles() {
         </table>
       </TableContainer>
       {/* Pagination */}
-      <div className="flex justify-end gap-2 mb-12">
+      <div className="mt-6 flex justify-center gap-4 mb-12">
         <Button
           size="sm"
           disabled={page <= 1}
@@ -171,7 +171,7 @@ export default function Roles() {
         </Button>
       </div>
       <Dialog open={!!editRole} onOpenChange={v => !v && setEditRole(null)}>
-        <DialogContent className="bg-glass backdrop-blur-lg text-white rounded-xl shadow-lg p-6 max-w-xl">
+        <DialogContent className="bg-white/10 backdrop-blur-lg text-white rounded-xl shadow-lg p-6 max-w-xl">
           <DialogTitle className="font-bold mb-2">
             {editRole?.id ? "Modifier le rôle" : "Nouveau rôle"}
           </DialogTitle>

--- a/src/pages/parametrage/Unites.jsx
+++ b/src/pages/parametrage/Unites.jsx
@@ -96,8 +96,9 @@ export default function Unites() {
         </Button>
       </div>
       {edit && (
-        <div className="modal fixed inset-0 flex items-center justify-center bg-black/50" role="dialog">
-          <div className="bg-white rounded-lg p-4">
+        <div className="fixed inset-0 flex items-center justify-center z-50">
+          <div className="absolute inset-0 bg-black/50" onClick={() => setEdit(null)} />
+          <div className="relative bg-white/10 backdrop-blur-xl border border-white/20 rounded-xl shadow-lg p-6 w-full max-w-md">
             <UniteForm
               unite={edit}
               onCancel={() => setEdit(null)}

--- a/src/pages/parametrage/Zones.jsx
+++ b/src/pages/parametrage/Zones.jsx
@@ -95,17 +95,17 @@ export default function Zones() {
           Suivant
         </Button>
       </div>
-      {edit && (
-        <div className="modal fixed inset-0 flex items-center justify-center bg-black/50" role="dialog">
-          <div className="bg-white rounded-lg p-4">
-            <ZoneForm
-              zone={edit}
-              onCancel={() => setEdit(null)}
-              onSave={handleSave}
-            />
+        {edit && (
+          <div className="fixed inset-0 flex items-center justify-center bg-black/50 z-50">
+            <div className="bg-white/10 backdrop-blur-xl rounded-xl shadow-lg border border-white/20 p-6 animate-fade-in">
+              <ZoneForm
+                zone={edit}
+                onCancel={() => setEdit(null)}
+                onSave={handleSave}
+              />
+            </div>
           </div>
-        </div>
-      )}
+        )}
     </div>
   );
 }

--- a/src/pages/produits/Produits.jsx
+++ b/src/pages/produits/Produits.jsx
@@ -187,7 +187,7 @@ export default function Produits() {
         </div>
         <div className="flex flex-wrap gap-4 mt-4">
           <Button
-            className="w-auto bg-white/20 text-white font-semibold px-4 py-2 rounded-md hover:bg-white/30 transition"
+            className="w-auto"
             onClick={() => {
               setShowForm(true);
               setSelectedProduct(null);
@@ -195,16 +195,10 @@ export default function Produits() {
           >
             <Plus className="w-4 h-4 mr-2" /> Nouveau produit
           </Button>
-          <Button
-            className="w-auto bg-white/20 text-white font-semibold px-4 py-2 rounded-md hover:bg-white/30 transition"
-            onClick={exportProductsToExcel}
-          >
+          <Button className="w-auto" onClick={exportProductsToExcel}>
             Export Excel
           </Button>
-          <Button
-            className="w-auto bg-white/20 text-white font-semibold px-4 py-2 rounded-md hover:bg-white/30 transition"
-            onClick={() => fileRef.current.click()}
-          >
+          <Button className="w-auto" onClick={() => fileRef.current.click()}>
             Import Excel
           </Button>
           <input

--- a/src/pages/promotions/PromotionForm.jsx
+++ b/src/pages/promotions/PromotionForm.jsx
@@ -26,7 +26,7 @@ export default function PromotionForm({ promotion = {}, onClose, onSave, saving 
             <Label htmlFor="desc-promo">Description</Label>
             <textarea
               id="desc-promo"
-              className="w-full px-4 py-2 bg-white/20 text-white placeholder-white/70 rounded-md border border-white/30 backdrop-blur-sm focus:outline-none focus:ring-2 focus:ring-white/50"
+              className="textarea"
               value={form.description}
               onChange={e => setForm(f => ({ ...f, description: e.target.value }))}
             />

--- a/src/pages/public/LandingPage.jsx
+++ b/src/pages/public/LandingPage.jsx
@@ -28,7 +28,7 @@ export default function LandingPage() {
       <GlassCard className="w-full max-w-2xl p-8 space-y-8 text-center relative z-10">
         <PageIntro />
         <div className="flex flex-col sm:flex-row gap-4 justify-center">
-          <Link to="/login" className="px-6 py-3 rounded-xl bg-white/20 hover:bg-white/30 transition">
+          <Link to="/login" className="px-6 py-3 rounded-xl font-semibold bg-white/10 hover:bg-white/20 text-white transition">
             Se connecter
           </Link>
           <Link to="/signup" className="px-6 py-3 rounded-xl bg-mamastockGold hover:bg-mamastockGoldHover text-mamastockBg transition">

--- a/src/pages/public/Onboarding.jsx
+++ b/src/pages/public/Onboarding.jsx
@@ -57,13 +57,13 @@ export default function Onboarding() {
         </Motion.div>
         <div className="flex justify-center gap-4">
           <button
-            className="px-5 py-2 rounded bg-mamastockGold text-mamastockBg hover:bg-mamastockGoldHover transition"
+            className="px-5 py-2 rounded-xl font-semibold bg-white/10 hover:bg-white/20 text-white transition"
             onClick={handleNext}
           >
             {step < steps.length - 1 ? 'Suivant' : 'Terminer'}
           </button>
           <button
-            className="px-5 py-2 rounded bg-glass border border-borderGlass backdrop-blur hover:bg-white/20 transition"
+            className="px-5 py-2 rounded-xl font-semibold bg-white/10 hover:bg-white/20 text-white transition"
             onClick={handleSkip}
           >
             Passer

--- a/src/pages/reporting/ReportingPDF.jsx
+++ b/src/pages/reporting/ReportingPDF.jsx
@@ -3,7 +3,7 @@ import GraphCost from "./GraphCost";
 
 export default function ReportingPDF() {
   return (
-    <div className="bg-glass border border-borderGlass backdrop-blur p-6 rounded-2xl shadow-lg">
+    <div className="bg-white/10 border border-white/20 backdrop-blur-xl p-6 rounded-2xl shadow-lg">
       <h2 className="text-xl font-bold text-mamastock-gold mb-4">Rapport complet</h2>
       <GraphCost />
       {/* Tu peux ajouter d’autres stats ici plus tard */}

--- a/src/pages/requisitions/Requisitions.jsx
+++ b/src/pages/requisitions/Requisitions.jsx
@@ -125,7 +125,7 @@ export default function Requisitions() {
         <Button onClick={handleExportPDF}>Export PDF</Button>
         <Link to="/requisitions/nouvelle" className="btn">+ Nouvelle réquisition</Link>
       </div>
-      <div className="bg-glass border border-borderGlass backdrop-blur shadow rounded-xl overflow-x-auto">
+      <div className="bg-white/5 text-white border border-white/10 rounded-xl overflow-x-auto">
         <table className="min-w-full table-auto text-center">
           <thead>
             <tr>

--- a/src/pages/signalements/SignalementDetail.jsx
+++ b/src/pages/signalements/SignalementDetail.jsx
@@ -3,7 +3,7 @@ export default function SignalementDetail({ signalement }) {
   if (!signalement) return null;
 
   return (
-    <div className="p-2 border border-borderGlass rounded mb-2 bg-glass backdrop-blur shadow">
+    <div className="p-2 border border-white/20 rounded mb-2 bg-white/10 backdrop-blur-xl shadow">
       <div className="font-bold text-mamastock-gold">{signalement.titre}</div>
       <div className="text-sm text-gray-700">{signalement.description}</div>
       <div className="text-xs mt-1 text-gray-500 italic">Statut : {signalement.statut}</div>

--- a/src/pages/signalements/SignalementForm.jsx
+++ b/src/pages/signalements/SignalementForm.jsx
@@ -4,6 +4,7 @@ import { useSignalements } from "@/hooks/useSignalements";
 import useAuth from "@/hooks/useAuth";
 import toast from "react-hot-toast";
 import GlassCard from "@/components/ui/GlassCard";
+import PrimaryButton from "@/components/ui/PrimaryButton";
 
 export default function SignalementForm({ onCreated }) {
   const { loading: authLoading } = useAuth();
@@ -62,13 +63,9 @@ export default function SignalementForm({ onCreated }) {
         <option value="en cours">En cours</option>
         <option value="résolu">Résolu</option>
       </select>
-      <button
-        type="submit"
-        disabled={authLoading || submitting}
-        className="w-full py-2 bg-white/30 text-white font-semibold rounded-md hover:bg-white/40 backdrop-blur focus:outline-none focus:ring-2 focus:ring-white/60 disabled:opacity-50"
-      >
+      <PrimaryButton type="submit" disabled={authLoading || submitting} className="w-full">
         Ajouter
-      </button>
+      </PrimaryButton>
       </form>
     </GlassCard>
   );

--- a/src/pages/stock/Transferts.jsx
+++ b/src/pages/stock/Transferts.jsx
@@ -131,7 +131,7 @@ export default function Transferts() {
         </table>
       </TableContainer>
       {showForm && (
-        <div className="fixed inset-0 bg-black/50 backdrop-blur flex items-center justify-center z-50">
+        <div className="fixed inset-0 bg-black/50 backdrop-blur-xl flex items-center justify-center z-50">
           <GlassCard title="Nouveau transfert" className="w-96 p-6">
             <form onSubmit={handleSubmit} className="space-y-3">
             <div className="flex gap-2">

--- a/src/pages/taches/Taches.jsx
+++ b/src/pages/taches/Taches.jsx
@@ -8,6 +8,7 @@ import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 import TableContainer from "@/components/ui/TableContainer";
 import TachesKanban from "@/components/taches/TachesKanban";
 import GlassCard from "@/components/ui/GlassCard";
+import toast from "react-hot-toast";
 
 export default function Taches() {
   const { taches, loading, error, getTaches, createTache } = useTaches();
@@ -29,8 +30,13 @@ export default function Taches() {
   const handleQuickSubmit = async e => {
     e.preventDefault();
     if (!quick.titre.trim()) return;
-    await createTache(quick);
-    setQuick({ titre: '', date_echeance: '' });
+    try {
+      await createTache(quick);
+      toast.success('Tâche ajoutée');
+      setQuick({ titre: '', date_echeance: '' });
+    } catch (err) {
+      toast.error(err?.message || 'Erreur ajout');
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- switch remaining modal containers to the transparent glass style
- update onboarding buttons with uniform Liquid Glass classes
- show a toast when quickly adding a task
- convert legacy `bg-glass` colors to the new bg-white glass scheme
- refine glass theme components and pagination

## Testing
- `npm test` *(fails: Missing Supabase credentials and other test errors)*

------
https://chatgpt.com/codex/tasks/task_e_688bab35884c832da3d44e2542c940ee