### PR TITLE
fix: specify product family relations

### DIFF
--- a/src/hooks/useEnrichedProducts.js
+++ b/src/hooks/useEnrichedProducts.js
@@ -16,7 +16,7 @@ export function useEnrichedProducts() {
       const { data, error } = await supabase
         .from("produits")
         .select(
-          "id, nom, famille_id, sous_famille_id, familles(nom), sous_familles(nom), liaisons:fournisseur_produits:produit_id(*, fournisseur:fournisseur_id(*))"
+          "id, nom, famille_id, sous_famille_id, familles:fk_produits_famille(nom), sous_familles:fk_produits_sous_famille(nom), liaisons:fournisseur_produits:produit_id(*, fournisseur:fournisseur_id(*))"
         )
         .eq("mama_id", mama_id);
 

--- a/src/hooks/useExport.js
+++ b/src/hooks/useExport.js
@@ -42,7 +42,9 @@ export default function useExport() {
       } else if (type === 'produits') {
         const res = await supabase
           .from('produits')
-          .select('id, nom, famille_id, sous_famille_id, familles(nom), sous_familles(nom), fournisseur_produits:produit_id(*, fournisseur:fournisseur_id(nom))')
+          .select(
+            'id, nom, famille_id, sous_famille_id, familles:fk_produits_famille(nom), sous_familles:fk_produits_sous_famille(nom), fournisseur_produits:produit_id(*, fournisseur:fournisseur_id(nom))'
+          )
           .eq('mama_id', mama_id);
         data = res.data || [];
       } else if (type === 'factures') {

--- a/src/hooks/useInvoiceItems.js
+++ b/src/hooks/useInvoiceItems.js
@@ -18,7 +18,7 @@ export function useInvoiceItems() {
     const { data, error } = await supabase
       .from("facture_lignes")
       .select(
-        "*, produit:produit_id(id, nom, famille:familles!produits_famille_id_fkey(id, nom), unite:unite_id(nom))"
+        "*, produit:produit_id(id, nom, famille:familles:fk_produits_famille(id, nom), unite:unite_id(nom))"
       )
       .eq("facture_id", invoiceId)
       .eq("mama_id", mama_id)
@@ -35,7 +35,7 @@ export function useInvoiceItems() {
     const { data, error } = await supabase
       .from("facture_lignes")
       .select(
-        "*, produit:produit_id(id, nom, famille:familles!produits_famille_id_fkey(id, nom), unite:unite_id(nom))"
+        "*, produit:produit_id(id, nom, famille:familles:fk_produits_famille(id, nom), unite:unite_id(nom))"
       )
       .eq("id", id)
       .eq("mama_id", mama_id)

--- a/src/hooks/useProducts.js
+++ b/src/hooks/useProducts.js
@@ -30,7 +30,7 @@ export function useProducts() {
     let query = supabase
       .from("produits")
       .select(
-        "*, famille:familles(nom), sous_famille:sous_familles(nom), unite:unite_id(nom), fournisseur:fournisseur_id(id, nom)",
+        "*, famille:familles:fk_produits_famille(nom), sous_famille:sous_familles:fk_produits_sous_famille(nom), unite:unite_id(nom), fournisseur:fournisseur_id(id, nom)",
         { count: "exact" }
       )
       .eq("mama_id", mama_id);
@@ -226,7 +226,7 @@ export function useProducts() {
       const { data, error } = await supabase
         .from("produits")
         .select(
-          "*, famille:familles(nom), sous_famille:sous_familles(nom), fournisseur:fournisseur_id(id, nom), unite:unite_id(nom)"
+          "*, famille:familles:fk_produits_famille(nom), sous_famille:sous_familles:fk_produits_sous_famille(nom), fournisseur:fournisseur_id(id, nom), unite:unite_id(nom)"
         )
         .eq("id", id)
         .eq("mama_id", mama_id)

--- a/src/hooks/useProduitsFournisseur.js
+++ b/src/hooks/useProduitsFournisseur.js
@@ -21,7 +21,7 @@ export function useProduitsFournisseur() {
       const { data, error } = await supabase
         .from("fournisseur_produits")
         .select(
-          "*, produit:produit_id(id, nom, famille:familles!produits_famille_id_fkey(id, nom), unite:unite_id(nom))"
+          "*, produit:produit_id(id, nom, famille:familles:fk_produits_famille(id, nom), unite:unite_id(nom))"
         )
         .eq("fournisseur_id", fournisseur_id)
         .eq("mama_id", mama_id);
@@ -41,7 +41,7 @@ export function useProduitsFournisseur() {
       const { data } = await supabase
         .from("fournisseur_produits")
         .select(
-          "*, produit:produit_id(id, nom, famille:familles!produits_famille_id_fkey(id, nom), unite:unite_id(nom))"
+          "*, produit:produit_id(id, nom, famille:familles:fk_produits_famille(id, nom), unite:unite_id(nom))"
         )
         .eq("fournisseur_id", fournisseur_id)
         .eq("mama_id", mama_id);

--- a/src/hooks/useStock.js
+++ b/src/hooks/useStock.js
@@ -18,7 +18,7 @@ export function useStock() {
     const { data, error } = await supabase
       .from("produits")
       .select(
-        "id, nom, stock_reel, stock_min, pmp, famille_id, sous_famille_id, familles(nom), sous_familles(nom)"
+        "id, nom, stock_reel, stock_min, pmp, famille_id, sous_famille_id, familles:fk_produits_famille(nom), sous_familles:fk_produits_sous_famille(nom)"
       )
       .eq("mama_id", mama_id);
     setLoading(false);

--- a/src/pages/Transferts.jsx
+++ b/src/pages/Transferts.jsx
@@ -44,7 +44,9 @@ export default function Transferts() {
     if (!mama_id) return;
     supabase
       .from("produits")
-      .select("id, nom, pmp, famille_id, sous_famille_id, familles(nom), sous_familles(nom)")
+      .select(
+        "id, nom, pmp, famille_id, sous_famille_id, familles:fk_produits_famille(nom), sous_familles:fk_produits_sous_famille(nom)"
+      )
       .eq("mama_id", mama_id)
       .then(({ data }) => setProduits(data || []));
     supabase

--- a/src/pages/mobile/MobileInventaire.jsx
+++ b/src/pages/mobile/MobileInventaire.jsx
@@ -16,7 +16,9 @@ export default function MobileInventaire() {
     if (authLoading || !mama_id) return;
     supabase
       .from("produits")
-      .select("id, nom, famille_id, sous_famille_id, familles(nom), sous_familles(nom)")
+      .select(
+        "id, nom, famille_id, sous_famille_id, familles:fk_produits_famille(nom), sous_familles:fk_produits_sous_famille(nom)"
+      )
       .eq("mama_id", mama_id)
       .then(({ data }) => setProduits(data || []));
   }, [mama_id, authLoading]);


### PR DESCRIPTION
## Summary
- use explicit `fk_produits_famille` and `fk_produits_sous_famille` relations for products across hooks and pages
- ensure product fetches only pull required family fields

## Testing
- `npm test` *(fails: Missing Supabase credentials and other test failures)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e089e02a4832d9d154fe64c6ed893