### PR TITLE
Fix unit display and relations for products

### DIFF
--- a/src/components/produits/ProduitForm.jsx
+++ b/src/components/produits/ProduitForm.jsx
@@ -38,6 +38,7 @@ export default function ProduitForm({
     produit?.sous_famille_id || "",
   );
   const [uniteId, setUniteId] = useState(produit?.unite_id || "");
+  const [uniteName, setUniteName] = useState(produit?.unite?.nom || "");
   const [fournisseurId, setFournisseurId] = useState(
     produit?.fournisseur_id || "",
   );
@@ -81,6 +82,7 @@ export default function ProduitForm({
       setFamilleId(produit.famille_id || "");
       setSousFamilleId(produit.sous_famille_id || "");
       setUniteId(produit.unite_id || "");
+      setUniteName(produit.unite?.nom || "");
       setFournisseurId(produit.fournisseur_id || "");
       setZoneStockId(produit.zone_stock_id || "");
       setStockMin(produit.stock_min || 0);
@@ -229,20 +231,24 @@ export default function ProduitForm({
           <label htmlFor="prod-unite" className="label text-white">
             Unité *
           </label>
-          <select
+          <input
             id="prod-unite"
+            list="unites-list"
             className="input bg-white text-gray-900"
-            value={uniteId}
-            onChange={(e) => setUniteId(e.target.value)}
+            value={uniteName}
+            onChange={(e) => {
+              const val = e.target.value;
+              setUniteName(val);
+              const found = uniteOptions.find((u) => u.nom === val);
+              setUniteId(found ? found.id : "");
+            }}
             required
-          >
-            <option value="">-- Choisir --</option>
+          />
+          <datalist id="unites-list">
             {uniteOptions.map((u) => (
-              <option key={u.id} value={u.id}>
-                {u.nom}
-              </option>
+              <option key={u.id} value={u.nom} />
             ))}
-          </select>
+          </datalist>
           {errors.unite && <p className="text-red-500 text-sm">{errors.unite}</p>}
         </div>
 

--- a/src/components/produits/ProduitRow.jsx
+++ b/src/components/produits/ProduitRow.jsx
@@ -16,7 +16,7 @@ export default function ProduitRow({
   return (
     <tr className={produit.actif ? "" : "opacity-50 bg-muted"}>
       <td
-        className="px-2 min-w-[240px] truncate"
+        className="px-2 min-w-[30ch] truncate"
         title={produit.nom}
       >
         {produit.nom}
@@ -33,7 +33,7 @@ export default function ProduitRow({
       >
         {produit.zone_stock?.nom || "-"}
       </td>
-      <td className="px-2 text-center">{produit.unite}</td>
+      <td className="px-2 text-center">{produit.unite?.nom ?? produit.unite ?? ""}</td>
       <td className="px-2 text-right">
         {produit.pmp != null ? Number(produit.pmp).toFixed(2) : "-"}
       </td>

--- a/src/hooks/useInvoiceItems.js
+++ b/src/hooks/useInvoiceItems.js
@@ -18,7 +18,7 @@ export function useInvoiceItems() {
     const { data, error } = await supabase
       .from("facture_lignes")
       .select(
-        "*, produit:produits!facture_lignes_produit_id_fkey(id, nom, famille:familles!fk_produits_famille(id, nom), unite:unites!fk_produits_unite(nom))"
+        "*, produit:produits!facture_lignes_produit_id_fkey(id, nom, famille:familles(nom), unite:unites(nom))"
       )
       .eq("facture_id", invoiceId)
       .eq("mama_id", mama_id)
@@ -35,7 +35,7 @@ export function useInvoiceItems() {
     const { data, error } = await supabase
       .from("facture_lignes")
       .select(
-        "*, produit:produits!facture_lignes_produit_id_fkey(id, nom, famille:familles!fk_produits_famille(id, nom), unite:unites!fk_produits_unite(nom))"
+        "*, produit:produits!facture_lignes_produit_id_fkey(id, nom, famille:familles(nom), unite:unites(nom))"
       )
       .eq("id", id)
       .eq("mama_id", mama_id)

--- a/src/hooks/useProducts.js
+++ b/src/hooks/useProducts.js
@@ -31,7 +31,7 @@ export function useProducts() {
     let query = supabase
       .from("produits")
       .select(
-        `*, famille:familles!fk_produits_famille(nom), sous_famille:sous_familles!fk_produits_sous_famille(nom), unite:unites!fk_produits_unite(nom), zone_stock:zones_stock!fk_produits_zone_stock(nom), main_fournisseur:fournisseur_id(nom)`,
+        `*, famille:familles(nom), sous_famille:sous_familles(nom), unite:unites(nom), zone_stock:zones_stock(nom), main_fournisseur:fournisseur_id(nom)`,
         { count: "exact" }
       )
       .eq("mama_id", mama_id);
@@ -74,7 +74,6 @@ export function useProducts() {
     const stockMap = Object.fromEntries((stockData || []).map(s => [s.produit_id, s.stock]));
     const final = (Array.isArray(data) ? data : []).map((p) => ({
       ...p,
-      unite: p.unite?.nom || "",
       pmp: pmpMap[p.id] ?? p.pmp,
       stock_theorique: stockMap[p.id] ?? p.stock_theorique,
     }));

--- a/src/pages/produits/Produits.jsx
+++ b/src/pages/produits/Produits.jsx
@@ -209,7 +209,7 @@ export default function Produits() {
     const { data, error } = await supabase
       .from("produits")
       .select(
-        `nom, famille:familles!fk_produits_famille(nom), sous_famille:sous_familles!fk_produits_sous_famille(nom), unite:unites!fk_produits_unite(nom), zone:zones_stock!fk_produits_zone_stock(nom), actif, seuil_min, pmp, dernier_prix, fournisseur_principal:fournisseur_id(nom)`
+        `nom, famille:familles(nom), sous_famille:sous_familles(nom), unite:unites(nom), zone:zones_stock(nom), actif, seuil_min, pmp, dernier_prix, fournisseur_principal:fournisseur_id(nom)`
       )
       .eq("mama_id", mama_id);
     if (error) {
@@ -432,7 +432,7 @@ export default function Produits() {
           <thead>
             <tr>
               <th
-                className="px-2 text-left cursor-pointer min-w-[240px]"
+                className="px-2 text-left cursor-pointer min-w-[30ch]"
                 onClick={() => toggleSort("nom")}
               >
                 Nom{renderArrow("nom")}
@@ -519,20 +519,10 @@ export default function Produits() {
             <Card key={produit.id} className="p-4">
               <div className="font-bold">{produit.nom}</div>
               <div className="text-sm">
-                Famille : {produit.famille?.nom}
-                {produit.sous_famille ? ` → ${produit.sous_famille.nom}` : ""}
-              </div>
-              <div className="text-sm">
-                Zone : {produit.zone_stock?.nom || "-"}
-              </div>
-              <div className="text-sm">
                 Unité : {produit.unite?.nom ?? produit.unite ?? "-"}
               </div>
               <div className="text-sm">
                 PMP : {produit.pmp != null ? Number(produit.pmp).toFixed(2) : "0.00"} €
-              </div>
-              <div className="text-sm">
-                Stock : {produit.stock ?? produit.stock_theorique ?? 0}
               </div>
               <div className="flex gap-2 mt-2">
                 <Button

--- a/test/Produits.test.jsx
+++ b/test/Produits.test.jsx
@@ -49,7 +49,7 @@ import Produits from '@/pages/produits/Produits.jsx';
 test('duplicate button calls hook', async () => {
   const duplicate = vi.fn();
   mockHook = () => ({
-    products: [{ id: '1', nom: 'Test', famille: 'F', unite: 'kg', pmp: 1, stock_reel: 10, actif: true, zone_stock: { nom: 'Z' }, zone_stock_id: 'z1' }],
+    products: [{ id: '1', nom: 'Test', famille: { nom: 'F' }, unite: { nom: 'kg' }, pmp: 1, stock_reel: 10, actif: true, zone_stock: { nom: 'Z' }, zone_stock_id: 'z1' }],
     total: 1,
     fetchProducts: vi.fn(),
     exportProductsToExcel: vi.fn(),

--- a/test/useInvoiceItems.test.js
+++ b/test/useInvoiceItems.test.js
@@ -36,7 +36,7 @@ test('fetchItemsByInvoice queries with invoice id and mama_id', async () => {
     await result.current.fetchItemsByInvoice('f1');
   });
   expect(fromMock).toHaveBeenCalledWith('facture_lignes');
-  expect(query.select).toHaveBeenCalledWith('*, produit:produits!facture_lignes_produit_id_fkey(id, nom, famille:familles!fk_produits_famille(id, nom), unite:unites!fk_produits_unite(nom))');
+  expect(query.select).toHaveBeenCalledWith('*, produit:produits!facture_lignes_produit_id_fkey(id, nom, famille:familles(nom), unite:unites(nom))');
   expect(query.eq).toHaveBeenNthCalledWith(1, 'facture_id', 'f1');
   expect(query.eq).toHaveBeenNthCalledWith(2, 'mama_id', 'm1');
   expect(query.order).toHaveBeenCalledWith('id');


### PR DESCRIPTION
## Summary
- fetch product units via `unite:unites(nom)` and keep full unit object
- show unit names in product rows, enlarge name column and simplify mobile view
- add unit autocomplete in product form and update related queries/tests

## Testing
- `npm test` *(fails: Missing Supabase credentials)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e43b24f7c832da0aa217c1ff9761e