### PR TITLE
feat: assign storage zones to products

### DIFF
--- a/db/Ajout.sql
+++ b/db/Ajout.sql
@@ -1,4 +1,16 @@
 -- Ajouts complémentaires pour le back-end Supabase
+-- Gestion des zones de stockage
+create table if not exists zones_stock (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid not null references mamas(id) on delete cascade,
+  nom text not null,
+  actif boolean default true,
+  created_at timestamptz default now()
+);
+
+alter table produits
+  add column if not exists zone_stock_id uuid references zones_stock(id) on delete set null;
+
 -- Ajout colonne manquante pour stocker la configuration du tableau de bord
 ALTER TABLE tableaux_de_bord ADD COLUMN IF NOT EXISTS liste_gadgets_json jsonb DEFAULT '[]'::jsonb;
 

--- a/src/components/produits/ProduitForm.jsx
+++ b/src/components/produits/ProduitForm.jsx
@@ -6,6 +6,7 @@ import { useFamilles } from "@/hooks/useFamilles";
 import { useSousFamilles } from "@/hooks/useSousFamilles";
 import { useUnites } from "@/hooks/useUnites";
 import { useFournisseurs } from "@/hooks/useFournisseurs";
+import useZonesStock from "@/hooks/useZonesStock";
 import { toast } from "react-hot-toast";
 import GlassCard from "@/components/ui/GlassCard";
 
@@ -29,6 +30,7 @@ export default function ProduitForm({
     setSousFamilles,
   } = useSousFamilles();
   const { unites, fetchUnites } = useUnites();
+  const { zones } = useZonesStock();
 
   const [nom, setNom] = useState(produit?.nom || "");
   const [familleId, setFamilleId] = useState(produit?.famille_id || "");
@@ -39,6 +41,7 @@ export default function ProduitForm({
   const [fournisseurId, setFournisseurId] = useState(
     produit?.fournisseur_id || "",
   );
+  const [zoneStockId, setZoneStockId] = useState(produit?.zone_stock_id || "");
   const [stockMin, setStockMin] = useState(produit?.stock_min || 0);
   const [actif, setActif] = useState(produit?.actif ?? true);
   const [allergenes, setAllergenes] = useState(produit?.allergenes || "");
@@ -79,6 +82,7 @@ export default function ProduitForm({
       setSousFamilleId(produit.sous_famille_id || "");
       setUniteId(produit.unite_id || "");
       setFournisseurId(produit.fournisseur_id || "");
+      setZoneStockId(produit.zone_stock_id || "");
       setStockMin(produit.stock_min || 0);
       setActif(produit.actif ?? true);
       setAllergenes(produit.allergenes || "");
@@ -105,6 +109,7 @@ export default function ProduitForm({
       sous_famille_id: sousFamilleId || null,
       unite_id: uniteId || null,
       fournisseur_id: fournisseurId || null,
+      zone_stock_id: zoneStockId || null,
       stock_min: Number(stockMin),
       actif,
       allergenes,
@@ -239,6 +244,25 @@ export default function ProduitForm({
             ))}
           </select>
           {errors.unite && <p className="text-red-500 text-sm">{errors.unite}</p>}
+        </div>
+
+        <div className="flex flex-col gap-1 p-2 rounded-xl">
+          <label htmlFor="prod-zone" className="label text-white">
+            Zone de stockage
+          </label>
+          <select
+            id="prod-zone"
+            className="input bg-white text-gray-900"
+            value={zoneStockId}
+            onChange={(e) => setZoneStockId(e.target.value)}
+          >
+            <option value="">Aucune</option>
+            {zones.map((z) => (
+              <option key={z.id} value={z.id}>
+                {z.nom}
+              </option>
+            ))}
+          </select>
         </div>
 
         {/* Groupe 2 : allergènes */}

--- a/src/components/produits/ProduitRow.jsx
+++ b/src/components/produits/ProduitRow.jsx
@@ -12,6 +12,7 @@ export default function ProduitRow({
     <tr className={produit.actif ? "" : "opacity-50"}>
       <td>{produit.nom}</td>
       <td>{produit.famille}</td>
+      <td>{produit.zone_stock?.nom || "-"}</td>
       <td>{produit.unite}</td>
       <td className="text-right">{produit.pmp != null ? Number(produit.pmp).toFixed(2) : '-'}</td>
       <td className="text-right">{produit.stock_theorique}</td>

--- a/src/hooks/useProducts.js
+++ b/src/hooks/useProducts.js
@@ -30,7 +30,7 @@ export function useProducts() {
     let query = supabase
       .from("produits")
       .select(
-        "*, famille:fk_produits_famille(nom), sous_famille:fk_produits_sous_famille(nom), unite:unite_id(nom), fournisseur:fournisseur_id(id, nom)",
+        "*, famille:fk_produits_famille(nom), sous_famille:fk_produits_sous_famille(nom), unite:unite_id(nom), fournisseur:fournisseur_id(id, nom), zone_stock:zone_stock_id(nom)",
         { count: "exact" }
       )
       .eq("mama_id", mama_id);
@@ -43,20 +43,22 @@ export function useProducts() {
     if (sousFamille) query = query.eq("sous_famille_id", sousFamille);
     if (typeof actif === "boolean") query = query.eq("actif", actif);
 
-    if (sortBy === "famille") {
+    if (sortBy === "zone_stock") {
+      query = query
+        .order("nom", { foreignTable: "zone_stock", ascending: order === "asc" })
+        .order("nom", { foreignTable: "famille", ascending: order === "asc" })
+        .order("nom", { ascending: order === "asc" });
+    } else if (sortBy === "famille") {
       query = query
         .order("nom", { foreignTable: "famille", ascending: order === "asc" })
-        .order("nom", {
-          foreignTable: "sous_famille",
-          ascending: order === "asc",
-        });
+        .order("nom", { foreignTable: "sous_famille", ascending: order === "asc" })
+        .order("nom", { ascending: order === "asc" });
     } else if (sortBy === "unite") {
       // order by the joined unite alias
-      query = query.order("nom", { foreignTable: "unite", ascending: order === "asc" });
+      query = query.order("nom", { foreignTable: "unite", ascending: order === "asc" }).order("nom", { ascending: order === "asc" });
     } else {
-      query = query.order(sortBy, { ascending: order === "asc" });
+      query = query.order(sortBy, { ascending: order === "asc" }).order("nom", { ascending: order === "asc" });
     }
-    query = query.order("nom", { ascending: true });
     query = query.range((page - 1) * limit, page * limit - 1);
 
     const { data, error, count } = await query;
@@ -142,6 +144,7 @@ export function useProducts() {
       actif,
       code,
       allergenes,
+      zone_stock_id,
     } = orig;
     const copy = {
       nom: `${orig.nom} (copie)`,
@@ -153,6 +156,7 @@ export function useProducts() {
       actif,
       code,
       allergenes,
+      zone_stock_id,
     };
     if (!mama_id) return { error: "Aucun mama_id" };
     setLoading(true);

--- a/src/hooks/useZonesStock.js
+++ b/src/hooks/useZonesStock.js
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react";
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/context/AuthContext";
+
+export default function useZonesStock() {
+  const { mama_id } = useAuth();
+  const [zones, setZones] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!mama_id) return;
+    const fetchZones = async () => {
+      const { data, error } = await supabase
+        .from("zones_stock")
+        .select("id, nom")
+        .eq("mama_id", mama_id)
+        .eq("actif", true)
+        .order("nom", { ascending: true });
+      if (!error) setZones(data);
+      setLoading(false);
+    };
+    fetchZones();
+  }, [mama_id]);
+
+  return { zones, loading };
+}

--- a/test/ProduitForm.test.jsx
+++ b/test/ProduitForm.test.jsx
@@ -25,6 +25,9 @@ vi.mock('@/hooks/useUnites', () => ({
 vi.mock('@/hooks/useFournisseurs', () => ({
   useFournisseurs: () => ({ fournisseurs: [], fetchFournisseurs: vi.fn() })
 }));
+vi.mock('@/hooks/useZonesStock', () => ({
+  default: () => ({ zones: [], loading: false })
+}));
 
 import ProduitForm from '@/components/produits/ProduitForm.jsx';
 
@@ -35,6 +38,7 @@ test('renders expected product inputs', () => {
   expect(screen.getByLabelText(/Famille/)).toBeInTheDocument();
   expect(screen.getByLabelText(/Sous-famille/)).toBeInTheDocument();
   expect(screen.getByLabelText(/Unité/)).toBeInTheDocument();
+  expect(screen.getByLabelText(/Zone de stockage/)).toBeInTheDocument();
   expect(screen.getByLabelText(/Allergènes/)).toBeInTheDocument();
   expect(screen.queryByLabelText(/Photo/)).toBeNull();
   expect(screen.getByLabelText(/Stock minimum/)).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- add schema hooks to manage zones_stock and product relation
- enable selecting and filtering storage zones on product forms and listings
- expose simple useZonesStock hook for active zone retrieval

## Testing
- `npx vitest run test/ProduitForm.test.jsx test/Produits.test.jsx`
- `npm test` *(fails: Missing Supabase credentials)*

------
https://chatgpt.com/codex/tasks/task_e_688e2a611f6c832db424edc9dac8f8e7