### PR TITLE
fix: improve family deletion and listing width

### DIFF
--- a/src/components/ui/ListingContainer.jsx
+++ b/src/components/ui/ListingContainer.jsx
@@ -5,7 +5,7 @@ import TableContainer from './TableContainer';
 
 export default function ListingContainer({ children, className = '', ...props }) {
   return (
-    <GlassCard width="w-full" className={`p-0 ${className}`} {...props}>
+    <GlassCard width="w-full max-w-full" className={`p-0 ${className}`} {...props}>
       <TableContainer className="p-0">{children}</TableContainer>
     </GlassCard>
   );

--- a/src/hooks/useFamillesWithSousFamilles.js
+++ b/src/hooks/useFamillesWithSousFamilles.js
@@ -61,7 +61,8 @@ export function useFamillesWithSousFamilles() {
     const { error } = await supabase
       .from('familles')
       .delete()
-      .match({ id, mama_id });
+      .eq('id', id)
+      .eq('mama_id', mama_id);
     if (!error) await fetchAll();
     return { error };
   }
@@ -90,7 +91,8 @@ export function useFamillesWithSousFamilles() {
     const { error } = await supabase
       .from('sous_familles')
       .delete()
-      .match({ id, mama_id });
+      .eq('id', id)
+      .eq('mama_id', mama_id);
     if (!error) await fetchAll();
     return { error };
   }

--- a/src/pages/parametrage/Familles.jsx
+++ b/src/pages/parametrage/Familles.jsx
@@ -106,7 +106,7 @@ export default function Familles() {
   if (!canEdit) return <Unauthorized />;
 
   return (
-    <div className="p-6 mx-auto w-full">
+    <div className="p-6 mx-auto w-full max-w-full">
       <Toaster position="top-right" />
       <h1 className="text-2xl font-bold mb-4">Familles de produits</h1>
       <TableHeader className="gap-2">
@@ -119,7 +119,7 @@ export default function Familles() {
         <Button onClick={() => setEdit({})}>+ Nouvelle famille</Button>
       </TableHeader>
       <ListingContainer className="w-full overflow-x-auto">
-        <table className="text-sm w-full">
+        <table className="text-sm w-full max-w-full">
           <thead>
             <tr>
               <th className="px-2 py-1">Nom</th>


### PR DESCRIPTION
## Summary
- ensure deletion of familles and sous-familles uses explicit filters and mama_id
- expand familles listing to use full width

## Testing
- `npm test` *(fails: expected "spy" to be called with arguments: [ 'requisitions' ])*


------
https://chatgpt.com/codex/tasks/task_e_688e1b2dbba4832d87942781fe4ff52e