### PR TITLE
fix: handle famille relations and deletions

### DIFF
--- a/src/hooks/useFiches.js
+++ b/src/hooks/useFiches.js
@@ -22,7 +22,10 @@ export function useFiches() {
     const sortField = ["nom", "cout_par_portion"].includes(sortBy) ? sortBy : "nom";
     let query = supabase
       .from("fiches_techniques")
-      .select("*, famille:famille_id(id, nom), lignes:fiche_lignes!fiche_id(id)", { count: "exact" })
+      .select(
+        "*, famille:familles!fiches_techniques_famille_id_fkey(id, nom), lignes:fiche_lignes!fiche_id(id)",
+        { count: "exact" }
+      )
       .eq("mama_id", mama_id)
       .order(sortField, { ascending: asc })
       .range((page - 1) * limit, page * limit - 1);
@@ -48,7 +51,7 @@ export function useFiches() {
     const { data, error } = await supabase
       .from("fiches_techniques")
       .select(
-        "*, famille:famille_id(id, nom), lignes:fiche_lignes!fiche_id(*, produit:produit_id(id, nom, unite_id, unite:unite_id(nom), pmp), sous_fiche:sous_fiche_id(id, nom, cout_par_portion))"
+        "*, famille:familles!fiches_techniques_famille_id_fkey(id, nom), lignes:fiche_lignes!fiche_id(*, produit:produit_id(id, nom, unite_id, unite:unite_id(nom), pmp), sous_fiche:sous_fiche_id(id, nom, cout_par_portion))"
       )
       .eq("id", id)
       .eq("mama_id", mama_id)

--- a/src/hooks/useInvoiceItems.js
+++ b/src/hooks/useInvoiceItems.js
@@ -18,7 +18,7 @@ export function useInvoiceItems() {
     const { data, error } = await supabase
       .from("facture_lignes")
       .select(
-        "*, produit:produit_id(id, nom, famille:famille_id(nom), unite:unite_id(nom))"
+        "*, produit:produit_id(id, nom, famille:familles!produits_famille_id_fkey(id, nom), unite:unite_id(nom))"
       )
       .eq("facture_id", invoiceId)
       .eq("mama_id", mama_id)
@@ -35,7 +35,7 @@ export function useInvoiceItems() {
     const { data, error } = await supabase
       .from("facture_lignes")
       .select(
-        "*, produit:produit_id(id, nom, famille:famille_id(nom), unite:unite_id(nom))"
+        "*, produit:produit_id(id, nom, famille:familles!produits_famille_id_fkey(id, nom), unite:unite_id(nom))"
       )
       .eq("id", id)
       .eq("mama_id", mama_id)

--- a/src/hooks/useProduitsFournisseur.js
+++ b/src/hooks/useProduitsFournisseur.js
@@ -21,7 +21,7 @@ export function useProduitsFournisseur() {
       const { data, error } = await supabase
         .from("fournisseur_produits")
         .select(
-          "*, produit:produit_id(id, nom, famille:famille_id(nom), unite:unite_id(nom))"
+          "*, produit:produit_id(id, nom, famille:familles!produits_famille_id_fkey(id, nom), unite:unite_id(nom))"
         )
         .eq("fournisseur_id", fournisseur_id)
         .eq("mama_id", mama_id);
@@ -41,7 +41,7 @@ export function useProduitsFournisseur() {
       const { data } = await supabase
         .from("fournisseur_produits")
         .select(
-          "*, produit:produit_id(id, nom, famille:famille_id(nom), unite:unite_id(nom))"
+          "*, produit:produit_id(id, nom, famille:familles!produits_famille_id_fkey(id, nom), unite:unite_id(nom))"
         )
         .eq("fournisseur_id", fournisseur_id)
         .eq("mama_id", mama_id);


### PR DESCRIPTION
## Summary
- extend families hook with parent id and paginated search
- query products with explicit famille relations
- clear product links when deleting a famille

## Testing
- `npm test` *(fails: Missing Supabase credentials)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688df2e15364832d9e49b689d5dad41f