### PR TITLE
Unify listing headers

### DIFF
--- a/src/components/ui/ListingContainer.jsx
+++ b/src/components/ui/ListingContainer.jsx
@@ -1,0 +1,12 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import React from 'react';
+import GlassCard from './GlassCard';
+import TableContainer from './TableContainer';
+
+export default function ListingContainer({ children, className = '', ...props }) {
+  return (
+    <GlassCard width="w-full" className={`p-0 ${className}`} {...props}>
+      <TableContainer className="p-0">{children}</TableContainer>
+    </GlassCard>
+  );
+}

--- a/src/components/ui/PaginationFooter.jsx
+++ b/src/components/ui/PaginationFooter.jsx
@@ -1,0 +1,19 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import React from 'react';
+import { Button } from './button';
+
+export default function PaginationFooter({ page, pages, onPageChange, className = '' }) {
+  return (
+    <div className={`flex justify-between mt-2 ${className}`}>
+      <Button variant="outline" onClick={() => onPageChange(Math.max(1, page - 1))} disabled={page <= 1}>
+        Précédent
+      </Button>
+      <span>
+        Page {page}/{pages}
+      </span>
+      <Button variant="outline" onClick={() => onPageChange(Math.min(pages, page + 1))} disabled={page >= pages}>
+        Suivant
+      </Button>
+    </div>
+  );
+}

--- a/src/components/ui/TableContainer.jsx
+++ b/src/components/ui/TableContainer.jsx
@@ -2,12 +2,22 @@
 import React from "react";
 
 export default function TableContainer({ className = "", children, ...props }) {
+  const enhanced = React.Children.map(children, child => {
+    if (React.isValidElement(child) && child.type === "table") {
+      const childClass = child.props.className || "";
+      return React.cloneElement(child, {
+        className: `listing-table ${childClass}`.trim(),
+      });
+    }
+    return child;
+  });
+
   return (
     <div
-      className={`bg-white/5 text-white border border-white/10 rounded-xl overflow-x-auto ${className}`}
+      className={`w-full bg-white/10 backdrop-blur-md text-white border border-white/20 rounded-2xl shadow-lg overflow-x-auto ${className}`}
       {...props}
     >
-      {children}
+      {enhanced}
     </div>
   );
 }

--- a/src/components/ui/TableHeader.jsx
+++ b/src/components/ui/TableHeader.jsx
@@ -1,0 +1,10 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import React from 'react';
+
+export default function TableHeader({ children, className = '', ...props }) {
+  return (
+    <div className={`flex flex-wrap gap-4 items-end mb-4 ${className}`} {...props}>
+      {children}
+    </div>
+  );
+}

--- a/src/globals.css
+++ b/src/globals.css
@@ -87,6 +87,15 @@ a:hover {
 .table-striped tbody tr:nth-child(even) {
   @apply bg-white/5;
 }
+.listing-table {
+  @apply w-full min-w-max table-auto text-left whitespace-nowrap;
+}
+.listing-table thead th {
+  @apply bg-white/10 backdrop-blur-md sticky top-0 z-10 px-4 py-2;
+}
+.listing-table tbody tr:nth-child(odd) {
+  @apply bg-white/5;
+}
 
 /* Dark mode auto */
 html.dark body {

--- a/src/pages/Utilisateurs.jsx
+++ b/src/pages/Utilisateurs.jsx
@@ -5,7 +5,9 @@ import useAuth from "@/hooks/useAuth";
 import UtilisateurForm from "@/components/utilisateurs/UtilisateurForm";
 import UtilisateurDetail from "@/components/utilisateurs/UtilisateurDetail";
 import { Button } from "@/components/ui/button";
-import TableContainer from "@/components/ui/TableContainer";
+import ListingContainer from "@/components/ui/ListingContainer";
+import PaginationFooter from "@/components/ui/PaginationFooter";
+import TableHeader from "@/components/ui/TableHeader";
 import GlassCard from "@/components/ui/GlassCard";
 import { Toaster, toast } from "react-hot-toast";
 import { saveAs } from "file-saver";
@@ -63,7 +65,7 @@ export default function Utilisateurs() {
     <div className="p-6 container mx-auto text-shadow">
       <Toaster position="top-right" />
       <GlassCard className="p-4 mb-4">
-        <div className="flex flex-wrap gap-4 items-end">
+        <TableHeader>
           <input
             type="search"
             value={search}
@@ -80,9 +82,9 @@ export default function Utilisateurs() {
             Ajouter un utilisateur
           </Button>
           <Button variant="outline" onClick={exportExcel}>Export Excel</Button>
-        </div>
+        </TableHeader>
       </GlassCard>
-      <TableContainer className="mb-4">
+      <ListingContainer className="mb-4">
         <Motion.table
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
@@ -125,17 +127,12 @@ export default function Utilisateurs() {
           ))}
         </tbody>
         </Motion.table>
-      </TableContainer>
-      <div className="mt-4 flex gap-2">
-        {Array.from({ length: nbPages }, (_, i) => (
-          <Button
-            key={i + 1}
-            size="sm"
-            variant={page === i + 1 ? "default" : "outline"}
-            onClick={() => setPage(i + 1)}
-          >{i + 1}</Button>
-        ))}
-      </div>
+      </ListingContainer>
+      <PaginationFooter
+        page={page}
+        pages={nbPages}
+        onPageChange={setPage}
+      />
       {showForm && (
         <UtilisateurForm
           utilisateur={selected}

--- a/src/pages/factures/Factures.jsx
+++ b/src/pages/factures/Factures.jsx
@@ -8,7 +8,9 @@ import FactureForm from "./FactureForm.jsx";
 import FactureDetail from "./FactureDetail.jsx";
 import { Button } from "@/components/ui/button";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
-import TableContainer from "@/components/ui/TableContainer";
+import ListingContainer from "@/components/ui/ListingContainer";
+import PaginationFooter from "@/components/ui/PaginationFooter";
+import TableHeader from "@/components/ui/TableHeader";
 import GlassCard from "@/components/ui/GlassCard";
 import { Toaster, toast } from "react-hot-toast";
 import { saveAs } from "file-saver";
@@ -93,7 +95,8 @@ export default function Factures() {
   return (
     <div className="p-6 container mx-auto text-shadow space-y-6">
       <Toaster position="top-right" />
-      <GlassCard className="flex flex-wrap gap-4 items-end">
+      <GlassCard>
+        <TableHeader className="items-end">
         <input
           list="factures-list"
           type="search"
@@ -162,8 +165,9 @@ export default function Factures() {
           </Button>
         )}
         <Button variant="outline" onClick={exportExcel}>Export Excel</Button>
+        </TableHeader>
       </GlassCard>
-      <TableContainer className="mb-4">
+      <ListingContainer className="mb-4">
         <Motion.table
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
@@ -203,24 +207,13 @@ export default function Factures() {
           ))}
         </tbody>
         </Motion.table>
-      </TableContainer>
-      <div className="flex justify-between items-center mb-4">
-        <Button
-          variant="outline"
-          disabled={page === 1}
-          onClick={() => setPage(p => Math.max(1, p - 1))}
-        >
-          Précédent
-        </Button>
-        <span className="px-2">Page {page}</span>
-        <Button
-          variant="outline"
-          disabled={page * pageSize >= total}
-          onClick={() => setPage(p => p + 1)}
-        >
-          Suivant
-        </Button>
-      </div>
+      </ListingContainer>
+      <PaginationFooter
+        page={page}
+        pages={Math.ceil(total / pageSize)}
+        onPageChange={setPage}
+        className="mb-4"
+      />
       {/* Modal d’ajout/modif */}
       {showForm && (
         <FactureForm

--- a/src/pages/fiches/Fiches.jsx
+++ b/src/pages/fiches/Fiches.jsx
@@ -7,7 +7,9 @@ import FicheForm from "./FicheForm.jsx";
 import FicheDetail from "./FicheDetail.jsx";
 import FicheRow from "@/components/fiches/FicheRow.jsx";
 import { Button } from "@/components/ui/button";
-import TableContainer from "@/components/ui/TableContainer";
+import ListingContainer from "@/components/ui/ListingContainer";
+import PaginationFooter from "@/components/ui/PaginationFooter";
+import TableHeader from "@/components/ui/TableHeader";
 import { useFamilles } from "@/hooks/useFamilles";
 import { Toaster, toast } from "react-hot-toast";
 import { motion as Motion } from "framer-motion";
@@ -72,7 +74,7 @@ export default function Fiches() {
   return (
     <div className="p-6 container mx-auto text-shadow">
       <Toaster position="top-right" />
-      <div className="flex flex-wrap gap-4 items-center mb-4">
+      <TableHeader>
         <input
           type="search"
           value={search}
@@ -137,8 +139,8 @@ export default function Fiches() {
         <Button variant="outline" onClick={exportPdf}>
           Export PDF
         </Button>
-      </div>
-      <TableContainer className="mb-4">
+      </TableHeader>
+      <ListingContainer className="mb-4">
         <Motion.table
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
@@ -184,22 +186,12 @@ export default function Fiches() {
             ))}
           </tbody>
         </Motion.table>
-      </TableContainer>
-      <div className="mt-4 flex gap-2 justify-center">
-        {Array.from(
-          { length: Math.max(1, Math.ceil(total / PAGE_SIZE)) },
-          (_, i) => (
-            <Button
-              key={i + 1}
-              size="sm"
-              variant={page === i + 1 ? "default" : "outline"}
-              onClick={() => setPage(i + 1)}
-            >
-              {i + 1}
-            </Button>
-          ),
-        )}
-      </div>
+      </ListingContainer>
+      <PaginationFooter
+        page={page}
+        pages={Math.max(1, Math.ceil(total / PAGE_SIZE))}
+        onPageChange={setPage}
+      />
       {showForm && (
         <FicheForm
           fiche={selected}

--- a/src/pages/fournisseurs/Fournisseurs.jsx
+++ b/src/pages/fournisseurs/Fournisseurs.jsx
@@ -8,6 +8,9 @@ import { useProducts } from "@/hooks/useProducts";
 import { useFournisseursInactifs } from "@/hooks/useFournisseursInactifs";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import ListingContainer from '@/components/ui/ListingContainer';
+import PaginationFooter from '@/components/ui/PaginationFooter';
+import TableHeader from '@/components/ui/TableHeader';
 import FournisseurRow from "@/components/fournisseurs/FournisseurRow";
 import { Dialog, DialogContent } from "@radix-ui/react-dialog";
 import jsPDF from "jspdf";
@@ -125,7 +128,7 @@ export default function Fournisseurs() {
 
       <Card>
         <CardHeader className="pb-4">
-          <div className="flex flex-wrap gap-4 items-end">
+          <TableHeader>
             <div className="relative flex-1">
               <input
                 className="input w-full pl-8"
@@ -144,10 +147,10 @@ export default function Fournisseurs() {
               <option value="true">Actif</option>
               <option value="false">Inactif</option>
             </select>
-          </div>
+          </TableHeader>
         </CardHeader>
         <CardContent className="pt-4">
-          <div className="flex flex-wrap gap-4">
+          <TableHeader>
             {canEdit && (
               <Button className="w-auto flex items-center" onClick={() => setShowCreate(true)}>
                 <PlusCircle className="mr-2" size={18} /> Ajouter fournisseur
@@ -159,7 +162,7 @@ export default function Fournisseurs() {
             <Button className="w-auto" onClick={exportPDF}>
               Export PDF
             </Button>
-          </div>
+          </TableHeader>
         </CardContent>
       </Card>
       {inactifs.length > 0 && (
@@ -220,65 +223,53 @@ export default function Fournisseurs() {
         </Card>
       </div>
       {/* Tableau fournisseurs */}
-      <Card className="mb-6">
-        <CardHeader>
-          <h2 className="font-semibold">Liste des fournisseurs</h2>
-        </CardHeader>
-        <CardContent className="pt-2">
-          <div className="overflow-x-auto rounded-xl backdrop-blur-xl">
-            <table className="min-w-full text-sm text-white text-center whitespace-nowrap table-striped">
-              <thead>
+      <h2 className="font-semibold mb-2">Liste des fournisseurs</h2>
+      <ListingContainer className="mb-6">
+        <table className="text-sm text-center">
+            <thead>
+              <tr>
+                <th className="py-2 px-3">Nom</th>
+                <th className="py-2 px-3">Téléphone</th>
+                <th className="py-2 px-3">Contact</th>
+                <th className="py-2 px-3">Email</th>
+                <th className="py-2 px-3">Nb Produits</th>
+                <th className="py-2 px-3"></th>
+                <th className="py-2 px-3"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {fournisseursFiltrés.length === 0 ? (
                 <tr>
-                  <th className="py-2 px-3">Nom</th>
-                  <th className="py-2 px-3">Téléphone</th>
-                  <th className="py-2 px-3">Contact</th>
-                  <th className="py-2 px-3">Email</th>
-                  <th className="py-2 px-3">Nb Produits</th>
-                  <th className="py-2 px-3"></th>
-                  <th className="py-2 px-3"></th>
+                  <td colSpan={7} className="py-4 text-muted-foreground">
+                    Aucun fournisseur trouvé
+                  </td>
                 </tr>
-              </thead>
-              <tbody>
-                {fournisseursFiltrés.length === 0 ? (
-                  <tr>
-                    <td colSpan={7} className="py-4 text-muted-foreground">
-                      Aucun fournisseur trouvé
-                    </td>
-                  </tr>
-                ) : (
-                  fournisseursFiltrés.map(f => (
-                    <FournisseurRow
-                      key={f.id}
-                      fournisseur={f}
-                      productCount={productCounts[f.id] ?? 0}
-                      canEdit={canEdit}
-                      onDetail={() => setSelected(f.id)}
-                      onEdit={() => setEditRow(f)}
-                      onDelete={async (id) => {
-                        if (!window.confirm('Désactiver ce fournisseur ?')) return;
-                        await disableFournisseur(id);
-                        toast.success('Fournisseur désactivé');
-                        refreshList();
-                      }}
-                    />
-                  ))
-                )}
-              </tbody>
-            </table>
-          </div>
-          <div className="mt-6 flex gap-4 justify-center">
-            {Array.from({ length: Math.max(1, Math.ceil(total / PAGE_SIZE)) }, (_, i) => (
-              <button
-                key={i + 1}
-                className={`px-3 py-1 rounded-xl font-semibold text-white ${page === i + 1 ? 'bg-white/30' : 'bg-white/20 hover:bg-white/30'}`}
-                onClick={() => setPage(i + 1)}
-              >
-                {i + 1}
-              </button>
-            ))}
-          </div>
-        </CardContent>
-      </Card>
+              ) : (
+                fournisseursFiltrés.map(f => (
+                  <FournisseurRow
+                    key={f.id}
+                    fournisseur={f}
+                    productCount={productCounts[f.id] ?? 0}
+                    canEdit={canEdit}
+                    onDetail={() => setSelected(f.id)}
+                    onEdit={() => setEditRow(f)}
+                    onDelete={async (id) => {
+                      if (!window.confirm('Désactiver ce fournisseur ?')) return;
+                      await disableFournisseur(id);
+                      toast.success('Fournisseur désactivé');
+                      refreshList();
+                    }}
+                  />
+                ))
+              )}
+            </tbody>
+        </table>
+      </ListingContainer>
+      <PaginationFooter
+        page={page}
+        pages={Math.max(1, Math.ceil(total / PAGE_SIZE))}
+        onPageChange={setPage}
+      />
 
       {/* Modal création/édition */}
       <Dialog open={showCreate || !!editRow} onOpenChange={v => { if (!v) { setShowCreate(false); setEditRow(null); } }}>

--- a/src/pages/menus/Menus.jsx
+++ b/src/pages/menus/Menus.jsx
@@ -10,7 +10,9 @@ import { Toaster, toast } from "react-hot-toast";
 import { saveAs } from "file-saver";
 import * as XLSX from "xlsx";
 import { motion as Motion } from "framer-motion";
-import TableContainer from "@/components/ui/TableContainer";
+import ListingContainer from "@/components/ui/ListingContainer";
+import PaginationFooter from "@/components/ui/PaginationFooter";
+import TableHeader from "@/components/ui/TableHeader";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 
 export default function Menus() {
@@ -91,7 +93,7 @@ export default function Menus() {
   return (
     <div className="p-6 container mx-auto">
       <Toaster position="top-right" />
-      <div className="flex flex-wrap gap-4 items-center mb-4">
+      <TableHeader>
         <input
           type="search"
           value={search}
@@ -121,8 +123,8 @@ export default function Menus() {
           Ajouter un menu
         </Button>
         <Button variant="outline" onClick={exportExcel}>Export Excel</Button>
-      </div>
-      <TableContainer className="mt-4">
+      </TableHeader>
+      <ListingContainer className="mt-4">
         <Motion.table
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
@@ -189,24 +191,13 @@ export default function Menus() {
           ))}
         </tbody>
         </Motion.table>
-      </TableContainer>
-      <div className="flex justify-center gap-2 my-4">
-        <Button
-          variant="outline"
-          disabled={page <= 1}
-          onClick={() => setPage(p => Math.max(1, p - 1))}
-        >
-          Précédent
-        </Button>
-        <span className="px-2">Page {page} / {pageCount}</span>
-        <Button
-          variant="outline"
-          disabled={page >= pageCount}
-          onClick={() => setPage(p => Math.min(pageCount, p + 1))}
-        >
-          Suivant
-        </Button>
-      </div>
+      </ListingContainer>
+      <PaginationFooter
+        page={page}
+        pages={pageCount}
+        onPageChange={setPage}
+        className="my-4"
+      />
       {showForm && (
         <MenuForm
           menu={selected}

--- a/src/pages/parametrage/Familles.jsx
+++ b/src/pages/parametrage/Familles.jsx
@@ -2,6 +2,9 @@
 import { useEffect, useState } from 'react';
 import { Toaster, toast } from 'react-hot-toast';
 import TableContainer from '@/components/ui/TableContainer';
+import ListingContainer from '@/components/ui/ListingContainer';
+import PaginationFooter from '@/components/ui/PaginationFooter';
+import TableHeader from '@/components/ui/TableHeader';
 import { Button } from '@/components/ui/button';
 import { useFamilles } from '@/hooks/useFamilles';
 import FamilleRow from '@/components/parametrage/FamilleRow';
@@ -51,7 +54,7 @@ export default function Familles() {
     <div className="p-6 max-w-2xl mx-auto">
       <Toaster position="top-right" />
       <h1 className="text-2xl font-bold mb-4">Familles de produits</h1>
-      <div className="flex gap-2 mb-4 items-end">
+      <TableHeader className="gap-2">
         <input
           className="input flex-1"
           placeholder="Recherche"
@@ -59,9 +62,9 @@ export default function Familles() {
           onChange={e => setSearch(e.target.value)}
         />
         <Button onClick={() => setEdit({})}>+ Nouvelle famille</Button>
-      </div>
-      <TableContainer>
-        <table className="min-w-full text-sm text-center">
+      </TableHeader>
+      <ListingContainer>
+        <table className="text-sm text-center">
           <thead>
             <tr>
               <th className="px-2 py-1">Nom</th>
@@ -82,18 +85,8 @@ export default function Familles() {
             )}
           </tbody>
         </table>
-      </TableContainer>
-      <div className="flex justify-between mt-2">
-        <Button variant="outline" onClick={() => setPage(p => Math.max(1, p - 1))} disabled={page === 1}>
-          Précédent
-        </Button>
-        <span>
-          Page {page}/{pages}
-        </span>
-        <Button variant="outline" onClick={() => setPage(p => Math.min(pages, p + 1))} disabled={page >= pages}>
-          Suivant
-        </Button>
-      </div>
+      </ListingContainer>
+      <PaginationFooter page={page} pages={pages} onPageChange={setPage} />
       {edit && (
         <div className="fixed inset-0 flex items-center justify-center z-50">
           <div className="absolute inset-0 bg-black/50" onClick={() => setEdit(null)} />

--- a/src/pages/parametrage/Unites.jsx
+++ b/src/pages/parametrage/Unites.jsx
@@ -2,6 +2,9 @@
 import { useEffect, useState } from 'react';
 import { Toaster, toast } from 'react-hot-toast';
 import TableContainer from '@/components/ui/TableContainer';
+import ListingContainer from '@/components/ui/ListingContainer';
+import PaginationFooter from '@/components/ui/PaginationFooter';
+import TableHeader from '@/components/ui/TableHeader';
 import { Button } from '@/components/ui/button';
 import { useUnites } from '@/hooks/useUnites';
 import UniteRow from '@/components/parametrage/UniteRow';
@@ -51,7 +54,7 @@ export default function Unites() {
     <div className="p-6 max-w-2xl mx-auto">
       <Toaster position="top-right" />
       <h1 className="text-2xl font-bold mb-4">Unités de produits</h1>
-      <div className="flex gap-2 mb-4 items-end">
+      <TableHeader className="gap-2">
         <input
           className="input flex-1"
           placeholder="Recherche"
@@ -59,9 +62,9 @@ export default function Unites() {
           onChange={e => setSearch(e.target.value)}
         />
         <Button onClick={() => setEdit({})}>+ Nouvelle unité</Button>
-      </div>
-      <TableContainer>
-        <table className="min-w-full text-sm text-center">
+      </TableHeader>
+      <ListingContainer>
+        <table className="text-sm text-center">
           <thead>
             <tr>
               <th className="px-2 py-1">Nom</th>
@@ -82,18 +85,8 @@ export default function Unites() {
             )}
           </tbody>
         </table>
-      </TableContainer>
-      <div className="flex justify-between mt-2">
-        <Button variant="outline" onClick={() => setPage(p => Math.max(1, p - 1))} disabled={page === 1}>
-          Précédent
-        </Button>
-        <span>
-          Page {page}/{pages}
-        </span>
-        <Button variant="outline" onClick={() => setPage(p => Math.min(pages, p + 1))} disabled={page >= pages}>
-          Suivant
-        </Button>
-      </div>
+      </ListingContainer>
+      <PaginationFooter page={page} pages={pages} onPageChange={setPage} />
       {edit && (
         <div className="fixed inset-0 flex items-center justify-center z-50">
           <div className="absolute inset-0 bg-black/50" onClick={() => setEdit(null)} />

--- a/src/pages/parametrage/Utilisateurs.jsx
+++ b/src/pages/parametrage/Utilisateurs.jsx
@@ -8,7 +8,9 @@ import UtilisateurForm from "./UtilisateurForm";
 import UtilisateurDetail from "@/components/utilisateurs/UtilisateurDetail";
 import UtilisateurRow from "@/components/parametrage/UtilisateurRow";
 import { Button } from "@/components/ui/button";
-import TableContainer from "@/components/ui/TableContainer";
+import ListingContainer from "@/components/ui/ListingContainer";
+import PaginationFooter from "@/components/ui/PaginationFooter";
+import TableHeader from "@/components/ui/TableHeader";
 import { Toaster, toast } from "react-hot-toast";
 import { motion as Motion } from "framer-motion";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
@@ -88,7 +90,7 @@ export default function Utilisateurs() {
   return (
     <div className="p-6 container mx-auto text-shadow">
       <Toaster position="top-right" />
-      <div className="flex flex-wrap gap-4 items-center mb-4">
+      <TableHeader>
         <input
           type="search"
           value={search}
@@ -149,12 +151,12 @@ export default function Utilisateurs() {
         </select>
         <Button variant="outline" onClick={() => exportUsersToExcel(filtres)}>Export Excel</Button>
         <Button variant="outline" onClick={() => exportUsersToCSV(filtres)}>Export CSV</Button>
-      </div>
+      </TableHeader>
       {error && (
         <div className="text-red-500 mb-2">{error.message}</div>
       )}
       {loading && <LoadingSpinner message="Chargement..." />}
-      <TableContainer className="mb-4">
+      <ListingContainer className="mb-4">
         <Motion.table
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
@@ -192,17 +194,12 @@ export default function Utilisateurs() {
           )}
         </tbody>
         </Motion.table>
-      </TableContainer>
-      <div className="mt-4 flex gap-2">
-        {Array.from({ length: nbPages }, (_, i) => (
-          <Button
-            key={i + 1}
-            size="sm"
-            variant={page === i + 1 ? "default" : "outline"}
-            onClick={() => setPage(i + 1)}
-          >{i + 1}</Button>
-        ))}
-      </div>
+      </ListingContainer>
+      <PaginationFooter
+        page={page}
+        pages={nbPages}
+        onPageChange={setPage}
+      />
       {showForm && (
         <UtilisateurForm
           utilisateur={selected}

--- a/src/pages/produits/Produits.jsx
+++ b/src/pages/produits/Produits.jsx
@@ -8,7 +8,9 @@ import ProduitFormModal from "@/components/produits/ProduitFormModal";
 import ProduitDetail from "@/components/produits/ProduitDetail";
 import { Button } from "@/components/ui/button";
 import GlassCard from "@/components/ui/GlassCard";
-import TableContainer from "@/components/ui/TableContainer";
+import ListingContainer from "@/components/ui/ListingContainer";
+import PaginationFooter from "@/components/ui/PaginationFooter";
+import TableHeader from "@/components/ui/TableHeader";
 import { Input } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
 import { Plus } from "lucide-react";
@@ -185,7 +187,7 @@ export default function Produits() {
             <option value="false">Inactif</option>
           </Select>
         </div>
-        <div className="flex flex-wrap gap-4 mt-4">
+        <TableHeader className="mt-4">
           <Button
             className="w-auto"
             onClick={() => {
@@ -209,11 +211,10 @@ export default function Produits() {
             data-testid="import-input"
             className="hidden"
           />
-        </div>
+        </TableHeader>
       </GlassCard>
-      <GlassCard className="p-0">
-        <TableContainer className="p-0">
-          <table className="min-w-full table-auto text-center text-white">
+      <ListingContainer>
+        <table className="min-w-full table-auto text-center">
             <thead>
               <tr>
               <th className="cursor-pointer" onClick={() => toggleSort("nom")}>
@@ -280,23 +281,12 @@ export default function Produits() {
             )}
           </tbody>
         </table>
-        <div className="mt-4 flex gap-2 justify-center">
-          {Array.from(
-            { length: Math.max(1, Math.ceil(total / PAGE_SIZE)) },
-            (_, i) => (
-              <Button
-                key={i + 1}
-                size="sm"
-                variant={page === i + 1 ? "default" : "outline"}
-                onClick={() => setPage(i + 1)}
-              >
-                {i + 1}
-              </Button>
-            ),
-          )}
-        </div>
-        </TableContainer>
-      </GlassCard>
+      </ListingContainer>
+      <PaginationFooter
+        page={page}
+        pages={Math.max(1, Math.ceil(total / PAGE_SIZE))}
+        onPageChange={setPage}
+      />
       {/* Modale création/édition */}
       <ProduitFormModal
         open={showForm}


### PR DESCRIPTION
## Summary
- introduce reusable `TableHeader` component for actions and filters
- use `TableHeader` across major listing pages
- lint passes but tests fail due to missing Supabase credentials

## Testing
- `npm run lint`
- `npm test` *(fails: Missing Supabase credentials and other setup issues)*

------
https://chatgpt.com/codex/tasks/task_e_688c8479dba4832d87df879fc914a4c9