### PR TITLE
feat: add menu groupe module

### DIFF
--- a/db/full_setup_final.sql
+++ b/db/full_setup_final.sql
@@ -996,7 +996,7 @@ do $$
 declare t text;
 begin
     foreach t in array array[
-      'mamas','roles','permissions','role_permissions','utilisateurs','familles','sous_familles','unites','zones_stock','fournisseurs','produits','commandes','bons_livraison','lignes_bl','factures','facture_lignes','fiches_techniques','stock_mouvements','stocks','inventaires','inventaire_lignes','documents','notifications','gadgets','ventes_fiches_carte','ventes_familles','feedback','consentements_utilisateur','periodes_comptables','taches','fournisseur_produits','fiche_lignes','transferts','transfert_lignes','mouvements','mouvements_centres_cout','tache_instances'
+      'mamas','roles','permissions','role_permissions','utilisateurs','familles','sous_familles','unites','zones_stock','fournisseurs','produits','commandes','bons_livraison','lignes_bl','factures','facture_lignes','fiches_techniques','stock_mouvements','stocks','inventaires','inventaire_lignes','documents','notifications','gadgets','ventes_fiches_carte','ventes_familles','feedback','consentements_utilisateur','periodes_comptables','taches','fournisseur_produits','fiche_lignes','transferts','transfert_lignes','mouvements','mouvements_centres_cout','menus_groupes','menus_groupes_fiches','tache_instances'
     ]
   loop
     execute format('drop trigger if exists set_timestamp on public.%I;', t);
@@ -1234,7 +1234,7 @@ do $$
 declare t text;
 begin
   foreach t in array array[
-    'mamas','roles','permissions','role_permissions','utilisateurs','familles','sous_familles','unites','zones_stock','fournisseurs','produits','commandes','bons_livraison','lignes_bl','factures','facture_lignes','fiches_techniques','stock_mouvements','stocks','inventaires','inventaire_lignes','documents','notifications','gadgets','ventes_fiches_carte','ventes_familles','feedback','consentements_utilisateur','periodes_comptables','taches','tache_instances','planning_previsionnel','planning_lignes','fournisseur_produits','fiche_lignes','transferts','transfert_lignes','mouvements','mouvements_centres_cout'
+    'mamas','roles','permissions','role_permissions','utilisateurs','familles','sous_familles','unites','zones_stock','fournisseurs','produits','commandes','bons_livraison','lignes_bl','factures','facture_lignes','fiches_techniques','stock_mouvements','stocks','inventaires','inventaire_lignes','documents','notifications','gadgets','ventes_fiches_carte','ventes_familles','feedback','consentements_utilisateur','periodes_comptables','taches','tache_instances','planning_previsionnel','planning_lignes','fournisseur_produits','fiche_lignes','transferts','transfert_lignes','mouvements','mouvements_centres_cout','menus_groupes','menus_groupes_fiches'
   ]
   loop
     execute format('alter table public.%I enable row level security;', t);
@@ -1259,6 +1259,34 @@ create policy utilisateurs_taches_policy on public.utilisateurs_taches
     )
   );
 
+-- Tables menus groupes
+create table if not exists menus_groupes (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid references mamas(id) not null,
+  nom text not null,
+  prix_vente numeric not null,
+  cout_total numeric,
+  marge numeric,
+  taux_food_cost numeric,
+  statut text default 'brouillon',
+  actif boolean default true,
+  created_at timestamp default now()
+);
+
+create table if not exists menus_groupes_fiches (
+  id uuid primary key default gen_random_uuid(),
+  menu_id uuid references menus_groupes(id) on delete cascade,
+  fiche_id uuid references fiches_techniques(id),
+  categorie text,
+  ordre integer,
+  mama_id uuid references mamas(id)
+);
+
+alter table menus_groupes enable row level security;
+alter table menus_groupes_fiches enable row level security;
+create policy rls_menus_groupes on menus_groupes using (mama_id = current_user_mama_id()) with check (mama_id = current_user_mama_id());
+create policy rls_menus_groupes_fiches on menus_groupes_fiches using (mama_id = current_user_mama_id()) with check (mama_id = current_user_mama_id());
+
 -- ========================
 -- GRANTS
 -- ========================
@@ -1266,7 +1294,7 @@ do $$
 declare t text;
 begin
   foreach t in array array[
-    'mamas','roles','permissions','role_permissions','utilisateurs','familles','sous_familles','unites','zones_stock','fournisseurs','produits','commandes','bons_livraison','lignes_bl','factures','facture_lignes','fiches_techniques','stock_mouvements','stocks','inventaires','inventaire_lignes','documents','notifications','gadgets','ventes_fiches_carte','ventes_familles','feedback','consentements_utilisateur','periodes_comptables','taches','tache_instances','planning_previsionnel','planning_lignes','fournisseur_produits','fiche_lignes','transferts','transfert_lignes','mouvements','mouvements_centres_cout'
+    'mamas','roles','permissions','role_permissions','utilisateurs','familles','sous_familles','unites','zones_stock','fournisseurs','produits','commandes','bons_livraison','lignes_bl','factures','facture_lignes','fiches_techniques','stock_mouvements','stocks','inventaires','inventaire_lignes','documents','notifications','gadgets','ventes_fiches_carte','ventes_familles','feedback','consentements_utilisateur','periodes_comptables','taches','tache_instances','planning_previsionnel','planning_lignes','fournisseur_produits','fiche_lignes','transferts','transfert_lignes','mouvements','mouvements_centres_cout','menus_groupes','menus_groupes_fiches'
   ]
   loop
     execute format('grant select, insert, update, delete on public.%I to authenticated;', t);

--- a/src/hooks/useMenusGroupes.js
+++ b/src/hooks/useMenusGroupes.js
@@ -1,0 +1,100 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { useState } from 'react';
+import { supabase } from '@/lib/supabase';
+import useAuth from '@/hooks/useAuth';
+
+export function useMenusGroupes() {
+  const { mama_id } = useAuth();
+  const [menus, setMenus] = useState([]);
+
+  async function fetchMenusGroupes() {
+    if (!mama_id) return [];
+    const { data } = await supabase
+      .from('menus_groupes')
+      .select('*')
+      .eq('mama_id', mama_id);
+    setMenus(Array.isArray(data) ? data : []);
+    return data || [];
+  }
+
+  async function fetchMenuGroupe(id) {
+    if (!mama_id || !id) return null;
+    const { data } = await supabase
+      .from('menus_groupes')
+      .select(
+        '*, fiches:menus_groupes_fiches(categorie, fiche_id, fiche:fiches_techniques(id, nom, cout_total, portions))'
+      )
+      .eq('id', id)
+      .eq('mama_id', mama_id)
+      .single();
+    return data || null;
+  }
+
+  async function createOrUpdateMenu(menu) {
+    if (!mama_id) return { error: 'Aucun mama_id' };
+    const { id, fiches = [], ...entete } = menu;
+    let menuId = id;
+    if (menuId) {
+      await supabase
+        .from('menus_groupes')
+        .update(entete)
+        .eq('id', menuId)
+        .eq('mama_id', mama_id);
+      await supabase
+        .from('menus_groupes_fiches')
+        .delete()
+        .eq('menu_id', menuId);
+    } else {
+      const { data } = await supabase
+        .from('menus_groupes')
+        .insert([{ ...entete, mama_id }])
+        .select('id')
+        .single();
+      menuId = data?.id;
+    }
+    if (menuId && fiches.length > 0) {
+      const rows = fiches.map((f, index) => ({
+        menu_id: menuId,
+        fiche_id: f.fiche_id,
+        categorie: f.categorie,
+        ordre: index,
+      }));
+      await supabase.from('menus_groupes_fiches').insert(rows);
+    }
+    return { id: menuId };
+  }
+
+  function calculateMenuStats(menu) {
+    const totalCost = (menu.fiches || []).reduce(
+      (sum, f) => sum + (Number(f.cout) || 0),
+      0
+    );
+    const marge = Number(menu.prix_vente || 0) - totalCost;
+    const taux_food_cost = Number(menu.prix_vente || 0) > 0
+      ? (totalCost / Number(menu.prix_vente)) * 100
+      : 0;
+    return { totalCost, marge, taux_food_cost };
+  }
+
+  async function exportMenuPDF() {
+    // Stub: l'export réel sera implémenté côté client
+    return true;
+  }
+
+  async function exportMenuExcel() {
+    // Stub: l'export réel sera implémenté côté client
+    return true;
+  }
+
+  return {
+    menus,
+    fetchMenusGroupes,
+    fetchMenuGroupe,
+    createOrUpdateMenu,
+    calculateMenuStats,
+    exportMenuPDF,
+    exportMenuExcel,
+  };
+}
+
+export default useMenusGroupes;

--- a/src/pages/menus/MenuGroupe.jsx
+++ b/src/pages/menus/MenuGroupe.jsx
@@ -1,0 +1,33 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { useEffect, useState } from 'react';
+import useMenusGroupes from '@/hooks/useMenusGroupes';
+
+export default function MenuGroupe() {
+  const { menus, fetchMenusGroupes } = useMenusGroupes();
+  const [filter, setFilter] = useState('all');
+
+  useEffect(() => {
+    fetchMenusGroupes();
+  }, []);
+
+  const filtered = menus.filter(m => filter === 'all' || m.statut === filter);
+
+  return (
+    <div>
+      <h1>Menus groupes</h1>
+      <select aria-label="filtre" value={filter} onChange={e => setFilter(e.target.value)}>
+        <option value="all">Tous</option>
+        <option value="valide">validé</option>
+        <option value="brouillon">brouillon</option>
+      </select>
+      <ul>
+        {filtered.map(m => (
+          <li key={m.id}>
+            {m.nom} - {Number(m.cout_total || 0).toFixed(2)}€ - marge {Number(m.marge || 0).toFixed(2)}%
+          </li>
+        ))}
+      </ul>
+      <button>Créer une formule</button>
+    </div>
+  );
+}

--- a/src/pages/menus/MenuGroupeForm.jsx
+++ b/src/pages/menus/MenuGroupeForm.jsx
@@ -1,0 +1,52 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { useState } from 'react';
+import useMenusGroupes from '@/hooks/useMenusGroupes';
+import { useFiches } from '@/hooks/useFiches';
+
+export default function MenuGroupeForm() {
+  const { createOrUpdateMenu, calculateMenuStats, exportMenuPDF, exportMenuExcel } = useMenusGroupes();
+  const { fiches } = useFiches();
+  const [nom, setNom] = useState('');
+  const [prix, setPrix] = useState(0);
+  const [items, setItems] = useState([]); // {categorie, fiche}
+
+  function addFiche() {
+    if (fiches.length === 0) return;
+    const fiche = fiches[0];
+    if (items.some(i => i.fiche.id === fiche.id)) return;
+    setItems([...items, { categorie: 'Entrée', fiche }]);
+  }
+
+  const stats = calculateMenuStats({
+    prix_vente: prix,
+    fiches: items.map(i => ({ cout: i.fiche.cout_unitaire })),
+  });
+
+  function handleSave() {
+    createOrUpdateMenu({
+      nom,
+      prix_vente: prix,
+      fiches: items.map(i => ({ fiche_id: i.fiche.id, categorie: i.categorie })),
+    });
+  }
+
+  return (
+    <div>
+      <h1>Formule groupe</h1>
+      <input aria-label="nom" value={nom} onChange={e => setNom(e.target.value)} />
+      <input aria-label="prix" type="number" value={prix} onChange={e => setPrix(Number(e.target.value) || 0)} />
+      <button onClick={addFiche}>Ajouter fiche</button>
+      <ul>
+        {items.map(i => (
+          <li key={i.fiche.id}>{i.categorie} - {i.fiche.nom}</li>
+        ))}
+      </ul>
+      <div>Coût total: {stats.totalCost.toFixed(2)} €</div>
+      <div>Marge: {stats.marge.toFixed(2)} €</div>
+      {stats.taux_food_cost > 70 && <div role="alert">Marge faible</div>}
+      <button onClick={handleSave}>Enregistrer</button>
+      <button onClick={() => exportMenuPDF({ nom, items })}>Exporter PDF</button>
+      <button onClick={() => exportMenuExcel({ nom, items })}>Exporter Excel</button>
+    </div>
+  );
+}

--- a/test/MenuGroupe.test.jsx
+++ b/test/MenuGroupe.test.jsx
@@ -1,0 +1,28 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { render, screen, fireEvent } from '@testing-library/react';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+const menus = [
+  { id: '1', nom: 'Menu A', cout_total: 10, marge: 20, statut: 'valide' },
+  { id: '2', nom: 'Menu B', cout_total: 15, marge: 25, statut: 'brouillon' },
+];
+
+vi.mock('@/hooks/useMenusGroupes', () => ({
+  default: () => ({ menus, fetchMenusGroupes: vi.fn() }),
+}));
+
+let MenuGroupe;
+
+beforeEach(async () => {
+  MenuGroupe = (await import('@/pages/menus/MenuGroupe.jsx')).default;
+});
+
+test('liste et filtre les menus groupes', () => {
+  render(<MenuGroupe />);
+  expect(screen.getByText('Menu A - 10.00€ - marge 20.00%')).toBeInTheDocument();
+  expect(screen.getByText('Menu B - 15.00€ - marge 25.00%')).toBeInTheDocument();
+  fireEvent.change(screen.getByLabelText('filtre'), { target: { value: 'valide' } });
+  expect(screen.getByText('Menu A - 10.00€ - marge 20.00%')).toBeInTheDocument();
+  expect(screen.queryByText('Menu B - 15.00€ - marge 25.00%')).toBeNull();
+  expect(screen.getByText('Créer une formule')).toBeInTheDocument();
+});

--- a/test/MenuGroupeForm.test.jsx
+++ b/test/MenuGroupeForm.test.jsx
@@ -1,0 +1,36 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { render, screen, fireEvent } from '@testing-library/react';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+vi.mock('@/hooks/useMenusGroupes', () => ({
+  default: () => ({
+    createOrUpdateMenu: vi.fn(),
+    calculateMenuStats: ({ prix_vente, fiches }) => {
+      const total = fiches.reduce((s, f) => s + (f.cout || 0), 0);
+      return {
+        totalCost: total,
+        marge: prix_vente - total,
+        taux_food_cost: prix_vente ? (total / prix_vente) * 100 : 0,
+      };
+    },
+    exportMenuPDF: vi.fn(),
+    exportMenuExcel: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useFiches', () => ({ useFiches: () => ({ fiches: [{ id: 'f1', nom: 'Salade', cout_unitaire: 8 }] }) }));
+
+let MenuGroupeForm;
+
+beforeEach(async () => {
+  MenuGroupeForm = (await import('@/pages/menus/MenuGroupeForm.jsx')).default;
+});
+
+test("ajout de fiche et alerte marge", () => {
+  render(<MenuGroupeForm />);
+  fireEvent.change(screen.getByLabelText('prix'), { target: { value: '10' } });
+  fireEvent.click(screen.getByText('Ajouter fiche'));
+  expect(screen.getByText('Coût total: 8.00 €')).toBeInTheDocument();
+  expect(screen.getByText('Marge: 2.00 €')).toBeInTheDocument();
+  expect(screen.getByRole('alert')).toBeInTheDocument();
+});

--- a/test/useMenusGroupes.test.js
+++ b/test/useMenusGroupes.test.js
@@ -1,0 +1,61 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { renderHook, act } from '@testing-library/react';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+const eqMock = vi.fn(() => Promise.resolve({ data: [], error: null }));
+const selectMock = vi.fn(() => ({ eq: eqMock }));
+const singleMock = vi.fn(() => Promise.resolve({ data: { id: 'm1' }, error: null }));
+const selectAfterInsertMock = vi.fn(() => ({ single: singleMock }));
+const insertMenuMock = vi.fn(() => ({ select: selectAfterInsertMock }));
+const insertLienMock = vi.fn(() => Promise.resolve({ data: null }));
+
+const fromMock = vi.fn((table) => {
+  if (table === 'menus_groupes') {
+    return { select: selectMock, insert: insertMenuMock };
+  }
+  if (table === 'menus_groupes_fiches') {
+    return { insert: insertLienMock };
+  }
+  return {};
+});
+
+vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1' }) }));
+
+let useMenusGroupes;
+
+beforeEach(async () => {
+  ({ useMenusGroupes } = await import('@/hooks/useMenusGroupes'));
+  fromMock.mockClear();
+  selectMock.mockClear();
+  eqMock.mockClear();
+  insertMenuMock.mockClear();
+  insertLienMock.mockClear();
+});
+
+test('fetchMenusGroupes queries supabase', async () => {
+  const { result } = renderHook(() => useMenusGroupes());
+  await act(async () => { await result.current.fetchMenusGroupes(); });
+  expect(fromMock).toHaveBeenCalledWith('menus_groupes');
+  expect(selectMock).toHaveBeenCalled();
+  expect(eqMock).toHaveBeenCalledWith('mama_id', 'm1');
+});
+
+test('createOrUpdateMenu inserts data and liens', async () => {
+  const { result } = renderHook(() => useMenusGroupes());
+  await act(async () => {
+    await result.current.createOrUpdateMenu({ nom: 'Formule', prix_vente: 10, fiches: [{ fiche_id: 'f1', categorie: 'Plat' }] });
+  });
+  expect(fromMock).toHaveBeenCalledWith('menus_groupes');
+  expect(insertMenuMock).toHaveBeenCalled();
+  expect(fromMock).toHaveBeenCalledWith('menus_groupes_fiches');
+  expect(insertLienMock).toHaveBeenCalled();
+});
+
+test('calculateMenuStats returns totals', () => {
+  const { result } = renderHook(() => useMenusGroupes());
+  const stats = result.current.calculateMenuStats({ prix_vente: 100, fiches: [{ cout: 40 }, { cout: 10 }] });
+  expect(stats.totalCost).toBe(50);
+  expect(stats.marge).toBe(50);
+  expect(Math.round(stats.taux_food_cost)).toBe(50);
+});


### PR DESCRIPTION
## Summary
- add hooks and components to manage grouped menus with margin calculations
- introduce SQL schema for `menus_groupes` with RLS policies and grants
- provide unit tests for hook and UI components

## Testing
- `npm test test/useMenusGroupes.test.js test/MenuGroupeForm.test.jsx test/MenuGroupe.test.jsx`

------
https://chatgpt.com/codex/tasks/task_e_6894dc1d1d40832d8e0a1e8c859ed7eb