### PR TITLE
feat: add accounting periods module

### DIFF
--- a/db/ajout.sql
+++ b/db/ajout.sql
@@ -32,3 +32,36 @@ FOR EACH ROW EXECUTE FUNCTION trg_apply_stock_bl();
 -- TODO: add similar triggers for deletions and status changes when required
 -- TODO: create triggers for fiches_lignes, inventaire_lignes and transfert_lignes
 --       to keep stock_theorique, consommation, dernier_prix, and PMP up to date
+
+-- Table des périodes comptables
+CREATE TABLE IF NOT EXISTS periodes_comptables (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  mama_id uuid NOT NULL REFERENCES mamas(id) ON DELETE CASCADE,
+  date_debut date NOT NULL,
+  date_fin date NOT NULL,
+  cloturee boolean DEFAULT false,
+  actuelle boolean DEFAULT false
+);
+
+CREATE INDEX IF NOT EXISTS idx_periodes_comptables_mama ON periodes_comptables(mama_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_periodes_actuelle ON periodes_comptables(mama_id) WHERE actuelle;
+
+ALTER TABLE periodes_comptables ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS periodes_comptables_all ON periodes_comptables;
+CREATE POLICY periodes_comptables_all ON periodes_comptables
+  FOR ALL USING (mama_id = current_user_mama_id())
+  WITH CHECK (mama_id = current_user_mama_id());
+
+CREATE OR REPLACE FUNCTION periode_actuelle(mid uuid)
+RETURNS TABLE(
+  id uuid,
+  mama_id uuid,
+  date_debut date,
+  date_fin date,
+  cloturee boolean,
+  actuelle boolean
+) AS $$
+  SELECT * FROM periodes_comptables
+  WHERE mama_id = mid AND actuelle = true
+  LIMIT 1;
+$$ LANGUAGE sql STABLE;

--- a/src/forms/PeriodeForm.jsx
+++ b/src/forms/PeriodeForm.jsx
@@ -1,0 +1,54 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { useState } from 'react';
+import PrimaryButton from '@/components/ui/PrimaryButton';
+import SecondaryButton from '@/components/ui/SecondaryButton';
+import { Input } from '@/components/ui/input';
+import GlassCard from '@/components/ui/GlassCard';
+
+export default function PeriodeForm({ onSave, onCancel }) {
+  const [debut, setDebut] = useState('');
+  const [fin, setFin] = useState('');
+
+  const handleSubmit = e => {
+    e.preventDefault();
+    if (!debut || !fin) return;
+    onSave({ date_debut: debut, date_fin: fin });
+  };
+
+  return (
+    <GlassCard title="Nouvelle période">
+      <form onSubmit={handleSubmit} className="space-y-3">
+        <div>
+          <label htmlFor="periode-debut" className="block text-sm mb-1 font-medium">
+            Début
+          </label>
+          <Input
+            id="periode-debut"
+            type="date"
+            value={debut}
+            onChange={e => setDebut(e.target.value)}
+            required
+          />
+        </div>
+        <div>
+          <label htmlFor="periode-fin" className="block text-sm mb-1 font-medium">
+            Fin
+          </label>
+          <Input
+            id="periode-fin"
+            type="date"
+            value={fin}
+            onChange={e => setFin(e.target.value)}
+            required
+          />
+        </div>
+        <div className="flex gap-2">
+          <PrimaryButton type="submit">Enregistrer</PrimaryButton>
+          <SecondaryButton type="button" onClick={onCancel}>
+            Annuler
+          </SecondaryButton>
+        </div>
+      </form>
+    </GlassCard>
+  );
+}

--- a/src/hooks/useFactures.js
+++ b/src/hooks/useFactures.js
@@ -2,9 +2,11 @@
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
 import useAuth from "@/hooks/useAuth";
+import usePeriodes from "@/hooks/usePeriodes";
 
 export function useFactures() {
   const { mama_id } = useAuth();
+  const { checkCurrentPeriode } = usePeriodes();
   const [factures, setFactures] = useState([]);
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(false);
@@ -96,6 +98,8 @@ export function useFactures() {
 
   async function createFacture(data) {
     if (!mama_id) return { error: "no mama_id" };
+    const { error: pErr } = await checkCurrentPeriode(data.date_facture);
+    if (pErr) return { error: pErr };
     setLoading(true);
     setError(null);
     const { data: inserted, error } = await supabase
@@ -114,6 +118,10 @@ export function useFactures() {
 
   async function updateFacture(id, fields) {
     if (!mama_id) return { error: "no mama_id" };
+    if (fields.date_facture) {
+      const { error: pErr } = await checkCurrentPeriode(fields.date_facture);
+      if (pErr) return { error: pErr };
+    }
     setLoading(true);
     setError(null);
     const { data: updated, error } = await supabase

--- a/src/hooks/useInventaires.js
+++ b/src/hooks/useInventaires.js
@@ -2,9 +2,11 @@
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
 import useAuth from "@/hooks/useAuth";
+import usePeriodes from "@/hooks/usePeriodes";
 
 export function useInventaires() {
   const { mama_id } = useAuth();
+  const { checkCurrentPeriode } = usePeriodes();
   const [inventaires, setInventaires] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
@@ -68,6 +70,12 @@ export function useInventaires() {
 
   async function createInventaire(inv) {
     if (!mama_id) return null;
+    const { date } = inv;
+    const { error: pErr } = await checkCurrentPeriode(date);
+    if (pErr) {
+      setError(pErr);
+      return null;
+    }
     setLoading(true);
     setError(null);
     const { lignes = [], date, ...entete } = inv;

--- a/src/hooks/useMouvements.js
+++ b/src/hooks/useMouvements.js
@@ -2,9 +2,11 @@
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
 import useAuth from "@/hooks/useAuth";
+import usePeriodes from "@/hooks/usePeriodes";
 
 export function useMouvements() {
   const { mama_id, user_id } = useAuth();
+  const { checkCurrentPeriode } = usePeriodes();
   const [mouvements, setMouvements] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
@@ -35,6 +37,8 @@ export function useMouvements() {
 
   async function createMouvement(payload) {
     if (!mama_id) return { error: "no mama_id" };
+    const { error: pErr } = await checkCurrentPeriode(payload.date);
+    if (pErr) return { error: pErr };
     setLoading(true);
     setError(null);
     const { data, error } = await supabase

--- a/src/hooks/usePeriodes.js
+++ b/src/hooks/usePeriodes.js
@@ -1,0 +1,119 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { useState } from 'react';
+import { supabase } from '@/lib/supabase';
+import useAuth from '@/hooks/useAuth';
+
+export default function usePeriodes() {
+  const { mama_id } = useAuth();
+  const [periodes, setPeriodes] = useState([]);
+  const [current, setCurrent] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  async function fetchPeriodes() {
+    if (!mama_id) return [];
+    setLoading(true);
+    setError(null);
+    const { data, error } = await supabase
+      .from('periodes_comptables')
+      .select('*')
+      .eq('mama_id', mama_id)
+      .order('date_debut', { ascending: false });
+    setLoading(false);
+    if (error) {
+      setError(error);
+      return [];
+    }
+    setPeriodes(Array.isArray(data) ? data : []);
+    setCurrent(data?.find(p => p.actuelle) || null);
+    return data || [];
+  }
+
+  async function createPeriode({ date_debut, date_fin }) {
+    if (!mama_id) return { error: 'no mama_id' };
+    setLoading(true);
+    setError(null);
+    const { data, error } = await supabase
+      .from('periodes_comptables')
+      .insert([{ mama_id, date_debut, date_fin, cloturee: false, actuelle: true }])
+      .select()
+      .single();
+    setLoading(false);
+    if (error) {
+      setError(error);
+      return { error };
+    }
+    await fetchPeriodes();
+    return { data };
+  }
+
+  async function cloturerPeriode(id) {
+    if (!mama_id) return { error: 'no mama_id' };
+    setLoading(true);
+    setError(null);
+    const { data: periode, error: selErr } = await supabase
+      .from('periodes_comptables')
+      .select('*')
+      .eq('id', id)
+      .eq('mama_id', mama_id)
+      .single();
+    if (selErr || !periode) {
+      setLoading(false);
+      setError(selErr);
+      return { error: selErr || new Error('Période introuvable') };
+    }
+    const { error: updErr } = await supabase
+      .from('periodes_comptables')
+      .update({ cloturee: true, actuelle: false })
+      .eq('id', id)
+      .eq('mama_id', mama_id);
+    if (updErr) {
+      setLoading(false);
+      setError(updErr);
+      return { error: updErr };
+    }
+    const debut = new Date(periode.date_fin);
+    debut.setDate(debut.getDate() + 1);
+    const fin = new Date(debut);
+    fin.setMonth(fin.getMonth() + 1);
+    fin.setDate(fin.getDate() - 1);
+    await supabase.from('periodes_comptables').insert([
+      {
+        mama_id,
+        date_debut: debut.toISOString().slice(0, 10),
+        date_fin: fin.toISOString().slice(0, 10),
+        cloturee: false,
+        actuelle: true,
+      },
+    ]);
+    setLoading(false);
+    await fetchPeriodes();
+    return { data: true };
+  }
+
+  async function checkCurrentPeriode(date) {
+    if (!mama_id) return { error: 'no mama_id' };
+    const { data, error } = await supabase
+      .from('periodes_comptables')
+      .select('*')
+      .eq('mama_id', mama_id)
+      .eq('actuelle', true)
+      .single();
+    if (error) return { error };
+    if (!data) return { error: new Error('Aucune période active') };
+    if (data.cloturee || date < data.date_debut || date > data.date_fin)
+      return { error: new Error('Période comptable clôturée') };
+    return { data };
+  }
+
+  return {
+    periodes,
+    current,
+    loading,
+    error,
+    fetchPeriodes,
+    createPeriode,
+    cloturerPeriode,
+    checkCurrentPeriode,
+  };
+}

--- a/src/hooks/useTransferts.js
+++ b/src/hooks/useTransferts.js
@@ -2,9 +2,11 @@
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
 import useAuth from "@/hooks/useAuth";
+import usePeriodes from "@/hooks/usePeriodes";
 
 export function useTransferts() {
   const { mama_id, user_id } = useAuth();
+  const { checkCurrentPeriode } = usePeriodes();
   const [transferts, setTransferts] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
@@ -32,6 +34,8 @@ export function useTransferts() {
 
   async function createTransfert(header, lignes = []) {
     if (!mama_id) return { error: "no mama_id" };
+    const { error: pErr } = await checkCurrentPeriode(header.date_transfert);
+    if (pErr) return { error: pErr };
     setLoading(true);
     setError(null);
     const { data: tr, error } = await supabase

--- a/src/pages/parametrage/Periodes.jsx
+++ b/src/pages/parametrage/Periodes.jsx
@@ -1,0 +1,96 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { useEffect, useState } from 'react';
+import { Toaster, toast } from 'react-hot-toast';
+import ListingContainer from '@/components/ui/ListingContainer';
+import TableHeader from '@/components/ui/TableHeader';
+import { Button } from '@/components/ui/button';
+import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
+import Unauthorized from '@/pages/auth/Unauthorized';
+import useAuth from '@/hooks/useAuth';
+import usePeriodes from '@/hooks/usePeriodes';
+import PeriodeForm from '@/forms/PeriodeForm';
+
+export default function Periodes() {
+  const { hasAccess, loading: authLoading } = useAuth();
+  const canEdit = hasAccess('parametrage', 'peut_modifier');
+  const {
+    periodes,
+    loading,
+    fetchPeriodes,
+    createPeriode,
+    cloturerPeriode,
+  } = usePeriodes();
+  const [showForm, setShowForm] = useState(false);
+
+  useEffect(() => {
+    fetchPeriodes();
+  }, [fetchPeriodes]);
+
+  const handleCreate = async values => {
+    const { error } = await createPeriode(values);
+    if (error) toast.error(error.message || 'Erreur lors de la création');
+    else {
+      toast.success('Période créée');
+      setShowForm(false);
+    }
+  };
+
+  const handleClose = async id => {
+    if (!confirm('Clôturer cette période ?')) return;
+    const { error } = await cloturerPeriode(id);
+    if (error) toast.error(error.message || 'Erreur de clôture');
+    else toast.success('Période clôturée');
+  };
+
+  if (authLoading || loading) return <LoadingSpinner message="Chargement..." />;
+  if (!canEdit) return <Unauthorized />;
+
+  return (
+    <div className="p-6 mx-auto w-full max-w-full">
+      <Toaster position="top-right" />
+      <h1 className="text-2xl font-bold mb-4">Périodes comptables</h1>
+      <TableHeader className="gap-2">
+        <Button onClick={() => setShowForm(true)}>+ Nouvelle période</Button>
+      </TableHeader>
+      <ListingContainer className="w-full overflow-x-auto">
+        <table className="text-sm w-full max-w-full">
+          <thead>
+            <tr>
+              <th className="px-2 py-1">Début</th>
+              <th className="px-2 py-1">Fin</th>
+              <th className="px-2 py-1">Statut</th>
+              <th className="px-2 py-1">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {periodes.length === 0 ? (
+              <tr>
+                <td colSpan="4" className="py-2">
+                  Aucune période
+                </td>
+              </tr>
+            ) : (
+              periodes.map(p => (
+                <tr key={p.id}>
+                  <td className="px-2 py-1">{p.date_debut}</td>
+                  <td className="px-2 py-1">{p.date_fin}</td>
+                  <td className="px-2 py-1">
+                    {p.actuelle ? 'En cours' : p.cloturee ? 'Clôturée' : 'Future'}
+                  </td>
+                  <td className="px-2 py-1">
+                    {p.actuelle && (
+                      <Button size="sm" onClick={() => handleClose(p.id)}>
+                        Clôturer
+                      </Button>
+                    )}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </ListingContainer>
+      {showForm && <PeriodeForm onSave={handleCreate} onCancel={() => setShowForm(false)} />}
+    </div>
+  );
+}

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -60,6 +60,7 @@ const MamaSettingsForm = lazyWithPreload(() => import("@/pages/parametrage/MamaS
 const Zones = lazyWithPreload(() => import("@/pages/parametrage/Zones.jsx"));
 const Familles = lazyWithPreload(() => import("@/pages/parametrage/Familles.jsx"));
 const Unites = lazyWithPreload(() => import("@/pages/parametrage/Unites.jsx"));
+const Periodes = lazyWithPreload(() => import("@/pages/parametrage/Periodes.jsx"));
 const Onboarding = lazyWithPreload(() => import("@/pages/public/Onboarding.jsx"));
 const Accueil = lazyWithPreload(() => import("@/pages/Accueil.jsx"));
 const Signup = lazyWithPreload(() => import("@/pages/public/Signup.jsx"));
@@ -149,6 +150,7 @@ export const routePreloadMap = {
   '/parametrage/zones-stock': Zones.preload,
   '/parametrage/familles': Familles.preload,
   '/parametrage/unites': Unites.preload,
+  '/parametrage/periodes': Periodes.preload,
   '/consentements': Consentements.preload,
   '/logs': Logs.preload,
   '/aide': AideContextuelle.preload,
@@ -474,6 +476,10 @@ export default function Router() {
           <Route
             path="/parametrage/unites"
             element={<ProtectedRoute moduleKey="parametrage"><Unites /></ProtectedRoute>}
+          />
+          <Route
+            path="/parametrage/periodes"
+            element={<ProtectedRoute moduleKey="parametrage"><Periodes /></ProtectedRoute>}
           />
           <Route
             path="/parametrage/access"


### PR DESCRIPTION
## Summary
- add `periodes_comptables` table with RLS policies and helper function
- implement accounting period management UI and hook
- enforce active period validation on invoices, inventories, transfers and movements

## Testing
- `npm test` *(fails: 24 failed, 85 passed)*


------
https://chatgpt.com/codex/tasks/task_e_6893247b6480832d8756f4f18e99cdc5