### PR TITLE
Refactor invoice form lines and reference handling

### DIFF
--- a/db/Ajout.sql
+++ b/db/Ajout.sql
@@ -59,6 +59,15 @@ VALUES
   ('audit', 'peut_voir')
 ON CONFLICT DO NOTHING;
 
+-- Correction de la colonne des lignes produits
+ALTER TABLE factures
+ADD COLUMN IF NOT EXISTS lignes_produits jsonb DEFAULT '[]';
+
+UPDATE factures
+SET lignes_produits = '[]'
+WHERE lignes_produits IS NULL
+   OR lignes_produits::text = '';
+
 -- Ajout/ajustement du module planning prévisionnel
 ALTER TABLE planning_previsionnel
   ADD COLUMN IF NOT EXISTS nom text,


### PR DESCRIPTION
## Summary
- rename invoice number to reference with BL prefix handling
- show PU and PMP side by side, update quantity/total behaviour
- add missing lignes_produits column migration

## Testing
- `npm run lint`
- `npm test` (fails: Missing Supabase credentials and multiple failing suites)


------
https://chatgpt.com/codex/tasks/task_e_6890c169f738832da00c56a99b7460bc