### PR TITLE
Fix product form families/unites autocomplete

### DIFF
--- a/src/components/produits/ProduitForm.jsx
+++ b/src/components/produits/ProduitForm.jsx
@@ -2,11 +2,12 @@
 // src/components/produits/ProduitForm.jsx
 import { useState, useEffect } from "react";
 import { useProducts } from "@/hooks/useProducts";
+import AutoCompleteFamilleField from "@/components/ui/AutoCompleteFamilleField";
+import AutoCompleteUniteField from "@/components/ui/AutoCompleteUniteField";
 import { useFamilles } from "@/hooks/useFamilles";
 import { useUnites } from "@/hooks/useUnites";
 import { useFournisseurs } from "@/hooks/useFournisseurs";
 import { toast } from "react-hot-toast";
-import AutoCompleteField from "@/components/ui/AutoCompleteField";
 import { Input } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
 import SecondaryButton from "@/components/ui/SecondaryButton";
@@ -20,9 +21,9 @@ export default function ProduitForm({
   onClose,
 }) {
   const editing = !!produit;
-  const { familles: famillesHook, fetchFamilles, addFamille } = useFamilles();
-  const { unites: unitesHook, fetchUnites, addUnite } = useUnites();
   const { fournisseurs, fetchFournisseurs } = useFournisseurs();
+  const { addFamille } = useFamilles();
+  const { addUnite } = useUnites();
 
   const [nom, setNom] = useState(produit?.nom || "");
   const [famille, setFamille] = useState({
@@ -43,19 +44,9 @@ export default function ProduitForm({
   const { addProduct, updateProduct, loading } = useProducts();
   const [saving, setSaving] = useState(false);
 
-  const familleOptions = [...famillesHook]
-    .filter((f, idx, arr) => arr.findIndex((ff) => ff.id === f.id) === idx)
-    .sort((a, b) => (a.nom || "").localeCompare(b.nom || ""));
-
-  const uniteOptions = [...unitesHook]
-    .filter((u, idx, arr) => arr.findIndex((uu) => uu.id === u.id) === idx)
-    .sort((a, b) => (a.nom || "").localeCompare(b.nom || ""));
-
   useEffect(() => {
-    fetchFamilles();
-    fetchUnites();
     fetchFournisseurs();
-  }, [fetchFamilles, fetchUnites, fetchFournisseurs]);
+  }, [fetchFournisseurs]);
 
   useEffect(() => {
     if (editing && produit) {
@@ -159,16 +150,10 @@ export default function ProduitForm({
               )}
             </div>
             <div>
-              <AutoCompleteField
+              <AutoCompleteFamilleField
                 label="Famille"
                 value={famille.id}
                 onChange={(obj) => setFamille(obj)}
-                options={familleOptions.map((f) => ({ id: f.id, nom: f.nom }))}
-                onAddNewValue={async (val) => {
-                  const { data, error } = await addFamille(val);
-                  if (error) toast.error(error.message || error);
-                  else return { id: data.id, nom: data.nom };
-                }}
                 required
               />
               {errors.famille && (
@@ -176,16 +161,10 @@ export default function ProduitForm({
               )}
             </div>
             <div>
-              <AutoCompleteField
+              <AutoCompleteUniteField
                 label="Unité"
                 value={unite.id}
                 onChange={(obj) => setUnite(obj)}
-                options={uniteOptions.map((u) => ({ id: u.id, nom: u.nom }))}
-                onAddNewValue={async (val) => {
-                  const { data, error } = await addUnite(val);
-                  if (error) toast.error(error.message || error);
-                  else return { id: data.id, nom: data.nom };
-                }}
                 required
               />
               {errors.unite && (

--- a/src/components/ui/AutoCompleteFamilleField.jsx
+++ b/src/components/ui/AutoCompleteFamilleField.jsx
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+import AutoCompleteField from './AutoCompleteField';
+import { useFamilles } from '@/hooks/useFamilles';
+import { toast } from 'react-hot-toast';
+
+export default function AutoCompleteFamilleField({ value, onChange, ...props }) {
+  const { familles, fetchFamilles, addFamille } = useFamilles();
+  useEffect(() => { fetchFamilles(); }, [fetchFamilles]);
+  const options = familles.map(f => ({ id: f.id, nom: f.nom })).sort((a,b)=>a.nom.localeCompare(b.nom));
+  const handleAdd = async (val) => {
+    const { data, error } = await addFamille(val);
+    if (error) toast.error(error.message || error);
+    else return { id: data.id, nom: data.nom };
+  };
+  return (
+    <AutoCompleteField
+      {...props}
+      value={value}
+      onChange={onChange}
+      options={options}
+      onAddNewValue={handleAdd}
+    />
+  );
+}

--- a/src/components/ui/AutoCompleteUniteField.jsx
+++ b/src/components/ui/AutoCompleteUniteField.jsx
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+import AutoCompleteField from './AutoCompleteField';
+import { useUnites } from '@/hooks/useUnites';
+import { toast } from 'react-hot-toast';
+
+export default function AutoCompleteUniteField({ value, onChange, ...props }) {
+  const { unites, fetchUnites, addUnite } = useUnites();
+  useEffect(() => { fetchUnites(); }, [fetchUnites]);
+  const options = unites.map(u => ({ id: u.id, nom: u.nom })).sort((a,b)=>a.nom.localeCompare(b.nom));
+  const handleAdd = async (val) => {
+    const { data, error } = await addUnite(val);
+    if (error) toast.error(error.message || error);
+    else return { id: data.id, nom: data.nom };
+  };
+  return (
+    <AutoCompleteField
+      {...props}
+      value={value}
+      onChange={onChange}
+      options={options}
+      onAddNewValue={handleAdd}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- add `AutoCompleteFamilleField` and `AutoCompleteUniteField` components
- update `ProduitForm` to use these components and hooks

## Testing
- `npm run lint`
- `npm test` *(fails: Missing Supabase credentials)*

------
https://chatgpt.com/codex/tasks/task_e_688cdae7bfa0832d9392a237cbae9a64