### PR TITLE
Harmonize family/unity handling

### DIFF
--- a/src/components/parametrage/FamilleRow.jsx
+++ b/src/components/parametrage/FamilleRow.jsx
@@ -6,7 +6,6 @@ export default function FamilleRow({ famille, onEdit, onDelete, onToggle }) {
     <tr>
       <td className="px-2 py-1">{famille.nom}</td>
       <td className="px-2 py-1">{famille.actif ? '🟢' : '🔴'}</td>
-      <td className="px-2 py-1">{new Date(famille.created_at).toLocaleDateString()}</td>
       <td className="px-2 py-1 flex gap-2 justify-center">
         <Button size="sm" variant="secondary" onClick={() => onEdit(famille)}>
           Modifier

--- a/src/components/parametrage/UniteRow.jsx
+++ b/src/components/parametrage/UniteRow.jsx
@@ -6,7 +6,6 @@ export default function UniteRow({ unite, onEdit, onDelete, onToggle }) {
     <tr>
       <td className="px-2 py-1">{unite.nom}</td>
       <td className="px-2 py-1">{unite.actif ? '🟢' : '🔴'}</td>
-      <td className="px-2 py-1">{new Date(unite.created_at).toLocaleDateString()}</td>
       <td className="px-2 py-1 flex gap-2 justify-center">
         <Button size="sm" variant="secondary" onClick={() => onEdit(unite)}>
           Modifier

--- a/src/components/produits/ProduitForm.jsx
+++ b/src/components/produits/ProduitForm.jsx
@@ -120,8 +120,8 @@ export default function ProduitForm({ produit, familles = [], unites = [], onSuc
                 label="Famille"
                 value={familleId}
                 onChange={obj => setFamilleId(obj?.id || "")}
-                options={[...famillesHook, ...familles].map(f => ({ value: f.id, label: f.nom }))}
-                onAddOption={async val => {
+                options={[...famillesHook, ...familles].map(f => ({ id: f.id, nom: f.nom }))}
+                onAddNewValue={async val => {
                   const { data, error } = await addFamille(val);
                   if (error) toast.error(error.message || error);
                   else return { id: data.id, nom: data.nom };
@@ -135,8 +135,8 @@ export default function ProduitForm({ produit, familles = [], unites = [], onSuc
                 label="Unité"
                 value={uniteId}
                 onChange={obj => setUniteId(obj?.id || "")}
-                options={[...unitesHook, ...unites].map(u => ({ value: u.id, label: u.nom }))}
-                onAddOption={async val => {
+                options={[...unitesHook, ...unites].map(u => ({ id: u.id, nom: u.nom }))}
+                onAddNewValue={async val => {
                   const { data, error } = await addUnite(val);
                   if (error) toast.error(error.message || error);
                   else return { id: data.id, nom: data.nom };

--- a/src/components/ui/AutoCompleteField.jsx
+++ b/src/components/ui/AutoCompleteField.jsx
@@ -8,44 +8,44 @@ export default function AutoCompleteField({
   value,
   onChange,
   options,
-  onAddOption,
+  onAddNewValue,
   required = false,
   disabledOptions = [],
 }) {
   const resolved = (options || []).map(opt =>
-    typeof opt === "string" ? { value: opt, label: opt } : opt
+    typeof opt === "string" ? { id: opt, nom: opt } : opt
   );
   const [inputValue, setInputValue] = useState(() => {
-    const match = resolved.find(o => o.value === value);
-    return match ? match.label : "";
+    const match = resolved.find(o => o.id === value);
+    return match ? match.nom : "";
   });
   const [showAdd, setShowAdd] = useState(false);
 
   useEffect(() => {
-    const match = resolved.find(o => o.value === value);
-    setInputValue(match ? match.label : "");
+    const match = resolved.find(o => o.id === value);
+    setInputValue(match ? match.nom : "");
   }, [value, resolved]);
 
   const disabledIds = disabledOptions.map(d =>
-    typeof d === "string" ? d : d.value
+    typeof d === "string" ? d : d.id
   );
 
   const isValid =
-    inputValue && resolved.some(o => o.label === inputValue && !disabledIds.includes(o.value));
-  const filtered = resolved.filter(o => !disabledIds.includes(o.value));
+    inputValue && resolved.some(o => o.nom === inputValue && !disabledIds.includes(o.id));
+  const filtered = resolved.filter(o => !disabledIds.includes(o.id));
 
   const handleInputChange = e => {
     const val = e.target.value;
     setInputValue(val);
-    const match = resolved.find(o => o.label === val);
-    if (match) onChange({ id: match.value, nom: match.label });
+    const match = resolved.find(o => o.nom === val);
+    if (match) onChange({ id: match.id, nom: match.nom });
     else onChange(val ? { id: null, nom: val } : { id: "", nom: "" });
     setShowAdd(val && !match);
   };
 
   const handleAddOption = async () => {
-    if (inputValue && onAddOption) {
-      const res = await onAddOption(inputValue);
+    if (inputValue && onAddNewValue) {
+      const res = await onAddNewValue(inputValue);
       if (res && res.id) {
         onChange({ id: res.id, nom: res.nom || inputValue });
         setInputValue(res.nom || inputValue);
@@ -57,8 +57,8 @@ export default function AutoCompleteField({
   };
 
   return (
-    <div className="flex flex-col gap-1 w-full">
-      <label className="text-sm text-black font-medium">
+    <div className="flex flex-col gap-2 w-full">
+      <label className="text-sm text-white font-medium">
         {label} {required && "*"}
       </label>
       <Input
@@ -73,7 +73,7 @@ export default function AutoCompleteField({
       />
       <datalist id={`list-${label}`}>
         {filtered.map((opt, idx) => (
-          <option key={idx} value={opt.label} />
+          <option key={idx} value={opt.nom} />
         ))}
       </datalist>
       {showAdd && (

--- a/src/components/ui/AutoCompleteZoneField.jsx
+++ b/src/components/ui/AutoCompleteZoneField.jsx
@@ -6,7 +6,7 @@ import { useZones } from '@/hooks/useZones';
 export default function AutoCompleteZoneField({ value, onChange, ...props }) {
   const { zones, fetchZones } = useZones();
   useEffect(() => { fetchZones(); }, [fetchZones]);
-  const options = zones.filter(z => z.actif).map(z => z.nom);
+  const options = zones.filter(z => z.actif).map(z => ({ id: z.id, nom: z.nom }));
   return (
     <AutoCompleteField
       {...props}

--- a/src/pages/achats/AchatForm.jsx
+++ b/src/pages/achats/AchatForm.jsx
@@ -1,5 +1,5 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useAchats } from "@/hooks/useAchats";
 import { useProduitsAutocomplete } from "@/hooks/useProduitsAutocomplete";
 import AutoCompleteField from "@/components/ui/AutoCompleteField";
@@ -17,16 +17,11 @@ export default function AchatForm({ achat, fournisseurs = [], onClose }) {
   const canEdit = hasAccess("achats", "peut_modifier");
   const [date_achat, setDateAchat] = useState(achat?.date_achat || "");
   const [produit_id, setProduitId] = useState(achat?.produit_id || "");
-  const [produitNom, setProduitNom] = useState("");
   const [fournisseur_id, setFournisseurId] = useState(achat?.fournisseur_id || "");
   const [quantite, setQuantite] = useState(achat?.quantite || 1);
   const [prix, setPrix] = useState(achat?.prix || 0);
   const [loading, setLoading] = useState(false);
 
-  useEffect(() => { if (achat?.produit_id && produitOptions.length) {
-    const p = produitOptions.find(p => p.id === achat.produit_id);
-    setProduitNom(p?.nom || "");
-  } }, [achat?.produit_id, produitOptions]);
 
   if (authLoading) return <LoadingSpinner message="Chargement..." />;
   if (!canEdit) return <Unauthorized />;
@@ -58,13 +53,12 @@ export default function AchatForm({ achat, fournisseurs = [], onClose }) {
           <input type="date" className="input" value={date_achat} onChange={e => setDateAchat(e.target.value)} required />
           <AutoCompleteField
             label=""
-            value={produitNom}
-            onChange={val => {
-              setProduitNom(val);
-              setProduitId(produitOptions.find(p => p.nom === val)?.id || "");
-              if (val.length >= 2) searchProduits(val);
+            value={produit_id}
+            onChange={obj => {
+              setProduitId(obj?.id || "");
+              if ((obj?.nom || "").length >= 2) searchProduits(obj.nom);
             }}
-            options={produitOptions.map(p => p.nom)}
+            options={produitOptions.map(p => ({ id: p.id, nom: p.nom }))}
           />
           <select className="input" value={fournisseur_id} onChange={e => setFournisseurId(e.target.value)} required>
             <option value="">Fournisseur</option>

--- a/src/pages/bons_livraison/BLForm.jsx
+++ b/src/pages/bons_livraison/BLForm.jsx
@@ -124,12 +124,12 @@ export default function BLForm({ bon, fournisseurs = [], onClose }) {
                   <td className="min-w-[150px]">
                     <AutoCompleteField
                       label=""
-                      value={l.produit_nom}
-                      onChange={val => {
-                        setLignes(ls => ls.map((it,i)=> i===idx ? { ...it, produit_nom: val, produit_id: produitOptions.find(p => p.nom === val)?.id || "" } : it));
-                        if (val.length >= 2) searchProduits(val);
+                      value={l.produit_id}
+                      onChange={obj => {
+                        setLignes(ls => ls.map((it,i)=> i===idx ? { ...it, produit_nom: obj?.nom || "", produit_id: obj?.id || "" } : it));
+                        if ((obj?.nom || "").length >= 2) searchProduits(obj.nom);
                       }}
-                      options={produitOptions.map(p => p.nom)}
+                      options={produitOptions.map(p => ({ id: p.id, nom: p.nom }))}
                     />
                   </td>
                   <td><input type="number" className="input" value={l.quantite_recue} onChange={e => setLignes(ls => ls.map((it,i)=> i===idx ? { ...it, quantite_recue: Number(e.target.value) } : it))} /></td>

--- a/src/pages/commandes/CommandeForm.jsx
+++ b/src/pages/commandes/CommandeForm.jsx
@@ -104,12 +104,12 @@ export default function CommandeForm({ commande, fournisseurs = [], onClose }) {
                   <td className="min-w-[150px]">
                     <AutoCompleteField
                       label=""
-                      value={l.produit_nom}
-                      onChange={val => {
-                        setLignes(ls => ls.map((it,i)=> i===idx ? { ...it, produit_nom: val, produit_id: produitOptions.find(p => p.nom === val)?.id || "" } : it));
-                        if (val.length >= 2) searchProduits(val);
+                      value={l.produit_id}
+                      onChange={obj => {
+                        setLignes(ls => ls.map((it,i)=> i===idx ? { ...it, produit_nom: obj?.nom || "", produit_id: obj?.id || "" } : it));
+                        if ((obj?.nom || "").length >= 2) searchProduits(obj.nom);
                       }}
-                      options={produitOptions.map(p => p.nom)}
+                      options={produitOptions.map(p => ({ id: p.id, nom: p.nom }))}
                     />
                   </td>
                   <td><input type="number" className="input" value={l.quantite} onChange={e => setLignes(ls => ls.map((it,i)=> i===idx ? { ...it, quantite: Number(e.target.value) } : it))} /></td>

--- a/src/pages/factures/FactureForm.jsx
+++ b/src/pages/factures/FactureForm.jsx
@@ -166,18 +166,18 @@ export default function FactureForm({ facture, fournisseurs = [], onClose }) {
               <td className="min-w-[150px]">
                 <AutoCompleteField
                   label=""
-                  value={l.produit_nom}
-                  onChange={val => {
+                  value={l.produit_id}
+                  onChange={obj => {
                     setLignes(ls => ls.map((it,i) =>
                       i===idx ? {
                         ...it,
-                        produit_nom: val,
-                        produit_id: produitOptions.find(p => p.nom === val)?.id || ""
+                        produit_nom: obj?.nom || "",
+                        produit_id: obj?.id || ""
                       } : it
                     ));
-                    if (val.length >= 2) searchProduits(val);
+                    if ((obj?.nom || "").length >= 2) searchProduits(obj.nom);
                   }}
-                  options={produitOptions.map(p => p.nom)}
+                  options={produitOptions.map(p => ({ id: p.id, nom: p.nom }))}
                 />
               </td>
               <td>

--- a/src/pages/mouvements/MouvementForm.jsx
+++ b/src/pages/mouvements/MouvementForm.jsx
@@ -13,7 +13,7 @@ import toast from "react-hot-toast";
 export default function MouvementForm({ onClose }) {
   const { createMouvement } = useMouvements();
   const { products, fetchProducts } = useProducts();
-  const { zones, fetchZones } = useZones();
+  const { fetchZones } = useZones();
   const [produitInput, setProduitInput] = useState("");
   const [form, setForm] = useState({
     type: "entrée",
@@ -96,20 +96,18 @@ export default function MouvementForm({ onClose }) {
         {form.type !== "entrée" && (
           <AutoCompleteZoneField
             placeholder="Zone source"
-            value={zones.find(z => z.id === form.zone_source_id)?.nom || ""}
-            onChange={val => {
-              const found = zones.find(z => z.nom === val);
-              setForm(f => ({ ...f, zone_source_id: found ? found.id : "" }));
+            value={form.zone_source_id}
+            onChange={obj => {
+              setForm(f => ({ ...f, zone_source_id: obj?.id || "" }));
             }}
           />
         )}
         {form.type !== "sortie" && form.type !== "correction" && (
           <AutoCompleteZoneField
             placeholder="Zone destination"
-            value={zones.find(z => z.id === form.zone_destination_id)?.nom || ""}
-            onChange={val => {
-              const found = zones.find(z => z.nom === val);
-              setForm(f => ({ ...f, zone_destination_id: found ? found.id : "" }));
+            value={form.zone_destination_id}
+            onChange={obj => {
+              setForm(f => ({ ...f, zone_destination_id: obj?.id || "" }));
             }}
           />
         )}

--- a/src/pages/mouvements/Mouvements.jsx
+++ b/src/pages/mouvements/Mouvements.jsx
@@ -88,18 +88,16 @@ export default function Mouvements() {
           onChange={e => setFilters(f => ({ ...f, fin: e.target.value }))}
         />
         <AutoCompleteZoneField
-          value={zones.find(z => z.id === filters.zone_source)?.nom || ''}
-          onChange={val => {
-            const found = zones.find(z => z.nom === val);
-            setFilters(f => ({ ...f, zone_source: found ? found.id : '' }));
+          value={filters.zone_source}
+          onChange={obj => {
+            setFilters(f => ({ ...f, zone_source: obj?.id || '' }));
           }}
           placeholder="Zone source"
         />
         <AutoCompleteZoneField
-          value={zones.find(z => z.id === filters.zone_destination)?.nom || ''}
-          onChange={val => {
-            const found = zones.find(z => z.nom === val);
-            setFilters(f => ({ ...f, zone_destination: found ? found.id : '' }));
+          value={filters.zone_destination}
+          onChange={obj => {
+            setFilters(f => ({ ...f, zone_destination: obj?.id || '' }));
           }}
           placeholder="Zone destination"
         />

--- a/src/pages/parametrage/Familles.jsx
+++ b/src/pages/parametrage/Familles.jsx
@@ -66,7 +66,6 @@ export default function Familles() {
             <tr>
               <th className="px-2 py-1">Nom</th>
               <th className="px-2 py-1">Statut</th>
-              <th className="px-2 py-1">Créée le</th>
               <th className="px-2 py-1">Actions</th>
             </tr>
           </thead>
@@ -76,7 +75,7 @@ export default function Familles() {
             ))}
             {familles.length === 0 && (
               <tr>
-                <td colSpan="4" className="py-2">
+                <td colSpan="3" className="py-2">
                   Aucune famille
                 </td>
               </tr>

--- a/src/pages/parametrage/Unites.jsx
+++ b/src/pages/parametrage/Unites.jsx
@@ -66,7 +66,6 @@ export default function Unites() {
             <tr>
               <th className="px-2 py-1">Nom</th>
               <th className="px-2 py-1">Statut</th>
-              <th className="px-2 py-1">Créée le</th>
               <th className="px-2 py-1">Actions</th>
             </tr>
           </thead>
@@ -76,7 +75,7 @@ export default function Unites() {
             ))}
             {unites.length === 0 && (
               <tr>
-                <td colSpan="4" className="py-2">
+                <td colSpan="3" className="py-2">
                   Aucune unité
                 </td>
               </tr>


### PR DESCRIPTION
## Summary
- refactor `AutoCompleteField` to work with `{id, nom}` objects
- adjust `ProduitForm` to save `famille_id` and `unite_id` via AutoComplete
- update other forms using AutoCompleteField/ZoneField
- drop created_at column display for paramétrage tables

## Testing
- `npm run lint`
- `npm test` *(fails: Missing Supabase credentials and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_688bc8a8fd48832d89d137a99df45278