### PR TITLE
Fix product family/unite IDs

### DIFF
--- a/src/components/produits/ProduitForm.jsx
+++ b/src/components/produits/ProduitForm.jsx
@@ -118,7 +118,7 @@ export default function ProduitForm({ produit, familles = [], unites = [], onSuc
               <AutoCompleteField
                 label="Famille"
                 value={familleId}
-                onChange={setFamilleId}
+                onChange={obj => setFamilleId(obj?.id || "")}
                 options={[...famillesHook, ...familles].map(f => ({ value: f.id, label: f.nom }))}
                 onAddOption={async val => {
                   const { data, error } = await addFamille(val);
@@ -133,7 +133,7 @@ export default function ProduitForm({ produit, familles = [], unites = [], onSuc
               <AutoCompleteField
                 label="Unité"
                 value={uniteId}
-                onChange={setUniteId}
+                onChange={obj => setUniteId(obj?.id || "")}
                 options={[...unitesHook, ...unites].map(u => ({ value: u.id, label: u.nom }))}
                 onAddOption={async val => {
                   const { data, error } = await addUnite(val);

--- a/src/components/ui/AutoCompleteField.jsx
+++ b/src/components/ui/AutoCompleteField.jsx
@@ -38,7 +38,8 @@ export default function AutoCompleteField({
     const val = e.target.value;
     setInputValue(val);
     const match = resolved.find(o => o.label === val);
-    onChange(match ? match.value : null);
+    if (match) onChange({ id: match.value, nom: match.label });
+    else onChange(val ? { id: null, nom: val } : null);
     setShowAdd(val && !match);
   };
 
@@ -46,8 +47,10 @@ export default function AutoCompleteField({
     if (inputValue && onAddOption) {
       const res = await onAddOption(inputValue);
       if (res && res.id) {
-        onChange(res.id);
+        onChange({ id: res.id, nom: res.nom || inputValue });
         setInputValue(res.nom || inputValue);
+      } else {
+        onChange({ id: null, nom: inputValue });
       }
       setShowAdd(false);
     }

--- a/src/hooks/useFamilles.js
+++ b/src/hooks/useFamilles.js
@@ -22,7 +22,7 @@ export function useFamilles() {
       setError(null);
       let query = supabase
         .from("familles")
-        .select("*", { count: "exact" })
+        .select("id, nom", { count: "exact" })
         .eq("mama_id", mama_id)
         .order("nom", { ascending: true });
       if (!includeInactive) query = query.eq("actif", true);

--- a/src/hooks/useUnites.js
+++ b/src/hooks/useUnites.js
@@ -21,7 +21,7 @@ export function useUnites() {
       setError(null);
       let query = supabase
         .from("unites")
-        .select("*", { count: "exact" })
+        .select("id, nom", { count: "exact" })
         .eq("mama_id", mama_id)
         .order("nom", { ascending: true });
       if (!includeInactive) query = query.eq("actif", true);


### PR DESCRIPTION
## Summary
- update AutoCompleteField to return `{id, nom}` objects on selection or creation
- record only the selected family and unit IDs in the product form
- simplify famille and unite queries to fetch only `id` and `nom`

## Testing
- `npm run lint`
- `npm test` *(fails: Missing Supabase credentials and other issues)*

------
https://chatgpt.com/codex/tasks/task_e_688bc4c02980832d93de670eeb2e2419