### PR TITLE
Fix fiche product links and costs

### DIFF
--- a/src/hooks/useFiches.js
+++ b/src/hooks/useFiches.js
@@ -51,7 +51,7 @@ export function useFiches() {
     const { data, error } = await supabase
       .from("fiches_techniques")
       .select(
-        "*, famille:familles!fiches_techniques_famille_id_fkey(id, nom), lignes:fiche_lignes!fiche_id(*, produit:produits!fiche_lignes_produit_id_fkey(id, nom, unite_id, unite:unite_id (nom), pmp), sous_fiche:sous_fiche_id(id, nom, cout_par_portion))"
+        "*, famille:familles!fiches_techniques_famille_id_fkey(id, nom), lignes:v_fiche_lignes_complete!fiche_id(*, sous_fiche:sous_fiche_id(id, nom, cout_par_portion))"
       )
       .eq("id", id)
       .eq("mama_id", mama_id)

--- a/src/hooks/useProducts.js
+++ b/src/hooks/useProducts.js
@@ -67,15 +67,19 @@ export function useProducts() {
     const [
       { data: pmpData },
       { data: stockData },
+      { data: lastPriceData },
     ] = await Promise.all([
       supabase.from('v_pmp').select('produit_id, pmp').eq('mama_id', mama_id),
       supabase.from('v_stocks').select('produit_id, stock').eq('mama_id', mama_id),
+      supabase.from('v_products_last_price').select('produit_id, dernier_prix').eq('mama_id', mama_id),
     ]);
     const pmpMap = Object.fromEntries((pmpData || []).map(p => [p.produit_id, p.pmp]));
     const stockMap = Object.fromEntries((stockData || []).map(s => [s.produit_id, s.stock]));
+    const lastPriceMap = Object.fromEntries((lastPriceData || []).map(l => [l.produit_id, l.dernier_prix]));
     const final = (Array.isArray(data) ? data : []).map((p) => ({
       ...p,
       pmp: pmpMap[p.id] ?? p.pmp,
+      dernier_prix: lastPriceMap[p.id] ?? p.dernier_prix,
       stock_theorique: stockMap[p.id] ?? p.stock_theorique,
     }));
     setProducts(final);

--- a/src/pages/fiches/FicheDetail.jsx
+++ b/src/pages/fiches/FicheDetail.jsx
@@ -41,11 +41,11 @@ export default function FicheDetail({ fiche: ficheProp, onClose }) {
 
   function exportExcel() {
     const rows = fiche.lignes?.map(l => ({
-      Produit: l.produit?.nom || l.sous_fiche?.nom,
+      Produit: l.produit_nom || l.sous_fiche?.nom,
       Quantite: l.quantite,
-      Unite: l.produit?.unite?.nom || (l.sous_fiche ? "portion" : ""),
-      Cout: l.produit?.pmp
-        ? (l.produit.pmp * l.quantite).toFixed(2)
+      Unite: l.unite_nom || (l.sous_fiche ? "portion" : ""),
+      Cout: l.produit_id
+        ? ((Number(l.pmp ?? l.dernier_prix ?? 0) * l.quantite).toFixed(2))
         : l.sous_fiche?.cout_par_portion
           ? (l.sous_fiche.cout_par_portion * l.quantite).toFixed(2)
           : "",
@@ -59,11 +59,11 @@ export default function FicheDetail({ fiche: ficheProp, onClose }) {
     const doc = new jsPDF();
     doc.text(fiche.nom, 10, 10);
     const rows = fiche.lignes?.map(l => [
-      l.produit?.nom || l.sous_fiche?.nom,
+      l.produit_nom || l.sous_fiche?.nom,
       l.quantite,
-      l.produit?.unite?.nom || (l.sous_fiche ? "portion" : ""),
-      l.produit?.pmp
-        ? (l.produit.pmp * l.quantite).toFixed(2)
+      l.unite_nom || (l.sous_fiche ? "portion" : ""),
+      l.produit_id
+        ? ((Number(l.pmp ?? l.dernier_prix ?? 0) * l.quantite).toFixed(2))
         : l.sous_fiche?.cout_par_portion
           ? (l.sous_fiche.cout_par_portion * l.quantite).toFixed(2)
           : "",
@@ -102,10 +102,10 @@ export default function FicheDetail({ fiche: ficheProp, onClose }) {
           <ul className="list-disc pl-6">
             {fiche.lignes?.map((l, i) => (
               <li key={i}>
-                {l.produit?.nom || l.sous_fiche?.nom} — {l.quantite}{" "}
-                {l.produit?.unite?.nom || (l.sous_fiche ? "portion" : "")} —{" "}
-                {l.produit?.pmp
-                  ? (l.produit.pmp * l.quantite).toFixed(2)
+                {l.produit_nom || l.sous_fiche?.nom} — {l.quantite}{" "}
+                {l.unite_nom || (l.sous_fiche ? "portion" : "")} —{" "}
+                {l.produit_id
+                  ? (Number(l.pmp ?? l.dernier_prix ?? 0) * l.quantite).toFixed(2)
                   : l.sous_fiche?.cout_par_portion
                     ? (l.sous_fiche.cout_par_portion * l.quantite).toFixed(2)
                     : "-"}


### PR DESCRIPTION
## Summary
- Load products with unit and last price in FicheForm and compute line costs with PMP or last price
- Show updated product info in fiche details and hook fiches to new detailed view
- Add SQL views & triggers to recalc fiche costs on product changes

## Testing
- `npm test` *(fails: 24 failed, 85 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68931b78978c832d84e49d31abec58cd