### PR TITLE
fix: enable unit deletion and status toggle

### DIFF
--- a/src/components/parametrage/UniteRow.jsx
+++ b/src/components/parametrage/UniteRow.jsx
@@ -5,13 +5,17 @@ export default function UniteRow({ unite, onEdit, onDelete, onToggle }) {
   return (
     <tr>
       <td className="px-2 py-1">{unite.nom}</td>
-      <td className="px-2 py-1">{unite.actif ? '🟢' : '🔴'}</td>
+      <td className="px-2 py-1">
+        <span className="transition-colors duration-200">
+          {unite.actif ? '🟢' : '🔴'}
+        </span>
+      </td>
       <td className="px-2 py-1 flex gap-2 justify-center">
         <Button size="sm" variant="secondary" onClick={() => onEdit(unite)}>
           Modifier
         </Button>
         <Button size="sm" variant="outline" onClick={() => onToggle(unite)}>
-          {unite.actif ? 'Désactiver' : 'Activer'}
+          {unite.actif ? '🔴 Désactiver' : '🟢 Activer'}
         </Button>
         <Button size="sm" variant="destructive" onClick={() => onDelete(unite)}>
           Supprimer

--- a/src/hooks/useUnites.js
+++ b/src/hooks/useUnites.js
@@ -15,13 +15,13 @@ export function useUnites() {
 
   // 1. Charger toutes les unités (filtrage recherche, batch)
   const fetchUnites = useCallback(
-    async ({ search = "", includeInactive = false, page, limit } = {}) => {
+    async ({ search = "", includeInactive = true, page, limit } = {}) => {
       if (!mama_id) return [];
       setLoading(true);
       setError(null);
       let query = supabase
         .from("unites")
-        .select("id, nom")
+        .select("id, nom, actif")
         .eq("mama_id", mama_id)
         .order("nom", { ascending: true });
       if (!includeInactive) query = query.eq("actif", true);
@@ -101,7 +101,7 @@ export function useUnites() {
     setError(null);
     const { error } = await supabase
       .from("unites")
-      .update({ actif: false })
+      .delete()
       .in("id", ids)
       .eq("mama_id", mama_id);
     if (error) setError(error);


### PR DESCRIPTION
## Summary
- fetch unit active flag and allow deletion from database
- refresh unit list after toggling active status or deleting
- show dynamic active indicator and toggle button icons

## Testing
- `npm test` *(fails: Missing Supabase credentials, useAuth must be used within AuthProvider, etc.)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e28c51e18832d9707b48fd2de3ce9