### PR TITLE
fix: use explicit Supabase aliases

### DIFF
--- a/src/hooks/useAchats.js
+++ b/src/hooks/useAchats.js
@@ -17,7 +17,7 @@ export function useAchats() {
     let q = supabase
       .from("achats")
       .select(
-        "*, fournisseur:fournisseurs(id, nom), produit:produits(id, nom)",
+        "*, fournisseur:fournisseur_id(id, nom), produit:produit_id(id, nom)",
         { count: "exact" },
       )
       .eq("mama_id", mama_id)
@@ -42,7 +42,7 @@ export function useAchats() {
     if (!id || !mama_id) return null;
     const { data, error } = await supabase
       .from("achats")
-      .select("*, fournisseur:fournisseurs(id, nom), produit:produits(id, nom)")
+      .select("*, fournisseur:fournisseur_id(id, nom), produit:produit_id(id, nom)")
       .eq("id", id)
       .eq("mama_id", mama_id)
       .single();

--- a/src/hooks/useAlerts.js
+++ b/src/hooks/useAlerts.js
@@ -15,7 +15,7 @@ export function useAlerts() {
     setError(null);
     let query = supabase
       .from("regles_alertes")
-      .select("*, produit:produits(id, nom)")
+      .select("*, produit:produit_id(id, nom)")
       .eq("mama_id", mama_id)
       .order("created_at", { ascending: false });
 

--- a/src/hooks/useBonsLivraison.js
+++ b/src/hooks/useBonsLivraison.js
@@ -16,7 +16,7 @@ export function useBonsLivraison() {
     setError(null);
     let q = supabase
       .from("bons_livraison")
-      .select("id, numero_bl, date_reception, commentaire, actif, fournisseur: fournisseurs(id, nom), lignes: lignes_bl(id)", { count: "exact" })
+      .select("id, numero_bl, date_reception, commentaire, actif, fournisseur_id, fournisseur:fournisseur_id(id, nom), lignes:lignes_bl!bl_id(id)", { count: "exact" })
       .eq("mama_id", mama_id)
       .order("date_reception", { ascending: false })
       .range((page - 1) * pageSize, page * pageSize - 1);
@@ -38,7 +38,7 @@ export function useBonsLivraison() {
     if (!id || !mama_id) return null;
     const { data, error } = await supabase
       .from("bons_livraison")
-      .select("id, numero_bl, date_reception, commentaire, actif, fournisseur:fournisseurs(id, nom), lignes:lignes_bl(id, quantite_recue, prix_unitaire, tva, produit:produits(nom))")
+      .select("id, numero_bl, date_reception, commentaire, actif, fournisseur_id, fournisseur:fournisseur_id(id, nom), lignes:lignes_bl!bl_id(id, bl_id, quantite_recue, prix_unitaire, tva, produit:produit_id(nom))")
       .eq("id", id)
       .eq("mama_id", mama_id)
       .single();

--- a/src/hooks/useCommandes.js
+++ b/src/hooks/useCommandes.js
@@ -16,7 +16,7 @@ export function useCommandes() {
     setError(null);
     let q = supabase
       .from("commandes")
-      .select("id, date_commande, statut, actif, fournisseur:fournisseurs(id, nom), lignes:commande_lignes(id)", { count: "exact" })
+      .select("id, date_commande, statut, actif, fournisseur_id, fournisseur:fournisseur_id(id, nom), lignes:commande_lignes!commande_id(id)", { count: "exact" })
       .eq("mama_id", mama_id)
       .order("date_commande", { ascending: false })
       .range((page - 1) * pageSize, page * pageSize - 1);

--- a/src/hooks/useComparatif.js
+++ b/src/hooks/useComparatif.js
@@ -22,7 +22,7 @@ export function useComparatif(productId) {
     setError(null);
     const { data, error } = await supabase
       .from("fournisseur_produits")
-      .select("prix_achat, date_livraison, fournisseur_id, fournisseur: fournisseurs(nom)")
+      .select("prix_achat, date_livraison, fournisseur_id, fournisseur:fournisseur_id(nom)")
       .eq("produit_id", id)
       .eq("mama_id", mama_id)
       .order("date_livraison", { ascending: false });

--- a/src/hooks/useDashboards.js
+++ b/src/hooks/useDashboards.js
@@ -15,7 +15,7 @@ export function useDashboards() {
     setError(null);
     const { data, error } = await supabase
       .from("tableaux_de_bord")
-      .select("*, gadgets:gadgets(*)")
+      .select("*, gadgets:gadgets!tableau_id(*)")
       .eq("utilisateur_id", user_id)
       .eq("mama_id", mama_id)
       .order("created_at", { ascending: true });

--- a/src/hooks/useEnrichedProducts.js
+++ b/src/hooks/useEnrichedProducts.js
@@ -17,7 +17,7 @@ export function useEnrichedProducts() {
         .from("produits")
         .select(`
           *,
-          liaisons: fournisseur_produits(*, fournisseur: fournisseurs(*))
+          liaisons:fournisseur_produits:produit_id(*, fournisseur:fournisseur_id(*))
         `)
         .eq("mama_id", mama_id);
 

--- a/src/hooks/useExport.js
+++ b/src/hooks/useExport.js
@@ -36,19 +36,19 @@ export default function useExport() {
       } else if (type === 'inventaire') {
         const res = await supabase
           .from('inventaires')
-          .select('*, lignes:inventaire_lignes(*)')
+          .select('*, lignes:inventaire_lignes!inventaire_id(*)')
           .eq('mama_id', mama_id);
         data = res.data || [];
       } else if (type === 'produits') {
         const res = await supabase
           .from('produits')
-          .select('*, fournisseur_produits(*, fournisseur:fournisseurs(nom))')
+          .select('*, fournisseur_produits:produit_id(*, fournisseur:fournisseur_id(nom))')
           .eq('mama_id', mama_id);
         data = res.data || [];
       } else if (type === 'factures') {
         let query = supabase
           .from('factures')
-          .select('*, lignes:facture_lignes(*)')
+          .select('*, lignes:facture_lignes!facture_id(*)')
           .eq('mama_id', mama_id);
         if (options.start) query = query.gte('date_facture', options.start);
         if (options.end) query = query.lte('date_facture', options.end);

--- a/src/hooks/useExportCompta.js
+++ b/src/hooks/useExportCompta.js
@@ -18,7 +18,7 @@ export default function useExportCompta() {
     const { data, error } = await supabase
       .from('facture_lignes')
       .select(
-        'quantite, prix, tva, factures(date_facture, fournisseur:fournisseurs(nom))'
+        'quantite, prix, tva, facture_id, factures:facture_id(date_facture, fournisseur:fournisseur_id(nom))'
       )
       .eq('mama_id', mama_id)
       .gte('factures.date_facture', start)

--- a/src/hooks/useFactures.js
+++ b/src/hooks/useFactures.js
@@ -46,7 +46,7 @@ export function useFactures() {
     let query = supabase
       .from("factures")
       .select(
-        "*, fournisseur:fournisseurs(id, nom), lignes:facture_lignes(id, produit:produits(nom))",
+        "*, fournisseur:fournisseur_id(id, nom), lignes:facture_lignes!facture_id(id, produit_id, produit:produit_id(nom))",
         { count: "exact" }
       )
       .eq("mama_id", mama_id)
@@ -85,7 +85,7 @@ export function useFactures() {
     setError(null);
     const { data, error } = await supabase
       .from("factures")
-      .select("*, fournisseur:fournisseurs(id, nom)")
+      .select("*, fournisseur:fournisseur_id(id, nom)")
       .eq("id", id)
       .eq("mama_id", mama_id)
       .single();

--- a/src/hooks/useFacturesAutocomplete.js
+++ b/src/hooks/useFacturesAutocomplete.js
@@ -14,7 +14,7 @@ export function useFacturesAutocomplete() {
     setError(null);
     let q = supabase
       .from("factures")
-      .select("id, numero, date_facture, fournisseur: fournisseurs(nom)")
+      .select("id, numero, date_facture, fournisseur_id, fournisseur:fournisseur_id(nom)")
       .eq("mama_id", mama_id);
     if (query) {
       q = q.ilike("numero", `%${query}%`);

--- a/src/hooks/useFiches.js
+++ b/src/hooks/useFiches.js
@@ -22,7 +22,7 @@ export function useFiches() {
     const sortField = ["nom", "cout_par_portion"].includes(sortBy) ? sortBy : "nom";
     let query = supabase
       .from("fiches_techniques")
-      .select("*, famille:familles(id, nom), lignes:fiche_lignes(id)", { count: "exact" })
+      .select("*, famille:famille_id(id, nom), lignes:fiche_lignes!fiche_id(id)", { count: "exact" })
       .eq("mama_id", mama_id)
       .order(sortField, { ascending: asc })
       .range((page - 1) * limit, page * limit - 1);
@@ -48,7 +48,7 @@ export function useFiches() {
     const { data, error } = await supabase
       .from("fiches_techniques")
       .select(
-        "*, famille:familles(id, nom), lignes:fiche_lignes(*, produit:produits(id, nom, unite:unites(nom), pmp), sous_fiche:fiches_techniques(id, nom, cout_par_portion))"
+        "*, famille:famille_id(id, nom), lignes:fiche_lignes!fiche_id(*, produit:produit_id(id, nom, unite_id, unite:unite_id(nom), pmp), sous_fiche:sous_fiche_id(id, nom, cout_par_portion))"
       )
       .eq("id", id)
       .eq("mama_id", mama_id)
@@ -175,7 +175,7 @@ export function useFiches() {
     setError(null);
     const { data: fiche, error: fetchError } = await supabase
       .from("fiches_techniques")
-      .select("*, lignes:fiche_lignes(*)")
+      .select("*, lignes:fiche_lignes!fiche_id(*)")
       .eq("id", id)
       .eq("mama_id", mama_id)
       .single();

--- a/src/hooks/useFournisseurApiConfig.js
+++ b/src/hooks/useFournisseurApiConfig.js
@@ -66,7 +66,7 @@ export function useFournisseurApiConfig() {
     setLoading(true);
     let query = supabase
       .from('fournisseurs_api_config')
-      .select('*, fournisseur:fournisseurs(id, nom)', { count: 'exact' })
+      .select('*, fournisseur:fournisseur_id(id, nom)', { count: 'exact' })
       .eq('mama_id', mama_id)
       .order('fournisseur_id');
     if (fournisseur_id) query = query.eq('fournisseur_id', fournisseur_id);

--- a/src/hooks/useInventaires.js
+++ b/src/hooks/useInventaires.js
@@ -16,7 +16,7 @@ export function useInventaires() {
     let query = supabase
       .from("inventaires")
       .select(
-        "*, lignes:inventaire_lignes(*, produit:produits(id, nom, unite:unites(nom), stock_theorique, pmp))"
+        "*, lignes:inventaire_lignes!inventaire_id(*, produit:produit_id(id, nom, unite_id, unite:unite_id(nom), stock_theorique, pmp))"
       )
       .eq("mama_id", mama_id);
     if (!includeArchives) query = query.eq("actif", true);
@@ -103,7 +103,7 @@ export function useInventaires() {
     const { data, error } = await supabase
       .from("inventaires")
       .select(
-        "*, lignes:inventaire_lignes(*, produit:produits(id, nom, unite:unites(nom), stock_theorique, pmp))"
+        "*, lignes:inventaire_lignes!inventaire_id(*, produit:produit_id(id, nom, unite_id, unite:unite_id(nom), stock_theorique, pmp))"
       )
       .eq("id", id)
       .eq("mama_id", mama_id)

--- a/src/hooks/useInvoiceItems.js
+++ b/src/hooks/useInvoiceItems.js
@@ -18,7 +18,7 @@ export function useInvoiceItems() {
     const { data, error } = await supabase
       .from("facture_lignes")
       .select(
-        "*, produit:produits(id, nom, famille:familles(nom), unite:unites(nom))"
+        "*, produit:produit_id(id, nom, famille:famille_id(nom), unite:unite_id(nom))"
       )
       .eq("facture_id", invoiceId)
       .eq("mama_id", mama_id)
@@ -35,7 +35,7 @@ export function useInvoiceItems() {
     const { data, error } = await supabase
       .from("facture_lignes")
       .select(
-        "*, produit:produits(id, nom, famille:familles(nom), unite:unites(nom))"
+        "*, produit:produit_id(id, nom, famille:famille_id(nom), unite:unite_id(nom))"
       )
       .eq("id", id)
       .eq("mama_id", mama_id)

--- a/src/hooks/useInvoices.js
+++ b/src/hooks/useInvoices.js
@@ -21,7 +21,7 @@ export function useInvoices() {
       .from("factures")
       .select(`
         *,
-        fournisseur: fournisseurs(id, nom)
+        fournisseur:fournisseur_id(id, nom)
       `)
       .eq("mama_id", mama_id)
       .order("date_facture", { ascending: false });
@@ -64,7 +64,7 @@ export function useInvoices() {
     setError(null);
     const { data, error } = await supabase
       .from("factures")
-      .select("*, fournisseur:fournisseurs(id, nom)")
+      .select("*, fournisseur:fournisseur_id(id, nom)")
       .eq("id", id)
       .eq("mama_id", mama_id)
       .single();

--- a/src/hooks/usePlanning.js
+++ b/src/hooks/usePlanning.js
@@ -28,7 +28,7 @@ export function usePlanning() {
     if (!id || !mama_id) return null;
     const { data, error } = await supabase
       .from("planning_previsionnel")
-      .select("*, lignes:planning_lignes(id, produit_id, quantite, observation, produit:produits(nom))")
+      .select("*, lignes:planning_lignes!planning_id(id, planning_id, produit_id, quantite, observation, produit:produit_id(nom))")
       .eq("id", id)
       .eq("mama_id", mama_id)
       .single();

--- a/src/hooks/useProducts.js
+++ b/src/hooks/useProducts.js
@@ -30,7 +30,7 @@ export function useProducts() {
     let query = supabase
       .from("produits")
       .select(
-        "*, sous_famille:familles!produits_sous_famille_id_fkey(id, nom, famille_parent_id, parent:familles!familles_famille_parent_id_fkey(id, nom)), unite:unites(nom), fournisseur:fournisseurs!fournisseur_id(id, nom)",
+        "*, sous_famille:familles!produits_sous_famille_id_fkey(id, nom, famille_parent_id, parent:familles!familles_famille_parent_id_fkey(id, nom)), unite:unite_id(nom), fournisseur:fournisseurs!fournisseur_id(id, nom)",
         { count: "exact" }
       )
       .eq("mama_id", mama_id);
@@ -206,7 +206,7 @@ export function useProducts() {
     const { data, error } = await supabase
       .from("fournisseur_produits")
       .select(
-        "*, fournisseur: fournisseurs(id, nom), derniere_livraison:date_livraison"
+        "*, fournisseur:fournisseur_id(id, nom), derniere_livraison:date_livraison"
       )
       .eq("produit_id", productId)
       .eq("mama_id", mama_id)
@@ -225,7 +225,7 @@ export function useProducts() {
       const { data, error } = await supabase
         .from("produits")
         .select(
-          "*, fournisseur:fournisseurs!fournisseur_id(id, nom), sous_famille:familles!produits_sous_famille_id_fkey(id, nom, parent:familles!familles_famille_parent_id_fkey(id, nom)), unite:unites(nom)"
+          "*, fournisseur:fournisseurs!fournisseur_id(id, nom), sous_famille:familles!produits_sous_famille_id_fkey(id, nom, parent:familles!familles_famille_parent_id_fkey(id, nom)), unite:unite_id(nom)"
         )
         .eq("id", id)
         .eq("mama_id", mama_id)

--- a/src/hooks/useProduitsFournisseur.js
+++ b/src/hooks/useProduitsFournisseur.js
@@ -21,7 +21,7 @@ export function useProduitsFournisseur() {
       const { data, error } = await supabase
         .from("fournisseur_produits")
         .select(
-          "*, produit:produits(id, nom, famille:familles(nom), unite:unites(nom))"
+          "*, produit:produit_id(id, nom, famille:famille_id(nom), unite:unite_id(nom))"
         )
         .eq("fournisseur_id", fournisseur_id)
         .eq("mama_id", mama_id);
@@ -41,7 +41,7 @@ export function useProduitsFournisseur() {
       const { data } = await supabase
         .from("fournisseur_produits")
         .select(
-          "*, produit:produits(id, nom, famille:familles(nom), unite:unites(nom))"
+          "*, produit:produit_id(id, nom, famille:famille_id(nom), unite:unite_id(nom))"
         )
         .eq("fournisseur_id", fournisseur_id)
         .eq("mama_id", mama_id);

--- a/src/hooks/useRequisitions.js
+++ b/src/hooks/useRequisitions.js
@@ -49,7 +49,7 @@ export function useRequisitions() {
     const { data, error } = await supabase
       .from("requisitions")
       .select(
-        "*, lignes:requisition_lignes(*, produit:produits(id, nom))"
+        "*, lignes:requisition_lignes!requisition_id(*, produit:produit_id(id, nom))"
       )
       .eq("id", id)
       .eq("mama_id", mama_id)

--- a/src/pages/catalogue/CatalogueSyncViewer.jsx
+++ b/src/pages/catalogue/CatalogueSyncViewer.jsx
@@ -17,7 +17,7 @@ export default function CatalogueSyncViewer({ fournisseur_id }) {
     setLoading(true);
     let query = supabase
       .from("catalogue_updates")
-      .select("*, produit:produits(nom)")
+      .select("*, produit:produit_id(nom)")
       .eq("mama_id", mama_id)
       .order("created_at", { ascending: false });
     if (fournisseur_id) query = query.eq("fournisseur_id", fournisseur_id);

--- a/src/pages/commandes/CommandesEnvoyees.jsx
+++ b/src/pages/commandes/CommandesEnvoyees.jsx
@@ -19,7 +19,7 @@ export default function CommandesEnvoyees() {
     setPageLoading(true);
     supabase
       .from("commandes")
-      .select("*, fournisseur:fournisseurs(nom)")
+      .select("*, fournisseur:fournisseur_id(nom)")
       .eq("mama_id", mama_id)
       .order("created_at", { ascending: false })
       .then(({ data }) => {

--- a/src/pages/fournisseurs/FournisseurDetail.jsx
+++ b/src/pages/fournisseurs/FournisseurDetail.jsx
@@ -46,7 +46,7 @@ export default function FournisseurDetail({ id }) {
       }),
       supabase
         .from("fournisseurs")
-        .select("id, nom, actif, created_at, contact:fournisseur_contacts(nom,email,tel)")
+        .select("id, nom, actif, created_at, contact:fournisseur_contacts!fournisseur_id(nom,email,tel)")
         .eq("id", id)
         .eq("mama_id", mama_id)
         .single()


### PR DESCRIPTION
## Summary
- use explicit foreign key aliases in Supabase selects
- normalize related table joins across hooks and pages

## Testing
- `npm test` *(fails: Missing Supabase credentials, act warnings, etc.)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688deaa48354832d8f0c751f29821888