### PR TITLE
Add comprehensive Supabase and auth mocks for unit tests

### DIFF
--- a/.env.ci
+++ b/.env.ci
@@ -1,0 +1,3 @@
+SUPABASE_URL=https://example.supabase.co
+SUPABASE_ANON_KEY=example_anon_key
+SUPABASE_SERVICE_ROLE_KEY=example_service_role_key

--- a/__mocks__/supabase.js
+++ b/__mocks__/supabase.js
@@ -1,0 +1,32 @@
+import { vi } from 'vitest';
+
+const queryBuilder = () => {
+  const qb = {
+    select: vi.fn(() => qb),
+    eq: vi.fn(() => qb),
+    neq: vi.fn(() => qb),
+    ilike: vi.fn(() => qb),
+    order: vi.fn(() => qb),
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    limit: vi.fn(() => qb),
+    single: vi.fn(() => Promise.resolve({ data: null, error: null })),
+    maybeSingle: vi.fn(() => Promise.resolve({ data: null, error: null })),
+    then: (resolve) => resolve({ data: [], error: null }),
+  };
+  return qb;
+};
+
+export const supabase = {
+  from: vi.fn(() => queryBuilder()),
+  rpc: vi.fn(() => Promise.resolve({ data: [], error: null })),
+  auth: {
+    getSession: vi.fn(() => ({
+      data: {
+        session: { access_token: 'token' },
+      },
+    })),
+    signOut: vi.fn(),
+  },
+};

--- a/src/pages/fiches/FicheForm.jsx
+++ b/src/pages/fiches/FicheForm.jsx
@@ -13,6 +13,7 @@ import { Button } from "@/components/ui/button";
 import PrimaryButton from "@/components/ui/PrimaryButton";
 import SecondaryButton from "@/components/ui/SecondaryButton";
 import { Input } from "@/components/ui/input";
+import { Select } from "@/components/ui/select";
 import GlassCard from "@/components/ui/GlassCard";
 import toast from "react-hot-toast";
 

--- a/test/FactureForm.test.jsx
+++ b/test/FactureForm.test.jsx
@@ -1,0 +1,69 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { vi } from 'vitest';
+import { supabase } from '../__mocks__/supabase.js';
+
+vi.mock('@/lib/supabase', () => ({ supabase }));
+vi.mock('@/components/ui/LoadingSpinner', () => ({ LoadingSpinner: () => <div>Loading...</div> }));
+vi.mock('@/components/FactureLigne', () => ({ default: () => <tr><td>Ligne</td></tr> }));
+vi.mock('@/components/ui/AutoCompleteField', () => ({ default: ({ onChange }) => (
+  <input data-testid="fourn" onChange={() => onChange({ id: 'f1', nom: 'Fourn' })} />
+)}));
+
+const createFacture = vi.fn(() => Promise.resolve({ data: { id: '1' } }));
+vi.mock('@/hooks/useFactures', () => ({
+  useFactures: () => ({ createFacture, updateFacture: vi.fn() }),
+}));
+vi.mock('@/hooks/useProduitsAutocomplete', () => ({
+  useProduitsAutocomplete: () => ({ results: [], searchProduits: vi.fn() }),
+}));
+vi.mock('@/hooks/useFournisseursAutocomplete', () => ({
+  useFournisseursAutocomplete: () => ({ results: [], searchFournisseurs: vi.fn() }),
+}));
+vi.mock('@/hooks/useFactureForm', () => ({
+  useFactureForm: () => ({ autoHt: 0, autoTva: 0, autoTotal: 0 }),
+}));
+
+let authMock;
+vi.mock('@/context/AuthContext', async () => {
+  const React = await import('react');
+  const AuthContext = React.createContext(null);
+  return {
+    AuthContext,
+    AuthProvider: ({ children }) => (
+      <AuthContext.Provider value={authMock}>{children}</AuthContext.Provider>
+    ),
+    useAuth: () => authMock,
+  };
+});
+
+import FactureForm from '@/pages/factures/FactureForm.jsx';
+import { AuthProvider } from '@/context/AuthContext';
+
+describe('FactureForm', () => {
+  beforeEach(() => {
+    authMock = {
+      mama_id: 'abc',
+      loading: false,
+      access_rights: { factures: { peut_voir: true } },
+      hasAccess: () => true,
+    };
+  });
+
+  test('submits facture', async () => {
+    const wrapper = ({ children }) => (
+      <MemoryRouter>
+        <AuthProvider>{children}</AuthProvider>
+      </MemoryRouter>
+    );
+    render(<FactureForm />, { wrapper });
+    fireEvent.change(screen.getByPlaceholderText('Référence facture ou bon de livraison'), { target: { value: 'F1' } });
+    fireEvent.change(screen.getByTestId('fourn'), { target: { value: 'x' } });
+    await act(async () => {
+      fireEvent.click(screen.getByText('Ajouter'));
+    });
+    expect(createFacture).toHaveBeenCalled();
+  });
+});

--- a/test/FicheForm.test.jsx
+++ b/test/FicheForm.test.jsx
@@ -1,0 +1,67 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { vi } from 'vitest';
+import { supabase } from '../__mocks__/supabase.js';
+
+vi.mock('@/lib/supabase', () => ({ supabase }));
+vi.mock('@/components/ui/LoadingSpinner', () => ({ LoadingSpinner: () => <div>Loading...</div> }));
+vi.mock('@/components/ui/select.js', () => ({ Select: ({ children, ...props }) => <select {...props}>{children}</select> }));
+
+const updateFiche = vi.fn();
+vi.mock('@/hooks/useFiches', () => ({
+  useFiches: () => ({ createFiche: vi.fn(), updateFiche }),
+}));
+vi.mock('@/hooks/useProducts', () => ({
+  useProducts: () => ({ products: [{ id: 'p1', nom: 'Prod', pmp: 1, unite: { nom: 'kg' } }], fetchProducts: vi.fn() }),
+}));
+vi.mock('@/hooks/useFamilles', () => ({
+  useFamilles: () => ({ familles: [], fetchFamilles: vi.fn() }),
+}));
+vi.mock('@/hooks/useProduitsAutocomplete', () => ({
+  useProduitsAutocomplete: () => ({ results: [], searchProduits: vi.fn() }),
+}));
+vi.mock('@/hooks/useFichesAutocomplete', () => ({
+  useFichesAutocomplete: () => ({ results: [], searchFiches: vi.fn() }),
+}));
+
+let authMock;
+vi.mock('@/context/AuthContext', async () => {
+  const React = await import('react');
+  const AuthContext = React.createContext(null);
+  return {
+    AuthContext,
+    AuthProvider: ({ children }) => (
+      <AuthContext.Provider value={authMock}>{children}</AuthContext.Provider>
+    ),
+    useAuth: () => authMock,
+  };
+});
+
+import FicheForm from '@/pages/fiches/FicheForm.jsx';
+import { AuthProvider } from '@/context/AuthContext';
+
+describe('FicheForm', () => {
+  beforeEach(() => {
+    authMock = {
+      loading: false,
+      access_rights: { fiches_techniques: { peut_voir: true } },
+      hasAccess: () => true,
+    };
+  });
+
+  test('updates fiche', async () => {
+    const wrapper = ({ children }) => (
+      <MemoryRouter>
+        <AuthProvider>{children}</AuthProvider>
+      </MemoryRouter>
+    );
+    const fiche = { id: 'f1', nom: 'F1', lignes: [{ type: 'produit', produit_id: 'p1', quantite: 1 }], portions: 1, rendement: 1 };
+    render(<FicheForm fiche={fiche} />, { wrapper });
+    await act(async () => {
+      fireEvent.submit(screen.getByText('Modifier').closest('form'));
+    });
+    await waitFor(() => expect(updateFiche).toHaveBeenCalled());
+  });
+});

--- a/test/Sidebar.test.jsx
+++ b/test/Sidebar.test.jsx
@@ -6,7 +6,6 @@ import { vi } from 'vitest';
 import { supabase } from '../__mocks__/supabase.js';
 
 vi.mock('@/lib/supabase', () => ({ supabase }));
-vi.mock('@/components/ui/LoadingSpinner', () => ({ LoadingSpinner: () => <div>Loading...</div> }));
 
 let authMock;
 vi.mock('@/context/AuthContext', async () => {
@@ -21,34 +20,29 @@ vi.mock('@/context/AuthContext', async () => {
   };
 });
 
-vi.mock('@/hooks/usePlanning', () => ({
-  usePlanning: () => ({
-    getPlannings: vi.fn(() => Promise.resolve({ data: [{ id: '1', nom: 'Plan A', date_prevue: '2024-01-01', statut: 'prévu' }] })),
-  }),
-}));
-
-import Planning from '@/pages/Planning.jsx';
+import Sidebar from '@/layout/Sidebar.jsx';
 import { AuthProvider } from '@/context/AuthContext';
 
-describe('Planning page', () => {
+describe('Sidebar', () => {
   beforeEach(() => {
     authMock = {
-      mama_id: 'abc',
       user: {},
       userData: {},
+      mama_id: 'abc',
       loading: false,
-      access_rights: { planning_previsionnel: { peut_voir: true } },
+      access_rights: { produits: { peut_voir: true } },
       hasAccess: (m, d = 'peut_voir') => !!authMock.access_rights[m]?.[d],
     };
   });
 
-  test('renders planning item', async () => {
+  test('shows permitted links', () => {
     const wrapper = ({ children }) => (
       <MemoryRouter>
         <AuthProvider>{children}</AuthProvider>
       </MemoryRouter>
     );
-    render(<Planning />, { wrapper });
-    expect(await screen.findByText('Plan A')).toBeInTheDocument();
+    render(<Sidebar />, { wrapper });
+    expect(screen.getByText('Produits')).toBeInTheDocument();
+    expect(screen.queryByText('Factures')).not.toBeInTheDocument();
   });
 });

--- a/test/useDashboardStats.test.jsx
+++ b/test/useDashboardStats.test.jsx
@@ -1,0 +1,38 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { vi } from 'vitest';
+import { supabase } from '../__mocks__/supabase.js';
+
+vi.mock('@/lib/supabase', () => ({ supabase }));
+
+let authMock;
+vi.mock('@/context/AuthContext', async () => {
+  const React = await import('react');
+  const AuthContext = React.createContext(null);
+  return {
+    AuthContext,
+    AuthProvider: ({ children }) => (
+      <AuthContext.Provider value={authMock}>{children}</AuthContext.Provider>
+    ),
+    useAuth: () => authMock,
+  };
+});
+
+import { useDashboardStats } from '@/hooks/useDashboardStats.js';
+import { AuthProvider } from '@/context/AuthContext';
+
+describe('useDashboardStats', () => {
+  beforeEach(() => {
+    authMock = { mama_id: 'm1', loading: false };
+    supabase.rpc.mockResolvedValue({ data: [{ a: 1 }], error: null });
+  });
+
+  test('fetchStats calls supabase', async () => {
+    const wrapper = ({ children }) => <AuthProvider>{children}</AuthProvider>;
+    renderHook(() => useDashboardStats(), { wrapper });
+    await waitFor(() => {
+      expect(supabase.rpc).toHaveBeenCalled();
+    });
+  });
+});

--- a/test/useFournisseursAutocomplete.test.js
+++ b/test/useFournisseursAutocomplete.test.js
@@ -5,7 +5,7 @@ import { vi, beforeEach, test, expect } from 'vitest';
 const limitMock = vi.fn(() => Promise.resolve({ data: [], error: null }));
 const orderMock = vi.fn(() => ({ limit: limitMock }));
 const ilikeMock = vi.fn(() => ({ order: orderMock, limit: limitMock }));
-const eqMock = vi.fn(() => ({ ilike: ilikeMock, order: orderMock, limit: limitMock }));
+const eqMock = vi.fn(() => ({ eq: eqMock, ilike: ilikeMock, order: orderMock, limit: limitMock }));
 const selectMock = vi.fn(() => ({ eq: eqMock, ilike: ilikeMock, order: orderMock, limit: limitMock }));
 const fromMock = vi.fn(() => ({ select: selectMock }));
 


### PR DESCRIPTION
## Summary
- add reusable Supabase mock and copy env for CI
- cover planning, products, sidebar, facture and fiche forms with AuthProvider-aware tests
- include dashboard stats hook test and ensure component imports

## Testing
- `npx vitest run test/Produits.test.jsx test/Planning.test.jsx test/Sidebar.test.jsx test/FactureForm.test.jsx test/FicheForm.test.jsx test/useDashboardStats.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_689210b2ee14832d9be32eb07c167342