### PR TITLE
fix: improve facture form product autocomplete and ui

### DIFF
--- a/src/components/FactureLigne.jsx
+++ b/src/components/FactureLigne.jsx
@@ -1,5 +1,4 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import AutoCompleteField from "@/components/ui/AutoCompleteField";
 import AutoCompleteZoneField from "@/components/ui/AutoCompleteZoneField";
 import { Input } from "@/components/ui/input";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -18,20 +17,24 @@ export default function FactureLigne({
   const { getProduct } = useProducts();
   const [loadingProd, setLoadingProd] = useState(false);
 
-  async function handleProduit(obj) {
-    onChange({
-      ...ligne,
-      produit_nom: obj?.nom_simple || obj?.nom || "",
-      produit_id: obj?.id || "",
-      unite: obj?.unite || "",
-      prix_unitaire: obj?.dernier_prix ?? ligne.prix_unitaire,
-      tva: obj?.tva ?? ligne.tva,
-    });
-    if (obj?.id) {
+  async function handleProduitSelection(name) {
+    const match = produitOptions.find(p => p.nom === name);
+    if (match) {
+      onChange({
+        ...ligne,
+        produit_nom: match.nom,
+        produit_id: match.id,
+        unite: match.unite || "",
+        prix_unitaire: match.dernier_prix ?? ligne.prix_unitaire,
+        tva: match.tva ?? ligne.tva,
+      });
       setLoadingProd(true);
-      const prod = await getProduct(obj.id);
+      const prod = await getProduct(match.id);
       onChange({ ...ligne, zone_stock_id: prod?.zone_stock_id || "" });
       setLoadingProd(false);
+    } else {
+      onChange({ ...ligne, produit_nom: name, produit_id: "" });
+      if (name.length >= 2) searchProduits(name);
     }
   }
 
@@ -41,29 +44,25 @@ export default function FactureLigne({
 
   return (
     <tr className="h-10">
-      <td className="min-w-[250px] p-1 align-middle">
-        <AutoCompleteField
-          id={`produit-${index}`}
+      <td className="p-1 align-middle">
+        <Input
+          list={`produits-${index}`}
           required
-          value={ligne.produit_id}
-          onChange={async obj => {
-            if (obj?.id && obj.id !== ligne.produit_id) {
-              handleProduit(obj);
-            } else if (!obj?.id) {
-              onChange({ ...ligne, produit_id: "", produit_nom: obj?.nom || "" });
-              const val = obj?.nom || "";
-              if (val.length >= 2) searchProduits(val);
-            }
-          }}
-          options={produitOptions}
-          className="h-10 min-w-[250px]"
+          value={ligne.produit_nom}
+          onChange={e => handleProduitSelection(e.target.value)}
+          className="h-10 min-w-[30ch] text-black"
         />
+        <datalist id={`produits-${index}`}>
+          {produitOptions.map(p => (
+            <option key={p.id} value={p.nom} />
+          ))}
+        </datalist>
       </td>
       <td className="p-1 align-middle">
         <Input
           type="number"
           required
-          className="h-10 w-full"
+          className="h-10 w-full text-black"
           value={ligne.quantite}
           onChange={e => update("quantite", Number(e.target.value))}
         />
@@ -72,15 +71,15 @@ export default function FactureLigne({
       <td className="p-1 align-middle">
         <Input
           type="number"
-          className="h-10 w-full"
+          className="h-10 w-full text-black"
           value={ligne.prix_unitaire}
           onChange={e => update("prix_unitaire", Number(e.target.value))}
         />
       </td>
-      <td className="p-1 align-middle w-16">
+      <td className="p-1 align-middle w-14">
         <Input
           type="number"
-          className="h-10 w-full"
+          className="h-10 w-full text-black"
           title="Taux de TVA appliqué"
           required
           value={ligne.tva}
@@ -93,7 +92,7 @@ export default function FactureLigne({
           onChange={obj => update("zone_stock_id", obj?.id || "")}
           disabled={loadingProd}
           required
-          className="h-10"
+          className="h-10 text-black"
         />
       </td>
       <td className="p-1 align-middle text-center">

--- a/src/components/ui/AutoCompleteField.jsx
+++ b/src/components/ui/AutoCompleteField.jsx
@@ -11,6 +11,7 @@ export default function AutoCompleteField({
   onAddNewValue,
   required = false,
   disabledOptions = [],
+  className = "",
   ...props
 }) {
   const resolved = useMemo(
@@ -18,16 +19,19 @@ export default function AutoCompleteField({
     [options],
   );
   const [inputValue, setInputValue] = useState(() => {
-    const match = resolved.find(o => o.id === value);
-    return match ? match.nom : "";
+    const match = resolved.find(o => o.id === value || o.nom === value);
+    return match ? match.nom : value || "";
   });
   const [showAdd, setShowAdd] = useState(false);
   const listId = useId();
 
   useEffect(() => {
-    if (!value) return; // avoid clearing typed text when value is empty
-    const match = resolved.find(o => o.id === value);
-    if (match) setInputValue(match.nom);
+    const match = resolved.find(o => o.id === value || o.nom === value);
+    if (match) {
+      setInputValue(match.nom);
+    } else if (typeof value === "string") {
+      setInputValue(value);
+    }
   }, [value, resolved]);
 
   const disabledIds = disabledOptions.map((d) =>
@@ -78,7 +82,7 @@ export default function AutoCompleteField({
         list={listId}
         value={inputValue}
         onChange={handleInputChange}
-        className={`${isValid ? "border-mamastockGold" : ""}`}
+        className={`${isValid ? "border-mamastockGold" : ""} ${className}`}
         aria-label={label}
         onKeyDown={e => {
           if (e.key === "Enter" && showAdd) {

--- a/src/pages/factures/FactureForm.jsx
+++ b/src/pages/factures/FactureForm.jsx
@@ -165,11 +165,11 @@ export default function FactureForm({ facture = null, fournisseurs = [], onClose
         <section className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
           <div className="flex flex-col">
             <label className="text-sm mb-1">Date *</label>
-            <Input type="date" value={date} onChange={e => setDate(e.target.value)} required />
+            <Input type="date" value={date} onChange={e => setDate(e.target.value)} required className="text-black" />
           </div>
           <div className="flex flex-col">
             <label className="text-sm mb-1">État</label>
-            <Select value={statut} onChange={e => setStatut(e.target.value)}>
+            <Select value={statut} onChange={e => setStatut(e.target.value)} className="text-black">
               <option value="brouillon">Brouillon</option>
               <option value="en attente">En attente</option>
               <option value="validée">Validée</option>
@@ -182,7 +182,7 @@ export default function FactureForm({ facture = null, fournisseurs = [], onClose
               type="text"
               value={numero}
               onChange={e => setNumero(e.target.value)}
-              className={numeroUsed ? "border-red-500" : ""}
+              className={`${numeroUsed ? "border-red-500" : ""} text-black`}
               required
             />
             {numeroUsed && <p className="text-xs text-red-500">Numéro déjà existant</p>}
@@ -193,7 +193,7 @@ export default function FactureForm({ facture = null, fournisseurs = [], onClose
               type="number"
               readOnly
               value={autoHt.toFixed(2)}
-              className="font-bold [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+              className="font-bold text-black [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
             />
           </div>
           <div className="flex flex-col lg:col-span-2">
@@ -207,18 +207,19 @@ export default function FactureForm({ facture = null, fournisseurs = [], onClose
               }}
               options={fournisseurOptions}
               required
+              className="text-black"
             />
           </div>
           <div className="flex flex-col lg:col-span-2">
             <label className="text-sm mb-1">Commentaire</label>
-            <Input type="text" value={commentaire} onChange={e => setCommentaire(e.target.value)} />
+            <Input type="text" value={commentaire} onChange={e => setCommentaire(e.target.value)} className="text-black" />
           </div>
         </section>
 
         <section>
           <h3 className="font-semibold mb-2">Lignes produits</h3>
           <div className="overflow-x-auto">
-            <table className="w-full text-sm">
+            <table className="w-full text-sm text-black">
               <thead>
                 <tr>
                   <th>Produit</th>
@@ -279,7 +280,7 @@ export default function FactureForm({ facture = null, fournisseurs = [], onClose
         </section>
 
         <section className="p-3 mt-4 bg-white/10 border border-white/20 rounded">
-          <div className="flex flex-wrap gap-4">
+          <div className="flex flex-wrap gap-4 text-black">
             <span className="font-bold">Total HT: {autoHt.toFixed(2)} €</span>
             <span className="font-bold">TVA: {autoTva.toFixed(2)} €</span>
             <span className="font-bold">TTC: {autoTotal.toFixed(2)} €</span>


### PR DESCRIPTION
## Summary
- fix facture line product autocomplete using datalist and inject selected product data
- make autocomplete field accept custom classes and preserve typed values
- polish facture form visuals with black text and narrower TVA input

## Testing
- `npm test` (fails: Cannot read properties of null (reading 'from'))
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fc85c6e60832d9d81ac29241e999f