### PR TITLE
refactor: simplify product listing

### DIFF
--- a/src/components/produits/ProduitRow.jsx
+++ b/src/components/produits/ProduitRow.jsx
@@ -2,10 +2,9 @@ import { Button } from "@/components/ui/button";
 
 export default function ProduitRow({
   produit,
-  onEdit,
   onDetail,
-  onDuplicate,
   onToggleActive,
+  onDelete,
   canEdit,
 }) {
   const belowMin =
@@ -16,22 +15,10 @@ export default function ProduitRow({
   return (
     <tr className={produit.actif ? "" : "opacity-50 bg-muted"}>
       <td
-        className="px-2 min-w-[30ch] truncate"
+        className="px-2 min-w-[30ch] break-words"
         title={produit.nom}
       >
         {produit.nom}
-      </td>
-      <td
-        className="px-2 truncate"
-        title={`${produit.famille?.nom || ""}${produit.sous_famille ? ` > ${produit.sous_famille.nom}` : ""}`}
-      >
-        {produit.famille?.nom} {produit.sous_famille ? `> ${produit.sous_famille.nom}` : ""}
-      </td>
-      <td
-        className="px-2 truncate"
-        title={produit.zone_stock?.nom || "-"}
-      >
-        {produit.zone_stock?.nom || "-"}
       </td>
       <td className="px-2 text-center">{produit.unite?.nom ?? produit.unite ?? ""}</td>
       <td className="px-2 text-right">
@@ -45,19 +32,12 @@ export default function ProduitRow({
         {produit.stock_theorique}
         {rupture && <span className="ml-1 text-red-600">⚠️</span>}
       </td>
-      <td className="px-2 text-right">{produit.seuil_min ?? "-"}</td>
       <td
         className="px-2 truncate"
-        title={produit.main_fournisseur?.nom || "-"}
+        title={produit.zone_stock?.nom || "-"}
       >
-        {produit.main_fournisseur?.nom || "-"}
+        {produit.zone_stock?.nom || "-"}
       </td>
-      <td className="px-2 text-right">
-        {produit.dernier_prix != null
-          ? Number(produit.dernier_prix).toFixed(2)
-          : "-"}
-      </td>
-      <td className="px-2 text-center">{produit.actif ? "✅" : "❌"}</td>
       <td className="px-2 whitespace-nowrap min-w-[100px]">
         <div className="flex justify-center gap-2">
           <Button size="sm" variant="secondary" onClick={() => onDetail(produit)}>
@@ -65,22 +45,19 @@ export default function ProduitRow({
           </Button>
           {canEdit && (
             <>
-              <Button size="sm" variant="outline" onClick={() => onEdit(produit)}>
-                Éditer
-              </Button>
               <Button
                 size="sm"
-                variant="destructive"
+                variant="outline"
                 onClick={() => onToggleActive(produit.id, !produit.actif)}
               >
                 {produit.actif ? "Désactiver" : "Activer"}
               </Button>
               <Button
                 size="sm"
-                variant="ghost"
-                onClick={() => onDuplicate(produit.id)}
+                variant="destructive"
+                onClick={() => onDelete(produit.id)}
               >
-                Dupliquer
+                Supprimer
               </Button>
             </>
           )}

--- a/src/hooks/useProducts.js
+++ b/src/hooks/useProducts.js
@@ -31,7 +31,7 @@ export function useProducts() {
     let query = supabase
       .from("produits")
       .select(
-        `*, famille:familles(nom), sous_famille:sous_familles(nom), unite:unites(nom), zone_stock:zones_stock(nom), main_fournisseur:fournisseur_id(nom)`,
+        `*, unite:unites(nom), zone_stock:zones_stock(nom)`,
         { count: "exact" }
       )
       .eq("mama_id", mama_id);

--- a/src/pages/produits/ProduitDetail.jsx
+++ b/src/pages/produits/ProduitDetail.jsx
@@ -115,6 +115,12 @@ export default function ProduitDetailPage() {
           </div>
         ) : (
           <>
+            {product && (
+              <div className="mb-4 text-sm">
+                <p>Fournisseur : {product.main_fournisseur?.nom || '-'}</p>
+                <p>Stock minimum : {product.seuil_min ?? '-'}</p>
+              </div>
+            )}
             <table className="min-w-full text-sm mb-6">
               <thead>
                 <tr>

--- a/test/Produits.test.jsx
+++ b/test/Produits.test.jsx
@@ -46,21 +46,33 @@ import { parseProduitsFile } from '@/utils/importExcelProduits';
 
 import Produits from '@/pages/produits/Produits.jsx';
 
-test('duplicate button calls hook', async () => {
-  const duplicate = vi.fn();
+test('toggle button calls hook', async () => {
+  const toggle = vi.fn();
   mockHook = () => ({
-    products: [{ id: '1', nom: 'Test', famille: { nom: 'F' }, unite: { nom: 'kg' }, pmp: 1, stock_reel: 10, actif: true, zone_stock: { nom: 'Z' }, zone_stock_id: 'z1' }],
+    products: [
+      {
+        id: '1',
+        nom: 'Test',
+        unite: { nom: 'kg' },
+        pmp: 1,
+        stock_theorique: 10,
+        actif: true,
+        zone_stock: { nom: 'Z' },
+        zone_stock_id: 'z1',
+      },
+    ],
     total: 1,
     fetchProducts: vi.fn(),
     exportProductsToExcel: vi.fn(),
     importProductsFromExcel: vi.fn(() => Promise.resolve([])),
     addProduct: vi.fn(),
-    duplicateProduct: duplicate,
+    toggleProductActive: toggle,
+    deleteProduct: vi.fn(),
   });
   render(<Produits />);
-  const button = await screen.findByText('Dupliquer');
+  const button = await screen.findByText('Désactiver');
   fireEvent.click(button);
-  expect(duplicate).toHaveBeenCalledWith('1');
+  expect(toggle).toHaveBeenCalledWith('1', false);
 });
 
 test('import input triggers parsing', async () => {
@@ -70,7 +82,8 @@ test('import input triggers parsing', async () => {
     fetchProducts: vi.fn(),
     exportProductsToExcel: vi.fn(),
     addProduct: vi.fn(),
-    duplicateProduct: vi.fn(),
+    toggleProductActive: vi.fn(),
+    deleteProduct: vi.fn(),
   });
   render(<Produits />);
   const input = screen.getByTestId('import-input');


### PR DESCRIPTION
## Summary
- streamline product list to show only core columns and grid-style mobile view
- expose supplier and minimum stock only on product detail view
- adjust products hook and tests for new actions

## Testing
- `npm run lint`
- `npm test` *(fails: Missing Supabase credentials)*

------
https://chatgpt.com/codex/tasks/task_e_688e46fce848832db2f0aecbd93bd94b