### PR TITLE
fix: enhance facture form autocompletion and layout

### DIFF
--- a/src/components/ui/AutoCompleteField.jsx
+++ b/src/components/ui/AutoCompleteField.jsx
@@ -1,5 +1,5 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useId } from "react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 
@@ -18,15 +18,16 @@ export default function AutoCompleteField({
     [options],
   );
   const [inputValue, setInputValue] = useState(() => {
-    const match = resolved.find((o) => o.id === value);
+    const match = resolved.find(o => o.id === value);
     return match ? match.nom : "";
   });
   const [showAdd, setShowAdd] = useState(false);
+  const listId = useId();
 
   useEffect(() => {
     if (!value) return; // avoid clearing typed text when value is empty
-    const match = resolved.find((o) => o.id === value);
-    setInputValue(match ? match.nom : "");
+    const match = resolved.find(o => o.id === value);
+    if (match) setInputValue(match.nom);
   }, [value, resolved]);
 
   const disabledIds = disabledOptions.map((d) =>
@@ -74,11 +75,12 @@ export default function AutoCompleteField({
         </label>
       )}
       <Input
+        list={listId}
         value={inputValue}
         onChange={handleInputChange}
         className={`${isValid ? "border-mamastockGold" : ""}`}
         aria-label={label}
-        onKeyDown={(e) => {
+        onKeyDown={e => {
           if (e.key === "Enter" && showAdd) {
             e.preventDefault();
             handleAddOption();
@@ -86,6 +88,11 @@ export default function AutoCompleteField({
         }}
         {...props}
       />
+      <datalist id={listId}>
+        {resolved.map(opt => (
+          <option key={opt.id} value={opt.nom} />
+        ))}
+      </datalist>
       {showAdd && onAddNewValue && (
         <Button
           type="button"

--- a/src/pages/factures/FactureForm.jsx
+++ b/src/pages/factures/FactureForm.jsx
@@ -162,7 +162,7 @@ export default function FactureForm({ facture = null, fournisseurs = [], onClose
   return (
     <GlassCard width="w-full" title={facture ? "Modifier la facture" : "Ajouter une facture"}>
       <form ref={formRef} onSubmit={handleSubmit} className="space-y-6">
-        <section className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-6 gap-4">
+        <section className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
           <div className="flex flex-col">
             <label className="text-sm mb-1">Date *</label>
             <Input type="date" value={date} onChange={e => setDate(e.target.value)} required />
@@ -193,10 +193,10 @@ export default function FactureForm({ facture = null, fournisseurs = [], onClose
               type="number"
               readOnly
               value={autoHt.toFixed(2)}
-              className="font-bold [appearance:textfield]"
+              className="font-bold [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
             />
           </div>
-          <div className="flex flex-col">
+          <div className="flex flex-col lg:col-span-2">
             <label className="text-sm mb-1">Fournisseur *</label>
             <AutoCompleteField
               value={fournisseur_id}
@@ -209,7 +209,7 @@ export default function FactureForm({ facture = null, fournisseurs = [], onClose
               required
             />
           </div>
-          <div className="flex flex-col">
+          <div className="flex flex-col lg:col-span-2">
             <label className="text-sm mb-1">Commentaire</label>
             <Input type="text" value={commentaire} onChange={e => setCommentaire(e.target.value)} />
           </div>


### PR DESCRIPTION
## Summary
- refine AutoCompleteField to keep typed text and show suggestions via datalist
- align facture form fields and hide spinner on computed totals

## Testing
- `npm test` *(fails: Missing Supabase credentials; several test suites failing)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fc48381fc832daf2f1f2582832d7f