### PR TITLE
refactor: enhance invoice form

### DIFF
--- a/src/hooks/useFactureForm.js
+++ b/src/hooks/useFactureForm.js
@@ -1,0 +1,19 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { useMemo } from "react";
+
+export function useFactureForm(lignes = [], totalHtInput = 0) {
+  const autoHt = useMemo(
+    () => lignes.reduce((s, l) => s + l.quantite * l.prix_unitaire, 0),
+    [lignes]
+  );
+  const autoTva = useMemo(
+    () => lignes.reduce((s, l) => s + l.quantite * l.prix_unitaire * (l.tva || 0) / 100, 0),
+    [lignes]
+  );
+  const autoTotal = useMemo(() => autoHt + autoTva, [autoHt, autoTva]);
+  const ecart = useMemo(
+    () => autoHt - Number(totalHtInput || 0),
+    [autoHt, totalHtInput]
+  );
+  return { autoHt, autoTva, autoTotal, ecart };
+}

--- a/src/hooks/useProduitsAutocomplete.js
+++ b/src/hooks/useProduitsAutocomplete.js
@@ -14,8 +14,8 @@ export function useProduitsAutocomplete() {
     setLoading(true);
     setError(null);
     let q = supabase
-      .from("v_produits_dernier_prix")
-      .select("id, nom, unite, tva")
+      .from("produits")
+      .select("id, nom, unite, tva, dernier_prix")
       .eq("mama_id", mama_id)
       .eq("actif", true);
     if (query) q = q.ilike("nom", `%${query}%`);
@@ -26,14 +26,9 @@ export function useProduitsAutocomplete() {
       setError(error);
       return [];
     }
-    const { data: pmpData } = await supabase
-      .from('v_pmp')
-      .select('produit_id, pmp')
-      .eq('mama_id', mama_id);
-    const pmpMap = Object.fromEntries((pmpData || []).map(p => [p.produit_id, p.pmp]));
     const final = (Array.isArray(data) ? data : []).map(p => ({
       ...p,
-      pmp: pmpMap[p.id] ?? 0,
+      dernier_prix: p.dernier_prix ?? 0,
     }));
     setResults(final);
     return final;


### PR DESCRIPTION
## Summary
- centralize invoice total calculations in a new `useFactureForm` hook
- refactor `FactureForm` layout and validation for clearer input and error handling
- fetch product suggestions directly from Supabase `produits` table

## Testing
- `npm run lint`
- `npm test` *(fails: Missing Supabase credentials and other test errors)*

------
https://chatgpt.com/codex/tasks/task_e_688f5f149eb0832db85dc487172a872e