### PR TITLE
feat: display families with nested subfamilies

### DIFF
--- a/src/components/parametrage/FamilleRow.jsx
+++ b/src/components/parametrage/FamilleRow.jsx
@@ -1,33 +1,92 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { useState } from 'react';
 import { Button } from '@/components/ui/button';
+import SousFamilleRow from './SousFamilleRow';
+import SousFamilleForm from './SousFamilleForm';
 
-export default function FamilleRow({ famille, onEdit, onDelete, onToggle, onAddSub }) {
+export default function FamilleRow({
+  famille,
+  onEdit,
+  onDelete,
+  onToggle,
+  onAddSousFamille,
+  onUpdateSousFamille,
+  onDeleteSousFamille,
+  onToggleSousFamille,
+}) {
+  const [open, setOpen] = useState(false);
+  const [adding, setAdding] = useState(false);
+  const hasActiveSous = famille.sous_familles?.some((sf) => sf.actif);
+
   return (
-    <tr>
-      <td className="px-2 py-1">{famille.nom}</td>
-      <td className="px-2 py-1">{famille.actif ? '🟢' : '🔴'}</td>
-      <td className="px-2 py-1">
-        <div className="flex gap-2 justify-center">
-          {onAddSub && (
-            <Button size="sm" onClick={() => onAddSub(famille)}>
+    <>
+      <tr className="bg-white/5">
+        <td className="px-2 py-1">
+          <button
+            type="button"
+            onClick={() => setOpen((o) => !o)}
+            className="mr-2 text-xs"
+          >
+            {open ? '▼' : '▶'}
+          </button>
+          {famille.nom}
+        </td>
+        <td className="px-2 py-1 text-center">{famille.actif ? '🟢' : '🔴'}</td>
+        <td className="px-2 py-1">
+          <div className="flex gap-2 justify-center flex-wrap">
+            <Button size="sm" onClick={() => setAdding(true)}>
               + Sous-famille
             </Button>
+            <Button size="sm" variant="secondary" onClick={() => onEdit(famille)}>
+              Modifier
+            </Button>
+            <Button size="sm" variant="outline" onClick={() => onToggle(famille)}>
+              {famille.actif ? 'Désactiver' : 'Activer'}
+            </Button>
+            <Button
+              size="sm"
+              className="bg-red-500 hover:bg-red-600 text-white"
+              onClick={() => onDelete(famille)}
+              disabled={hasActiveSous}
+            >
+              🗑 Supprimer
+            </Button>
+          </div>
+        </td>
+      </tr>
+      {open && (
+        <>
+          {famille.sous_familles?.map((sf) => (
+            <SousFamilleRow
+              key={sf.id}
+              sousFamille={sf}
+              onUpdate={onUpdateSousFamille}
+              onDelete={onDeleteSousFamille}
+              onToggle={onToggleSousFamille}
+            />
+          ))}
+          {adding && (
+            <tr>
+              <td colSpan={3} className="px-2 py-1">
+                <SousFamilleForm
+                  onSubmit={async (data) => {
+                    await onAddSousFamille(famille.id, data);
+                    setAdding(false);
+                  }}
+                  onCancel={() => setAdding(false)}
+                />
+              </td>
+            </tr>
           )}
-          <Button size="sm" variant="secondary" onClick={() => onEdit(famille)}>
-            Modifier
-          </Button>
-          <Button size="sm" variant="outline" onClick={() => onToggle(famille)}>
-            {famille.actif ? 'Désactiver' : 'Activer'}
-          </Button>
-          <Button
-            size="sm"
-            className="bg-red-500 hover:bg-red-600 text-white"
-            onClick={() => onDelete(famille)}
-          >
-            🗑 Supprimer
-          </Button>
-        </div>
-      </td>
-    </tr>
+          {(!famille.sous_familles || famille.sous_familles.length === 0) && !adding && (
+            <tr>
+              <td colSpan={3} className="px-2 py-1 pl-6 text-sm text-muted-foreground">
+                Aucune sous-famille
+              </td>
+            </tr>
+          )}
+        </>
+      )}
+    </>
   );
 }

--- a/src/components/parametrage/SousFamilleList.jsx
+++ b/src/components/parametrage/SousFamilleList.jsx
@@ -81,6 +81,19 @@ export default function SousFamilleList({ famille }) {
     await fetchSousFamilles();
   }
 
+  async function handleToggle(sf) {
+    if (!mama_id) return toast.error('Action non autorisée');
+    const { error } = await supabase
+      .from('sous_familles')
+      .update({ actif: !sf.actif })
+      .match({ id: sf.id, mama_id });
+    if (error) toast.error(error.message);
+    else {
+      toast.success('Sous-famille mise à jour');
+      await fetchSousFamilles();
+    }
+  }
+
   return (
     <Card>
       <CardHeader className="flex items-center justify-between">
@@ -122,6 +135,7 @@ export default function SousFamilleList({ famille }) {
                     sousFamille={sf}
                     onUpdate={handleUpdate}
                     onDelete={handleDelete}
+                    onToggle={handleToggle}
                   />
                 ))}
               </tbody>

--- a/src/components/parametrage/SousFamilleRow.jsx
+++ b/src/components/parametrage/SousFamilleRow.jsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import SousFamilleForm from './SousFamilleForm';
 
-export default function SousFamilleRow({ sousFamille, onUpdate, onDelete }) {
+export default function SousFamilleRow({ sousFamille, onUpdate, onDelete, onToggle }) {
   const [editing, setEditing] = useState(false);
 
   if (editing) {
@@ -25,12 +25,19 @@ export default function SousFamilleRow({ sousFamille, onUpdate, onDelete }) {
 
   return (
     <tr>
-      <td className="px-2 py-1">{sousFamille.nom}</td>
-      <td className="px-2 py-1 text-center">{sousFamille.actif ? '✔️' : '❌'}</td>
+      <td className="px-2 py-1 pl-6">{sousFamille.nom}</td>
+      <td className="px-2 py-1 text-center">{sousFamille.actif ? '🟢' : '🔴'}</td>
       <td className="px-2 py-1">
         <div className="flex gap-2 justify-center">
           <Button size="sm" variant="secondary" onClick={() => setEditing(true)}>
             Modifier
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => onToggle(sousFamille)}
+          >
+            {sousFamille.actif ? 'Désactiver' : 'Activer'}
           </Button>
           <Button
             size="sm"

--- a/src/hooks/useFamillesWithSousFamilles.js
+++ b/src/hooks/useFamillesWithSousFamilles.js
@@ -1,0 +1,122 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { useState, useCallback } from 'react';
+import { supabase } from '@/lib/supabaseClient';
+import useAuth from '@/hooks/useAuth';
+
+export function useFamillesWithSousFamilles() {
+  const { mama_id } = useAuth();
+  const [familles, setFamilles] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const fetchAll = useCallback(async () => {
+    if (!mama_id) return [];
+    setLoading(true);
+    setError(null);
+    const [famRes, sousRes] = await Promise.all([
+      supabase
+        .from('familles')
+        .select('id, nom, actif')
+        .eq('mama_id', mama_id)
+        .order('nom', { ascending: true }),
+      supabase
+        .from('sous_familles')
+        .select('id, nom, actif, famille_id')
+        .eq('mama_id', mama_id),
+    ]);
+    if (famRes.error || sousRes.error) {
+      setError(famRes.error || sousRes.error);
+      setFamilles([]);
+    } else {
+      const grouped = (famRes.data || []).map((f) => ({
+        ...f,
+        sous_familles: (sousRes.data || []).filter((sf) => sf.famille_id === f.id),
+      }));
+      setFamilles(grouped);
+    }
+    setLoading(false);
+  }, [mama_id]);
+
+  async function addFamille(values) {
+    if (!mama_id) return { error: 'Aucun mama_id' };
+    const { error } = await supabase
+      .from('familles')
+      .insert([{ ...values, mama_id }]);
+    if (!error) await fetchAll();
+    return { error };
+  }
+
+  async function updateFamille(id, values) {
+    if (!mama_id) return { error: 'Aucun mama_id' };
+    const { error } = await supabase
+      .from('familles')
+      .update(values)
+      .match({ id, mama_id });
+    if (!error) await fetchAll();
+    return { error };
+  }
+
+  async function deleteFamille(id) {
+    if (!mama_id) return { error: 'Aucun mama_id' };
+    const { error } = await supabase
+      .from('familles')
+      .delete()
+      .match({ id, mama_id });
+    if (!error) await fetchAll();
+    return { error };
+  }
+
+  async function addSousFamille(famille_id, values) {
+    if (!mama_id) return { error: 'Aucun mama_id' };
+    const { error } = await supabase
+      .from('sous_familles')
+      .insert([{ ...values, famille_id, mama_id }]);
+    if (!error) await fetchAll();
+    return { error };
+  }
+
+  async function updateSousFamille(id, values) {
+    if (!mama_id) return { error: 'Aucun mama_id' };
+    const { error } = await supabase
+      .from('sous_familles')
+      .update(values)
+      .match({ id, mama_id });
+    if (!error) await fetchAll();
+    return { error };
+  }
+
+  async function deleteSousFamille(id) {
+    if (!mama_id) return { error: 'Aucun mama_id' };
+    const { error } = await supabase
+      .from('sous_familles')
+      .delete()
+      .match({ id, mama_id });
+    if (!error) await fetchAll();
+    return { error };
+  }
+
+  async function toggleFamille(famille) {
+    return updateFamille(famille.id, { nom: famille.nom, actif: !famille.actif });
+  }
+
+  async function toggleSousFamille(sf) {
+    return updateSousFamille(sf.id, { nom: sf.nom, actif: !sf.actif });
+  }
+
+  return {
+    familles,
+    loading,
+    error,
+    fetchAll,
+    addFamille,
+    updateFamille,
+    deleteFamille,
+    addSousFamille,
+    updateSousFamille,
+    deleteSousFamille,
+    toggleFamille,
+    toggleSousFamille,
+  };
+}
+
+export default useFamillesWithSousFamilles;

--- a/src/pages/parametrage/Familles.jsx
+++ b/src/pages/parametrage/Familles.jsx
@@ -2,96 +2,111 @@
 import { useEffect, useState } from 'react';
 import { Toaster, toast } from 'react-hot-toast';
 import ListingContainer from '@/components/ui/ListingContainer';
-import PaginationFooter from '@/components/ui/PaginationFooter';
 import TableHeader from '@/components/ui/TableHeader';
 import { Button } from '@/components/ui/button';
-import { useFamilles } from '@/hooks/useFamilles';
 import FamilleRow from '@/components/parametrage/FamilleRow';
 import FamilleForm from '@/forms/FamilleForm';
-import SousFamilleModal from '@/components/parametrage/SousFamilleModal';
 import useAuth from '@/hooks/useAuth';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import Unauthorized from '@/pages/auth/Unauthorized';
+import { useFamillesWithSousFamilles } from '@/hooks/useFamillesWithSousFamilles';
 
 export default function Familles() {
   const {
     familles,
-    total,
-    fetchFamilles,
+    loading,
+    fetchAll,
     addFamille,
     updateFamille,
     deleteFamille,
-    loading,
-  } = useFamilles();
+    addSousFamille,
+    updateSousFamille,
+    deleteSousFamille,
+    toggleFamille,
+    toggleSousFamille,
+  } = useFamillesWithSousFamilles();
   const { mama_id, hasAccess, loading: authLoading } = useAuth();
   const canEdit = hasAccess('parametrage', 'peut_modifier');
   const [search, setSearch] = useState('');
-  const [page, setPage] = useState(1);
   const [edit, setEdit] = useState(null);
-  const [subFamille, setSubFamille] = useState(null);
   const [actionLoading, setActionLoading] = useState(false);
 
   useEffect(() => {
     if (!authLoading && mama_id) {
-      fetchFamilles({ search, page, limit: 50 });
+      fetchAll();
     }
-  }, [fetchFamilles, search, page, authLoading, mama_id]);
+  }, [fetchAll, authLoading, mama_id]);
 
   const handleSave = async (values) => {
     setActionLoading(true);
-    try {
-      if (edit?.id) await updateFamille(edit.id, values);
-      else await addFamille(values);
-      await fetchFamilles({ search, page, limit: 50 });
-      setEdit(null);
+    const { error } = edit?.id
+      ? await updateFamille(edit.id, values)
+      : await addFamille(values);
+    if (error) toast.error(error.message || 'Erreur lors de la sauvegarde.');
+    else {
       toast.success('Famille enregistrée');
-    } catch (err) {
-      toast.error(err.message || 'Erreur lors de la sauvegarde.');
-    } finally {
-      setActionLoading(false);
+      setEdit(null);
     }
+    setActionLoading(false);
   };
 
   const handleDelete = async (famille) => {
     if (!window.confirm('Supprimer cette famille ?')) return;
     setActionLoading(true);
-    try {
-      const { error } = await deleteFamille(famille.id, mama_id);
-      if (error) {
-        if (error.code === '23503') {
-          toast.error('Cette famille est utilisée par des produits.');
-        } else {
-          toast.error(error.message || 'Erreur lors de la suppression.');
-        }
+    const { error } = await deleteFamille(famille.id);
+    if (error) {
+      if (error.code === '23503') {
+        toast.error('Cette famille est utilisée par des produits.');
       } else {
-        toast.success('Famille supprimée.');
+        toast.error(error.message || 'Erreur lors de la suppression.');
       }
-    } catch (err) {
-      toast.error(err.message || 'Erreur lors de la suppression.');
-    } finally {
-      await fetchFamilles({ search, page, limit: 50 });
-      setActionLoading(false);
+    } else {
+      toast.success('Famille supprimée');
     }
+    setActionLoading(false);
   };
 
   const handleToggle = async (famille) => {
     setActionLoading(true);
-    await updateFamille(famille.id, {
-      actif: !famille.actif,
-      nom: famille.nom,
-    });
-    await fetchFamilles({ search, page, limit: 50 });
+    const { error } = await toggleFamille(famille);
+    if (error) toast.error(error.message || 'Erreur lors de la mise à jour');
     setActionLoading(false);
   };
 
-  const pages = Math.ceil(total / 50) || 1;
+  const handleAddSous = async (familleId, data) => {
+    const { error } = await addSousFamille(familleId, data);
+    if (error) toast.error(error.message || "Erreur lors de l'ajout");
+    else toast.success('Sous-famille ajoutée');
+  };
+
+  const handleUpdateSous = async (id, data) => {
+    const { error } = await updateSousFamille(id, data);
+    if (error) toast.error(error.message || 'Erreur lors de la mise à jour');
+    else toast.success('Sous-famille mise à jour');
+  };
+
+  const handleDeleteSous = async (sf) => {
+    if (!window.confirm('Supprimer cette sous-famille ?')) return;
+    const { error } = await deleteSousFamille(sf.id);
+    if (error) toast.error(error.message || 'Erreur lors de la suppression');
+    else toast.success('Sous-famille supprimée');
+  };
+
+  const handleToggleSous = async (sf) => {
+    const { error } = await toggleSousFamille(sf);
+    if (error) toast.error(error.message || 'Erreur lors du changement de statut');
+  };
+
+  const filtered = familles.filter((f) =>
+    f.nom.toLowerCase().includes(search.toLowerCase())
+  );
 
   if (authLoading || loading || actionLoading)
     return <LoadingSpinner message="Chargement..." />;
   if (!canEdit) return <Unauthorized />;
 
   return (
-    <div className="p-6 mx-auto max-w-5xl">
+    <div className="p-6 mx-auto w-full">
       <Toaster position="top-right" />
       <h1 className="text-2xl font-bold mb-4">Familles de produits</h1>
       <TableHeader className="gap-2">
@@ -99,11 +114,11 @@ export default function Familles() {
           className="input flex-1"
           placeholder="Recherche"
           value={search}
-          onChange={e => setSearch(e.target.value)}
+          onChange={(e) => setSearch(e.target.value)}
         />
         <Button onClick={() => setEdit({})}>+ Nouvelle famille</Button>
       </TableHeader>
-      <ListingContainer className="min-w-[1000px]">
+      <ListingContainer className="w-full overflow-x-auto">
         <table className="text-sm w-full">
           <thead>
             <tr>
@@ -113,43 +128,45 @@ export default function Familles() {
             </tr>
           </thead>
           <tbody>
-            {familles.length === 0 ? (
+            {filtered.length === 0 ? (
               <tr>
                 <td colSpan="3" className="py-2">
                   Aucune famille
                 </td>
               </tr>
             ) : (
-              familles.map((f) => (
+              filtered.map((f) => (
                 <FamilleRow
                   key={f.id}
                   famille={f}
                   onEdit={setEdit}
                   onDelete={handleDelete}
                   onToggle={handleToggle}
-                  onAddSub={() => setSubFamille(f)}
+                  onAddSousFamille={handleAddSous}
+                  onUpdateSousFamille={handleUpdateSous}
+                  onDeleteSousFamille={handleDeleteSous}
+                  onToggleSousFamille={handleToggleSous}
                 />
               ))
             )}
           </tbody>
         </table>
       </ListingContainer>
-        <PaginationFooter page={page} pages={pages} onPageChange={setPage} />
-        {edit && (
-          <div className="fixed inset-0 flex items-center justify-center z-50">
-            <div className="absolute inset-0 bg-black/50" onClick={() => setEdit(null)} />
-            <div className="relative bg-white/10 backdrop-blur-xl border border-white/20 rounded-xl shadow-lg p-6 w-full max-w-md">
-              <FamilleForm
-                famille={edit}
-                onCancel={() => setEdit(null)}
-                onSave={handleSave}
-              />
-            </div>
+      {edit && (
+        <div className="fixed inset-0 flex items-center justify-center z-50">
+          <div
+            className="absolute inset-0 bg-black/50"
+            onClick={() => setEdit(null)}
+          />
+          <div className="relative bg-white/10 backdrop-blur-xl border border-white/20 rounded-xl shadow-lg p-6 w-full max-w-md">
+            <FamilleForm
+              famille={edit}
+              onCancel={() => setEdit(null)}
+              onSave={handleSave}
+            />
           </div>
-        )}
-        {subFamille && (
-          <SousFamilleModal famille={subFamille} onClose={() => setSubFamille(null)} />
-        )}
-      </div>
-    );
-  }
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- combine families and sub-families in a single responsive listing
- manage sub-family actions inline with each family row
- add hook to load and mutate families with sub-families

## Testing
- `npm test` *(fails: Missing Supabase credentials and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_688e18bb29c0832d9b62c6500e0ba69e