### PR TITLE
Improve invoice line display and reference handling

### DIFF
--- a/src/components/FactureLigne.jsx
+++ b/src/components/FactureLigne.jsx
@@ -70,13 +70,14 @@ export default function FactureLigne({
   function handleQuantite(val) {
     const replaced = String(val).replace(',', '.');
     const qNum = parseFloat(replaced);
-    const isValid = !isNaN(qNum);
-    const pu = parseNum(ligne.pu);
-    let newLine = { ...ligne, quantite: isValid ? qNum : 0 };
-    if (!ligne.manuallyEdited) {
-      newLine.total_ht = isValid ? parseFloat((qNum * pu).toFixed(2)) : 0;
+    if (!isNaN(qNum)) {
+      const pu = parseNum(ligne.pu);
+      const newLine = { ...ligne, quantite: qNum };
+      if (!ligne.manuallyEdited) {
+        newLine.total_ht = parseFloat((qNum * pu).toFixed(2));
+      }
+      onChange(newLine);
     }
-    onChange(newLine);
   }
 
   function handleTotal(val) {
@@ -119,12 +120,8 @@ export default function FactureLigne({
           onKeyDown={e => e.key === "Enter" && e.preventDefault()}
         />
       </td>
-      <td className="p-1 align-middle">
-        <input
-          value={ligne.unite || ""}
-          readOnly
-          style={{ border: "none", background: "transparent", width: "100%", padding: "0.5rem", textAlign: "center" }}
-        />
+      <td className="p-1 align-middle h-10 text-center">
+        <span>{ligne.unite || ""} | TVA {ligne.tva || 0}</span>
       </td>
       <td className="p-1 align-middle">
         <div className="relative">
@@ -140,9 +137,9 @@ export default function FactureLigne({
         </div>
       </td>
       <td className="p-1 align-middle">
-        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-          <span>PU : {puNum.toFixed(2)} €</span>
-          <span style={{ color: "gray", fontSize: "0.85rem" }}>PMP : {pmp.toFixed(2)} €</span>
+        <div style={{ display: "flex", justifyContent: "space-between", padding: "0.25rem 0.5rem" }}>
+          <span><strong>PU:</strong> {puNum.toFixed(2)} €</span>
+          <span style={{ color: "gray" }}><strong>PMP:</strong> {pmp.toFixed(2)} €</span>
         </div>
       </td>
       <td className="min-w-[20ch] p-1 align-middle">
@@ -162,13 +159,6 @@ export default function FactureLigne({
               </option>
             ))}
         </Select>
-      </td>
-      <td className="p-1 align-middle">
-        <input
-          value={ligne.tva ?? 0}
-          readOnly
-          style={{ border: "none", background: "transparent", width: "100%", padding: "0.5rem", textAlign: "center" }}
-        />
       </td>
       <td className="p-1 align-middle">
         <Button

--- a/src/pages/factures/FactureForm.jsx
+++ b/src/pages/factures/FactureForm.jsx
@@ -350,11 +350,10 @@ export default function FactureForm({ facture = null, fournisseurs = [], onClose
                 <tr>
                   <th>Produit</th>
                   <th>Quantité</th>
-                  <th>Unité</th>
+                  <th>Unité | TVA</th>
                   <th>Total HT</th>
-                  <th>PU</th>
+                  <th>PU | PMP</th>
                   <th>Zone</th>
-                  <th>TVA</th>
                   <th>Actions</th>
                 </tr>
               </thead>

--- a/src/pages/factures/Factures.jsx
+++ b/src/pages/factures/Factures.jsx
@@ -33,7 +33,7 @@ export default function Factures() {
   const [showImport, setShowImport] = useState(false);
   const [selected, setSelected] = useState(null);
   const [search, setSearch] = useState("");
-  const [statutFilter, setStatutFilter] = useState("Brouillon");
+  const [statutFilter, setStatutFilter] = useState("");
   const [fournisseurFilter, setFournisseurFilter] = useState("");
   const [fournisseurInput, setFournisseurInput] = useState("");
   const [actifFilter, setActifFilter] = useState("true");


### PR DESCRIPTION
## Summary
- refine invoice line table headers combining PU/PMP and Unité/TVA
- allow decimal quantities with comma conversion
- default invoice status filter to no selection

## Testing
- `psql "postgresql://postgres:postgres@localhost:5432/postgres" -c "ALTER TABLE factures ADD COLUMN IF NOT EXISTS lignes_produits jsonb DEFAULT '[]';" && psql "postgresql://postgres:postgres@localhost:5432/postgres" -c "UPDATE factures SET lignes_produits = '[]' WHERE lignes_produits IS NULL OR lignes_produits::text = '' OR lignes_produits::text NOT LIKE '[%';"` *(fails: connection refused)*
- `npm test` *(fails: Missing Supabase credentials)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890c60ea6b0832d99a186a0276606a3