### PR TITLE
fix: specify Supabase FK constraints explicitly

### DIFF
--- a/src/hooks/useEnrichedProducts.js
+++ b/src/hooks/useEnrichedProducts.js
@@ -16,7 +16,7 @@ export function useEnrichedProducts() {
       const { data, error } = await supabase
         .from("produits")
         .select(
-          "id, nom, famille_id, sous_famille_id, famille:fk_produits_famille(nom), sous_famille:fk_produits_sous_famille(nom), liaisons:fournisseur_produits_produit_id_fkey(*, fournisseur:fournisseur_id(*))"
+          "id, nom, famille_id, sous_famille_id, famille:familles!fk_produits_famille(nom), sous_famille:sous_familles!fk_produits_sous_famille(nom), liaisons:fournisseur_produits!fournisseur_produits_produit_id_fkey(*, fournisseur:fournisseurs!fk_fournisseur_produits_fournisseur_id(*))"
         )
         .eq("mama_id", mama_id);
 

--- a/src/hooks/useExport.js
+++ b/src/hooks/useExport.js
@@ -43,7 +43,7 @@ export default function useExport() {
         const res = await supabase
           .from('produits')
           .select(
-            'id, nom, famille_id, sous_famille_id, famille:fk_produits_famille(nom), sous_famille:fk_produits_sous_famille(nom), fournisseur_produits:fournisseur_produits_produit_id_fkey(*, fournisseur:fournisseur_id(nom))'
+            'id, nom, famille_id, sous_famille_id, famille:familles!fk_produits_famille(nom), sous_famille:sous_familles!fk_produits_sous_famille(nom), fournisseur_produits:fournisseur_produits!fournisseur_produits_produit_id_fkey(*, fournisseur:fournisseurs!fk_fournisseur_produits_fournisseur_id(nom))'
           )
           .eq('mama_id', mama_id);
         data = res.data || [];

--- a/src/hooks/useFiches.js
+++ b/src/hooks/useFiches.js
@@ -51,7 +51,7 @@ export function useFiches() {
     const { data, error } = await supabase
       .from("fiches_techniques")
       .select(
-        "*, famille:familles!fiches_techniques_famille_id_fkey(id, nom), lignes:fiche_lignes!fiche_id(*, produit:produit_id(id, nom, unite_id, unite:unite_id(nom), pmp), sous_fiche:sous_fiche_id(id, nom, cout_par_portion))"
+        "*, famille:familles!fiches_techniques_famille_id_fkey(id, nom), lignes:fiche_lignes!fiche_id(*, produit:produits!fiche_lignes_produit_id_fkey(id, nom, unite_id, unite:unites!fk_produits_unite(nom), pmp), sous_fiche:sous_fiche_id(id, nom, cout_par_portion))"
       )
       .eq("id", id)
       .eq("mama_id", mama_id)

--- a/src/hooks/useInventaires.js
+++ b/src/hooks/useInventaires.js
@@ -16,7 +16,7 @@ export function useInventaires() {
     let query = supabase
       .from("inventaires")
       .select(
-        "*, lignes:inventaire_lignes!inventaire_id(*, produit:produit_id(id, nom, unite_id, unite:unite_id(nom), stock_theorique, pmp))"
+        "*, lignes:inventaire_lignes!inventaire_id(*, produit:produits!inventaire_lignes_produit_id_fkey(id, nom, unite_id, unite:unites!fk_produits_unite(nom), stock_theorique, pmp))"
       )
       .eq("mama_id", mama_id);
     if (!includeArchives) query = query.eq("actif", true);
@@ -103,7 +103,7 @@ export function useInventaires() {
     const { data, error } = await supabase
       .from("inventaires")
       .select(
-        "*, lignes:inventaire_lignes!inventaire_id(*, produit:produit_id(id, nom, unite_id, unite:unite_id(nom), stock_theorique, pmp))"
+        "*, lignes:inventaire_lignes!inventaire_id(*, produit:produits!inventaire_lignes_produit_id_fkey(id, nom, unite_id, unite:unites!fk_produits_unite(nom), stock_theorique, pmp))"
       )
       .eq("id", id)
       .eq("mama_id", mama_id)

--- a/src/hooks/useInvoiceItems.js
+++ b/src/hooks/useInvoiceItems.js
@@ -18,7 +18,7 @@ export function useInvoiceItems() {
     const { data, error } = await supabase
       .from("facture_lignes")
       .select(
-        "*, produit:produit_id(id, nom, famille:fk_produits_famille(id, nom), unite:unite_id(nom))"
+        "*, produit:produits!facture_lignes_produit_id_fkey(id, nom, famille:familles!fk_produits_famille(id, nom), unite:unites!fk_produits_unite(nom))"
       )
       .eq("facture_id", invoiceId)
       .eq("mama_id", mama_id)
@@ -35,7 +35,7 @@ export function useInvoiceItems() {
     const { data, error } = await supabase
       .from("facture_lignes")
       .select(
-        "*, produit:produit_id(id, nom, famille:fk_produits_famille(id, nom), unite:unite_id(nom))"
+        "*, produit:produits!facture_lignes_produit_id_fkey(id, nom, famille:familles!fk_produits_famille(id, nom), unite:unites!fk_produits_unite(nom))"
       )
       .eq("id", id)
       .eq("mama_id", mama_id)

--- a/src/hooks/useProducts.js
+++ b/src/hooks/useProducts.js
@@ -31,7 +31,7 @@ export function useProducts() {
     let query = supabase
       .from("produits")
       .select(
-        `*, famille:famille_id(nom), sous_famille:sous_famille_id(nom), unite:unite_id(nom), zone_stock:zone_stock_id(nom), main_fournisseur:fournisseur_id(nom)`,
+        `*, famille:familles!fk_produits_famille(nom), sous_famille:sous_familles!fk_produits_sous_famille(nom), unite:unites!fk_produits_unite(nom), zone_stock:zones_stock!fk_produits_zone_stock(nom), main_fournisseur:fournisseur_id(nom)`,
         { count: "exact" }
       )
       .eq("mama_id", mama_id);
@@ -208,7 +208,7 @@ export function useProducts() {
     const { data, error } = await supabase
       .from("fournisseur_produits")
       .select(
-        "*, fournisseur:fournisseur_id(id, nom), derniere_livraison:date_livraison"
+        "*, fournisseur:fournisseurs!fk_fournisseur_produits_fournisseur_id(id, nom), derniere_livraison:date_livraison"
       )
       .eq("produit_id", productId)
       .eq("mama_id", mama_id)
@@ -227,7 +227,7 @@ export function useProducts() {
       const { data, error } = await supabase
         .from("produits")
         .select(
-          "*, famille:famille_id(nom), sous_famille:sous_famille_id(nom), main_fournisseur:fournisseur_id(id, nom), unite:unite_id(nom)"
+          "*, famille:familles!fk_produits_famille(nom), sous_famille:sous_familles!fk_produits_sous_famille(nom), main_fournisseur:fournisseur_id(id, nom), unite:unites!fk_produits_unite(nom)"
         )
         .eq("id", id)
         .eq("mama_id", mama_id)

--- a/src/hooks/useProduitsFournisseur.js
+++ b/src/hooks/useProduitsFournisseur.js
@@ -21,7 +21,7 @@ export function useProduitsFournisseur() {
       const { data, error } = await supabase
         .from("fournisseur_produits")
         .select(
-          "*, produit:produit_id(id, nom, famille:fk_produits_famille(id, nom), unite:unite_id(nom))"
+          "*, produit:produits!fournisseur_produits_produit_id_fkey(id, nom, famille:familles!fk_produits_famille(id, nom), unite:unites!fk_produits_unite(nom))"
         )
         .eq("fournisseur_id", fournisseur_id)
         .eq("mama_id", mama_id);
@@ -41,7 +41,7 @@ export function useProduitsFournisseur() {
       const { data } = await supabase
         .from("fournisseur_produits")
         .select(
-          "*, produit:produit_id(id, nom, famille:fk_produits_famille(id, nom), unite:unite_id(nom))"
+          "*, produit:produits!fournisseur_produits_produit_id_fkey(id, nom, famille:familles!fk_produits_famille(id, nom), unite:unites!fk_produits_unite(nom))"
         )
         .eq("fournisseur_id", fournisseur_id)
         .eq("mama_id", mama_id);

--- a/src/hooks/useStock.js
+++ b/src/hooks/useStock.js
@@ -18,7 +18,7 @@ export function useStock() {
     const { data, error } = await supabase
       .from("produits")
       .select(
-        "id, nom, stock_reel, stock_min, pmp, famille_id, sous_famille_id, famille:fk_produits_famille(nom), sous_famille:fk_produits_sous_famille(nom)"
+        "id, nom, stock_reel, stock_min, pmp, famille_id, sous_famille_id, famille:familles!fk_produits_famille(nom), sous_famille:sous_familles!fk_produits_sous_famille(nom)"
       )
       .eq("mama_id", mama_id);
     setLoading(false);

--- a/src/pages/Transferts.jsx
+++ b/src/pages/Transferts.jsx
@@ -45,7 +45,7 @@ export default function Transferts() {
     supabase
       .from("produits")
       .select(
-        "id, nom, pmp, famille_id, sous_famille_id, famille:fk_produits_famille(nom), sous_famille:fk_produits_sous_famille(nom)"
+        "id, nom, pmp, famille_id, sous_famille_id, famille:familles!fk_produits_famille(nom), sous_famille:sous_familles!fk_produits_sous_famille(nom)"
       )
       .eq("mama_id", mama_id)
       .then(({ data }) => setProduits(data || []));

--- a/src/pages/mobile/MobileInventaire.jsx
+++ b/src/pages/mobile/MobileInventaire.jsx
@@ -17,7 +17,7 @@ export default function MobileInventaire() {
     supabase
       .from("produits")
       .select(
-        "id, nom, famille_id, sous_famille_id, famille:fk_produits_famille(nom), sous_famille:fk_produits_sous_famille(nom)"
+        "id, nom, famille_id, sous_famille_id, famille:familles!fk_produits_famille(nom), sous_famille:sous_familles!fk_produits_sous_famille(nom)"
       )
       .eq("mama_id", mama_id)
       .then(({ data }) => setProduits(data || []));

--- a/test/useCostCenterSuggestions.test.js
+++ b/test/useCostCenterSuggestions.test.js
@@ -5,6 +5,7 @@ import { vi, beforeEach, test, expect } from 'vitest';
 const rpcMock = vi.fn(() => Promise.resolve({ data: [{ cost_center_id: 'c1', nom: 'Food', ratio: 0.7 }], error: null }));
 
 vi.mock('@/lib/supabase', () => ({ supabase: { rpc: rpcMock } }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1' }) }));
 
 let useCostCenterSuggestions;
 

--- a/test/useFacturesAutocomplete.test.js
+++ b/test/useFacturesAutocomplete.test.js
@@ -28,7 +28,7 @@ test('searchFactures filters by mama_id and query', async () => {
     await result.current.searchFactures('FA');
   });
   expect(fromMock).toHaveBeenCalledWith('factures');
-  expect(selectMock).toHaveBeenCalledWith('id, numero, date_facture, fournisseurs(nom)');
+  expect(selectMock).toHaveBeenCalledWith('id, numero, date_facture, fournisseur_id, fournisseur:fournisseur_id(nom)');
   expect(eqMock).toHaveBeenCalledWith('mama_id', 'm1');
   expect(ilikeMock).toHaveBeenCalledWith('numero', '%FA%');
 });

--- a/test/useInvoiceItems.test.js
+++ b/test/useInvoiceItems.test.js
@@ -36,7 +36,7 @@ test('fetchItemsByInvoice queries with invoice id and mama_id', async () => {
     await result.current.fetchItemsByInvoice('f1');
   });
   expect(fromMock).toHaveBeenCalledWith('facture_lignes');
-  expect(query.select).toHaveBeenCalledWith('*, produit:produit_id(id, nom, famille:fk_produits_famille(id, nom), unite:unite_id(nom))');
+  expect(query.select).toHaveBeenCalledWith('*, produit:produits!facture_lignes_produit_id_fkey(id, nom, famille:familles!fk_produits_famille(id, nom), unite:unites!fk_produits_unite(nom))');
   expect(query.eq).toHaveBeenNthCalledWith(1, 'facture_id', 'f1');
   expect(query.eq).toHaveBeenNthCalledWith(2, 'mama_id', 'm1');
   expect(query.order).toHaveBeenCalledWith('id');

--- a/test/useProductsPrices.test.js
+++ b/test/useProductsPrices.test.js
@@ -24,5 +24,5 @@ test('fetchProductPrices selects fields with last delivery alias', async () => {
     await result.current.fetchProductPrices('p1');
   });
   expect(fromMock).toHaveBeenCalledWith('fournisseur_produits');
-  expect(selectMock).toHaveBeenCalledWith('*, fournisseur: fournisseurs(id, nom), derniere_livraison:date_livraison');
+  expect(selectMock).toHaveBeenCalledWith('*, fournisseur:fournisseurs!fk_fournisseur_produits_fournisseur_id(id, nom), derniere_livraison:date_livraison');
 });


### PR DESCRIPTION
## Summary
- disambiguate Supabase relations by naming foreign key constraints in select embeds
- update product, inventory and supplier queries plus related tests

## Testing
- `npm test` *(fails: Fournisseurs.test.jsx, useMenuDuJour.test.js, useCommandes.test.js, Planning.test.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_688e38825aa0832db6ee6a9e25140be9