### PR TITLE
fix: standardize product select relations

### DIFF
--- a/src/hooks/useEnrichedProducts.js
+++ b/src/hooks/useEnrichedProducts.js
@@ -16,7 +16,7 @@ export function useEnrichedProducts() {
       const { data, error } = await supabase
         .from("produits")
         .select(
-          "id, nom, famille_id, sous_famille_id, familles:fk_produits_famille(nom), sous_familles:fk_produits_sous_famille(nom), liaisons:fournisseur_produits:produit_id(*, fournisseur:fournisseur_id(*))"
+          "id, nom, famille_id, sous_famille_id, famille:fk_produits_famille(nom), sous_famille:fk_produits_sous_famille(nom), liaisons:fournisseur_produits_produit_id_fkey(*, fournisseur:fournisseur_id(*))"
         )
         .eq("mama_id", mama_id);
 

--- a/src/hooks/useExport.js
+++ b/src/hooks/useExport.js
@@ -43,7 +43,7 @@ export default function useExport() {
         const res = await supabase
           .from('produits')
           .select(
-            'id, nom, famille_id, sous_famille_id, familles:fk_produits_famille(nom), sous_familles:fk_produits_sous_famille(nom), fournisseur_produits:produit_id(*, fournisseur:fournisseur_id(nom))'
+            'id, nom, famille_id, sous_famille_id, famille:fk_produits_famille(nom), sous_famille:fk_produits_sous_famille(nom), fournisseur_produits:fournisseur_produits_produit_id_fkey(*, fournisseur:fournisseur_id(nom))'
           )
           .eq('mama_id', mama_id);
         data = res.data || [];

--- a/src/hooks/useInvoiceItems.js
+++ b/src/hooks/useInvoiceItems.js
@@ -18,7 +18,7 @@ export function useInvoiceItems() {
     const { data, error } = await supabase
       .from("facture_lignes")
       .select(
-        "*, produit:produit_id(id, nom, famille:familles:fk_produits_famille(id, nom), unite:unite_id(nom))"
+        "*, produit:produit_id(id, nom, famille:fk_produits_famille(id, nom), unite:unite_id(nom))"
       )
       .eq("facture_id", invoiceId)
       .eq("mama_id", mama_id)
@@ -35,7 +35,7 @@ export function useInvoiceItems() {
     const { data, error } = await supabase
       .from("facture_lignes")
       .select(
-        "*, produit:produit_id(id, nom, famille:familles:fk_produits_famille(id, nom), unite:unite_id(nom))"
+        "*, produit:produit_id(id, nom, famille:fk_produits_famille(id, nom), unite:unite_id(nom))"
       )
       .eq("id", id)
       .eq("mama_id", mama_id)

--- a/src/hooks/useProducts.js
+++ b/src/hooks/useProducts.js
@@ -30,7 +30,7 @@ export function useProducts() {
     let query = supabase
       .from("produits")
       .select(
-        "*, famille:familles:fk_produits_famille(nom), sous_famille:sous_familles:fk_produits_sous_famille(nom), unite:unite_id(nom), fournisseur:fournisseur_id(id, nom)",
+        "*, famille:fk_produits_famille(nom), sous_famille:fk_produits_sous_famille(nom), unite:unite_id(nom), fournisseur:fournisseur_id(id, nom)",
         { count: "exact" }
       )
       .eq("mama_id", mama_id);
@@ -226,7 +226,7 @@ export function useProducts() {
       const { data, error } = await supabase
         .from("produits")
         .select(
-          "*, famille:familles:fk_produits_famille(nom), sous_famille:sous_familles:fk_produits_sous_famille(nom), fournisseur:fournisseur_id(id, nom), unite:unite_id(nom)"
+          "*, famille:fk_produits_famille(nom), sous_famille:fk_produits_sous_famille(nom), fournisseur:fournisseur_id(id, nom), unite:unite_id(nom)"
         )
         .eq("id", id)
         .eq("mama_id", mama_id)

--- a/src/hooks/useProduitsFournisseur.js
+++ b/src/hooks/useProduitsFournisseur.js
@@ -21,7 +21,7 @@ export function useProduitsFournisseur() {
       const { data, error } = await supabase
         .from("fournisseur_produits")
         .select(
-          "*, produit:produit_id(id, nom, famille:familles:fk_produits_famille(id, nom), unite:unite_id(nom))"
+          "*, produit:produit_id(id, nom, famille:fk_produits_famille(id, nom), unite:unite_id(nom))"
         )
         .eq("fournisseur_id", fournisseur_id)
         .eq("mama_id", mama_id);
@@ -41,7 +41,7 @@ export function useProduitsFournisseur() {
       const { data } = await supabase
         .from("fournisseur_produits")
         .select(
-          "*, produit:produit_id(id, nom, famille:familles:fk_produits_famille(id, nom), unite:unite_id(nom))"
+          "*, produit:produit_id(id, nom, famille:fk_produits_famille(id, nom), unite:unite_id(nom))"
         )
         .eq("fournisseur_id", fournisseur_id)
         .eq("mama_id", mama_id);

--- a/src/hooks/useStock.js
+++ b/src/hooks/useStock.js
@@ -18,7 +18,7 @@ export function useStock() {
     const { data, error } = await supabase
       .from("produits")
       .select(
-        "id, nom, stock_reel, stock_min, pmp, famille_id, sous_famille_id, familles:fk_produits_famille(nom), sous_familles:fk_produits_sous_famille(nom)"
+        "id, nom, stock_reel, stock_min, pmp, famille_id, sous_famille_id, famille:fk_produits_famille(nom), sous_famille:fk_produits_sous_famille(nom)"
       )
       .eq("mama_id", mama_id);
     setLoading(false);

--- a/src/pages/Transferts.jsx
+++ b/src/pages/Transferts.jsx
@@ -45,7 +45,7 @@ export default function Transferts() {
     supabase
       .from("produits")
       .select(
-        "id, nom, pmp, famille_id, sous_famille_id, familles:fk_produits_famille(nom), sous_familles:fk_produits_sous_famille(nom)"
+        "id, nom, pmp, famille_id, sous_famille_id, famille:fk_produits_famille(nom), sous_famille:fk_produits_sous_famille(nom)"
       )
       .eq("mama_id", mama_id)
       .then(({ data }) => setProduits(data || []));

--- a/src/pages/mobile/MobileInventaire.jsx
+++ b/src/pages/mobile/MobileInventaire.jsx
@@ -17,7 +17,7 @@ export default function MobileInventaire() {
     supabase
       .from("produits")
       .select(
-        "id, nom, famille_id, sous_famille_id, familles:fk_produits_famille(nom), sous_familles:fk_produits_sous_famille(nom)"
+        "id, nom, famille_id, sous_famille_id, famille:fk_produits_famille(nom), sous_famille:fk_produits_sous_famille(nom)"
       )
       .eq("mama_id", mama_id)
       .then(({ data }) => setProduits(data || []));

--- a/test/useAlerts.test.js
+++ b/test/useAlerts.test.js
@@ -32,7 +32,7 @@ test('fetchRules queries regles_alertes with filters', async () => {
   const { result } = renderHook(() => useAlerts());
   await act(async () => { await result.current.fetchRules({ search: 'foo', actif: true }); });
   expect(fromMock).toHaveBeenCalledWith('regles_alertes');
-  expect(queryObj.select).toHaveBeenCalledWith('*, produit:produits(id, nom)');
+  expect(queryObj.select).toHaveBeenCalledWith('*, produit:produit_id(id, nom)');
   expect(queryObj.eq).toHaveBeenCalledWith('mama_id', 'm1');
   expect(queryObj.eq).toHaveBeenCalledWith('actif', true);
   expect(queryObj.ilike).toHaveBeenCalledWith('produit.nom', '%foo%');

--- a/test/useInvoiceItems.test.js
+++ b/test/useInvoiceItems.test.js
@@ -36,7 +36,7 @@ test('fetchItemsByInvoice queries with invoice id and mama_id', async () => {
     await result.current.fetchItemsByInvoice('f1');
   });
   expect(fromMock).toHaveBeenCalledWith('facture_lignes');
-  expect(query.select).toHaveBeenCalledWith('*, produit:produits(id, nom, famille:familles(nom), unite:unites(nom))');
+  expect(query.select).toHaveBeenCalledWith('*, produit:produit_id(id, nom, famille:fk_produits_famille(id, nom), unite:unite_id(nom))');
   expect(query.eq).toHaveBeenNthCalledWith(1, 'facture_id', 'f1');
   expect(query.eq).toHaveBeenNthCalledWith(2, 'mama_id', 'm1');
   expect(query.order).toHaveBeenCalledWith('id');


### PR DESCRIPTION
## Summary
- align Supabase product queries with `alias:fk_constraint` syntax
- update related hooks, pages and tests to use explicit foreign key names

## Testing
- `npm test` *(fails: Missing Supabase credentials)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e0af2d798832db7be6b7bc50c2c4a