### PR TITLE
feat: add cave requisitions module

### DIFF
--- a/src/pages/requisitions/RequisitionDetail.jsx
+++ b/src/pages/requisitions/RequisitionDetail.jsx
@@ -33,7 +33,7 @@ function RequisitionDetailPage() {
           <strong>Date :</strong> {requisition.date_demande}
         </div>
         <div>
-          <strong>Zone :</strong> {requisition.zone_id}
+          <strong>Zone :</strong> Cave
         </div>
         <div>
           <strong>Commentaire :</strong> {requisition.commentaire}
@@ -49,7 +49,7 @@ function RequisitionDetailPage() {
                   className="w-6 h-6 rounded object-cover"
                 />
                 <span>
-                  {l.produit?.nom || l.produit_id} - {l.quantite_demandee} (stock {l.stock_theorique_avant} → {l.stock_theorique_apres})
+                  {l.produit?.nom || l.produit_id} - {l.quantite_demandee} {l.unite?.nom || ""} (stock {l.stock_theorique_avant} → {l.stock_theorique_apres})
                 </span>
               </li>
             ))}

--- a/test/useRequisitions.test.js
+++ b/test/useRequisitions.test.js
@@ -30,28 +30,29 @@ test('getRequisitions applies filters', async () => {
   const { result } = renderHook(() => useRequisitions());
   await act(async () => {
     await result.current.getRequisitions({
-      zone: 'z1',
       statut: 'draft',
+      utilisateur: 'u2',
+      produit: 'p1',
       debut: '2025-01-01',
       fin: '2025-01-31',
       page: 2,
     });
   });
   expect(fromMock).toHaveBeenCalledWith('requisitions');
-  expect(query.select).toHaveBeenCalledWith('*', { count: 'exact' });
+  expect(query.select).toHaveBeenCalledWith('*, lignes:requisition_lignes(produit_id, unite_id)', { count: 'exact' });
   expect(query.eq).toHaveBeenCalledWith('mama_id', 'm1');
   expect(query.eq).toHaveBeenCalledWith('actif', true);
-  expect(query.eq).toHaveBeenCalledWith('zone_destination_id', 'z1');
   expect(query.eq).toHaveBeenCalledWith('statut', 'draft');
-  expect(query.gte).toHaveBeenCalledWith('date', '2025-01-01');
-  expect(query.lte).toHaveBeenCalledWith('date', '2025-01-31');
+  expect(query.eq).toHaveBeenCalledWith('utilisateur_id', 'u2');
+  expect(query.gte).toHaveBeenCalledWith('date_demande', '2025-01-01');
+  expect(query.lte).toHaveBeenCalledWith('date_demande', '2025-01-31');
   expect(query.range).toHaveBeenCalledWith(10, 19);
 });
 
 test('createRequisition inserts header and lines', async () => {
   const { result } = renderHook(() => useRequisitions());
   await act(async () => {
-    await result.current.createRequisition({ lignes: [{ produit_id: 'p1', quantite: 2 }] });
+    await result.current.createRequisition({ zone_id: 'z1', lignes: [{ produit_id: 'p1', quantite_demandee: 2, unite_id: 'u9' }] });
   });
   expect(fromMock).toHaveBeenCalledWith('requisitions');
   expect(query.insert).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- lock requisitions to cave zone and add product/user filters
- add unit selection to requisitions and show details
- support filters in useRequisitions hook

## Testing
- `npm run lint`
- `npm test test/useRequisitions.test.js`
- `npm test` *(fails: An update to FournisseurApiSettingsForm inside a test was not wrapped in act(...); FAIL useMenus.test.js; FAIL usePromotions.test.js; FAIL useRequisitions.test.js; FAIL visual_update.test.js; FAIL weekly_report.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_689509e80240832da153879fc11334f6