### PR TITLE
feat(stock): add mouvements module

### DIFF
--- a/src/hooks/useMouvements.js
+++ b/src/hooks/useMouvements.js
@@ -1,5 +1,5 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import { supabase } from "@/lib/supabase";
 import useAuth from "@/hooks/useAuth";
 import usePeriodes from "@/hooks/usePeriodes";
@@ -11,74 +11,71 @@ export function useMouvements() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
 
-  async function getMouvements({ type = "", produit = "", zone_source = "", zone_destination = "", debut = "", fin = "" } = {}) {
-    if (!mama_id) return [];
-    setLoading(true);
-    setError(null);
-    let query = supabase
-      .from("stock_mouvements")
-      .select("*", { count: "exact" })
-      .eq("mama_id", mama_id)
-      .order("date", { ascending: false });
+  const fetchMouvements = useCallback(
+    async (
+      { type = "", produit = "", zone = "", debut = "", fin = "" } = {}
+    ) => {
+      if (!mama_id) return [];
+      setLoading(true);
+      setError(null);
+      let query = supabase
+        .from("stock_mouvements")
+        .select(
+          "id, date, type, quantite, zone_id, motif, produits:produit_id(nom, unite)"
+        )
+        .eq("mama_id", mama_id)
+        .order("date", { ascending: false });
 
-    if (type) query = query.eq("type", type);
-    if (produit) query = query.eq("produit_id", produit);
-    if (debut) query = query.gte("date", debut);
-    if (fin) query = query.lte("date", fin);
-    if (zone_source) query = query.eq("zone_source_id", zone_source);
-    if (zone_destination) query = query.eq("zone_destination_id", zone_destination);
+      if (type) query = query.eq("type", type);
+      if (produit) query = query.eq("produit_id", produit);
+      if (zone) query = query.eq("zone_id", zone);
+      if (debut) query = query.gte("date", debut);
+      if (fin) query = query.lte("date", fin);
 
-    const { data, error } = await query;
-    if (!error) setMouvements(data || []);
-    setLoading(false);
-    if (error) setError(error);
-    return data || [];
-  }
+      const { data, error } = await query;
+      if (!error) setMouvements(data || []);
+      setLoading(false);
+      if (error) setError(error);
+      return data || [];
+    },
+    [mama_id]
+  );
 
-  async function createMouvement(payload) {
-    if (!mama_id) return { error: "no mama_id" };
-    const { error: pErr } = await checkCurrentPeriode(payload.date);
-    if (pErr) return { error: pErr };
-    setLoading(true);
-    setError(null);
-    const toInsert = { ...payload, mama_id, auteur_id: user_id };
-    if (payload.motif) {
-      toInsert.commentaire = payload.motif;
-      delete toInsert.motif;
-    }
-    const { data, error } = await supabase
-      .from("stock_mouvements")
-      .insert([toInsert])
-      .select()
-      .single();
-    setLoading(false);
-    if (error) {
-      setError(error);
-      return { error };
-    }
-    setMouvements(m => [data, ...m]);
-    return { data };
-  }
+  const createMouvement = useCallback(
+    async payload => {
+      if (!mama_id) return { error: "no mama_id" };
+      const date = payload.date || new Date().toISOString();
+      const { error: pErr } = await checkCurrentPeriode(date);
+      if (pErr) return { error: pErr };
+      setLoading(true);
+      setError(null);
+      const toInsert = {
+        ...payload,
+        date,
+        mama_id,
+        auteur_id: user_id,
+      };
+      if (payload.motif) {
+        toInsert.commentaire = payload.motif;
+        delete toInsert.motif;
+      }
+      const { data, error } = await supabase
+        .from("stock_mouvements")
+        .insert([toInsert])
+        .select()
+        .single();
+      setLoading(false);
+      if (error) {
+        setError(error);
+        return { error };
+      }
+      setMouvements(m => [data, ...m]);
+      return { data };
+    },
+    [mama_id, user_id, checkCurrentPeriode]
+  );
 
-  async function deleteMouvement(id) {
-    if (!id || !mama_id) return { error: "no id" };
-    setLoading(true);
-    setError(null);
-    const { error } = await supabase
-      .from("stock_mouvements")
-      .delete()
-      .eq("id", id)
-      .eq("mama_id", mama_id);
-    setLoading(false);
-    if (error) {
-      setError(error);
-      return { error };
-    }
-    setMouvements(m => m.filter(row => row.id !== id));
-    return { data: true };
-  }
-
-  return { mouvements, loading, error, getMouvements, createMouvement, deleteMouvement };
+  return { mouvements, loading, error, fetchMouvements, createMouvement };
 }
 
 export default useMouvements;

--- a/src/pages/stock/MouvementForm.jsx
+++ b/src/pages/stock/MouvementForm.jsx
@@ -1,16 +1,33 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { useState } from "react";
-import { useStock } from "@/hooks/useStock";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
-import toast from "react-hot-toast";
 import GlassCard from "@/components/ui/GlassCard";
+import { useMouvements } from "@/hooks/useMouvements";
+import { useProducts } from "@/hooks/useProducts";
+import { useZones } from "@/hooks/useZones";
+import toast from "react-hot-toast";
 
 export default function MouvementForm({ onClose }) {
-  const { createMouvement } = useStock();
-  const [form, setForm] = useState({ produit_id: "", quantite: 0, type: "entree", commentaire: "" });
+  const { createMouvement } = useMouvements();
+  const { products, fetchProducts } = useProducts();
+  const { zones, fetchZones } = useZones();
+  const [form, setForm] = useState({
+    produit_id: "",
+    type: "entree_manuelle",
+    quantite: 0,
+    zone_id: "",
+    motif: "",
+  });
   const [loading, setLoading] = useState(false);
 
-  const handleSubmit = async (e) => {
+  useEffect(() => {
+    fetchProducts({ limit: 1000 });
+    fetchZones();
+  }, [fetchProducts, fetchZones]);
+
+  const handleChange = (field, value) => setForm(f => ({ ...f, [field]: value }));
+
+  const handleSubmit = async e => {
     e.preventDefault();
     if (loading) return;
     if (!form.produit_id || !form.quantite) {
@@ -32,42 +49,78 @@ export default function MouvementForm({ onClose }) {
 
   return (
     <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center">
-      <GlassCard title="Nouveau mouvement" className="w-80">
-        <form onSubmit={handleSubmit} className="space-y-2">
-        <input
-          className="input mb-2 w-full"
-          placeholder="Produit ID"
-          value={form.produit_id}
-          onChange={(e) => setForm({ ...form, produit_id: e.target.value })}
-        />
-        <input
-          className="input mb-2 w-full"
-          type="number"
-          step="0.01"
-          placeholder="Quantité"
-          value={form.quantite}
-          onChange={(e) => setForm({ ...form, quantite: parseFloat(e.target.value) })}
-        />
-        <select
-          className="input mb-2 w-full"
-          value={form.type}
-          onChange={(e) => setForm({ ...form, type: e.target.value })}
-        >
-          <option value="entree">Entrée</option>
-          <option value="sortie">Sortie</option>
-          <option value="transfert">Transfert</option>
-        </select>
-        <textarea
-          className="input mb-2 w-full"
-          rows={2}
-          placeholder="Commentaire"
-          value={form.commentaire}
-          onChange={(e) => setForm({ ...form, commentaire: e.target.value })}
-        />
-        <div className="flex gap-2 justify-end mt-4">
-          <Button type="submit" disabled={loading}>Valider</Button>
-          <Button type="button" variant="outline" onClick={onClose} disabled={loading}>Annuler</Button>
-        </div>
+      <GlassCard title="Nouveau mouvement" className="w-96">
+        <form onSubmit={handleSubmit} className="space-y-2" aria-label="mouvement-form">
+          <label className="block text-sm font-medium">
+            Produit
+            <select
+              aria-label="Produit"
+              className="input w-full"
+              value={form.produit_id}
+              onChange={e => handleChange("produit_id", e.target.value)}
+            >
+              <option value="">Sélectionner</option>
+              {products.map(p => (
+                <option key={p.id} value={p.id}>{p.nom}</option>
+              ))}
+            </select>
+          </label>
+          <label className="block text-sm font-medium">
+            Type
+            <select
+              aria-label="Type"
+              className="input w-full"
+              value={form.type}
+              onChange={e => handleChange("type", e.target.value)}
+            >
+              <option value="entree_manuelle">Entrée manuelle</option>
+              <option value="sortie_manuelle">Sortie manuelle</option>
+              <option value="ajustement">Ajustement</option>
+            </select>
+          </label>
+          <label className="block text-sm font-medium">
+            Quantité
+            <input
+              aria-label="Quantité"
+              type="number"
+              step="0.01"
+              className="input w-full"
+              value={form.quantite}
+              onChange={e => handleChange("quantite", parseFloat(e.target.value))}
+            />
+          </label>
+          {zones.length > 0 && (
+            <label className="block text-sm font-medium">
+              Zone
+              <select
+                aria-label="Zone"
+                className="input w-full"
+                value={form.zone_id}
+                onChange={e => handleChange("zone_id", e.target.value)}
+              >
+                <option value="">Aucune</option>
+                {zones.map(z => (
+                  <option key={z.id} value={z.id}>{z.nom}</option>
+                ))}
+              </select>
+            </label>
+          )}
+          <label className="block text-sm font-medium">
+            Motif
+            <textarea
+              aria-label="Motif"
+              className="input w-full"
+              rows={2}
+              value={form.motif}
+              onChange={e => handleChange("motif", e.target.value)}
+            />
+          </label>
+          <div className="flex gap-2 justify-end pt-2">
+            <Button type="submit" disabled={loading}>Valider</Button>
+            <Button type="button" variant="outline" onClick={onClose} disabled={loading}>
+              Annuler
+            </Button>
+          </div>
         </form>
       </GlassCard>
     </div>

--- a/src/pages/stock/Mouvements.jsx
+++ b/src/pages/stock/Mouvements.jsx
@@ -1,49 +1,123 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState } from "react";
-import { useStock } from "@/hooks/useStock";
 import { Button } from "@/components/ui/button";
-import ListingContainer from "@/components/ui/ListingContainer";
-import TableHeader from "@/components/ui/TableHeader";
+import TableContainer from "@/components/ui/TableContainer";
+import { useProducts } from "@/hooks/useProducts";
+import { useZones } from "@/hooks/useZones";
+import { useMouvements } from "@/hooks/useMouvements";
 import MouvementForm from "./MouvementForm";
 
-export default function MouvementsPage() {
-  const { fetchMouvements, mouvements } = useStock();
+export default function Mouvements() {
+  const { products, fetchProducts } = useProducts();
+  const { zones, fetchZones } = useZones();
+  const { mouvements, fetchMouvements } = useMouvements();
+  const [filters, setFilters] = useState({
+    type: "",
+    produit: "",
+    zone: "",
+    debut: "",
+    fin: "",
+  });
   const [showForm, setShowForm] = useState(false);
 
   useEffect(() => {
-    fetchMouvements();
-  }, [fetchMouvements]);
+    fetchProducts({ limit: 1000 });
+    fetchZones();
+  }, [fetchProducts, fetchZones]);
+
+  useEffect(() => {
+    fetchMouvements(filters);
+  }, [filters, fetchMouvements]);
+
+  const zoneName = id => zones.find(z => z.id === id)?.nom || "";
 
   return (
-    <div className="p-6 max-w-5xl mx-auto">
-      <h1 className="text-xl font-bold mb-4">Mouvements de stock</h1>
-      <TableHeader className="justify-end mb-2">
-        <Button onClick={() => setShowForm(true)}>Nouveau mouvement</Button>
-      </TableHeader>
-      <ListingContainer>
-        <table className="text-sm">
+    <div className="p-6 max-w-6xl mx-auto text-shadow">
+      <h1 className="text-2xl font-bold mb-4">Mouvements de stock</h1>
+      <div className="flex flex-wrap gap-4 mb-4 items-end">
+        <select
+          aria-label="Type"
+          className="form-input"
+          value={filters.type}
+          onChange={e => setFilters(f => ({ ...f, type: e.target.value }))}
+        >
+          <option value="">Tous types</option>
+          <option value="entree_manuelle">Entrée manuelle</option>
+          <option value="sortie_manuelle">Sortie manuelle</option>
+          <option value="ajustement">Ajustement</option>
+        </select>
+        <select
+          aria-label="Produit"
+          className="form-input"
+          value={filters.produit}
+          onChange={e => setFilters(f => ({ ...f, produit: e.target.value }))}
+        >
+          <option value="">Tous produits</option>
+          {products.map(p => (
+            <option key={p.id} value={p.id}>{p.nom}</option>
+          ))}
+        </select>
+        <select
+          aria-label="Zone"
+          className="form-input"
+          value={filters.zone}
+          onChange={e => setFilters(f => ({ ...f, zone: e.target.value }))}
+        >
+          <option value="">Toutes zones</option>
+          {zones.map(z => (
+            <option key={z.id} value={z.id}>{z.nom}</option>
+          ))}
+        </select>
+        <input
+          type="date"
+          aria-label="Début"
+          className="form-input"
+          value={filters.debut}
+          onChange={e => setFilters(f => ({ ...f, debut: e.target.value }))}
+        />
+        <input
+          type="date"
+          aria-label="Fin"
+          className="form-input"
+          value={filters.fin}
+          onChange={e => setFilters(f => ({ ...f, fin: e.target.value }))}
+        />
+        <Button onClick={() => setShowForm(true)}>Ajouter un mouvement</Button>
+      </div>
+      <TableContainer>
+        <table className="min-w-full text-sm text-center">
           <thead>
             <tr>
               <th className="p-2">Date</th>
+              <th className="p-2">Type</th>
               <th className="p-2">Produit</th>
               <th className="p-2">Quantité</th>
-              <th className="p-2">Type</th>
-              <th className="p-2">Utilisateur</th>
+              <th className="p-2">Unité</th>
+              <th className="p-2">Zone</th>
+              <th className="p-2">Origine</th>
             </tr>
           </thead>
           <tbody>
-            {mouvements.map((m) => (
+            {mouvements.map(m => (
               <tr key={m.id}>
-                <td className="p-2">{m.date}</td>
-                <td className="p-2">{m.produit_id}</td>
-                <td className="p-2 text-right">{m.quantite}</td>
+                <td className="p-2">{m.date?.slice(0, 10)}</td>
                 <td className="p-2">{m.type}</td>
-                <td className="p-2">{m.auteur_id || "-"}</td>
+                <td className="p-2">{m.produits?.nom || ""}</td>
+                <td className="p-2">{m.quantite}</td>
+                <td className="p-2">{m.produits?.unite || ""}</td>
+                <td className="p-2">{zoneName(m.zone_id)}</td>
+                <td className="p-2">
+                  {m.inventaire_id
+                    ? "inventaire"
+                    : m.transfert_id
+                    ? "transfert"
+                    : "manuel"}
+                </td>
               </tr>
             ))}
           </tbody>
         </table>
-      </ListingContainer>
+      </TableContainer>
       {showForm && <MouvementForm onClose={() => setShowForm(false)} />}
     </div>
   );

--- a/test/Mouvements.test.jsx
+++ b/test/Mouvements.test.jsx
@@ -1,0 +1,53 @@
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import React from 'react';
+import { vi } from 'vitest';
+
+let mockHook;
+vi.mock('@/hooks/useMouvements', () => ({
+  useMouvements: () => mockHook(),
+}));
+vi.mock('@/hooks/useProducts', () => ({
+  useProducts: () => ({ products: [{ id: 'p1', nom: 'Produit 1', unite: 'kg' }], fetchProducts: vi.fn() }),
+}));
+vi.mock('@/hooks/useZones', () => ({
+  useZones: () => ({ zones: [{ id: 'z1', nom: 'Zone 1' }], fetchZones: vi.fn() }),
+}));
+vi.mock('react-hot-toast', () => ({
+  __esModule: true,
+  default: { error: vi.fn(), success: vi.fn() },
+}));
+
+import Mouvements from '@/pages/stock/Mouvements.jsx';
+
+const mouvementsData = [
+  {
+    id: '1',
+    date: '2025-01-01',
+    type: 'entree_manuelle',
+    quantite: 5,
+    zone_id: 'z1',
+    produits: { nom: 'Produit 1', unite: 'kg' },
+  },
+];
+
+function setup() {
+  const fetch = vi.fn();
+  const create = vi.fn(() => Promise.resolve({}));
+  mockHook = () => ({ mouvements: mouvementsData, fetchMouvements: fetch, createMouvement: create });
+  render(<Mouvements />);
+  return { fetch, create };
+}
+
+test('renders mouvements table and submits form', async () => {
+  const { fetch, create } = setup();
+  await waitFor(() => expect(fetch).toHaveBeenCalled());
+  expect(screen.getByText('Produit 1', { selector: 'td' })).toBeInTheDocument();
+  fireEvent.click(screen.getByRole('button', { name: /ajouter un mouvement/i }));
+  const form = await waitFor(() => screen.getByLabelText('mouvement-form'));
+  fireEvent.change(within(form).getByLabelText('Produit'), { target: { value: 'p1' } });
+  fireEvent.change(within(form).getByLabelText('Type'), { target: { value: 'entree_manuelle' } });
+  fireEvent.change(within(form).getByLabelText('Quantité'), { target: { value: '3' } });
+  fireEvent.change(within(form).getByLabelText('Zone'), { target: { value: 'z1' } });
+  fireEvent.click(within(form).getByRole('button', { name: /valider/i }));
+  await waitFor(() => expect(create).toHaveBeenCalled());
+});


### PR DESCRIPTION
## Summary
- build `useMouvements` hook to fetch & create stock movements with product join
- add stock movements page with filters and listing
- add manual movement form and related tests

## Testing
- `npm test test/useMouvements.test.js test/Mouvements.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_689451e9fa4c832d952aea9b61358197