### PR TITLE
fix: improve invoice form product selection and totals

### DIFF
--- a/src/hooks/useProduitsAutocomplete.js
+++ b/src/hooks/useProduitsAutocomplete.js
@@ -14,9 +14,10 @@ export function useProduitsAutocomplete() {
     setLoading(true);
     setError(null);
     let q = supabase
-      .from("v_produits_dernier_prix")
-      .select("id, nom, unite, tva, dernier_prix")
-      .eq("mama_id", mama_id);
+      .from("produits")
+      .select("id, nom, tva, dernier_prix, unite:unites(nom)")
+      .eq("mama_id", mama_id)
+      .eq("actif", true);
     if (query) q = q.ilike("nom", `%${query}%`);
     q = q.order("nom", { ascending: true }).limit(10);
     const { data, error } = await q;
@@ -29,7 +30,7 @@ export function useProduitsAutocomplete() {
       id: p.id,
       produit_id: p.id,
       nom: p.nom,
-      unite: p.unite,
+      unite: p.unite?.nom || "",
       tva: p.tva ?? 0,
       dernier_prix: p.dernier_prix ?? 0,
     }));

--- a/test/useProduitsAutocomplete.test.js
+++ b/test/useProduitsAutocomplete.test.js
@@ -27,8 +27,9 @@ test('searchProduits filters by mama_id and query', async () => {
   await act(async () => {
     await result.current.searchProduits('car');
   });
-  expect(fromMock).toHaveBeenCalledWith('v_produits_dernier_prix');
-  expect(selectMock).toHaveBeenCalledWith('id, nom, unite, tva, dernier_prix');
+  expect(fromMock).toHaveBeenCalledWith('produits');
+  expect(selectMock).toHaveBeenCalledWith('id, nom, tva, dernier_prix, unite:unites(nom)');
   expect(eqMock).toHaveBeenCalledWith('mama_id', 'm1');
+  expect(eqMock).toHaveBeenCalledWith('actif', true);
   expect(ilikeMock).toHaveBeenCalledWith('nom', '%car%');
 });


### PR DESCRIPTION
## Summary
- replace product autocomplete source with `produits` table filtered by `actif` and `mama_id`
- allow manual entry of invoice Total HT and display dynamic HT gap
- add optional Bonus Pro and Maintenance fields to invoices and keep form open after save

## Testing
- `npm run lint`
- `npm test` *(fails: Missing Supabase credentials)*

------
https://chatgpt.com/codex/tasks/task_e_688fd9f09d20832dacaa626ceef49864