### PR TITLE
feat: analyse coût carte

### DIFF
--- a/router_mapping.json
+++ b/router_mapping.json
@@ -192,6 +192,10 @@
     "module": "analyse"
   },
   {
+    "route": "/analyse/costing-carte",
+    "module": "analyse"
+  },
+  {
     "route": "/analyse/analytique",
     "module": "analyse"
   },

--- a/src/hooks/useCostingCarte.js
+++ b/src/hooks/useCostingCarte.js
@@ -1,0 +1,45 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { useState, useCallback } from 'react'
+import { supabase } from '@/lib/supabase'
+import useAuth from '@/hooks/useAuth'
+
+export function useCostingCarte() {
+  const { mama_id } = useAuth()
+  const [fiches, setFiches] = useState([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
+
+  const fetchFichesPourLaCarte = useCallback(async () => {
+    if (!mama_id) return []
+    setLoading(true)
+    setError(null)
+    try {
+      const { data, error } = await supabase
+        .from('fiches_techniques')
+        .select('id, nom, famille, sous_famille, type, portions, cout_total, prix_vente')
+        .eq('mama_id', mama_id)
+        .eq('actif', true)
+        .not('prix_vente', 'is', null)
+        .gt('prix_vente', 0)
+        .gt('portions', 0)
+        .order('nom')
+      if (error) throw error
+      const rows = (data || []).map(f => {
+        const cout = f.cout_total && f.portions ? f.cout_total / f.portions : 0
+        const marge = f.prix_vente - cout
+        const taux = f.prix_vente > 0 ? (cout / f.prix_vente) * 100 : null
+        return { ...f, cout_unitaire: cout, marge_brute: marge, taux_food_cost: taux }
+      })
+      setFiches(rows)
+      return rows
+    } catch (e) {
+      setError(e)
+      setFiches([])
+      return []
+    } finally {
+      setLoading(false)
+    }
+  }, [mama_id])
+
+  return { fiches, loading, error, fetchFichesPourLaCarte }
+}

--- a/src/pages/analyse/CostingCarte.jsx
+++ b/src/pages/analyse/CostingCarte.jsx
@@ -1,0 +1,118 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { useEffect, useState, useMemo } from 'react'
+import { Navigate } from 'react-router-dom'
+import useAuth from '@/hooks/useAuth'
+import { useCostingCarte } from '@/hooks/useCostingCarte'
+import TableContainer from '@/components/ui/TableContainer'
+import { LoadingSpinner } from '@/components/ui/LoadingSpinner'
+import { Button } from '@/components/ui/button'
+import * as XLSX from 'xlsx'
+
+const DEFAULT_SEUIL = 35
+
+export default function CostingCarte() {
+  const { role, loading: authLoading } = useAuth()
+  const { fiches, loading, error, fetchFichesPourLaCarte } = useCostingCarte()
+  const [typeFilter, setTypeFilter] = useState('')
+  const [familleFilter, setFamilleFilter] = useState('')
+  const [seuil, setSeuil] = useState(DEFAULT_SEUIL)
+  const [sortKey, setSortKey] = useState('nom')
+  const [sortDir, setSortDir] = useState('asc')
+
+  useEffect(() => { fetchFichesPourLaCarte() }, [fetchFichesPourLaCarte])
+
+  const familles = useMemo(() => Array.from(new Set(fiches.map(f => f.famille).filter(Boolean))).sort(), [fiches])
+
+  const filtered = fiches
+    .filter(f => (!typeFilter || f.type === typeFilter))
+    .filter(f => (!familleFilter || f.famille === familleFilter))
+  const sorted = [...filtered].sort((a, b) => {
+    const dir = sortDir === 'asc' ? 1 : -1
+    if (sortKey === 'nom') return a.nom.localeCompare(b.nom) * dir
+    return (a[sortKey] - b[sortKey]) * dir
+  })
+
+  const exportExcel = () => {
+    const wb = XLSX.utils.book_new()
+    XLSX.utils.book_append_sheet(wb, XLSX.utils.json_to_sheet(sorted), 'Costing')
+    XLSX.writeFile(wb, 'costing_carte.xlsx')
+  }
+
+  if (authLoading) return <LoadingSpinner message="Chargement..." />
+  if (!['manager', 'admin', 'superadmin'].includes(role)) return <Navigate to="/unauthorized" replace />
+  if (loading) return <LoadingSpinner message="Chargement..." />
+  if (error) return <div className="p-8 text-red-600">{error.message || error.toString()}</div>
+
+  const toggleSort = key => {
+    if (sortKey === key) setSortDir(d => (d === 'asc' ? 'desc' : 'asc'))
+    else { setSortKey(key); setSortDir('asc') }
+  }
+
+  return (
+    <div className="p-6 container mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Analyse coût carte</h1>
+      <div className="flex flex-wrap gap-2 mb-4 items-end">
+        <label className="flex flex-col text-sm">
+          Type
+          <select className="form-select" value={typeFilter} onChange={e => setTypeFilter(e.target.value)}>
+            <option value="">Tous</option>
+            <option value="plat">Plat</option>
+            <option value="boisson">Boisson</option>
+            <option value="dessert">Dessert</option>
+          </select>
+        </label>
+        <label className="flex flex-col text-sm">
+          Famille
+          <select className="form-select" value={familleFilter} onChange={e => setFamilleFilter(e.target.value)}>
+            <option value="">Toutes</option>
+            {familles.map(f => (
+              <option key={f} value={f}>{f}</option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col text-sm">
+          Seuil FC%
+          <input type="number" className="form-input" value={seuil} onChange={e => setSeuil(Number(e.target.value))} />
+        </label>
+        <Button variant="outline" onClick={exportExcel}>Exporter</Button>
+      </div>
+      <TableContainer>
+        <table className="min-w-full text-sm table-auto">
+          <thead>
+            <tr>
+              <th className="px-2 py-1 cursor-pointer" onClick={() => toggleSort('nom')}>Nom</th>
+              <th className="px-2 py-1 cursor-pointer" onClick={() => toggleSort('type')}>Type</th>
+              <th className="px-2 py-1 cursor-pointer" onClick={() => toggleSort('famille')}>Famille</th>
+              <th className="px-2 py-1 cursor-pointer" onClick={() => toggleSort('cout_unitaire')}>Coût unitaire</th>
+              <th className="px-2 py-1 cursor-pointer" onClick={() => toggleSort('prix_vente')}>Prix vente</th>
+              <th className="px-2 py-1 cursor-pointer" onClick={() => toggleSort('marge_brute')}>Marge</th>
+              <th className="px-2 py-1 cursor-pointer" onClick={() => toggleSort('taux_food_cost')}>Taux %</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map(f => {
+              const fc = f.taux_food_cost
+              const rowClass = fc > seuil ? 'text-red-600' : ''
+              return (
+                <tr key={f.id} className={rowClass}>
+                  <td className="border px-2 py-1">{f.nom}</td>
+                  <td className="border px-2 py-1">{f.type}</td>
+                  <td className="border px-2 py-1">{f.famille}</td>
+                  <td className="border px-2 py-1 text-right">{f.cout_unitaire.toFixed(2)}</td>
+                  <td className="border px-2 py-1 text-right">{f.prix_vente.toFixed(2)}</td>
+                  <td className="border px-2 py-1 text-right">{f.marge_brute.toFixed(2)}</td>
+                  <td className="border px-2 py-1 text-right">{fc.toFixed(1)}</td>
+                </tr>
+              )
+            })}
+            {sorted.length === 0 && (
+              <tr>
+                <td colSpan="7" className="p-4 text-center text-gray-500">Aucune fiche</td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </TableContainer>
+    </div>
+  )
+}

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -51,6 +51,7 @@ const Documents = lazyWithPreload(() => import("@/pages/documents/Documents.jsx"
 const Analyse = lazyWithPreload(() => import("@/pages/analyse/Analyse.jsx"));
 const AnalyseCostCenter = lazyWithPreload(() => import("@/pages/analyse/AnalyseCostCenter.jsx"));
 const AnalytiqueDashboard = lazyWithPreload(() => import("@/pages/analytique/AnalytiqueDashboard.jsx"));
+const CostingCarte = lazyWithPreload(() => import("@/pages/analyse/CostingCarte.jsx"));
 const Utilisateurs = lazyWithPreload(() => import("@/pages/parametrage/Utilisateurs.jsx"));
 const Mamas = lazyWithPreload(() => import("@/pages/parametrage/Mamas.jsx"));
 const Permissions = lazyWithPreload(() => import("@/pages/parametrage/Permissions.jsx"));
@@ -140,6 +141,7 @@ export const routePreloadMap = {
   '/tableaux-de-bord': TableauxDeBord.preload,
   '/comparatif': Comparatif.preload,
   '/surcouts': Surcouts.preload,
+  '/analyse/costing-carte': CostingCarte.preload,
   '/alertes': Alertes.preload,
   '/parametrage/utilisateurs': Utilisateurs.preload,
   '/parametrage/mamas': Mamas.preload,
@@ -412,6 +414,10 @@ export default function Router() {
           <Route
             path="/analyse/cost-centers"
             element={<ProtectedRoute moduleKey="analyse"><AnalyseCostCenter /></ProtectedRoute>}
+          />
+          <Route
+            path="/analyse/costing-carte"
+            element={<ProtectedRoute moduleKey="analyse"><CostingCarte /></ProtectedRoute>}
           />
           <Route
             path="/analyse/analytique"

--- a/test/CostingCarte.test.jsx
+++ b/test/CostingCarte.test.jsx
@@ -1,0 +1,33 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { render, screen, fireEvent } from '@testing-library/react'
+import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { vi, test, expect } from 'vitest'
+
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ role: 'manager', loading: false }) }))
+vi.mock('@/hooks/useCostingCarte', () => ({
+  useCostingCarte: () => ({
+    fiches: [
+      { id: 1, nom: 'Plat', type: 'plat', famille: 'A', prix_vente: 10, cout_unitaire: 3, marge_brute: 7, taux_food_cost: 30 },
+      { id: 2, nom: 'Vin', type: 'boisson', famille: 'B', prix_vente: 5, cout_unitaire: 3, marge_brute: 2, taux_food_cost: 60 }
+    ],
+    fetchFichesPourLaCarte: vi.fn(),
+    loading: false,
+    error: null
+  })
+}))
+
+import CostingCarte from '@/pages/analyse/CostingCarte.jsx'
+
+test('filters by type', () => {
+  render(<CostingCarte />, { wrapper: MemoryRouter })
+  fireEvent.change(screen.getByLabelText(/Type/i), { target: { value: 'plat' } })
+  expect(screen.getByText('Plat', { selector: 'td' })).toBeInTheDocument()
+  expect(screen.queryByText('Vin')).toBeNull()
+})
+
+test('high food cost highlighted', () => {
+  render(<CostingCarte />, { wrapper: MemoryRouter })
+  const row = screen.getByText('Vin').closest('tr')
+  expect(row.className).toMatch(/text-red-600/)
+})

--- a/test/useCostingCarte.test.jsx
+++ b/test/useCostingCarte.test.jsx
@@ -1,0 +1,42 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { renderHook, act } from '@testing-library/react'
+import { vi, beforeEach, afterEach, test, expect } from 'vitest'
+import { supabase } from '@/lib/supabase'
+import { AuthContext } from '@/context/AuthContext'
+
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1' }) }))
+
+let useCostingCarte
+let fromSpy
+
+const wrapper = ({ children }) => (
+  <AuthContext.Provider value={{ mama_id: 'm1' }}>{children}</AuthContext.Provider>
+)
+
+beforeEach(async () => {
+  ;({ useCostingCarte } = await import('@/hooks/useCostingCarte'))
+  const sample = [
+    { id: 1, nom: 'Test', famille: 'A', sous_famille: null, type: 'plat', portions: 2, cout_total: 10, prix_vente: 20 }
+  ]
+  const orderMock = vi.fn(() => Promise.resolve({ data: sample, error: null }))
+  const query = {
+    select: vi.fn(() => query),
+    eq: vi.fn(() => query),
+    not: vi.fn(() => query),
+    gt: vi.fn(() => query),
+    order: orderMock,
+  }
+  fromSpy = vi.spyOn(supabase, 'from').mockReturnValue(query)
+})
+
+afterEach(() => { fromSpy.mockRestore() })
+
+test('calculates margins and ratios', async () => {
+  const { result } = renderHook(() => useCostingCarte(), { wrapper })
+  await act(async () => { await result.current.fetchFichesPourLaCarte() })
+  expect(result.current.fiches[0]).toMatchObject({
+    cout_unitaire: 5,
+    marge_brute: 15,
+    taux_food_cost: 25,
+  })
+})


### PR DESCRIPTION
## Summary
- add costing data hook for fiches techniques
- display costing analysis page with filters and highlighting
- register costing carte route and mapping

## Testing
- `npx vitest run test/useCostingCarte.test.jsx test/CostingCarte.test.jsx`
- `npm test` *(fails: 24 failed, 90 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689466345260832d82eb54baed1a5885