### PR TITLE
feat(produits): add zone de stockage support

### DIFF
--- a/src/components/produits/ProduitRow.jsx
+++ b/src/components/produits/ProduitRow.jsx
@@ -17,7 +17,7 @@ export default function ProduitRow({
     <tr className={produit.actif ? "" : "opacity-50 bg-muted"}>
       <td className="truncate max-w-[200px]">{produit.nom}</td>
       <td>{produit.famille?.nom} {produit.sous_famille ? `> ${produit.sous_famille.nom}` : ""}</td>
-      <td>{produit.zone?.nom || "-"}</td>
+      <td className="truncate max-w-[160px]">{produit.zone_stock?.nom || "-"}</td>
       <td>{produit.unite}</td>
       <td className="text-right">{produit.pmp != null ? Number(produit.pmp).toFixed(2) : "-"}</td>
       <td className={"text-right" + (belowMin ? " text-red-600 font-semibold" : "") }>

--- a/src/hooks/useProducts.js
+++ b/src/hooks/useProducts.js
@@ -31,7 +31,7 @@ export function useProducts() {
     let query = supabase
       .from("produits")
       .select(
-        `*, famille:famille_id(nom), sous_famille:sous_famille_id(nom), unite:unite_id(nom), zone:zone_id(nom), main_fournisseur:fournisseur_id(nom)`,
+        `*, famille:famille_id(nom), sous_famille:sous_famille_id(nom), unite:unite_id(nom), zone_stock:zone_stock_id(nom), main_fournisseur:fournisseur_id(nom)`,
         { count: "exact" }
       )
       .eq("mama_id", mama_id);
@@ -40,12 +40,12 @@ export function useProducts() {
       query = query.ilike("nom", `%${search}%`);
     }
     if (sousFamille) query = query.eq("sous_famille_id", sousFamille);
-    if (zone) query = query.eq("zone_id", zone);
+    if (zone) query = query.eq("zone_stock_id", zone);
     if (typeof actif === "boolean") query = query.eq("actif", actif);
 
-    if (sortBy === "zone") {
+    if (sortBy === "zone_stock") {
       query = query
-        .order("nom", { foreignTable: "zone", ascending: order === "asc" })
+        .order("nom", { foreignTable: "zone_stock", ascending: order === "asc" })
         .order("nom", { foreignTable: "famille", ascending: order === "asc" })
         .order("nom", { ascending: order === "asc" });
     } else if (sortBy === "famille") {
@@ -141,7 +141,7 @@ export function useProducts() {
       actif,
       code,
       allergenes,
-      zone_id,
+      zone_stock_id,
     } = orig;
     const copy = {
       nom: `${orig.nom} (copie)`,
@@ -153,7 +153,7 @@ export function useProducts() {
       actif,
       code,
       allergenes,
-      zone_id,
+      zone_stock_id,
     };
     if (!mama_id) return { error: "Aucun mama_id" };
     setLoading(true);

--- a/src/pages/produits/Produits.jsx
+++ b/src/pages/produits/Produits.jsx
@@ -112,7 +112,7 @@ export default function Produits() {
   const invalidCount = importRows.length - validCount;
 
   const filteredProducts = products.filter((p) => {
-    if (zoneFilter && p.zone_id !== zoneFilter) return false;
+    if (zoneFilter && p.zone_stock_id !== zoneFilter) return false;
     return true;
   });
 
@@ -390,9 +390,9 @@ export default function Produits() {
               </th>
               <th
                 className="cursor-pointer"
-                onClick={() => toggleSort("zone")}
+                onClick={() => toggleSort("zone_stock")}
               >
-                Zone{renderArrow("zone")}
+                Zone de stockage{renderArrow("zone_stock")}
               </th>
               <th>Unité</th>
               <th className="cursor-pointer text-right" onClick={() => toggleSort("pmp")}> 
@@ -473,6 +473,9 @@ export default function Produits() {
                 </div>
                 <div className="text-sm text-muted-foreground truncate">
                   {p.famille?.nom} {p.sous_famille ? `> ${p.sous_famille.nom}` : ""}
+                </div>
+                <div className="text-sm text-muted-foreground truncate">
+                  {p.zone_stock?.nom || "Sans zone"}
                 </div>
                 <div className="flex justify-between text-sm mt-1">
                   <span>{p.unite} — {p.pmp != null ? Number(p.pmp).toFixed(2) : "-"}</span>

--- a/test/Produits.test.jsx
+++ b/test/Produits.test.jsx
@@ -1,5 +1,5 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { fireEvent } from '@testing-library/react';
 import React from 'react';
 import { vi } from 'vitest';


### PR DESCRIPTION
## Summary
- include stockage zone relationship in product fetch
- show zone de stockage in product listings and mobile cards
- truncate long zone names in rows for readability

## Testing
- `npm test` *(fails: Missing Supabase credentials, useAuth must be used within AuthProvider)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e3300bedc832db314b84a09e38b8e