### PR TITLE
feat: add MamaStock logo in sidebars

### DIFF
--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -4,7 +4,7 @@ import { Link, useLocation } from "react-router-dom";
 // l'utilisateur possède le droit "peut_voir". Les droits proviennent
 // du contexte d'authentification (merge utilisateur + rôle).
 import useAuth from "@/hooks/useAuth";
-import MamaLogo from "@/components/ui/MamaLogo";
+import logo from "@/assets/logo-mamastock.png";
 
 export default function Sidebar() {
   const { access_rights, isSuperadmin, loading, pending, hasAccess } = useAuth();
@@ -16,9 +16,7 @@ export default function Sidebar() {
 
   return (
     <aside className="w-64 bg-white/10 border border-white/10 backdrop-blur-xl text-white p-4 h-screen shadow-md text-shadow">
-      <div className="mb-6">
-        <MamaLogo width={140} />
-      </div>
+      <img src={logo} alt="MamaStock" className="h-16 mx-auto mt-4 mb-6" />
       <nav className="flex flex-col gap-2 text-sm">
         {has("dashboard") && <Link to="/dashboard">Dashboard</Link>}
 

--- a/src/layout/Sidebar.jsx
+++ b/src/layout/Sidebar.jsx
@@ -2,7 +2,7 @@
 import { Link, useLocation } from "react-router-dom";
 import { routePreloadMap } from "@/router";
 import useAuth from "@/hooks/useAuth";
-import logo from "@/assets/logo-mamastock.svg";
+import logo from "@/assets/logo-mamastock.png";
 import {
   Boxes,
   ClipboardList,
@@ -179,9 +179,7 @@ export default function Sidebar() {
 
   return (
     <aside className="w-64 bg-white/10 border border-white/10 backdrop-blur-xl text-white h-screen shadow-md text-shadow hidden md:flex md:flex-col animate-fade-in-down">
-      <div className="flex justify-center py-4 bg-black/20 border-b border-muted">
-        <img src={logo} alt="MamaStock" className="h-10" />
-      </div>
+      <img src={logo} alt="MamaStock" className="h-16 mx-auto mt-4 mb-6" />
       <nav className="flex flex-col gap-4 text-sm p-4 flex-1 overflow-y-auto">
         {peutVoir("dashboard") && (
           <Item to="/dashboard" icon={<Home size={16} />} label="Dashboard" />


### PR DESCRIPTION
## Summary
- replace SVG logo with PNG and center it at the top of the main sidebar
- show PNG logo without shadow in admin sidebar

## Testing
- `npm test` *(fails: Missing Supabase credentials, act warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688ddab61c74832d9c06bea53bab3a21