### PR TITLE
feat: support unit relations

### DIFF
--- a/src/components/FactureLigne.jsx
+++ b/src/components/FactureLigne.jsx
@@ -38,7 +38,7 @@ export default function FactureLigne({
         onChange({
           ...newLigne,
           zone_stock_id: prod?.zone_stock_id || "",
-          unite: prod?.unite?.nom || newLigne.unite,
+          unite: prod?.unites?.nom || newLigne.unite,
         });
       } catch (error) {
         console.error(error);

--- a/src/components/inventaires/InventaireForm.jsx
+++ b/src/components/inventaires/InventaireForm.jsx
@@ -210,7 +210,7 @@ export default function InventaireForm({ inventaire, onClose }) {
                       required
                     />
                   </td>
-                  <td>{prod?.unite || "-"}</td>
+                  <td>{prod?.unites?.nom || "-"}</td>
                   <td>{stock_debut}</td>
                   <td>{entrees}</td>
                   <td>{sorties}</td>

--- a/src/components/produits/ProduitForm.jsx
+++ b/src/components/produits/ProduitForm.jsx
@@ -11,6 +11,7 @@ import { toast } from "react-hot-toast";
 import GlassCard from "@/components/ui/GlassCard";
 import { Input } from "@/components/ui/input";
 import { Checkbox } from "@/components/ui/checkbox";
+import AutoCompleteField from "@/components/ui/AutoCompleteField";
 
 export default function ProduitForm({
   produit,
@@ -40,7 +41,6 @@ export default function ProduitForm({
     produit?.sous_famille_id || "",
   );
   const [uniteId, setUniteId] = useState(produit?.unite_id || "");
-  const [uniteName, setUniteName] = useState(produit?.unite?.nom || "");
   const [fournisseurId, setFournisseurId] = useState(
     produit?.fournisseur_id || "",
   );
@@ -85,7 +85,6 @@ export default function ProduitForm({
       setFamilleId(produit.famille_id || "");
       setSousFamilleId(produit.sous_famille_id || "");
       setUniteId(produit.unite_id || "");
-      setUniteName(produit.unite?.nom || "");
       setFournisseurId(produit.fournisseur_id || "");
       setZoneStockId(produit.zone_stock_id || "");
       setStockMin(produit.stock_min || 0);
@@ -233,27 +232,13 @@ export default function ProduitForm({
         </div>
 
         <div className="flex flex-col gap-1 p-2 rounded-xl">
-          <label htmlFor="prod-unite" className="label text-white">
-            Unité *
-          </label>
-          <input
-            id="prod-unite"
-            list="unites-list"
-            className="input bg-white text-gray-900"
-            value={uniteName}
-            onChange={(e) => {
-              const val = e.target.value;
-              setUniteName(val);
-              const found = uniteOptions.find((u) => u.nom === val);
-              setUniteId(found ? found.id : "");
-            }}
+          <AutoCompleteField
+            label="Unité *"
+            value={uniteId}
+            onChange={(obj) => setUniteId(obj?.id || "")}
+            options={uniteOptions}
             required
           />
-          <datalist id="unites-list">
-            {uniteOptions.map((u) => (
-              <option key={u.id} value={u.nom} />
-            ))}
-          </datalist>
           {errors.unite && <p className="text-red-500 text-sm">{errors.unite}</p>}
         </div>
 

--- a/src/components/produits/ProduitRow.jsx
+++ b/src/components/produits/ProduitRow.jsx
@@ -20,7 +20,7 @@ export default function ProduitRow({
       >
         {produit.nom}
       </td>
-      <td className="px-2 text-center">{produit.unite?.nom ?? produit.unite ?? ""}</td>
+      <td className="px-2 text-center">{produit.unites?.nom ?? ""}</td>
       <td className="px-2 text-right">
         {produit.pmp != null ? Number(produit.pmp).toFixed(2) : "-"}
       </td>

--- a/src/components/stock/StockDetail.jsx
+++ b/src/components/stock/StockDetail.jsx
@@ -30,7 +30,7 @@ export default function StockDetail({ produit, mouvements, onClose }) {
       <div className="bg-white/10 border border-white/20 backdrop-blur-xl rounded-2xl shadow-lg p-8 min-w-[400px] max-w-[95vw] flex flex-col gap-2 relative">
         <Button variant="outline" className="absolute top-2 right-2" onClick={onClose}>Fermer</Button>
         <h2 className="font-bold text-xl mb-4">{produit.nom} — Mouvements</h2>
-        <div className="mb-2">Stock réel : {produit.stock_reel} {produit.unite}</div>
+        <div className="mb-2">Stock réel : {produit.stock_reel} {produit.unites?.nom || ''}</div>
         <div className="mb-2">Valorisation : {(produit.pmp * produit.stock_reel).toFixed(2)} €</div>
         <div>
           <table className="min-w-full bg-white/10 border border-white/20 rounded backdrop-blur-xl text-xs">

--- a/src/hooks/useDashboard.js
+++ b/src/hooks/useDashboard.js
@@ -31,7 +31,7 @@ export function useDashboard() {
     try {
       const { data: produitsRaw, error: errorProd } = await supabase
         .from("v_produits_dernier_prix")
-        .select("id, nom, famille, unite, stock_reel, stock_min")
+        .select("id, nom, unite_id, unites:unite_id (nom), famille, stock_reel, stock_min")
         .eq("mama_id", mama_id);
       if (errorProd) throw errorProd;
       const { data: pmpData } = await supabase

--- a/src/hooks/useFiches.js
+++ b/src/hooks/useFiches.js
@@ -51,7 +51,7 @@ export function useFiches() {
     const { data, error } = await supabase
       .from("fiches_techniques")
       .select(
-        "*, famille:familles!fiches_techniques_famille_id_fkey(id, nom), lignes:fiche_lignes!fiche_id(*, produit:produits!fiche_lignes_produit_id_fkey(id, nom, unite_id, unite:unites!fk_produits_unite(nom), pmp), sous_fiche:sous_fiche_id(id, nom, cout_par_portion))"
+        "*, famille:familles!fiches_techniques_famille_id_fkey(id, nom), lignes:fiche_lignes!fiche_id(*, produit:produits!fiche_lignes_produit_id_fkey(id, nom, unite_id, unites:unite_id (nom), pmp), sous_fiche:sous_fiche_id(id, nom, cout_par_portion))"
       )
       .eq("id", id)
       .eq("mama_id", mama_id)

--- a/src/hooks/useInventaires.js
+++ b/src/hooks/useInventaires.js
@@ -16,7 +16,7 @@ export function useInventaires() {
     let query = supabase
       .from("inventaires")
       .select(
-        "*, lignes:inventaire_lignes!inventaire_id(*, produit:produits!inventaire_lignes_produit_id_fkey(id, nom, unite_id, unite:unites!fk_produits_unite(nom), stock_theorique, pmp))"
+        "*, lignes:inventaire_lignes!inventaire_id(*, produit:produits!inventaire_lignes_produit_id_fkey(id, nom, unite_id, unites:unite_id (nom), stock_theorique, pmp))"
       )
       .eq("mama_id", mama_id);
     if (!includeArchives) query = query.eq("actif", true);
@@ -103,7 +103,7 @@ export function useInventaires() {
     const { data, error } = await supabase
       .from("inventaires")
       .select(
-        "*, lignes:inventaire_lignes!inventaire_id(*, produit:produits!inventaire_lignes_produit_id_fkey(id, nom, unite_id, unite:unites!fk_produits_unite(nom), stock_theorique, pmp))"
+        "*, lignes:inventaire_lignes!inventaire_id(*, produit:produits!inventaire_lignes_produit_id_fkey(id, nom, unite_id, unites:unite_id (nom), stock_theorique, pmp))"
       )
       .eq("id", id)
       .eq("mama_id", mama_id)

--- a/src/hooks/useInvoiceItems.js
+++ b/src/hooks/useInvoiceItems.js
@@ -18,7 +18,7 @@ export function useInvoiceItems() {
     const { data, error } = await supabase
       .from("facture_lignes")
       .select(
-        "*, produit:produits!facture_lignes_produit_id_fkey(id, nom, famille:familles(nom), unite:unites(nom))"
+        "*, produit:produits!facture_lignes_produit_id_fkey(id, nom, unite_id, unites:unite_id (nom), famille:familles(nom))"
       )
       .eq("facture_id", invoiceId)
       .eq("mama_id", mama_id)
@@ -35,7 +35,7 @@ export function useInvoiceItems() {
     const { data, error } = await supabase
       .from("facture_lignes")
       .select(
-        "*, produit:produits!facture_lignes_produit_id_fkey(id, nom, famille:familles(nom), unite:unites(nom))"
+        "*, produit:produits!facture_lignes_produit_id_fkey(id, nom, unite_id, unites:unite_id (nom), famille:familles(nom))"
       )
       .eq("id", id)
       .eq("mama_id", mama_id)

--- a/src/hooks/useProducts.js
+++ b/src/hooks/useProducts.js
@@ -32,7 +32,7 @@ export function useProducts() {
     let query = supabase
       .from("produits")
       .select(
-        `*, unite:unites(nom), zone_stock:zones_stock(nom), famille:familles(nom), sous_famille:sous_familles(nom)`,
+        `*, unites:unite_id (nom), zone_stock:zones_stock(nom), famille:familles(nom), sous_famille:sous_familles(nom)`,
         { count: "exact" }
       )
       .eq("mama_id", mama_id);
@@ -56,7 +56,7 @@ export function useProducts() {
         .order("nom", { ascending: order === "asc" });
     } else if (sortBy === "unite") {
       query = query
-        .order("nom", { foreignTable: "unite", ascending: order === "asc" })
+        .order("nom", { foreignTable: "unites", ascending: order === "asc" })
         .order("nom", { ascending: order === "asc" });
     } else {
       query = query.order(sortBy, { ascending: order === "asc" }).order("nom", { ascending: order === "asc" });
@@ -230,7 +230,7 @@ export function useProducts() {
       const { data, error } = await supabase
         .from("produits")
         .select(
-          "*, famille:familles!fk_produits_famille(nom), sous_famille:sous_familles!fk_produits_sous_famille(nom), main_fournisseur:fournisseur_id(id, nom), unite:unites!fk_produits_unite(nom)"
+          "*, famille:familles!fk_produits_famille(nom), sous_famille:sous_familles!fk_produits_sous_famille(nom), main_fournisseur:fournisseur_id(id, nom), unites:unite_id (nom)"
         )
         .eq("id", id)
         .eq("mama_id", mama_id)
@@ -250,7 +250,7 @@ export function useProducts() {
       id: p.id,
       nom: p.nom,
       famille: p.famille?.nom || "",
-      unite: p.unite,
+      unite: p.unites?.nom || "",
       code: p.code,
       allergenes: p.allergenes,
       pmp: p.pmp,

--- a/src/hooks/useProduitsAutocomplete.js
+++ b/src/hooks/useProduitsAutocomplete.js
@@ -15,7 +15,7 @@ export function useProduitsAutocomplete() {
     setError(null);
     let q = supabase
       .from("produits")
-      .select("id, nom, tva, dernier_prix, unite:unites(nom)")
+      .select("id, nom, tva, dernier_prix, unite_id, unites:unite_id (nom)")
       .eq("mama_id", mama_id)
       .eq("actif", true);
     if (query) q = q.ilike("nom", `%${query}%`);
@@ -30,7 +30,8 @@ export function useProduitsAutocomplete() {
       id: p.id,
       produit_id: p.id,
       nom: p.nom,
-      unite: p.unite?.nom || "",
+      unite_id: p.unite_id || "",
+      unite: p.unites?.nom || "",
       tva: p.tva ?? 0,
       dernier_prix: p.dernier_prix ?? 0,
     }));

--- a/src/hooks/useProduitsFournisseur.js
+++ b/src/hooks/useProduitsFournisseur.js
@@ -21,7 +21,7 @@ export function useProduitsFournisseur() {
       const { data, error } = await supabase
         .from("fournisseur_produits")
         .select(
-          "*, produit:produits!fournisseur_produits_produit_id_fkey(id, nom, famille:familles!fk_produits_famille(id, nom), unite:unites!fk_produits_unite(nom))"
+          "*, produit:produits!fournisseur_produits_produit_id_fkey(id, nom, unite_id, unites:unite_id (nom), famille:familles!fk_produits_famille(id, nom))"
         )
         .eq("fournisseur_id", fournisseur_id)
         .eq("mama_id", mama_id);
@@ -41,7 +41,7 @@ export function useProduitsFournisseur() {
       const { data } = await supabase
         .from("fournisseur_produits")
         .select(
-          "*, produit:produits!fournisseur_produits_produit_id_fkey(id, nom, famille:familles!fk_produits_famille(id, nom), unite:unites!fk_produits_unite(nom))"
+          "*, produit:produits!fournisseur_produits_produit_id_fkey(id, nom, unite_id, unites:unite_id (nom), famille:familles!fk_produits_famille(id, nom))"
         )
         .eq("fournisseur_id", fournisseur_id)
         .eq("mama_id", mama_id);

--- a/src/hooks/useProduitsInventaire.js
+++ b/src/hooks/useProduitsInventaire.js
@@ -16,7 +16,7 @@ export function useProduitsInventaire() {
       setError(null);
       let query = supabase
         .from('v_produits_dernier_prix')
-        .select('id, nom, unite, famille')
+        .select('id, nom, unite_id, unites:unite_id (nom), famille')
         .eq('mama_id', mama_id)
         .eq('actif', true);
       if (famille) query = query.ilike('famille', `%${famille}%`);
@@ -39,6 +39,7 @@ export function useProduitsInventaire() {
       const stockMap = Object.fromEntries((stockData || []).map(s => [s.produit_id, s.stock]));
       const final = (Array.isArray(data) ? data : []).map(p => ({
         ...p,
+        unite: p.unites?.nom || '',
         pmp: pmpMap[p.id] ?? 0,
         stock_theorique: stockMap[p.id] ?? 0,
       }));

--- a/src/hooks/useStock.js
+++ b/src/hooks/useStock.js
@@ -18,7 +18,7 @@ export function useStock() {
     const { data, error } = await supabase
       .from("produits")
       .select(
-        "id, nom, stock_reel, stock_min, pmp, famille_id, sous_famille_id, famille:familles!fk_produits_famille(nom), sous_famille:sous_familles!fk_produits_sous_famille(nom)"
+        "id, nom, unite_id, unites:unite_id (nom), stock_reel, stock_min, pmp, famille_id, sous_famille_id, famille:familles!fk_produits_famille(nom), sous_famille:sous_familles!fk_produits_sous_famille(nom)"
       )
       .eq("mama_id", mama_id);
     setLoading(false);

--- a/src/pages/Stock.jsx
+++ b/src/pages/Stock.jsx
@@ -88,7 +88,7 @@ export default function Stock() {
                 </Button>
               </td>
               <td className="border px-4 py-2">{s.stock_reel}</td>
-              <td className="border px-4 py-2">{s.unite}</td>
+              <td className="border px-4 py-2">{s.unites?.nom}</td>
               <td className="border px-4 py-2">{s.pmp?.toFixed(2)}</td>
               <td className="border px-4 py-2">{(s.pmp * s.stock_reel).toFixed(2)} €</td>
               <td className="border px-4 py-2">

--- a/src/pages/factures/FactureForm.jsx
+++ b/src/pages/factures/FactureForm.jsx
@@ -41,7 +41,7 @@ export default function FactureForm({ facture = null, fournisseurs = [], onClose
       total_ht: l.prix_unitaire != null ? String(l.prix_unitaire * l.quantite) : "",
       tva: l.tva ?? 20,
       zone_stock_id: l.zone_stock_id || "",
-      unite: l.produit?.unite?.nom || l.produit?.unite || "",
+      unite: l.produit?.unites?.nom || "",
     })) || [
       {
         produit_id: "",

--- a/src/pages/fiches/FicheDetail.jsx
+++ b/src/pages/fiches/FicheDetail.jsx
@@ -43,7 +43,7 @@ export default function FicheDetail({ fiche: ficheProp, onClose }) {
     const rows = fiche.lignes?.map(l => ({
       Produit: l.produit?.nom || l.sous_fiche?.nom,
       Quantite: l.quantite,
-      Unite: l.produit?.unite || (l.sous_fiche ? "portion" : ""),
+      Unite: l.produit?.unites?.nom || (l.sous_fiche ? "portion" : ""),
       Cout: l.produit?.pmp
         ? (l.produit.pmp * l.quantite).toFixed(2)
         : l.sous_fiche?.cout_par_portion
@@ -61,7 +61,7 @@ export default function FicheDetail({ fiche: ficheProp, onClose }) {
     const rows = fiche.lignes?.map(l => [
       l.produit?.nom || l.sous_fiche?.nom,
       l.quantite,
-      l.produit?.unite || (l.sous_fiche ? "portion" : ""),
+      l.produit?.unites?.nom || (l.sous_fiche ? "portion" : ""),
       l.produit?.pmp
         ? (l.produit.pmp * l.quantite).toFixed(2)
         : l.sous_fiche?.cout_par_portion
@@ -103,7 +103,7 @@ export default function FicheDetail({ fiche: ficheProp, onClose }) {
             {fiche.lignes?.map((l, i) => (
               <li key={i}>
                 {l.produit?.nom || l.sous_fiche?.nom} — {l.quantite}{" "}
-                {l.produit?.unite || (l.sous_fiche ? "portion" : "")} —{" "}
+                {l.produit?.unites?.nom || (l.sous_fiche ? "portion" : "")} —{" "}
                 {l.produit?.pmp
                   ? (l.produit.pmp * l.quantite).toFixed(2)
                   : l.sous_fiche?.cout_par_portion

--- a/src/pages/fiches/FicheForm.jsx
+++ b/src/pages/fiches/FicheForm.jsx
@@ -233,7 +233,7 @@ export default function FicheForm({ fiche, onClose }) {
                         required
                       />
                     </td>
-                    <td>{l.type === 'produit' ? prod?.unite || '-' : 'portion'}</td>
+                    <td>{l.type === 'produit' ? prod?.unites?.nom || '-' : 'portion'}</td>
                     <td>{l.type === 'produit' ? (prod?.pmp ? prod.pmp.toFixed(2) : '-') : sf?.cout_par_portion?.toFixed(2) || '-'}</td>
                     <td>{l.type === 'produit' ? (prod?.pmp ? (prod.pmp * l.quantite).toFixed(2) : '-') : sf?.cout_par_portion ? (sf.cout_par_portion * l.quantite).toFixed(2) : '-'}</td>
                     <td><Button size="sm" variant="outline" onClick={() => removeLigne(i)}>Suppr.</Button></td>

--- a/src/pages/inventaire/InventaireDetail.jsx
+++ b/src/pages/inventaire/InventaireDetail.jsx
@@ -68,7 +68,7 @@ export default function InventaireDetail() {
       head: [["Produit", "Unité", "Physique", "Théorique", "Prix", "Valeur", "Écart", "Valeur écart"]],
       body: (inventaire.lignes || []).map(l => [
         l.product?.nom,
-        l.product?.unite,
+        l.product?.unites?.nom,
         l.quantite,
         l.product?.stock_theorique,
         l.product?.pmp,
@@ -118,7 +118,7 @@ export default function InventaireDetail() {
               return (
                 <tr key={idx} className="border-b last:border-none">
                   <td className="p-2">{l.product?.nom}</td>
-                  <td className="p-2">{l.product?.unite}</td>
+                  <td className="p-2">{l.product?.unites?.nom}</td>
                   <td className="p-2">{l.quantite}</td>
                   <td className="p-2">{l.product?.stock_theorique}</td>
                   <td className="p-2">{l.product?.pmp}</td>

--- a/src/pages/produits/ProduitDetail.jsx
+++ b/src/pages/produits/ProduitDetail.jsx
@@ -118,6 +118,7 @@ export default function ProduitDetailPage() {
             {product && (
               <div className="mb-4 text-sm">
                 <p>Fournisseur : {product.main_fournisseur?.nom || '-'}</p>
+                <p>Unité : {product.unites?.nom || '-'}</p>
                 <p>Stock minimum : {product.seuil_min ?? '-'}</p>
               </div>
             )}

--- a/src/pages/produits/Produits.jsx
+++ b/src/pages/produits/Produits.jsx
@@ -329,7 +329,7 @@ export default function Produits() {
                 <span>{produit.actif ? "✅" : "❌"}</span>
               </div>
               <div className="text-sm mt-1 flex flex-wrap gap-2">
-                <span>{produit.unite?.nom ?? produit.unite ?? ""}</span>
+                <span>{produit.unites?.nom ?? ""}</span>
                 <span>Stock: {produit.stock_theorique}</span>
                 <span>PMP: {produit.pmp != null ? Number(produit.pmp).toFixed(2) : "-"}</span>
               </div>

--- a/src/utils/exportExcelProduits.js
+++ b/src/utils/exportExcelProduits.js
@@ -30,7 +30,7 @@ export async function exportExcelProduits(mama_id) {
   const { data, error } = await supabase
     .from("produits")
     .select(
-      `nom, unite:unites(nom), famille:familles(nom), sous_famille:sous_familles(nom), zone_stock:zones_stock(nom), stock_theorique, pmp, actif, seuil_min`
+      `nom, unite_id, unites:unite_id (nom), famille:familles(nom), sous_famille:sous_familles(nom), zone_stock:zones_stock(nom), stock_theorique, pmp, actif, seuil_min`
     )
     .eq("mama_id", mama_id);
 
@@ -38,7 +38,7 @@ export async function exportExcelProduits(mama_id) {
 
   const rows = (data || []).map((p) => ({
     nom: p.nom,
-    unite: p.unite?.nom || "",
+    unite: p.unites?.nom || "",
     famille: p.famille?.nom || "",
     sous_famille: p.sous_famille?.nom || "",
     zone_stock: p.zone_stock?.nom || "",

--- a/test/Produits.test.jsx
+++ b/test/Produits.test.jsx
@@ -47,7 +47,7 @@ test('toggle button calls hook', async () => {
       {
         id: '1',
         nom: 'Test',
-        unite: { nom: 'kg' },
+        unites: { nom: 'kg' },
         pmp: 1,
         stock_theorique: 10,
         actif: true,

--- a/test/useInvoiceItems.test.js
+++ b/test/useInvoiceItems.test.js
@@ -36,7 +36,7 @@ test('fetchItemsByInvoice queries with invoice id and mama_id', async () => {
     await result.current.fetchItemsByInvoice('f1');
   });
   expect(fromMock).toHaveBeenCalledWith('facture_lignes');
-  expect(query.select).toHaveBeenCalledWith('*, produit:produits!facture_lignes_produit_id_fkey(id, nom, famille:familles(nom), unite:unites(nom))');
+    expect(query.select).toHaveBeenCalledWith('*, produit:produits!facture_lignes_produit_id_fkey(id, nom, unite_id, unites:unite_id (nom), famille:familles(nom))');
   expect(query.eq).toHaveBeenNthCalledWith(1, 'facture_id', 'f1');
   expect(query.eq).toHaveBeenNthCalledWith(2, 'mama_id', 'm1');
   expect(query.order).toHaveBeenCalledWith('id');

--- a/test/useProduitsAutocomplete.test.js
+++ b/test/useProduitsAutocomplete.test.js
@@ -28,7 +28,7 @@ test('searchProduits filters by mama_id and query', async () => {
     await result.current.searchProduits('car');
   });
   expect(fromMock).toHaveBeenCalledWith('produits');
-  expect(selectMock).toHaveBeenCalledWith('id, nom, tva, dernier_prix, unite:unites(nom)');
+  expect(selectMock).toHaveBeenCalledWith('id, nom, tva, dernier_prix, unite_id, unites:unite_id (nom)');
   expect(eqMock).toHaveBeenCalledWith('mama_id', 'm1');
   expect(eqMock).toHaveBeenCalledWith('actif', true);
   expect(ilikeMock).toHaveBeenCalledWith('nom', '%car%');

--- a/test/useProduitsInventaire.test.js
+++ b/test/useProduitsInventaire.test.js
@@ -30,7 +30,7 @@ test('fetchProduits filters by family and search', async () => {
   expect(fromMock).toHaveBeenCalledWith('v_produits_dernier_prix');
   expect(fromMock).toHaveBeenCalledWith('v_pmp');
   expect(fromMock).toHaveBeenCalledWith('v_stocks');
-  expect(selectMock).toHaveBeenCalledWith('id, nom, unite, famille');
+  expect(selectMock).toHaveBeenCalledWith('id, nom, unite_id, unites:unite_id (nom), famille');
   expect(eqMock).toHaveBeenCalledWith('mama_id', 'm1');
   expect(eqMock).toHaveBeenCalledWith('actif', true);
   expect(ilikeMock).toHaveBeenCalledWith('famille', '%Viande%');

--- a/test/visual_update.test.js
+++ b/test/visual_update.test.js
@@ -70,7 +70,7 @@ test('produits creation and disable refresh list', async () => {
   const { result } = renderHook(() => useProducts());
 
   await act(async () => {
-    await result.current.addProduct({ nom: 'P', famille: 'F', unite: 'kg' });
+    await result.current.addProduct({ nom: 'P', famille: 'F', unite_id: 'u1' });
   });
 
   const afterCreate = result.current.products.length === 1;


### PR DESCRIPTION
## Summary
- replace text unit field with `AutoCompleteField` bound to `unite_id`
- show related unit names in product list, detail and invoice forms
- align Supabase queries on `unite_id`/`unites` relation throughout hooks and exports

## Testing
- `npm test` *(fails: Missing Supabase credentials)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689075f023e4832d9725db8ff1f1d651