### PR TITLE
feat(stock): add transferts module

### DIFF
--- a/src/pages/stock/TransfertForm.jsx
+++ b/src/pages/stock/TransfertForm.jsx
@@ -3,7 +3,6 @@ import { useState, useEffect } from "react";
 import { useTransferts } from "@/hooks/useTransferts";
 import { useProducts } from "@/hooks/useProducts";
 import { useZones } from "@/hooks/useZones";
-import { supabase } from "@/lib/supabase";
 import { Button } from "@/components/ui/button";
 import GlassCard from "@/components/ui/GlassCard";
 import toast from "react-hot-toast";
@@ -13,14 +12,12 @@ export default function TransfertForm({ onClose, onSaved }) {
   const { products, fetchProducts } = useProducts();
   const { zones, fetchZones } = useZones();
 
-  const [formHead, setFormHead] = useState({
+  const [header, setHeader] = useState({
     zone_source_id: "",
-    zone_dest_id: "",
-    commentaire: "",
+    zone_destination_id: "",
+    motif: "",
   });
-  const [lignes, setLignes] = useState([
-    { produit_id: "", quantite: 0, commentaire: "", stock_avant: 0, stock_apres: 0 },
-  ]);
+  const [lignes, setLignes] = useState([{ produit_id: "", quantite: "" }]);
   const [saving, setSaving] = useState(false);
 
   useEffect(() => {
@@ -29,69 +26,38 @@ export default function TransfertForm({ onClose, onSaved }) {
   }, [fetchProducts, fetchZones]);
 
   const handleAddLine = () => {
-    setLignes(l => [
-      ...l,
-      { produit_id: "", quantite: 0, commentaire: "", stock_avant: 0, stock_apres: 0 },
-    ]);
+    setLignes((l) => [...l, { produit_id: "", quantite: "" }]);
   };
 
-  const fetchStock = async produitId => {
-    if (!formHead.zone_source_id || !produitId) return 0;
-    const { data, error } = await supabase
-      .from("stocks")
-      .select("quantite")
-      .eq("zone_id", formHead.zone_source_id)
-      .eq("produit_id", produitId)
-      .maybeSingle();
-    if (error) return 0;
-    return Number(data?.quantite || 0);
+  const handleLineChange = (idx, field, value) => {
+    const next = [...lignes];
+    next[idx][field] = value;
+    setLignes(next);
   };
 
-  const handleLineChange = async (index, field, value) => {
-    const updated = [...lignes];
-    updated[index][field] = value;
-    if (field === "produit_id") {
-      const stock = await fetchStock(value);
-      updated[index].stock_avant = stock;
-      updated[index].stock_apres = stock - Number(updated[index].quantite || 0);
-    }
-    if (field === "quantite") {
-      updated[index].stock_apres =
-        (Number(updated[index].stock_avant) || 0) - Number(value || 0);
-    }
-    setLignes(updated);
-  };
-
-  const handleSubmit = async e => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
     if (saving) return;
-    if (!formHead.zone_source_id || !formHead.zone_dest_id) {
+    if (!header.zone_source_id || !header.zone_destination_id) {
       toast.error("Zones requises");
       return;
     }
-    if (formHead.zone_source_id === formHead.zone_dest_id) {
+    if (header.zone_source_id === header.zone_destination_id) {
       toast.error("Zones différentes requises");
       return;
     }
-    if (lignes.some(l => !l.produit_id || !l.quantite)) {
+    if (lignes.some((l) => !l.produit_id || Number(l.quantite) <= 0)) {
       toast.error("Produits et quantités obligatoires");
       return;
     }
     setSaving(true);
-    const payloadLines = lignes.map(l => ({
-      produit_id: l.produit_id,
-      quantite: Number(l.quantite),
-      commentaire: l.commentaire,
-    }));
-    const { error } = await createTransfert(formHead, payloadLines);
+    const { error } = await createTransfert(header, lignes);
     setSaving(false);
     if (error) {
       toast.error(error.message);
       return;
     }
     toast.success("Transfert enregistré");
-    setFormHead({ zone_source_id: "", zone_dest_id: "", commentaire: "" });
-    setLignes([{ produit_id: "", quantite: 0, commentaire: "", stock_avant: 0, stock_apres: 0 }]);
     onSaved?.();
     onClose?.();
   };
@@ -99,41 +65,48 @@ export default function TransfertForm({ onClose, onSaved }) {
   return (
     <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-[60]">
       <GlassCard title="Nouveau transfert" className="w-[42rem]">
-        <form onSubmit={handleSubmit} className="space-y-2">
+        <form onSubmit={handleSubmit} className="space-y-4">
           <div className="flex gap-2">
             <select
               className="input flex-1"
-              value={formHead.zone_source_id}
-              onChange={e => setFormHead(f => ({ ...f, zone_source_id: e.target.value }))}
+              value={header.zone_source_id}
+              onChange={(e) =>
+                setHeader((h) => ({ ...h, zone_source_id: e.target.value }))
+              }
             >
               <option value="">Zone source</option>
-              {zones.map(z => (
-                <option key={z.id} value={z.id}>{z.nom}</option>
+              {zones.map((z) => (
+                <option key={z.id} value={z.id}>
+                  {z.nom}
+                </option>
               ))}
             </select>
             <select
               className="input flex-1"
-              value={formHead.zone_dest_id}
-              onChange={e => setFormHead(f => ({ ...f, zone_dest_id: e.target.value }))}
+              value={header.zone_destination_id}
+              onChange={(e) =>
+                setHeader((h) => ({ ...h, zone_destination_id: e.target.value }))
+              }
             >
               <option value="">Zone destination</option>
-              {zones.map(z => (
-                <option key={z.id} value={z.id}>{z.nom}</option>
+              {zones.map((z) => (
+                <option key={z.id} value={z.id}>
+                  {z.nom}
+                </option>
               ))}
             </select>
           </div>
           <textarea
             className="textarea w-full"
-            placeholder="Commentaire"
-            value={formHead.commentaire}
-            onChange={e => setFormHead(f => ({ ...f, commentaire: e.target.value }))}
+            placeholder="Motif"
+            value={header.motif}
+            onChange={(e) => setHeader((h) => ({ ...h, motif: e.target.value }))}
           />
           <table className="w-full text-sm">
             <thead>
               <tr>
                 <th>Produit</th>
                 <th>Qté</th>
-                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -143,11 +116,15 @@ export default function TransfertForm({ onClose, onSaved }) {
                     <select
                       className="input"
                       value={l.produit_id}
-                      onChange={e => handleLineChange(idx, "produit_id", e.target.value)}
+                      onChange={(e) =>
+                        handleLineChange(idx, "produit_id", e.target.value)
+                      }
                     >
                       <option value="">Produit</option>
-                      {products.map(p => (
-                        <option key={p.id} value={p.id}>{p.nom}</option>
+                      {products.map((p) => (
+                        <option key={p.id} value={p.id}>
+                          {p.nom}
+                        </option>
                       ))}
                     </select>
                   </td>
@@ -156,16 +133,9 @@ export default function TransfertForm({ onClose, onSaved }) {
                       type="number"
                       className="input w-24"
                       value={l.quantite}
-                      onChange={e => handleLineChange(idx, "quantite", e.target.value)}
-                    />
-                  </td>
-                  <td>
-                    <input
-                      type="text"
-                      className="input"
-                      placeholder="Commentaire"
-                      value={l.commentaire}
-                      onChange={e => handleLineChange(idx, "commentaire", e.target.value)}
+                      onChange={(e) =>
+                        handleLineChange(idx, "quantite", e.target.value)
+                      }
                     />
                   </td>
                 </tr>
@@ -175,12 +145,22 @@ export default function TransfertForm({ onClose, onSaved }) {
           <Button type="button" onClick={handleAddLine} className="mt-2">
             Ajouter une ligne
           </Button>
-          <div className="flex justify-end gap-2 mt-4">
-            <Button type="submit" disabled={saving}>Valider</Button>
-            <Button type="button" variant="outline" onClick={onClose} disabled={saving}>Annuler</Button>
+          <div className="flex justify-end gap-2">
+            <Button type="submit" disabled={saving}>
+              Valider
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onClose}
+              disabled={saving}
+            >
+              Annuler
+            </Button>
           </div>
         </form>
       </GlassCard>
     </div>
   );
 }
+

--- a/src/pages/stock/Transferts.jsx
+++ b/src/pages/stock/Transferts.jsx
@@ -2,84 +2,135 @@
 import { useState, useEffect } from "react";
 import useAuth from "@/hooks/useAuth";
 import { useTransferts } from "@/hooks/useTransferts";
+import { useZones } from "@/hooks/useZones";
+import { useProducts } from "@/hooks/useProducts";
 import { Button } from "@/components/ui/button";
-import ListingContainer from "@/components/ui/ListingContainer";
-import TableHeader from "@/components/ui/TableHeader";
+import TableContainer from "@/components/ui/TableContainer";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 import TransfertForm from "./TransfertForm";
 
 export default function Transferts() {
   const { isAuthenticated, loading: authLoading } = useAuth();
   const { transferts, fetchTransferts } = useTransferts();
-  const [periode, setPeriode] = useState({ debut: "", fin: "" });
+  const { zones, fetchZones } = useZones();
+  const { products, fetchProducts } = useProducts();
+  const [filters, setFilters] = useState({
+    debut: "",
+    fin: "",
+    zone_source_id: "",
+    zone_destination_id: "",
+    produit_id: "",
+  });
   const [showForm, setShowForm] = useState(false);
 
   useEffect(() => {
-    if (periode.debut && periode.fin)
-      fetchTransferts({ debut: periode.debut, fin: periode.fin });
-  }, [periode, fetchTransferts]);
+    fetchZones();
+    fetchProducts({});
+  }, [fetchZones, fetchProducts]);
+
+  useEffect(() => {
+    fetchTransferts(filters);
+  }, [filters, fetchTransferts]);
 
   if (authLoading) return <LoadingSpinner message="Chargement..." />;
   if (!isAuthenticated) return null;
 
   return (
-    <div className="p-6 space-y-4">
-      <TableHeader className="items-end gap-4">
-        <div>
-          <label>Début</label>
-          <input
-            type="date"
-            className="form-input"
-            value={periode.debut}
-            onChange={(e) =>
-              setPeriode((p) => ({ ...p, debut: e.target.value }))
-            }
-          />
-        </div>
-        <div>
-          <label>Fin</label>
-          <input
-            type="date"
-            className="form-input"
-            value={periode.fin}
-            onChange={(e) => setPeriode((p) => ({ ...p, fin: e.target.value }))}
-          />
-        </div>
+    <div className="p-6 max-w-6xl mx-auto text-shadow">
+      <h1 className="text-2xl font-bold mb-4">Transferts</h1>
+      <div className="flex flex-wrap gap-4 mb-4 items-end">
+        <input
+          type="date"
+          aria-label="Début"
+          className="form-input"
+          value={filters.debut}
+          onChange={(e) => setFilters((f) => ({ ...f, debut: e.target.value }))}
+        />
+        <input
+          type="date"
+          aria-label="Fin"
+          className="form-input"
+          value={filters.fin}
+          onChange={(e) => setFilters((f) => ({ ...f, fin: e.target.value }))}
+        />
+        <select
+          aria-label="Zone source"
+          className="form-input"
+          value={filters.zone_source_id}
+          onChange={(e) =>
+            setFilters((f) => ({ ...f, zone_source_id: e.target.value }))
+          }
+        >
+          <option value="">Zone source</option>
+          {zones.map((z) => (
+            <option key={z.id} value={z.id}>
+              {z.nom}
+            </option>
+          ))}
+        </select>
+        <select
+          aria-label="Zone destination"
+          className="form-input"
+          value={filters.zone_destination_id}
+          onChange={(e) =>
+            setFilters((f) => ({ ...f, zone_destination_id: e.target.value }))
+          }
+        >
+          <option value="">Zone destination</option>
+          {zones.map((z) => (
+            <option key={z.id} value={z.id}>
+              {z.nom}
+            </option>
+          ))}
+        </select>
+        <select
+          aria-label="Produit"
+          className="form-input"
+          value={filters.produit_id}
+          onChange={(e) =>
+            setFilters((f) => ({ ...f, produit_id: e.target.value }))
+          }
+        >
+          <option value="">Produit</option>
+          {products.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.nom}
+            </option>
+          ))}
+        </select>
         <Button onClick={() => setShowForm(true)}>Nouveau transfert</Button>
-      </TableHeader>
-      <ListingContainer>
-        <table className="text-sm">
+      </div>
+      <TableContainer>
+        <table className="min-w-full text-sm text-center">
           <thead>
             <tr>
-              <th>Date</th>
-              <th>Produit</th>
-              <th>Zone source</th>
-              <th>Zone destination</th>
-              <th className="text-right">Quantité</th>
+              <th className="p-2">Date</th>
+              <th className="p-2">Zone source</th>
+              <th className="p-2">Zone destination</th>
+              <th className="p-2">Nb produits</th>
+              <th className="p-2">Statut</th>
             </tr>
           </thead>
           <tbody>
             {transferts.map((t) => (
-              <tr key={t.transfert_id}>
-                <td>{t.date_transfert}</td>
-                <td>{t.produit || ""}</td>
-                <td>{t.zone_source || ""}</td>
-                <td>{t.zone_dest || ""}</td>
-                <td className="text-right">{t.quantite}</td>
+              <tr key={t.id}>
+                <td className="p-2">{t.date_transfert?.slice(0, 10)}</td>
+                <td className="p-2">{t.zone_source?.nom || ""}</td>
+                <td className="p-2">{t.zone_destination?.nom || ""}</td>
+                <td className="p-2">{t.lignes?.length || 0}</td>
+                <td className="p-2">{t.statut || "enregistré"}</td>
               </tr>
             ))}
           </tbody>
         </table>
-      </ListingContainer>
+      </TableContainer>
       {showForm && (
         <TransfertForm
           onClose={() => setShowForm(false)}
-          onSaved={() => {
-            if (periode.debut && periode.fin)
-              fetchTransferts({ debut: periode.debut, fin: periode.fin });
-          }}
+          onSaved={() => fetchTransferts(filters)}
         />
       )}
     </div>
   );
 }
+

--- a/test/Transferts.test.jsx
+++ b/test/Transferts.test.jsx
@@ -1,0 +1,75 @@
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { vi } from 'vitest';
+
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ isAuthenticated: true, loading: false }) }));
+
+let mockTransferts;
+let mockProducts;
+let mockZones;
+
+vi.mock('@/hooks/useTransferts', () => ({ useTransferts: () => mockTransferts() }));
+vi.mock('@/hooks/useProducts', () => ({ useProducts: () => mockProducts() }));
+vi.mock('@/hooks/useZones', () => ({ useZones: () => mockZones() }));
+vi.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          maybeSingle: vi.fn(() => Promise.resolve({ data: null, error: null }))
+        }))
+      }))
+    }))
+  }
+}));
+
+import Transferts from '@/pages/stock/Transferts.jsx';
+
+beforeAll(() => {
+  window.matchMedia = window.matchMedia || function () {
+    return { matches: false, addListener: () => {}, removeListener: () => {} };
+  };
+});
+
+test('renders transferts and submits form', async () => {
+  const createTransfert = vi.fn(() => Promise.resolve({}));
+  mockTransferts = () => ({
+    transferts: [
+      {
+        id: 't1',
+        date_transfert: '2025-01-01',
+        zone_source: { nom: 'A' },
+        zone_destination: { nom: 'B' },
+        lignes: [{ produit_id: 'p1' }],
+      },
+    ],
+    fetchTransferts: vi.fn(),
+    createTransfert,
+  });
+  mockProducts = () => ({ products: [{ id: 'p1', nom: 'Prod1' }], fetchProducts: vi.fn() });
+  mockZones = () => ({ zones: [{ id: 'A', nom: 'A' }, { id: 'B', nom: 'B' }], fetchZones: vi.fn() });
+
+  await act(async () => {
+    render(<Transferts />);
+  });
+
+  expect(screen.getByText('2025-01-01')).toBeInTheDocument();
+
+  await act(async () => {
+    fireEvent.click(screen.getByText('Nouveau transfert'));
+  });
+
+  const allSelects = screen.getAllByRole('combobox');
+  const selects = allSelects.slice(-3);
+  await act(async () => {
+    fireEvent.change(selects[0], { target: { value: 'A' } });
+    fireEvent.change(selects[1], { target: { value: 'B' } });
+    fireEvent.change(selects[2], { target: { value: 'p1' } });
+  });
+  const qty = screen.getByRole('spinbutton');
+  await act(async () => {
+    fireEvent.change(qty, { target: { value: '2' } });
+    fireEvent.click(screen.getByText('Valider'));
+  });
+  expect(createTransfert).toHaveBeenCalled();
+});
+

--- a/test/useTransferts.test.js
+++ b/test/useTransferts.test.js
@@ -1,0 +1,119 @@
+import { renderHook, act } from '@testing-library/react';
+import { vi, beforeEach, test, expect } from 'vitest';
+
+const baseQuery = {
+  select: vi.fn(() => baseQuery),
+  eq: vi.fn(() => baseQuery),
+  gte: vi.fn(() => baseQuery),
+  lte: vi.fn(() => baseQuery),
+  order: vi.fn(() => baseQuery),
+  single: vi.fn(() => ({ data: {}, error: null })),
+};
+
+const queryTransferts = {
+  ...baseQuery,
+  insert: vi.fn(() => ({
+    select: vi.fn(() => ({
+      single: vi.fn(() => ({ data: { id: 't1' }, error: null })),
+    })),
+  })),
+};
+
+const queryLignes = {
+  ...baseQuery,
+  insert: vi.fn(() => ({ data: [], error: null })),
+};
+
+const queryMouvements = {
+  ...baseQuery,
+  insert: vi.fn(() => ({ data: [], error: null })),
+};
+
+const fromMock = vi.fn((table) => {
+  if (table === 'transferts') return queryTransferts;
+  if (table === 'transfert_lignes') return queryLignes;
+  if (table === 'stock_mouvements') return queryMouvements;
+  return baseQuery;
+});
+
+vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1', user_id: 'u1' }) }));
+vi.mock('@/hooks/usePeriodes', () => ({ default: () => ({ checkCurrentPeriode: vi.fn(() => ({})) }) }));
+
+let useTransferts;
+
+beforeEach(async () => {
+  ({ useTransferts } = await import('@/hooks/useTransferts'));
+  fromMock.mockClear();
+  [queryTransferts, queryLignes, queryMouvements, baseQuery].forEach((q) => {
+    Object.values(q).forEach((fn) => fn.mockClear && fn.mockClear());
+  });
+});
+
+test('fetchTransferts applies filters', async () => {
+  const { result } = renderHook(() => useTransferts());
+  await act(async () => {
+    await result.current.fetchTransferts({
+      debut: '2025-01-01',
+      fin: '2025-01-31',
+      zone_source_id: 'zs',
+      zone_destination_id: 'zd',
+      produit_id: 'p1',
+    });
+  });
+  expect(fromMock).toHaveBeenCalledWith('transferts');
+  expect(queryTransferts.eq).toHaveBeenCalledWith('mama_id', 'm1');
+  expect(queryTransferts.eq).toHaveBeenCalledWith('zone_source_id', 'zs');
+  expect(queryTransferts.eq).toHaveBeenCalledWith('zone_dest_id', 'zd');
+  expect(queryTransferts.eq).toHaveBeenCalledWith('transfert_lignes.produit_id', 'p1');
+  expect(queryTransferts.gte).toHaveBeenCalledWith('date_transfert', '2025-01-01');
+  expect(queryTransferts.lte).toHaveBeenCalledWith('date_transfert', '2025-01-31');
+});
+
+test('createTransfert inserts header, lines and mouvements', async () => {
+  const { result } = renderHook(() => useTransferts());
+  await act(async () => {
+    await result.current.createTransfert(
+      { zone_source_id: 'zs', zone_destination_id: 'zd', motif: 'test' },
+      [{ produit_id: 'p1', quantite: 2 }]
+    );
+  });
+  expect(fromMock).toHaveBeenNthCalledWith(1, 'transferts');
+  expect(fromMock).toHaveBeenNthCalledWith(2, 'transfert_lignes');
+  expect(fromMock).toHaveBeenNthCalledWith(3, 'stock_mouvements');
+  const insertedHeader = queryTransferts.insert.mock.calls[0][0][0];
+  expect(insertedHeader).toMatchObject({
+    mama_id: 'm1',
+    zone_source_id: 'zs',
+    zone_dest_id: 'zd',
+    motif: 'test',
+    utilisateur_id: 'u1',
+  });
+  const insertedLine = queryLignes.insert.mock.calls[0][0][0];
+  expect(insertedLine).toMatchObject({
+    mama_id: 'm1',
+    produit_id: 'p1',
+    quantite: 2,
+    transfert_id: 't1',
+  });
+  const mouvements = queryMouvements.insert.mock.calls[0][0];
+  expect(mouvements).toHaveLength(2);
+  expect(mouvements[0]).toMatchObject({
+    type: 'sortie_transfert',
+    zone_id: 'zs',
+  });
+  expect(mouvements[1]).toMatchObject({
+    type: 'entree_transfert',
+    zone_id: 'zd',
+  });
+});
+
+test('getTransfertById fetches detail', async () => {
+  const { result } = renderHook(() => useTransferts());
+  await act(async () => {
+    await result.current.getTransfertById('t1');
+  });
+  expect(fromMock).toHaveBeenCalledWith('transferts');
+  expect(queryTransferts.eq).toHaveBeenCalledWith('id', 't1');
+});
+


### PR DESCRIPTION
## Summary
- implement `useTransferts` hook with full CRUD and stock movement logging
- add `Transferts` listing page with filters and creation form
- provide tests for transfer hook and UI

## Testing
- `npm test test/useTransferts.test.js test/Transferts.test.jsx`

------
https://chatgpt.com/codex/tasks/task_e_68945702b754832d95eb5e70967d8827