### PR TITLE
fix: unlock subfamily name field

### DIFF
--- a/src/components/parametrage/SousFamilleForm.jsx
+++ b/src/components/parametrage/SousFamilleForm.jsx
@@ -6,16 +6,21 @@ import { Input } from '@/components/ui/input';
 export default function SousFamilleForm({ initialData = { nom: '', actif: true }, onSubmit, onCancel }) {
   const [nom, setNom] = useState(initialData.nom ?? '');
   const [actif, setActif] = useState(initialData.actif ?? true);
+  const [error, setError] = useState('');
 
   useEffect(() => {
     setNom(initialData.nom ?? '');
     setActif(initialData.actif ?? true);
-  }, [initialData]);
+  }, [initialData.nom, initialData.actif]);
 
   const handleSubmit = e => {
     e.preventDefault();
     const trimmedNom = nom.trim();
-    if (!trimmedNom) return;
+    if (!trimmedNom) {
+      setError('Le nom est requis');
+      return;
+    }
+    setError('');
     onSubmit({ nom: trimmedNom, actif });
   };
 
@@ -26,8 +31,10 @@ export default function SousFamilleForm({ initialData = { nom: '', actif: true }
         value={nom}
         onChange={e => setNom(e.target.value)}
         placeholder="Nom de la sous-famille"
+        aria-invalid={error ? 'true' : undefined}
         required
       />
+      {error && <p className="text-sm text-red-500">{error}</p>}
       <label className="inline-flex items-center gap-2 text-sm">
         <input
           type="checkbox"


### PR DESCRIPTION
## Summary
- keep SousFamille `nom` editable with local state and update only when initial values change
- display a small validation error when name is empty

## Testing
- `npm test` *(fails: Missing Supabase credentials, unwrapped updates, 21 failed / 87 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688e1ef37338832dba8cbc3bdda14211