### PR TITLE
feat(taches): finalize task management module

### DIFF
--- a/router_mapping.json
+++ b/router_mapping.json
@@ -132,6 +132,10 @@
     "module": "taches"
   },
   {
+    "route": "/taches/:id",
+    "module": "taches"
+  },
+  {
     "route": "/taches/alertes",
     "module": "alertes"
   },

--- a/src/hooks/useTacheAssignation.js
+++ b/src/hooks/useTacheAssignation.js
@@ -1,0 +1,41 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { useState, useCallback } from "react";
+import { supabase } from "@/lib/supabase";
+
+export function useTacheAssignation() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const assignUsers = useCallback(async (tacheId, userIds = []) => {
+    setLoading(true);
+    setError(null);
+    const rows = userIds.map(uid => ({ tache_id: tacheId, utilisateur_id: uid }));
+    const { error } = await supabase.from("utilisateurs_taches").insert(rows);
+    setLoading(false);
+    if (error) {
+      setError(error.message || error);
+      return { error };
+    }
+    return {};
+  }, []);
+
+  const unassignUser = useCallback(async (tacheId, userId) => {
+    setLoading(true);
+    setError(null);
+    const { error } = await supabase
+      .from("utilisateurs_taches")
+      .delete()
+      .eq("tache_id", tacheId)
+      .eq("utilisateur_id", userId);
+    setLoading(false);
+    if (error) {
+      setError(error.message || error);
+      return { error };
+    }
+    return {};
+  }, []);
+
+  return { assignUsers, unassignUser, loading, error };
+}
+
+export default useTacheAssignation;

--- a/src/layout/Sidebar.jsx
+++ b/src/layout/Sidebar.jsx
@@ -116,11 +116,10 @@ export default function Sidebar() {
       ],
     },
     {
-      title: "Tâches",
+      title: "Organisation",
       items: [
         { module: "taches", to: "/taches", label: "Tâches", icon: <CheckSquare size={16} /> },
         { module: "alertes", to: "/taches/alertes", label: "Alertes", icon: <ClipboardList size={16} /> },
-        { module: "produits", to: "/promotions", label: "Promotions", icon: <Gift size={16} /> },
       ],
     },
     {

--- a/src/pages/taches/TacheDetail.jsx
+++ b/src/pages/taches/TacheDetail.jsx
@@ -1,29 +1,55 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
-import { useTasks } from "@/hooks/useTasks";
-import useAuth from "@/hooks/useAuth";
-import TacheForm from "@/components/taches/TacheForm";
+import { Button } from "@/components/ui/button";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import { useTaches } from "@/hooks/useTaches";
 
 export default function TacheDetail() {
   const { id } = useParams();
-  const { fetchTaskById } = useTasks();
-  const { mama_id, loading: authLoading } = useAuth();
-  const [task, setTask] = useState(null);
+  const { getTache, updateTache } = useTaches();
+  const [tache, setTache] = useState(null);
 
   useEffect(() => {
-    if (!authLoading && mama_id) {
-      fetchTaskById(id).then(setTask);
-    }
-  }, [authLoading, mama_id, fetchTaskById, id]);
+    getTache(id).then(setTache);
+  }, [id, getTache]);
 
-  if (!task) return <LoadingSpinner message="Chargement..." />;
+  if (!tache) return <LoadingSpinner message="Chargement..." />;
+
+  const handleDone = async () => {
+    await updateTache(id, {
+      ...tache,
+      assignes: (tache.utilisateurs_taches || []).map(a => a.utilisateur_id),
+      statut: "terminee",
+    });
+    setTache(t => ({ ...t, statut: "terminee" }));
+  };
 
   return (
-    <div className="p-8">
-      <h1 className="text-2xl font-bold mb-4">Modifier la tâche</h1>
-      <TacheForm task={task} />
+    <div className="p-6 space-y-4 text-sm">
+      <h1 className="text-2xl font-bold">{tache.titre}</h1>
+      <p>{tache.description}</p>
+      <p>Priorité : {tache.priorite}</p>
+      <p>Échéance : {tache.date_echeance}</p>
+      <p>Statut : {tache.statut}</p>
+      <p>
+        Assignés :
+        {(tache.utilisateurs_taches || [])
+          .map(a => a.utilisateur?.nom)
+          .filter(Boolean)
+          .join(", ") || " - "}
+      </p>
+      <Button onClick={handleDone} disabled={tache.statut === "terminee"}>
+        Terminer la tâche
+      </Button>
+      <div>
+        <h2 className="font-semibold mt-4">Commentaires</h2>
+        <p className="text-gray-500 text-xs">Aucun commentaire</p>
+      </div>
+      <div>
+        <h2 className="font-semibold mt-4">Historique</h2>
+        <p className="text-gray-500 text-xs">Historique non disponible</p>
+      </div>
     </div>
   );
 }

--- a/src/pages/taches/TacheForm.jsx
+++ b/src/pages/taches/TacheForm.jsx
@@ -14,14 +14,9 @@ export default function TacheForm({ task }) {
   const [form, setForm] = useState({
     titre: task?.titre || "",
     description: task?.description || "",
-    assignes: task?.assignes || [],
-    utilisateur_id: task?.utilisateur_id || "",
-    date_debut: task?.date_debut || "",
-    delai_jours: task?.delai_jours || "",
-    date_echeance: task?.date_echeance || "",
+    assignes: task?.utilisateurs_taches?.map(a => a.utilisateur_id) || [],
     priorite: task?.priorite || "moyenne",
-    recurrente: task?.recurrente || false,
-    frequence: task?.frequence || "hebdomadaire",
+    date_echeance: task?.date_echeance || "",
     statut: task?.statut || "a_faire",
   });
   const [loading, setLoading] = useState(false);
@@ -31,12 +26,10 @@ export default function TacheForm({ task }) {
   }, [fetchUsers]);
 
   const handleChange = e => {
-    const { name, value, type, checked, options } = e.target;
+    const { name, value, options } = e.target;
     if (name === "assignes") {
       const vals = Array.from(options).filter(o => o.selected).map(o => o.value);
       setForm(f => ({ ...f, assignes: vals }));
-    } else if (type === "checkbox") {
-      setForm(f => ({ ...f, [name]: checked }));
     } else {
       setForm(f => ({ ...f, [name]: value }));
     }
@@ -65,74 +58,80 @@ export default function TacheForm({ task }) {
   return (
     <GlassCard title={task ? "Modifier la tâche" : "Nouvelle tâche"} className="max-w-md">
       <form onSubmit={handleSubmit} className="space-y-2">
-      <label className="block">
-        <span>Titre</span>
-        <input className="input w-full" name="titre" value={form.titre} onChange={handleChange} required />
-      </label>
-      <label className="block">
-        <span>Description</span>
-        <textarea className="input w-full" name="description" value={form.description} onChange={handleChange} />
-      </label>
-      <label className="block">
-        <span>Date de début</span>
-        <input type="date" className="input w-full" name="date_debut" value={form.date_debut} onChange={handleChange} required />
-      </label>
-      <label className="block">
-        <span>Délai en jours</span>
-        <input type="number" className="input w-full" name="delai_jours" value={form.delai_jours} onChange={handleChange} />
-      </label>
-      <label className="block">
-        <span>Ou échéance précise</span>
-        <input type="date" className="input w-full" name="date_echeance" value={form.date_echeance} onChange={handleChange} />
-      </label>
-      <label className="block">
-        <span>Priorité</span>
-        <select className="input w-full" name="priorite" value={form.priorite} onChange={handleChange}>
-          <option value="basse">Basse</option>
-          <option value="moyenne">Moyenne</option>
-          <option value="haute">Haute</option>
-        </select>
-      </label>
-      <label className="block">
-        <span>Récurrente ?</span>
-        <input type="checkbox" name="recurrente" checked={form.recurrente} onChange={handleChange} />
-      </label>
-      {form.recurrente && (
         <label className="block">
-          <span>Fréquence</span>
-          <select className="input w-full" name="frequence" value={form.frequence} onChange={handleChange}>
-            <option value="quotidien">Quotidien</option>
-            <option value="hebdomadaire">Hebdomadaire</option>
-            <option value="mensuel">Mensuel</option>
+          <span>Titre</span>
+          <input
+            className="input w-full"
+            name="titre"
+            value={form.titre}
+            onChange={handleChange}
+            required
+          />
+        </label>
+        <label className="block">
+          <span>Description</span>
+          <textarea
+            className="input w-full"
+            name="description"
+            value={form.description}
+            onChange={handleChange}
+          />
+        </label>
+        <label className="block">
+          <span>Assignés</span>
+          <select
+            multiple
+            name="assignes"
+            value={form.assignes}
+            onChange={handleChange}
+            className="input w-full"
+          >
+            {users.map(u => (
+              <option key={u.id} value={u.id}>
+                {u.nom}
+              </option>
+            ))}
           </select>
         </label>
-      )}
-      <label className="block">
-        <span>Assignés</span>
-        <select multiple name="assignes" value={form.assignes} onChange={handleChange} className="input w-full">
-          {users.map(u => (
-            <option key={u.id} value={u.id}>{u.nom}</option>
-          ))}
-        </select>
-      </label>
-      <label className="block">
-        <span>Responsable</span>
-        <select name="utilisateur_id" value={form.utilisateur_id} onChange={handleChange} className="input w-full">
-          <option value="">--</option>
-          {users.map(u => (
-            <option key={u.id} value={u.id}>{u.nom}</option>
-          ))}
-        </select>
-      </label>
-      <label className="block">
-        <span>Statut</span>
-        <select className="input w-full" name="statut" value={form.statut} onChange={handleChange}>
-          <option value="a_faire">À faire</option>
-          <option value="en_cours">En cours</option>
-          <option value="terminee">Terminée</option>
-        </select>
-      </label>
-      <Button type="submit" disabled={loading}>{task ? "Mettre à jour" : "Créer"}</Button>
+        <label className="block">
+          <span>Priorité</span>
+          <select
+            className="input w-full"
+            name="priorite"
+            value={form.priorite}
+            onChange={handleChange}
+          >
+            <option value="basse">Basse</option>
+            <option value="moyenne">Moyenne</option>
+            <option value="haute">Haute</option>
+          </select>
+        </label>
+        <label className="block">
+          <span>Échéance</span>
+          <input
+            type="date"
+            className="input w-full"
+            name="date_echeance"
+            value={form.date_echeance}
+            onChange={handleChange}
+          />
+        </label>
+        <label className="block">
+          <span>Statut</span>
+          <select
+            className="input w-full"
+            name="statut"
+            value={form.statut}
+            onChange={handleChange}
+          >
+            <option value="a_faire">À faire</option>
+            <option value="en_cours">En cours</option>
+            <option value="terminee">Terminée</option>
+          </select>
+        </label>
+        <Button type="submit" disabled={loading}>
+          {task ? "Mettre à jour" : "Créer"}
+        </Button>
       </form>
     </GlassCard>
   );

--- a/src/pages/taches/Taches.jsx
+++ b/src/pages/taches/Taches.jsx
@@ -14,8 +14,8 @@ export default function Taches() {
   const { taches, loading, error, getTaches, createTache } = useTaches();
   const { users, fetchUsers } = useUtilisateurs();
   const [filters, setFilters] = useState({ statut: "", priorite: "", assigne: "", start: "", end: "" });
-  const [view, setView] = useState('table');
-  const [quick, setQuick] = useState({ titre: '', date_echeance: '' });
+  const [view, setView] = useState("table");
+  const [quick, setQuick] = useState({ titre: "", date_echeance: "" });
 
   useEffect(() => {
     fetchUsers({ actif: true });
@@ -35,7 +35,7 @@ export default function Taches() {
       toast.success('Tâche ajoutée');
       setQuick({ titre: '', date_echeance: '' });
     } catch (err) {
-      toast.error(err?.message || 'Erreur ajout');
+      toast.error(err?.message || "Erreur ajout");
     }
   };
 
@@ -52,8 +52,21 @@ export default function Taches() {
       </div>
       <GlassCard title="Ajouter rapidement" className="mb-4">
         <form onSubmit={handleQuickSubmit} className="flex gap-2 flex-wrap items-end">
-          <input className="input flex-1" name="titre" value={quick.titre} onChange={handleQuickChange} placeholder="Nouvelle tâche" required />
-          <input type="date" className="form-input" name="date_echeance" value={quick.date_echeance} onChange={handleQuickChange} />
+          <input
+            className="input flex-1"
+            name="titre"
+            value={quick.titre}
+            onChange={handleQuickChange}
+            placeholder="Nouvelle tâche"
+            required
+          />
+          <input
+            type="date"
+            className="form-input"
+            name="date_echeance"
+            value={quick.date_echeance}
+            onChange={handleQuickChange}
+          />
           <Button type="submit">Ajouter</Button>
         </form>
       </GlassCard>
@@ -65,20 +78,44 @@ export default function Taches() {
             <option value="en_cours">En cours</option>
             <option value="terminee">Terminée</option>
           </select>
-        <select name="priorite" value={filters.priorite} onChange={handleChange} className="form-input">
+        <select
+          name="priorite"
+          value={filters.priorite}
+          onChange={handleChange}
+          className="form-input"
+        >
           <option value="">-- Priorité --</option>
           <option value="basse">Basse</option>
           <option value="moyenne">Moyenne</option>
           <option value="haute">Haute</option>
         </select>
-        <select name="assigne" value={filters.assigne} onChange={handleChange} className="form-input">
+        <select
+          name="assigne"
+          value={filters.assigne}
+          onChange={handleChange}
+          className="form-input"
+        >
           <option value="">-- Assigné --</option>
           {users.map(u => (
-            <option key={u.id} value={u.id}>{u.nom}</option>
+            <option key={u.id} value={u.id}>
+              {u.nom}
+            </option>
           ))}
         </select>
-        <input type="date" name="start" value={filters.start} onChange={handleChange} className="form-input" />
-        <input type="date" name="end" value={filters.end} onChange={handleChange} className="form-input" />
+        <input
+          type="date"
+          name="start"
+          value={filters.start}
+          onChange={handleChange}
+          className="form-input"
+        />
+        <input
+          type="date"
+          name="end"
+          value={filters.end}
+          onChange={handleChange}
+          className="form-input"
+        />
         <Button onClick={() => getTaches(filters)}>Filtrer</Button>
         </div>
       </GlassCard>
@@ -91,26 +128,35 @@ export default function Taches() {
               <tr>
                 <th className="px-2 py-1">Statut</th>
                 <th className="px-2 py-1">Titre</th>
-                <th className="px-2 py-1">Début</th>
+                <th className="px-2 py-1">Priorité</th>
                 <th className="px-2 py-1">Échéance</th>
                 <th className="px-2 py-1">Assignés</th>
-                <th className="px-2 py-1">Récurrence</th>
               </tr>
             </thead>
             <tbody>
               {taches.map(t => (
                 <tr key={t.id} className="border-t">
                   <td className="px-2 py-1">{t.statut}</td>
-                  <td className="px-2 py-1">{t.titre}</td>
-                  <td className="px-2 py-1">{t.date_debut}</td>
+                  <td className="px-2 py-1">
+                    <Link to={`/taches/${t.id}`} className="underline">
+                      {t.titre}
+                    </Link>
+                  </td>
+                  <td className="px-2 py-1">{t.priorite}</td>
                   <td className="px-2 py-1">{t.date_echeance}</td>
-                  <td className="px-2 py-1">{(t.assignes || []).length}</td>
-                  <td className="px-2 py-1">{t.recurrente ? t.frequence : ''}</td>
+                  <td className="px-2 py-1">
+                    {(t.utilisateurs_taches || [])
+                      .map(a => a.utilisateur?.nom)
+                      .filter(Boolean)
+                      .join(", ")}
+                  </td>
                 </tr>
               ))}
               {taches.length === 0 && !loading && (
                 <tr>
-                  <td colSpan="6" className="py-4 text-center text-gray-500">Aucune tâche</td>
+                  <td colSpan="5" className="py-4 text-center text-gray-500">
+                    Aucune tâche
+                  </td>
                 </tr>
               )}
             </tbody>

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -45,6 +45,7 @@ const StockTransferts = lazyWithPreload(() => import("@/pages/stock/Transferts.j
 const Alertes = lazyWithPreload(() => import("@/pages/Alertes.jsx"));
 const Taches = lazyWithPreload(() => import("@/pages/taches/Taches.jsx"));
 const TacheForm = lazyWithPreload(() => import("@/pages/taches/TacheForm.jsx"));
+const TacheDetail = lazyWithPreload(() => import("@/pages/taches/TacheDetail.jsx"));
 const AlertesTaches = lazyWithPreload(() => import("@/pages/taches/Alertes.jsx"));
 const Promotions = lazyWithPreload(() => import("@/pages/promotions/Promotions.jsx"));
 const Documents = lazyWithPreload(() => import("@/pages/documents/Documents.jsx"));
@@ -127,6 +128,8 @@ export const routePreloadMap = {
   '/planning': Planning.preload,
   '/planning/simulation': SimulationPlanner.preload,
   '/taches': Taches.preload,
+  '/taches/new': TacheForm.preload,
+  '/taches/:id': TacheDetail.preload,
   '/taches/alertes': AlertesTaches.preload,
   '/promotions': Promotions.preload,
   '/fiches': Fiches.preload,
@@ -351,6 +354,10 @@ export default function Router() {
           <Route
             path="/taches/new"
             element={<ProtectedRoute moduleKey="taches"><TacheForm /></ProtectedRoute>}
+          />
+          <Route
+            path="/taches/:id"
+            element={<ProtectedRoute moduleKey="taches"><TacheDetail /></ProtectedRoute>}
           />
           <Route
             path="/taches/alertes"


### PR DESCRIPTION
## Summary
- add SQL schema for tasks and assignment relations with RLS and view
- build React hooks and pages to manage tasks with multi-assignment and detail view
- wire routes and sidebar to expose tasks module

## Testing
- `npm test test/useTaches.test.js`
- `npx eslint src/pages/taches/Taches.jsx src/pages/taches/TacheForm.jsx src/pages/taches/TacheDetail.jsx src/hooks/useTaches.js src/hooks/useTacheAssignation.js`

------
https://chatgpt.com/codex/tasks/task_e_689330eeeaa8832d9dd0fc51472bc2c2