### PR TITLE
fix: improve product Excel import

### DIFF
--- a/src/components/produits/ModalImportProduits.jsx
+++ b/src/components/produits/ModalImportProduits.jsx
@@ -15,16 +15,30 @@ export default function ModalImportProduits({ open, onClose, onSuccess }) {
   const fileRef = useRef(null);
   const [rows, setRows] = useState([]);
   const [maps, setMaps] = useState(null);
-  const [reference, setReference] = useState({ familles: [], unites: [], zones: [] });
+  const [reference, setReference] = useState({
+    familles: [],
+    sousFamilles: [],
+    unites: [],
+    zones: [],
+  });
   const [importing, setImporting] = useState(false);
 
   async function handleFileChange(e) {
     const file = e.target.files[0];
     if (!file) return;
     const parsed = await parseProduitsFile(file, mama_id);
-    setRows(parsed.rows);
+    const limitedRows = parsed.rows.slice(0, 200);
+    if (parsed.rows.length > 200) {
+      toast("Seules les 200 premières lignes sont affichées");
+    }
+    setRows(limitedRows);
     setMaps(parsed.maps);
-    setReference({ familles: parsed.familles, unites: parsed.unites, zones: parsed.zones });
+    setReference({
+      familles: parsed.familles,
+      sousFamilles: parsed.sousFamilles,
+      unites: parsed.unites,
+      zones: parsed.zones,
+    });
     if (fileRef.current) fileRef.current.value = "";
   }
 
@@ -66,7 +80,7 @@ export default function ModalImportProduits({ open, onClose, onSuccess }) {
                 {validCount} valides / {invalidCount} à corriger
               </span>
             </div>
-            <div className="max-h-[500px] overflow-y-auto border rounded">
+            <div className="max-h-[60vh] overflow-y-auto border rounded">
               <ImportPreviewTable
                 rows={rows}
                 onUpdate={handleUpdate}

--- a/src/components/ui/ImportPreviewTable.jsx
+++ b/src/components/ui/ImportPreviewTable.jsx
@@ -1,7 +1,8 @@
 import { validateProduitRow } from "@/utils/importExcelProduits";
 
 export default function ImportPreviewTable({ rows, onUpdate, maps, reference }) {
-  const { familles = [], unites = [], zones = [] } = reference || {};
+  const { familles = [], sousFamilles = [], unites = [], zones = [] } =
+    reference || {};
 
   function handleChange(index, field, value) {
     const updated = [...rows];
@@ -47,7 +48,7 @@ export default function ImportPreviewTable({ rows, onUpdate, maps, reference }) 
             <tr key={row.id} className={row.status === "error" ? "bg-red-50" : "bg-green-50"}>
               {renderCell(row, idx, "nom")}
               {renderCell(row, idx, "famille_nom", "familles-list")}
-              {renderCell(row, idx, "sous_famille_nom")}
+              {renderCell(row, idx, "sous_famille_nom", "sousfamilles-list")}
               {renderCell(row, idx, "unite_nom", "unites-list")}
               {renderCell(row, idx, "zone_stock_nom", "zones-list")}
               {renderCell(row, idx, "stock_min")}
@@ -59,6 +60,11 @@ export default function ImportPreviewTable({ rows, onUpdate, maps, reference }) 
       <datalist id="familles-list">
         {familles.map((f) => (
           <option key={f.id} value={f.nom} />
+        ))}
+      </datalist>
+      <datalist id="sousfamilles-list">
+        {sousFamilles.map((sf) => (
+          <option key={sf.id} value={sf.nom} />
         ))}
       </datalist>
       <datalist id="unites-list">

--- a/src/components/ui/SmartDialog.jsx
+++ b/src/components/ui/SmartDialog.jsx
@@ -1,68 +1,56 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import React from "react";
-import {
-  Dialog as RadixDialog,
-  DialogOverlay,
-  DialogContent,
-  DialogTitle,
-  DialogDescription,
-  DialogClose,
-} from "@radix-ui/react-dialog";
+import * as Dialog from "@radix-ui/react-dialog";
 import { AnimatePresence, motion as Motion } from "framer-motion";
 
 export default function SmartDialog({ open, onClose, title, description, children }) {
   return (
-    <RadixDialog open={open} onOpenChange={(v) => !v && onClose?.()}>
+    <Dialog.Root open={open} onOpenChange={(v) => !v && onClose?.()}>
       <AnimatePresence>
         {open && (
-          <RadixDialogContent asChild forceMount>
-            <>
-              <RadixDialogOverlay asChild>
-                <Motion.div
-                  className="fixed inset-0 bg-black/50 backdrop-blur-sm z-40"
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
-                  exit={{ opacity: 0 }}
-                  onClick={onClose}
-                />
-              </RadixDialogOverlay>
+          <Dialog.Portal forceMount>
+            <Dialog.Overlay asChild>
               <Motion.div
-                className="fixed inset-0 z-50 flex items-center justify-center p-4"
-                initial={{ opacity: 0, scale: 0.95 }}
-                animate={{ opacity: 1, scale: 1 }}
-                exit={{ opacity: 0, scale: 0.95 }}
-                transition={{ type: "spring", stiffness: 260, damping: 20 }}
-              >
-                <div className="relative bg-white/10 border border-white/20 backdrop-blur-xl rounded-2xl shadow-xl p-6 w-full max-w-lg">
-                  {title && (
-                    <DialogTitle className="text-lg font-semibold mb-4">
-                      {title}
-                    </DialogTitle>
-                  )}
-                  {description && (
-                    <DialogDescription className="sr-only">
-                      {description}
-                    </DialogDescription>
-                  )}
-                  <DialogClose
-                    asChild
-                    onClick={onClose}
+                className="fixed inset-0 bg-black/50 backdrop-blur-sm z-40"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                onClick={onClose}
+              />
+            </Dialog.Overlay>
+            <Motion.div
+              className="fixed inset-0 z-50 flex items-center justify-center p-4"
+              initial={{ opacity: 0, scale: 0.95 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.95 }}
+              transition={{ type: "spring", stiffness: 260, damping: 20 }}
+            >
+              <Dialog.Content className="relative bg-white/10 border border-white/20 backdrop-blur-xl rounded-2xl shadow-xl p-6 w-full max-w-lg">
+                {title && (
+                  <Dialog.Title className="text-lg font-semibold mb-4">
+                    {title}
+                  </Dialog.Title>
+                )}
+                {description && (
+                  <Dialog.Description className="sr-only">
+                    {description}
+                  </Dialog.Description>
+                )}
+                <Dialog.Close asChild onClick={onClose}>
+                  <button
+                    className="absolute top-3 right-3 text-mamastockGold hover:text-mamastockGold/80"
+                    aria-label="Fermer"
+                    type="button"
                   >
-                    <button
-                      className="absolute top-3 right-3 text-mamastockGold hover:text-mamastockGold/80"
-                      aria-label="Fermer"
-                      type="button"
-                    >
-                      ×
-                    </button>
-                  </DialogClose>
-                  {children}
-                </div>
-              </Motion.div>
-            </>
-          </RadixDialogContent>
+                    ×
+                  </button>
+                </Dialog.Close>
+                {children}
+              </Dialog.Content>
+            </Motion.div>
+          </Dialog.Portal>
         )}
       </AnimatePresence>
-    </RadixDialog>
+    </Dialog.Root>
   );
 }

--- a/src/pages/produits/Produits.jsx
+++ b/src/pages/produits/Produits.jsx
@@ -20,7 +20,7 @@ import {
   exportExcelProduits,
   downloadProduitsTemplate,
 } from "@/utils/exportExcelProduits";
-import ModalImportProduits from "@/components/produits/ModalImportProduits.jsx";
+import ModalImportProduits from "@/components/produits/ModalImportProduits";
 
 const PAGE_SIZE = 50;
 

--- a/src/utils/exportExcelProduits.js
+++ b/src/utils/exportExcelProduits.js
@@ -2,7 +2,7 @@ import * as XLSX from "xlsx";
 import { saveAs } from "file-saver";
 import { supabase } from "@/lib/supabase";
 
-const HEADERS = [
+const EXPORT_HEADERS = [
   "nom",
   "famille",
   "sous_famille",
@@ -16,6 +16,17 @@ const HEADERS = [
   "stock_min",
   "dernier_prix",
   "fournisseur_id",
+];
+
+// Template used for importing new products
+const TEMPLATE_HEADERS = [
+  "nom",
+  "famille",
+  "sous_famille",
+  "unite",
+  "zone_stock",
+  "stock_min",
+  "actif",
 ];
 
 export async function exportExcelProduits(mama_id) {
@@ -45,16 +56,16 @@ export async function exportExcelProduits(mama_id) {
   }));
 
   const wb = XLSX.utils.book_new();
-  const ws = XLSX.utils.json_to_sheet(rows, { header: HEADERS });
+  const ws = XLSX.utils.json_to_sheet(rows, { header: EXPORT_HEADERS });
   XLSX.utils.book_append_sheet(wb, ws, "Produits");
   const buf = XLSX.write(wb, { bookType: "xlsx", type: "array" });
   saveAs(new Blob([buf]), "produits_export_mamastock.xlsx");
 }
 
 export function downloadProduitsTemplate() {
-  const example = Object.fromEntries(HEADERS.map((h) => [h, ""]));
+  const example = Object.fromEntries(TEMPLATE_HEADERS.map((h) => [h, ""]));
   const wb = XLSX.utils.book_new();
-  const ws = XLSX.utils.json_to_sheet([example], { header: HEADERS });
+  const ws = XLSX.utils.json_to_sheet([example], { header: TEMPLATE_HEADERS });
   XLSX.utils.book_append_sheet(wb, ws, "Template");
   const buf = XLSX.write(wb, { bookType: "xlsx", type: "array" });
   saveAs(new Blob([buf]), "produits_template_mamastock.xlsx");

--- a/test/ImportProduitsExcel.test.js
+++ b/test/ImportProduitsExcel.test.js
@@ -1,0 +1,75 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { describe, it, expect, vi } from 'vitest';
+import * as XLSX from 'xlsx';
+import { parseProduitsFile, validateProduitRow } from '@/utils/importExcelProduits.js';
+
+// Mock supabase to return reference data
+const famillesData = [
+  { id: 1, nom: 'Legumes' },
+  { id: 2, nom: 'Fruits' },
+];
+const sousFamillesData = [
+  { id: 10, nom: 'Rouge' },
+  { id: 11, nom: 'Racine' },
+];
+const unitesData = [{ id: 100, nom: 'Kg' }];
+const zonesData = [{ id: 200, nom: 'Reserve' }];
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: (table) => ({
+      select: () => ({
+        eq: () => {
+          switch (table) {
+            case 'familles':
+              return Promise.resolve({ data: famillesData });
+            case 'sous_familles':
+              return Promise.resolve({ data: sousFamillesData });
+            case 'unites':
+              return Promise.resolve({ data: unitesData });
+            case 'zones_stock':
+              return Promise.resolve({ data: zonesData });
+            case 'fournisseurs':
+              return Promise.resolve({ data: [] });
+            default:
+              return Promise.resolve({ data: [] });
+          }
+        },
+      }),
+    }),
+  },
+}));
+
+function buildFile(rows) {
+  const wb = XLSX.utils.book_new();
+  const ws = XLSX.utils.json_to_sheet(rows);
+  XLSX.utils.book_append_sheet(wb, ws, 'Feuil1');
+  const buf = XLSX.write(wb, { type: 'array', bookType: 'xlsx' });
+  return {
+    arrayBuffer: async () => buf,
+  };
+}
+
+describe('parseProduitsFile', () => {
+  it('detects invalid rows and allows correction', async () => {
+    const file = buildFile([
+      { nom: 'Tomate', famille: 'Legumes', sous_famille: 'Rouge', unite: 'Kg', zone_stock: 'Reserve', stock_min: 5, actif: true },
+      { nom: 'Carotte', famille: 'Legumes', sous_famille: 'Racine', unite: 'Kg', zone_stock: 'Reserve', stock_min: 2, actif: true },
+      { nom: 'Pomme', famille: 'Fruits', sous_famille: '', unite: 'Kg', zone_stock: 'Reserve', stock_min: 1, actif: true },
+      { nom: 'Mystery', famille: 'Invalide', sous_famille: '', unite: 'Kg', zone_stock: 'Reserve', stock_min: 0, actif: true },
+    ]);
+    const { rows, maps } = await parseProduitsFile(file, '1');
+    expect(rows).toHaveLength(4);
+    const statuses = rows.map((r) => r.status);
+    expect(statuses.filter((s) => s === 'ok')).toHaveLength(3);
+    expect(statuses.filter((s) => s === 'error')).toHaveLength(1);
+
+    // Correct the invalid row
+    const idx = statuses.indexOf('error');
+    const corrected = validateProduitRow(
+      { ...rows[idx], famille_nom: 'Legumes' },
+      maps
+    );
+    expect(corrected.status).toBe('ok');
+  });
+});


### PR DESCRIPTION
## Summary
- fix Radix dialog usage and streamline SmartDialog
- enhance product import modal with inline validation and scrolling preview
- add Excel template generator and validation test for product imports

## Testing
- `npm test test/ImportProduitsExcel.test.js`

------
https://chatgpt.com/codex/tasks/task_e_688e5c80ad94832da2664065e7f8fb04