### PR TITLE
Refactor product line entry layout

### DIFF
--- a/src/components/FactureLigne.jsx
+++ b/src/components/FactureLigne.jsx
@@ -106,22 +106,23 @@ export default function FactureLigne({
           options={produitOptions}
           required
           placeholder="Nom du produit..."
-          className="h-10 min-w-[40ch]"
+          className="h-10 w-full"
         />
       </td>
       <td className="p-1 align-middle">
         <Input
-          type="text"
+          type="number"
+          step="any"
           required
           className="h-10 w-full"
           value={ligne.quantite}
-          onChange={e => handleQuantite(e.target.value)}
+          onChange={e => handleQuantite(e.target.value.replace(',', '.'))}
           onBlur={() => handleQuantite(ligne.quantite)}
           onKeyDown={e => e.key === "Enter" && e.preventDefault()}
         />
       </td>
-      <td className="p-1 align-middle h-10 text-center">
-        <span>{ligne.unite || ""} | TVA {ligne.tva || 0}</span>
+      <td className="p-1 align-middle">
+        <div className="h-10 flex items-center px-2">{ligne.unite || ""}</div>
       </td>
       <td className="p-1 align-middle">
         <div className="relative">
@@ -137,12 +138,15 @@ export default function FactureLigne({
         </div>
       </td>
       <td className="p-1 align-middle">
-        <div style={{ display: "flex", justifyContent: "space-between", padding: "0.25rem 0.5rem" }}>
-          <span><strong>PU:</strong> {puNum.toFixed(2)} €</span>
-          <span style={{ color: "gray" }}><strong>PMP:</strong> {pmp.toFixed(2)} €</span>
+        <div className="h-10 flex items-center px-2">
+          <span>PU: {puNum.toFixed(2)} €</span>
+          <span className="text-gray-500 ml-2">PMP: {pmp.toFixed(2)} €</span>
         </div>
       </td>
-      <td className="min-w-[20ch] p-1 align-middle">
+      <td className="p-1 align-middle">
+        <div className="h-10 flex items-center px-2">{ligne.tva || 0}%</div>
+      </td>
+      <td className="p-1 align-middle">
         <Select
           value={ligne.zone_stock_id}
           onChange={e => onChange({ ...ligne, zone_stock_id: e.target.value })}
@@ -160,7 +164,7 @@ export default function FactureLigne({
             ))}
         </Select>
       </td>
-      <td className="p-1 align-middle">
+      <td className="p-1 align-middle text-right">
         <Button
           type="button"
           size="sm"
@@ -168,7 +172,7 @@ export default function FactureLigne({
           onClick={() => onRemove?.(index)}
           className="h-10 px-2"
         >
-          X
+          ❌
         </Button>
       </td>
     </tr>

--- a/src/pages/factures/FactureForm.jsx
+++ b/src/pages/factures/FactureForm.jsx
@@ -345,16 +345,27 @@ export default function FactureForm({ facture = null, fournisseurs = [], onClose
         <section>
           <h3 className="font-semibold mb-2">Lignes produits</h3>
           <div className="overflow-x-auto">
-            <table className="w-full text-sm">
+            <table className="w-full text-sm table-fixed">
+              <colgroup>
+                <col style={{ width: "25%" }} />
+                <col style={{ width: "10%" }} />
+                <col style={{ width: "10%" }} />
+                <col style={{ width: "10%" }} />
+                <col style={{ width: "15%" }} />
+                <col style={{ width: "8%" }} />
+                <col style={{ width: "12%" }} />
+                <col style={{ width: "5%" }} />
+              </colgroup>
               <thead>
                 <tr>
-                  <th>Produit</th>
-                  <th>Quantité</th>
-                  <th>Unité | TVA</th>
-                  <th>Total HT</th>
-                  <th>PU | PMP</th>
-                  <th>Zone</th>
-                  <th>Actions</th>
+                  <th className="text-left">Produit</th>
+                  <th className="text-left">Quantité</th>
+                  <th className="text-left">Unité</th>
+                  <th className="text-left">Total HT</th>
+                  <th className="text-left">PU / PMP</th>
+                  <th className="text-left">TVA</th>
+                  <th className="text-left">Zone</th>
+                  <th className="text-right">Actions</th>
                 </tr>
               </thead>
               <tbody>


### PR DESCRIPTION
## Summary
- restructure invoice line table with dedicated columns and fixed widths
- show PU and PMP together with separate TVA column
- accept comma decimal quantities and keep manual totals

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890ca65b14c832dac95905ce258589f