### PR TITLE
Fix product form references

### DIFF
--- a/src/components/produits/ProduitForm.jsx
+++ b/src/components/produits/ProduitForm.jsx
@@ -16,8 +16,6 @@ import { Card, CardContent } from "@/components/ui/card";
 
 export default function ProduitForm({
   produit,
-  familles = [],
-  unites = [],
   onSuccess,
   onClose,
 }) {
@@ -45,11 +43,11 @@ export default function ProduitForm({
   const { addProduct, updateProduct, loading } = useProducts();
   const [saving, setSaving] = useState(false);
 
-  const familleOptions = [...famillesHook, ...familles]
+  const familleOptions = [...famillesHook]
     .filter((f, idx, arr) => arr.findIndex((ff) => ff.id === f.id) === idx)
     .sort((a, b) => (a.nom || "").localeCompare(b.nom || ""));
 
-  const uniteOptions = [...unitesHook, ...unites]
+  const uniteOptions = [...unitesHook]
     .filter((u, idx, arr) => arr.findIndex((uu) => uu.id === u.id) === idx)
     .sort((a, b) => (a.nom || "").localeCompare(b.nom || ""));
 

--- a/src/components/produits/ProduitFormModal.jsx
+++ b/src/components/produits/ProduitFormModal.jsx
@@ -4,7 +4,7 @@ import ModalGlass from "@/components/ui/ModalGlass";
 import ProduitForm from "./ProduitForm";
 import { useEffect } from "react";
 
-export default function ProduitFormModal({ open, produit, familles, unites, onClose, onSuccess }) {
+export default function ProduitFormModal({ open, produit, onClose, onSuccess }) {
   // Fermer avec ESC
   useEffect(() => {
     function handleKey(e) {
@@ -16,13 +16,7 @@ export default function ProduitFormModal({ open, produit, familles, unites, onCl
 
   return (
     <ModalGlass open={open} onClose={onClose}>
-      <ProduitForm
-        produit={produit}
-        familles={familles}
-        unites={unites}
-        onSuccess={onSuccess}
-        onClose={onClose}
-      />
+      <ProduitForm produit={produit} onSuccess={onSuccess} onClose={onClose} />
     </ModalGlass>
   );
 }

--- a/src/pages/produits/Produits.jsx
+++ b/src/pages/produits/Produits.jsx
@@ -291,8 +291,6 @@ export default function Produits() {
       <ProduitFormModal
         open={showForm}
         produit={selectedProduct}
-        familles={familles}
-        unites={unites}
         onClose={() => {
           setShowForm(false);
           setSelectedProduct(null);

--- a/test/ProduitForm.test.jsx
+++ b/test/ProduitForm.test.jsx
@@ -32,7 +32,7 @@ import ProduitForm from '@/components/produits/ProduitForm.jsx';
 test('renders additional product inputs', () => {
   mockHook = () => ({ addProduct: vi.fn(), updateProduct: vi.fn(), loading: false });
   render(
-    <ProduitForm familles={[]} unites={[]} onSuccess={vi.fn()} onClose={vi.fn()} />
+    <ProduitForm onSuccess={vi.fn()} onClose={vi.fn()} />
   );
   expect(screen.getByLabelText(/Code interne/)).toBeInTheDocument();
   expect(screen.getByLabelText(/Allergènes/)).toBeInTheDocument();
@@ -43,7 +43,7 @@ test('PMP input read-only or hidden', () => {
   mockHook = () => ({ addProduct: vi.fn(), updateProduct: vi.fn(), loading: false });
   // create mode: no PMP field
   const { rerender } = render(
-    <ProduitForm familles={[]} unites={[]} onSuccess={vi.fn()} onClose={vi.fn()} />
+    <ProduitForm onSuccess={vi.fn()} onClose={vi.fn()} />
   );
   expect(screen.queryByLabelText(/PMP/)).toBeNull();
 
@@ -51,8 +51,6 @@ test('PMP input read-only or hidden', () => {
   rerender(
     <ProduitForm
       produit={{ id: '1', nom: 'p', famille: 'f', unite: 'u', pmp: 5 }}
-      familles={[]}
-      unites={[]}
       onSuccess={vi.fn()}
       onClose={vi.fn()}
     />


### PR DESCRIPTION
## Summary
- update product form props to rely on hooks for families and units
- simplify product form modal
- adjust product listing page
- update unit test accordingly

## Testing
- `npm run lint`
- `npm test` *(fails: Missing Supabase credentials)*

------
https://chatgpt.com/codex/tasks/task_e_688ca8ac8a7c832d9a28a931efe49bdb