### PR TITLE
feat: add Supabase utilisateur module

### DIFF
--- a/db/utilisateurs.sql
+++ b/db/utilisateurs.sql
@@ -1,0 +1,83 @@
+-- MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+-- Table et sécurité pour les utilisateurs MamaStock
+
+create table if not exists public.utilisateurs (
+  id uuid primary key default gen_random_uuid(),
+  nom text not null,
+  email text not null,
+  auth_id uuid unique,
+  role_id uuid references public.roles(id) on delete restrict,
+  mama_id uuid references public.mamas(id) on delete cascade,
+  actif boolean default true,
+  created_at timestamp default now(),
+  updated_at timestamp default now()
+);
+
+-- RLS policies
+alter table public.utilisateurs enable row level security;
+
+drop policy if exists utilisateurs_select on public.utilisateurs;
+drop policy if exists utilisateurs_insert on public.utilisateurs;
+drop policy if exists utilisateurs_update on public.utilisateurs;
+
+create policy utilisateurs_select on public.utilisateurs
+  for select using (
+    mama_id = current_user_mama_id()
+  );
+
+create policy utilisateurs_insert on public.utilisateurs
+  for insert with check (
+    current_user_role() = 'admin'
+    and mama_id = current_user_mama_id()
+  );
+
+create policy utilisateurs_update on public.utilisateurs
+  for update using (
+    current_user_role() = 'admin'
+    and mama_id = current_user_mama_id()
+  );
+
+grant all on public.utilisateurs to authenticated;
+
+-- RPC function for creating a user and sending credentials
+create or replace function public.create_utilisateur(
+  p_email text,
+  p_nom text,
+  p_role_id uuid,
+  p_mama_id uuid
+) returns json
+language plpgsql
+security definer
+as $$
+declare
+  v_auth_id uuid;
+  v_password text;
+begin
+  -- ensure email not already used
+  if exists(select 1 from auth.users where lower(email) = lower(p_email)) then
+    raise exception 'email exists';
+  end if;
+
+  -- generate password
+  v_password := encode(gen_random_bytes(9), 'base64');
+
+  -- create auth user
+  insert into auth.users(email, encrypted_password)
+  values (p_email, crypt(v_password, gen_salt('bf'))) returning id into v_auth_id;
+
+  -- insert into utilisateurs table
+  insert into public.utilisateurs(nom, email, auth_id, role_id, mama_id, actif)
+  values(p_nom, p_email, v_auth_id, p_role_id, p_mama_id, true);
+
+  -- send email via http (placeholder)
+  perform net.http_post(
+    url => 'https://example.com/send',
+    body => jsonb_build_object('email', p_email, 'password', v_password)
+  );
+
+  return json_build_object('success', true);
+exception when others then
+  return json_build_object('success', false, 'error', SQLERRM);
+end;$$;
+
+grant execute on function public.create_utilisateur(text, text, uuid, uuid) to authenticated;

--- a/src/components/Utilisateurs/UtilisateurForm.jsx
+++ b/src/components/Utilisateurs/UtilisateurForm.jsx
@@ -1,0 +1,92 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { useState, useEffect } from "react";
+import { useUtilisateurs } from "@/hooks/useUtilisateurs";
+import { useRoles } from "@/hooks/useRoles";
+import useAuth from "@/hooks/useAuth";
+import GlassCard from "@/components/ui/GlassCard";
+import { Input } from "@/components/ui/input";
+import { Select } from "@/components/ui/select";
+import PrimaryButton from "@/components/ui/PrimaryButton";
+import SecondaryButton from "@/components/ui/SecondaryButton";
+import toast from "react-hot-toast";
+
+export default function UtilisateurForm({ utilisateur, onClose }) {
+  const { createUtilisateur, updateUtilisateur } = useUtilisateurs();
+  const { roles, fetchRoles } = useRoles();
+  const { mama_id } = useAuth();
+  const [nom, setNom] = useState(utilisateur?.nom || "");
+  const [email, setEmail] = useState(utilisateur?.email || "");
+  const [roleId, setRoleId] = useState(utilisateur?.role_id || "");
+  const [actif, setActif] = useState(utilisateur?.actif ?? true);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    fetchRoles();
+  }, [fetchRoles]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (loading) return;
+    setLoading(true);
+    const data = { nom, email, role_id: roleId, actif, mama_id };
+    try {
+      if (utilisateur?.id) {
+        await updateUtilisateur(utilisateur.id, data);
+        toast.success("Utilisateur modifié !");
+      } else {
+        await createUtilisateur(data);
+        toast.success("Utilisateur créé !");
+      }
+      onClose?.();
+    } catch (err) {
+      toast.error(err?.message || "Erreur lors de l'enregistrement.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <GlassCard title={utilisateur ? "Modifier l’utilisateur" : "Ajouter un utilisateur"}>
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <Input
+          className="mb-2"
+          type="text"
+          value={nom}
+          onChange={e => setNom(e.target.value)}
+          placeholder="Nom"
+          required
+        />
+        <Input
+          className="mb-2"
+          type="email"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+          placeholder="Email"
+          required
+          readOnly={!!utilisateur?.id}
+        />
+        <Select
+          className="mb-2"
+          value={roleId}
+          onChange={e => setRoleId(e.target.value)}
+          required
+        >
+          {roles.map(r => (
+            <option key={r.id} value={r.id}>{r.nom}</option>
+          ))}
+        </Select>
+        <label className="flex items-center gap-2 mb-2">
+          <input type="checkbox" checked={actif} onChange={e => setActif(e.target.checked)} />
+          Actif
+        </label>
+        <div className="flex gap-2 mt-4">
+          <PrimaryButton type="submit" disabled={loading} className="flex items-center gap-2">
+            {loading && <span className="loader-glass" />}
+            {utilisateur ? "Modifier" : "Ajouter"}
+          </PrimaryButton>
+          <SecondaryButton type="button" onClick={onClose}>Annuler</SecondaryButton>
+        </div>
+      </form>
+    </GlassCard>
+  );
+}

--- a/src/components/Utilisateurs/UtilisateurRow.jsx
+++ b/src/components/Utilisateurs/UtilisateurRow.jsx
@@ -1,0 +1,20 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+
+export default function UtilisateurRow({ utilisateur, onEdit, onToggleActive, canEdit }) {
+  return (
+    <tr className={utilisateur.actif ? "" : "opacity-60"}>
+      <td>{utilisateur.nom}</td>
+      <td>{utilisateur.email}</td>
+      <td>{utilisateur.role}</td>
+      <td>{utilisateur.actif ? "Actif" : "Inactif"}</td>
+      {canEdit && (
+        <td>
+          <button className="btn btn-sm mr-2" onClick={() => onEdit(utilisateur)}>Éditer</button>
+          <button className="btn btn-sm" onClick={() => onToggleActive(utilisateur)}>
+            {utilisateur.actif ? "Désactiver" : "Activer"}
+          </button>
+        </td>
+      )}
+    </tr>
+  );
+}

--- a/test/Utilisateurs.test.jsx
+++ b/test/Utilisateurs.test.jsx
@@ -1,0 +1,24 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { render, screen } from '@testing-library/react';
+import { vi, test } from 'vitest';
+
+vi.mock('@/hooks/useUtilisateurs', () => ({
+  useUtilisateurs: () => ({
+    users: [],
+    loading: false,
+    error: null,
+    getUtilisateurs: vi.fn(),
+    toggleUserActive: vi.fn(),
+  }),
+}));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1', role: 'admin', loading: false }) }));
+vi.mock('@/hooks/useRoles', () => ({ useRoles: () => ({ roles: [], fetchRoles: vi.fn() }) }));
+vi.mock('@/components/Utilisateurs/UtilisateurRow', () => ({ default: () => <tr data-testid="row" /> }));
+vi.mock('@/components/Utilisateurs/UtilisateurForm', () => ({ default: () => <div>form</div> }));
+
+import Utilisateurs from '@/pages/parametrage/Utilisateurs.jsx';
+
+test('renders add user button', () => {
+  render(<Utilisateurs />);
+  expect(screen.getByText('Ajouter un utilisateur')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add SQL table and RLS policies for `utilisateurs` with `create_utilisateur` RPC
- implement React list, form and row components for managing users
- update hook to use RPC and expose CRUD helpers with tests

## Testing
- `npm test test/useUtilisateurs.test.js test/Utilisateurs.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68959df95124832d9c55a6892f775ec0