### PR TITLE
fix: improve facture form autocomplete and UX

### DIFF
--- a/src/components/ui/AutoCompleteField.jsx
+++ b/src/components/ui/AutoCompleteField.jsx
@@ -85,9 +85,9 @@ export default function AutoCompleteField({
         className={`${isValid ? "border-mamastockGold" : ""} ${className}`}
         aria-label={label}
         onKeyDown={e => {
-          if (e.key === "Enter" && showAdd) {
+          if (e.key === "Enter") {
             e.preventDefault();
-            handleAddOption();
+            if (showAdd) handleAddOption();
           }
         }}
         {...props}

--- a/src/hooks/useProduitsAutocomplete.js
+++ b/src/hooks/useProduitsAutocomplete.js
@@ -14,10 +14,9 @@ export function useProduitsAutocomplete() {
     setLoading(true);
     setError(null);
     let q = supabase
-      .from("produits")
-      .select("id, nom, unite, tva, dernier_prix, famille:familles(nom)")
-      .eq("mama_id", mama_id)
-      .eq("actif", true);
+      .from("v_produits_dernier_prix")
+      .select("id, nom, unite, tva, dernier_prix")
+      .eq("mama_id", mama_id);
     if (query) q = q.ilike("nom", `%${query}%`);
     q = q.order("nom", { ascending: true }).limit(10);
     const { data, error } = await q;
@@ -28,8 +27,8 @@ export function useProduitsAutocomplete() {
     }
     const final = (Array.isArray(data) ? data : []).map(p => ({
       id: p.id,
-      nom: `${p.nom} (${p.unite}) [${p.famille?.nom || ""}]`,
-      nom_simple: p.nom,
+      produit_id: p.id,
+      nom: p.nom,
       unite: p.unite,
       tva: p.tva ?? 0,
       dernier_prix: p.dernier_prix ?? 0,

--- a/test/useProduitsAutocomplete.test.js
+++ b/test/useProduitsAutocomplete.test.js
@@ -27,9 +27,8 @@ test('searchProduits filters by mama_id and query', async () => {
   await act(async () => {
     await result.current.searchProduits('car');
   });
-  expect(fromMock).toHaveBeenCalledWith('produits');
-  expect(selectMock).toHaveBeenCalledWith('id, nom, unite, tva, dernier_prix, famille:familles(nom)');
+  expect(fromMock).toHaveBeenCalledWith('v_produits_dernier_prix');
+  expect(selectMock).toHaveBeenCalledWith('id, nom, unite, tva, dernier_prix');
   expect(eqMock).toHaveBeenCalledWith('mama_id', 'm1');
-  expect(eqMock).toHaveBeenCalledWith('actif', true);
   expect(ilikeMock).toHaveBeenCalledWith('nom', '%car%');
 });


### PR DESCRIPTION
## Summary
- query active products from `v_produits_dernier_prix` with `mama_id` filter
- switch facture lines to AutoCompleteField and clean numeric styling
- keep fournisseur name state and confirm before closing unsaved drafts

## Testing
- `npm run lint`
- `npm test` *(fails: Missing Supabase credentials, wrapper warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688fd3b53ef8832d8c461bc7066c1a42