### PR TITLE
fix: import Select component in FactureForm

### DIFF
--- a/src/pages/factures/FactureForm.jsx
+++ b/src/pages/factures/FactureForm.jsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import PrimaryButton from "@/components/ui/PrimaryButton";
 import SecondaryButton from "@/components/ui/SecondaryButton";
 import { Input } from "@/components/ui/input";
+import { Select } from "@/components/ui/select";
 import GlassCard from "@/components/ui/GlassCard";
 import toast from "react-hot-toast";
 import { uploadFile, deleteFile, pathFromUrl } from "@/hooks/useStorage";


### PR DESCRIPTION
## Summary
- import shared Select component to resolve ReferenceError in FactureForm

## Testing
- `npm test` (fails: Missing Supabase credentials, other failures)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f4809e5a4832db3b6e2c3d575fa7c