### PR TITLE
Fix product form with famille_id/unite_id autocomplete

### DIFF
--- a/src/components/produits/ProduitForm.jsx
+++ b/src/components/produits/ProduitForm.jsx
@@ -21,6 +21,7 @@ export default function ProduitForm({ produit, familles = [], unites = [], onSuc
   const { fournisseurs, fetchFournisseurs } = useFournisseurs();
 
   const [nom, setNom] = useState(produit?.nom || "");
+  // Stocke uniquement les IDs sélectionnés via l'autocomplétion
   const [familleId, setFamilleId] = useState(produit?.famille_id || "");
   const [uniteId, setUniteId] = useState(produit?.unite_id || "");
   const [fournisseurId, setFournisseurId] = useState(produit?.fournisseur_id || "");

--- a/src/components/ui/AutoCompleteField.jsx
+++ b/src/components/ui/AutoCompleteField.jsx
@@ -39,7 +39,7 @@ export default function AutoCompleteField({
     setInputValue(val);
     const match = resolved.find(o => o.label === val);
     if (match) onChange({ id: match.value, nom: match.label });
-    else onChange(val ? { id: null, nom: val } : null);
+    else onChange(val ? { id: null, nom: val } : { id: "", nom: "" });
     setShowAdd(val && !match);
   };
 

--- a/src/hooks/useFamilles.js
+++ b/src/hooks/useFamilles.js
@@ -22,15 +22,15 @@ export function useFamilles() {
       setError(null);
       let query = supabase
         .from("familles")
-        .select("id, nom", { count: "exact" })
+        .select("id, nom")
         .eq("mama_id", mama_id)
         .order("nom", { ascending: true });
       if (!includeInactive) query = query.eq("actif", true);
       if (search) query = query.ilike("nom", `%${search}%`);
       if (limit) query = query.range((page - 1) * limit, page * limit - 1);
-      const { data, error, count } = await query;
+      const { data, error } = await query;
       setFamilles(Array.isArray(data) ? data : []);
-      setTotal(count || (data ? data.length : 0));
+      setTotal(data ? data.length : 0);
       setLoading(false);
       if (error) setError(error);
       return data || [];

--- a/src/hooks/useUnites.js
+++ b/src/hooks/useUnites.js
@@ -21,15 +21,15 @@ export function useUnites() {
       setError(null);
       let query = supabase
         .from("unites")
-        .select("id, nom", { count: "exact" })
+        .select("id, nom")
         .eq("mama_id", mama_id)
         .order("nom", { ascending: true });
       if (!includeInactive) query = query.eq("actif", true);
       if (search) query = query.ilike("nom", `%${search}%`);
       if (limit) query = query.range((page - 1) * limit, page * limit - 1);
-      const { data, error, count } = await query;
+      const { data, error } = await query;
       setUnites(Array.isArray(data) ? data : []);
-      setTotal(count || (data ? data.length : 0));
+      setTotal(data ? data.length : 0);
       setLoading(false);
       if (error) setError(error);
       return data || [];


### PR DESCRIPTION
## Summary
- return empty object from `AutoCompleteField` when clearing
- fetch only `id, nom` in `useFamilles` and `useUnites`
- clarify state in `ProduitForm`

## Testing
- `npm run lint`
- `npm test` *(fails: Missing Supabase credentials etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688bc64cf338832dbd5844bc7a220325