### PR TITLE
feat: add excel import/export for products

### DIFF
--- a/src/components/produits/ModalImportProduits.jsx
+++ b/src/components/produits/ModalImportProduits.jsx
@@ -1,0 +1,59 @@
+import { useState, useRef } from "react";
+import ModalGlass from "@/components/ui/ModalGlass";
+import ImportPreviewTable from "@/components/ui/ImportPreviewTable";
+import { parseProduitsFile, insertProduits } from "@/utils/importExcelProduits";
+import useAuth from "@/hooks/useAuth";
+import { Button } from "@/components/ui/button";
+import { toast } from "react-hot-toast";
+
+export default function ModalImportProduits({ open, onClose, onSuccess }) {
+  const { mama_id } = useAuth();
+  const fileRef = useRef(null);
+  const [rows, setRows] = useState([]);
+  const [importing, setImporting] = useState(false);
+
+  async function handleFileChange(e) {
+    const file = e.target.files[0];
+    if (!file) return;
+    const parsed = await parseProduitsFile(file, mama_id);
+    setRows(parsed);
+    if (fileRef.current) fileRef.current.value = "";
+  }
+
+  async function handleImport() {
+    const validRows = rows.filter((r) => r.errors.length === 0);
+    if (!validRows.length) return;
+    setImporting(true);
+    const results = await insertProduits(validRows);
+    const invalid = rows.filter((r) => r.errors.length > 0);
+    const failed = results.filter((r) => r.insertError);
+    const successCount = results.length - failed.length;
+    if (successCount) toast.success(`${successCount} produits importés`);
+    if (failed.length) toast.error(`${failed.length} erreurs d'insertion`);
+    setRows([...invalid, ...results]);
+    setImporting(false);
+    if (onSuccess) onSuccess();
+  }
+
+  return (
+    <ModalGlass open={open} onClose={onClose}>
+      <div className="space-y-4">
+        <input
+          type="file"
+          accept=".xlsx,.csv"
+          ref={fileRef}
+          onChange={handleFileChange}
+        />
+        {rows.length > 0 && (
+          <ImportPreviewTable rows={rows} onImport={handleImport} importing={importing} />
+        )}
+        <div className="text-right">
+          <Button variant="outline" onClick={onClose}>
+            Fermer
+          </Button>
+        </div>
+      </div>
+    </ModalGlass>
+  );
+}
+

--- a/src/components/ui/ImportPreviewTable.jsx
+++ b/src/components/ui/ImportPreviewTable.jsx
@@ -1,0 +1,65 @@
+import { Button } from "@/components/ui/button";
+
+export default function ImportPreviewTable({ rows, onImport, importing }) {
+  const allValid = rows.every((r) => r.errors.length === 0);
+  return (
+    <div className="space-y-2">
+      <div className="overflow-x-auto">
+        <table className="min-w-full table-auto text-sm">
+          <thead>
+            <tr>
+              <th>Nom</th>
+              <th>Famille</th>
+              <th>Sous-famille</th>
+              <th>Unité</th>
+              <th>Zone stock</th>
+              <th>Code</th>
+              <th>Allergènes</th>
+              <th>Actif</th>
+              <th>PMP</th>
+              <th>Stock théorique</th>
+              <th>Stock min</th>
+              <th>Dernier prix</th>
+              <th>Fournisseur ID</th>
+              <th>Statut</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, idx) => (
+              <tr key={idx} className={row.errors.length ? "bg-red-50" : "bg-green-50"}>
+                <td>{row.nom}</td>
+                <td>{row.famille_nom}</td>
+                <td>{row.sous_famille_nom}</td>
+                <td>{row.unite_nom}</td>
+                <td>{row.zone_stock_nom}</td>
+                <td>{row.code}</td>
+                <td>{row.allergenes}</td>
+                <td>{row.actif ? "Oui" : "Non"}</td>
+                <td className="text-right">{row.pmp ?? ""}</td>
+                <td className="text-right">{row.stock_theorique ?? ""}</td>
+                <td className="text-right">{row.stock_min ?? ""}</td>
+                <td className="text-right">{row.dernier_prix ?? ""}</td>
+                <td>{row.fournisseur_id ?? ""}</td>
+                <td>
+                  {row.errors.length
+                    ? `❌ ${row.errors.join(", ")}`
+                    : row.insertError
+                    ? `❌ ${row.insertError}`
+                    : "✅ OK"}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {allValid && (
+        <div className="text-right">
+          <Button onClick={onImport} disabled={importing || rows.length === 0}>
+            Importer maintenant
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/src/utils/exportExcelProduits.js
+++ b/src/utils/exportExcelProduits.js
@@ -1,0 +1,62 @@
+import * as XLSX from "xlsx";
+import { saveAs } from "file-saver";
+import { supabase } from "@/lib/supabase";
+
+const HEADERS = [
+  "nom",
+  "famille",
+  "sous_famille",
+  "unite",
+  "zone_stock",
+  "code",
+  "allergenes",
+  "actif",
+  "pmp",
+  "stock_theorique",
+  "stock_min",
+  "dernier_prix",
+  "fournisseur_id",
+];
+
+export async function exportExcelProduits(mama_id) {
+  const { data, error } = await supabase
+    .from("produits")
+    .select(
+      `nom, famille:familles(nom), sous_famille:sous_familles(nom), unite:unites(nom), zone_stock:zones_stock(nom), code, allergenes, actif, pmp, stock_theorique, seuil_min, dernier_prix, fournisseur_id`
+    )
+    .eq("mama_id", mama_id);
+
+  if (error) throw error;
+
+  const rows = (data || []).map((p) => ({
+    nom: p.nom,
+    famille: p.famille?.nom || "",
+    sous_famille: p.sous_famille?.nom || "",
+    unite: p.unite?.nom || "",
+    zone_stock: p.zone_stock?.nom || "",
+    code: p.code || "",
+    allergenes: p.allergenes || "",
+    actif: p.actif ? "TRUE" : "FALSE",
+    pmp: p.pmp ?? "",
+    stock_theorique: p.stock_theorique ?? "",
+    stock_min: p.seuil_min ?? "",
+    dernier_prix: p.dernier_prix ?? "",
+    fournisseur_id: p.fournisseur_id || "",
+  }));
+
+  const wb = XLSX.utils.book_new();
+  const ws = XLSX.utils.json_to_sheet(rows, { header: HEADERS });
+  XLSX.utils.book_append_sheet(wb, ws, "Produits");
+  const buf = XLSX.write(wb, { bookType: "xlsx", type: "array" });
+  saveAs(new Blob([buf]), "produits_export_mamastock.xlsx");
+}
+
+export function downloadProduitsTemplate() {
+  const example = Object.fromEntries(HEADERS.map((h) => [h, ""]));
+  const wb = XLSX.utils.book_new();
+  const ws = XLSX.utils.json_to_sheet([example], { header: HEADERS });
+  XLSX.utils.book_append_sheet(wb, ws, "Template");
+  const buf = XLSX.write(wb, { bookType: "xlsx", type: "array" });
+  saveAs(new Blob([buf]), "produits_template_mamastock.xlsx");
+}
+

--- a/src/utils/importExcelProduits.js
+++ b/src/utils/importExcelProduits.js
@@ -11,69 +11,94 @@ function parseBoolean(value) {
 }
 
 export async function parseProduitsFile(file, mama_id) {
-  let workbook;
-  if (file.name.endsWith(".csv")) {
-    const text = await file.text();
-    workbook = XLSX.read(text, { type: "string" });
-  } else {
-    const data = await file.arrayBuffer();
-    workbook = XLSX.read(data, { type: "array" });
-  }
+  const data = await file.arrayBuffer();
+  const workbook = XLSX.read(data, { type: "array" });
   const sheet = workbook.Sheets[workbook.SheetNames[0]];
   const raw = XLSX.utils.sheet_to_json(sheet, { defval: "" });
-  const rows = [];
 
-  for (const r of raw) {
-    const row = Object.fromEntries(
-      Object.entries(r).map(([k, v]) => [k.toLowerCase().trim(), v]),
+  const [famillesRes, sousFamillesRes, unitesRes, zonesRes, fournisseursRes] =
+    await Promise.all([
+      supabase.from("familles").select("id, nom").eq("mama_id", mama_id),
+      supabase.from("sous_familles").select("id, nom").eq("mama_id", mama_id),
+      supabase.from("unites").select("id, nom").eq("mama_id", mama_id),
+      supabase.from("zones_stock").select("id, nom").eq("mama_id", mama_id),
+      supabase.from("fournisseurs").select("id").eq("mama_id", mama_id),
+    ]);
+
+  const mapByName = (res) =>
+    new Map((res.data || []).map((x) => [x.nom.toLowerCase(), x.id]));
+  const famillesMap = mapByName(famillesRes);
+  const sousFamillesMap = mapByName(sousFamillesRes);
+  const unitesMap = mapByName(unitesRes);
+  const zonesMap = mapByName(zonesRes);
+  const fournisseurIds = new Set((fournisseursRes.data || []).map((f) => String(f.id)));
+
+  return raw.map((r) => {
+    const n = Object.fromEntries(
+      Object.entries(r).map(([k, v]) => [k.toLowerCase().trim(), typeof v === "string" ? v.trim() : v])
     );
-    if (Object.values(row).every((v) => String(v).trim() === "")) continue;
 
-    const produit = {
-      id: row.id ? String(row.id).trim() : uuidv4(),
-      nom: String(row.nom || "").trim(),
-      famille: String(row.famille || "").trim(),
-      unite: String(row.unite || "").trim(),
-      code: String(row.code || "").trim(),
-      allergenes: String(row.allergenes || "").trim(),
-      pmp: parseFloat(row.pmp) || 0,
-      stock_theorique: parseFloat(row.stock_theorique) || 0,
-      stock_min: parseFloat(row.stock_min) || 0,
-      dernier_prix: parseFloat(row.dernier_prix) || 0,
-      actif: parseBoolean(row.actif),
+    const row = {
+      id: uuidv4(),
+      nom: String(n.nom || "").trim(),
+      famille_nom: String(n.famille || "").trim(),
+      sous_famille_nom: String(n.sous_famille || "").trim(),
+      unite_nom: String(n.unite || "").trim(),
+      zone_stock_nom: String(n.zone_stock || "").trim(),
+      code: String(n.code || "").trim(),
+      allergenes: String(n.allergenes || "").trim(),
+      actif: parseBoolean(n.actif),
+      pmp: n.pmp !== "" ? Number(n.pmp) : null,
+      stock_theorique: n.stock_theorique !== "" ? Number(n.stock_theorique) : null,
+      stock_min: n.stock_min !== "" ? Number(n.stock_min) : null,
+      dernier_prix: n.dernier_prix !== "" ? Number(n.dernier_prix) : null,
+      fournisseur_id: String(n.fournisseur_id || "").trim() || null,
+      famille_id: null,
+      sous_famille_id: null,
+      unite_id: null,
+      zone_stock_id: null,
       mama_id,
+      errors: [],
     };
 
-    const errors = [];
-    if (!produit.nom) errors.push("nom manquant");
-    if (!produit.famille) errors.push("famille manquante");
-    if (!produit.unite) errors.push("unite manquante");
-    if (row.pmp && isNaN(parseFloat(row.pmp))) errors.push("pmp invalide");
-    if (row.stock_theorique && isNaN(parseFloat(row.stock_theorique)))
-      errors.push("stock_theorique invalide");
-    if (row.stock_min && isNaN(parseFloat(row.stock_min)))
-      errors.push("stock_min invalide");
-    if (row.dernier_prix && isNaN(parseFloat(row.dernier_prix)))
-      errors.push("dernier_prix invalide");
+    if (!row.nom) row.errors.push("nom manquant");
 
-    rows.push({ ...produit, errors });
-  }
-  return rows;
+    row.famille_id = famillesMap.get(row.famille_nom.toLowerCase());
+    if (!row.famille_id) row.errors.push("famille inconnue");
+
+    row.sous_famille_id = sousFamillesMap.get(row.sous_famille_nom.toLowerCase());
+    if (row.sous_famille_nom && !row.sous_famille_id)
+      row.errors.push("sous_famille inconnue");
+
+    row.unite_id = unitesMap.get(row.unite_nom.toLowerCase());
+    if (!row.unite_id) row.errors.push("unite inconnue");
+
+    row.zone_stock_id = zonesMap.get(row.zone_stock_nom.toLowerCase());
+    if (!row.zone_stock_id) row.errors.push("zone_stock inconnue");
+
+    if (row.fournisseur_id && !fournisseurIds.has(row.fournisseur_id))
+      row.errors.push("fournisseur inconnu");
+
+    return row;
+  });
 }
 
 export async function insertProduits(rows) {
   const results = [];
-  for (const row of rows) {
-    const { errors: _errors, ...payload } = row;
+  for (const r of rows) {
+    const { errors: _e, famille_nom: _fa, sous_famille_nom: _sf, unite_nom: _u, zone_stock_nom: _z, ...payload } = r;
+    payload.seuil_min = payload.stock_min;
+    delete payload.stock_min;
     try {
-      const { error } = await supabase.from("produits").insert([payload]);
-      if (error) {
-        results.push({ ...row, insertError: error.message });
-      } else {
-        results.push({ ...row, insertError: null });
-      }
-    } catch (e) {
-      results.push({ ...row, insertError: e.message });
+      const { data, error } = await supabase
+        .from("produits")
+        .insert([payload])
+        .select("id")
+        .single();
+      if (error) results.push({ ...r, insertError: error.message });
+      else results.push({ ...r, id: data.id, insertError: null });
+    } catch (err) {
+      results.push({ ...r, insertError: err.message });
     }
   }
   return results;


### PR DESCRIPTION
## Summary
- add utilities to export products and download excel template
- validate and insert products from excel with full preview
- integrate import modal into products page

## Testing
- `npm test` (fails: Missing Supabase credentials)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e49d87374832d85618c9abc267dbf