### PR TITLE
feat(produits): lier familles et sous-familles dynamiquement

### DIFF
--- a/src/hooks/useSousFamilles.js
+++ b/src/hooks/useSousFamilles.js
@@ -1,0 +1,40 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { useState, useCallback } from "react";
+import { supabase } from "@/lib/supabase";
+import useAuth from "@/hooks/useAuth";
+
+export function useSousFamilles() {
+  const { mama_id } = useAuth();
+  const [sousFamilles, setSousFamilles] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const fetchSousFamilles = useCallback(
+    async (familleId) => {
+      if (!mama_id || !familleId) {
+        setSousFamilles([]);
+        return [];
+      }
+      setLoading(true);
+      setError(null);
+      const { data, error } = await supabase
+        .from("sous_familles")
+        .select("id, nom, famille_id")
+        .eq("mama_id", mama_id)
+        .eq("actif", true)
+        .eq("famille_id", familleId)
+        .order("nom", { ascending: true });
+      if (error) {
+        setError(error);
+        setSousFamilles([]);
+      } else {
+        setSousFamilles(Array.isArray(data) ? data : []);
+      }
+      setLoading(false);
+      return data || [];
+    },
+    [mama_id]
+  );
+
+  return { sousFamilles, loading, error, fetchSousFamilles, setSousFamilles };
+}

--- a/test/ProduitForm.test.jsx
+++ b/test/ProduitForm.test.jsx
@@ -10,6 +10,15 @@ vi.mock('@/hooks/useProducts', () => ({
 vi.mock('@/hooks/useFamilles', () => ({
   useFamilles: () => ({ familles: [], fetchFamilles: vi.fn(), addFamille: vi.fn() })
 }));
+vi.mock('@/hooks/useSousFamilles', () => ({
+  useSousFamilles: () => ({
+    sousFamilles: [],
+    fetchSousFamilles: vi.fn(),
+    loading: false,
+    error: null,
+    setSousFamilles: vi.fn(),
+  }),
+}));
 vi.mock('@/hooks/useUnites', () => ({
   useUnites: () => ({ unites: [], fetchUnites: vi.fn(), addUnite: vi.fn() })
 }));


### PR DESCRIPTION
## Summary
- fetch familles and sous-familles from Supabase filtered by mama
- add dynamic family and subfamily selects in product form
- cover product form tests for new subfamily hook

## Testing
- `npm test` *(fails: Missing Supabase credentials and other test errors)*

------
https://chatgpt.com/codex/tasks/task_e_688deecbc9bc832dbcde906151eb049d