### PR TITLE
Add fiche line component and tests for fiche module

### DIFF
--- a/src/components/fiches/FicheLigne.jsx
+++ b/src/components/fiches/FicheLigne.jsx
@@ -1,0 +1,84 @@
+import { Select } from "@/components/ui/select";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+export default function FicheLigne({ ligne, products, ficheOptions, onChange, onRemove }) {
+  const prod = products.find((p) => p.id === ligne.produit_id);
+  const sf = ficheOptions.find((f) => f.id === ligne.sous_fiche_id);
+  const prixUnitaire =
+    ligne.type === "produit"
+      ? prod?.pmp ?? prod?.dernier_prix ?? null
+      : sf?.cout_par_portion ?? null;
+  const cout =
+    prixUnitaire !== null
+      ? Number(prixUnitaire) * Number(ligne.quantite)
+      : null;
+
+  return (
+    <tr>
+      <td>
+        <Select
+          className="w-full"
+          value={ligne.type}
+          onChange={(e) => onChange("type", e.target.value)}
+        >
+          <option value="produit">Produit</option>
+          <option value="sous_fiche">Sous-fiche</option>
+        </Select>
+      </td>
+      <td>
+        {ligne.type === "produit" ? (
+          <Select
+            className="w-full"
+            value={ligne.produit_id}
+            onChange={(e) => onChange("produit_id", e.target.value)}
+            required
+          >
+            <option value="">Sélectionner</option>
+            {products.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.nom}
+                {p.unite?.nom ? ` (${p.unite.nom})` : ""}
+              </option>
+            ))}
+          </Select>
+        ) : (
+          <Select
+            className="w-full"
+            value={ligne.sous_fiche_id}
+            onChange={(e) => onChange("sous_fiche_id", e.target.value)}
+            required
+          >
+            <option value="">Sélectionner</option>
+            {ficheOptions.map((f) => (
+              <option key={f.id} value={f.id}>
+                {f.nom}
+              </option>
+            ))}
+          </Select>
+        )}
+      </td>
+      <td>
+        <Input
+          type="number"
+          className="w-full"
+          min={0}
+          step="0.01"
+          value={ligne.quantite}
+          onChange={(e) => onChange("quantite", Number(e.target.value))}
+          required
+        />
+      </td>
+      <td>{ligne.type === "produit" ? prod?.unite?.nom || "-" : "portion"}</td>
+      <td>
+        {prixUnitaire !== null ? Number(prixUnitaire).toFixed(2) : "-"}
+      </td>
+      <td>{cout !== null ? cout.toFixed(2) : "-"}</td>
+      <td>
+        <Button size="sm" variant="outline" onClick={onRemove}>
+          Suppr.
+        </Button>
+      </td>
+    </tr>
+  );
+}

--- a/src/pages/fiches/FicheForm.jsx
+++ b/src/pages/fiches/FicheForm.jsx
@@ -15,6 +15,7 @@ import SecondaryButton from "@/components/ui/SecondaryButton";
 import { Input } from "@/components/ui/input";
 import GlassCard from "@/components/ui/GlassCard";
 import toast from "react-hot-toast";
+import FicheLigne from "@/components/fiches/FicheLigne.jsx";
 
 export default function FicheForm({ fiche, onClose }) {
   const { access_rights, loading: authLoading } = useAuth();
@@ -175,70 +176,16 @@ export default function FicheForm({ fiche, onClose }) {
               </tr>
             </thead>
             <tbody>
-              {lignes.map((l, i) => {
-                const prod = products.find(p => p.id === l.produit_id);
-                const sf = ficheOptions.find(f => f.id === l.sous_fiche_id);
-                return (
-                  <tr key={i}>
-                    <td>
-                      <Select
-                        className="w-full"
-                        value={l.type}
-                        onChange={e => updateLigne(i, 'type', e.target.value)}
-                      >
-                        <option value="produit">Produit</option>
-                        <option value="sous_fiche">Sous-fiche</option>
-                      </Select>
-                    </td>
-                    <td>
-                      {l.type === 'produit' ? (
-                        <Select
-                          className="w-full"
-                          value={l.produit_id}
-                          onChange={e => updateLigne(i, 'produit_id', e.target.value)}
-                          required
-                        >
-                          <option value="">Sélectionner</option>
-                          {products.map(p => (
-                            <option key={p.id} value={p.id}>
-                              {p.nom}{p.unite?.nom ? ` (${p.unite.nom})` : ''}
-                            </option>
-                          ))}
-                        </Select>
-                      ) : (
-                        <Select
-                          className="w-full"
-                          value={l.sous_fiche_id}
-                          onChange={e => updateLigne(i, 'sous_fiche_id', e.target.value)}
-                          required
-                        >
-                          <option value="">Sélectionner</option>
-                          {ficheOptions.map(f => (
-                            <option key={f.id} value={f.id}>
-                              {f.nom}
-                            </option>
-                          ))}
-                        </Select>
-                      )}
-                    </td>
-                    <td>
-                      <Input
-                        type="number"
-                        className="w-full"
-                        min={0}
-                        step="0.01"
-                        value={l.quantite}
-                        onChange={e => updateLigne(i, 'quantite', Number(e.target.value))}
-                        required
-                      />
-                    </td>
-                    <td>{l.type === 'produit' ? prod?.unite?.nom || '-' : 'portion'}</td>
-                    <td>{l.type === 'produit' ? (prod?.pmp ?? prod?.dernier_prix ?? null) ? Number(prod.pmp ?? prod.dernier_prix).toFixed(2) : '-' : sf?.cout_par_portion?.toFixed(2) || '-'}</td>
-                    <td>{l.type === 'produit' ? (prod?.pmp ?? prod?.dernier_prix ?? null) ? ((Number(prod.pmp ?? prod.dernier_prix) * l.quantite).toFixed(2)) : '-' : sf?.cout_par_portion ? (sf.cout_par_portion * l.quantite).toFixed(2) : '-'}</td>
-                    <td><Button size="sm" variant="outline" onClick={() => removeLigne(i)}>Suppr.</Button></td>
-                  </tr>
-                );
-              })}
+              {lignes.map((l, i) => (
+                <FicheLigne
+                  key={i}
+                  ligne={l}
+                  products={products}
+                  ficheOptions={ficheOptions}
+                  onChange={(field, val) => updateLigne(i, field, val)}
+                  onRemove={() => removeLigne(i)}
+                />
+              ))}
             </tbody>
           </table>
         </TableContainer>

--- a/test/FicheDetail.test.jsx
+++ b/test/FicheDetail.test.jsx
@@ -1,0 +1,42 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { render, screen } from '@testing-library/react';
+import { vi, test } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ access_rights: { fiches_techniques: { peut_voir: true } }, loading: false }) }));
+let getFicheByIdMock;
+vi.mock('@/hooks/useFiches', () => ({ useFiches: () => ({ getFicheById: getFicheByIdMock }) }));
+vi.mock('@/hooks/useFicheCoutHistory', () => ({ useFicheCoutHistory: () => ({ history: [], fetchFicheCoutHistory: vi.fn() }) }));
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }) => <div>{children}</div>,
+  LineChart: ({ children }) => <div>{children}</div>,
+  Line: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  Tooltip: () => null,
+}));
+vi.mock('xlsx', () => ({ utils: { book_new: vi.fn(), book_append_sheet: vi.fn(), json_to_sheet: vi.fn() }, writeFile: vi.fn() }), { virtual: true });
+vi.mock('jspdf', () => ({ default: vi.fn(() => ({ text: vi.fn(), autoTable: vi.fn(), save: vi.fn(), lastAutoTable: { finalY: 0 } })) }));
+vi.mock('jspdf-autotable', () => ({}), { virtual: true });
+
+import FicheDetail from '@/pages/fiches/FicheDetail.jsx';
+
+test('renders cost per portion and lines', () => {
+  const fiche = {
+    id: '1',
+    nom: 'Fiche',
+    portions: 2,
+    cout_total: 6,
+    cout_par_portion: 3,
+    lignes: [{ produit_nom: 'Prod', quantite: 2, unite_nom: 'kg', produit_id: 'p1', pmp: 3 }],
+  };
+  getFicheByIdMock = vi.fn(() => Promise.resolve(fiche));
+  render(
+    <MemoryRouter>
+      <FicheDetail fiche={fiche} onClose={vi.fn()} />
+    </MemoryRouter>
+  );
+  const portion = screen.getByText(/Coût\/portion/).parentElement;
+  expect(portion).toHaveTextContent('3.00 €');
+  expect(screen.getByText(/Prod/)).toBeInTheDocument();
+});

--- a/test/FicheForm.test.jsx
+++ b/test/FicheForm.test.jsx
@@ -1,0 +1,20 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { render, screen } from '@testing-library/react';
+import { vi, test } from 'vitest';
+
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ access_rights: { fiches_techniques: { peut_voir: true } }, loading: false }) }));
+vi.mock('@/hooks/useFiches', () => ({ useFiches: () => ({ createFiche: vi.fn(), updateFiche: vi.fn() }) }));
+vi.mock('@/hooks/useProducts', () => ({ useProducts: () => ({ products: [{ id: 'p1', nom: 'Prod', pmp: 3, unite: { nom: 'kg' } }], fetchProducts: vi.fn() }) }));
+vi.mock('@/hooks/useFamilles', () => ({ useFamilles: () => ({ familles: [], fetchFamilles: vi.fn() }) }));
+vi.mock('@/hooks/useFichesAutocomplete', () => ({ useFichesAutocomplete: () => ({ results: [], searchFiches: vi.fn() }) }));
+
+import FicheForm from '@/pages/fiches/FicheForm.jsx';
+
+test('calculates cost per portion', () => {
+  const fiche = { portions: 2, lignes: [{ type: 'produit', produit_id: 'p1', quantite: 2 }] };
+  render(<FicheForm fiche={fiche} onClose={vi.fn()} />);
+  const total = screen.getByText(/Coût total/).parentElement;
+  const portion = screen.getByText(/Coût\/portion/).parentElement;
+  expect(total).toHaveTextContent('6.00 €');
+  expect(portion).toHaveTextContent('3.00 €');
+});

--- a/test/useFiches.test.js
+++ b/test/useFiches.test.js
@@ -1,0 +1,55 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { renderHook, act } from '@testing-library/react';
+import { vi, beforeEach, test, expect } from 'vitest';
+
+const rangeMock = vi.fn(() => Promise.resolve({ data: [], count: 0, error: null }));
+const orderMock = vi.fn(() => ({ range: rangeMock }));
+const ilikeMock = vi.fn(() => ({ order: orderMock, range: rangeMock }));
+const eqMock = vi.fn(() => ({ ilike: ilikeMock, order: orderMock, range: rangeMock }));
+const selectMock = vi.fn(() => ({ eq: eqMock, ilike: ilikeMock, order: orderMock, range: rangeMock }));
+
+const insertLinesMock = vi.fn(() => Promise.resolve({ error: null }));
+const singleMock = vi.fn(() => Promise.resolve({ data: { id: 'f1' }, error: null }));
+const selectInsertMock = vi.fn(() => ({ single: singleMock }));
+const insertMainMock = vi.fn(() => ({ select: selectInsertMock }));
+
+const fromMock = vi.fn((table) => {
+  if (table === 'fiches_techniques') {
+    return { select: selectMock, insert: insertMainMock, update: vi.fn(), delete: vi.fn() };
+  }
+  if (table === 'fiche_lignes') {
+    return { insert: insertLinesMock };
+  }
+  return { select: selectMock };
+});
+
+vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1' }) }));
+
+let useFiches;
+
+beforeEach(async () => {
+  ({ useFiches } = await import('@/hooks/useFiches'));
+  fromMock.mockClear();
+  selectMock.mockClear();
+  orderMock.mockClear();
+  insertMainMock.mockClear();
+  insertLinesMock.mockClear();
+});
+
+test('getFiches defaults sort field when invalid', async () => {
+  const { result } = renderHook(() => useFiches());
+  await act(async () => {
+    await result.current.getFiches({ sortBy: 'foo' });
+  });
+  expect(orderMock).toHaveBeenCalledWith('nom', { ascending: true });
+});
+
+test('createFiche inserts fiche and lines', async () => {
+  const { result } = renderHook(() => useFiches());
+  await act(async () => {
+    await result.current.createFiche({ nom: 'f', lignes: [{ produit_id: 'p1', quantite: 1 }] });
+  });
+  expect(insertMainMock).toHaveBeenCalled();
+  expect(insertLinesMock).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- factor FicheForm lines into new `FicheLigne` component with product/sub-fiche pricing
- compute and display total and per-portion costs in FicheForm
- add unit tests for fiche hook and UI components

## Testing
- `npm test test/useFiches.test.js test/FicheForm.test.jsx test/FicheDetail.test.jsx`

------
https://chatgpt.com/codex/tasks/task_e_689503a61f84832dbd4d8ee8a7d64c64