### PR TITLE
feat: track supplier emails

### DIFF
--- a/db/ajout.sql
+++ b/db/ajout.sql
@@ -95,3 +95,19 @@ for update using (
 );
 
 grant select, insert, update, delete on public.templates_commandes to authenticated;
+
+-- Historique des emails envoyés pour les commandes fournisseur
+create table if not exists public."emails_envoyés" (
+  id uuid primary key default gen_random_uuid(),
+  commande_id uuid references public.commandes(id) on delete cascade,
+  email text not null,
+  statut text default 'en_attente',
+  "envoyé_le" timestamptz default now(),
+  mama_id uuid not null references public.mamas(id) on delete cascade
+);
+
+alter table public."emails_envoyés" enable row level security;
+create policy rls_emails_envoyes on public."emails_envoyés"
+  for all
+  using (mama_id = current_user_mama_id());
+grant all on public."emails_envoyés" to authenticated;

--- a/supabase/functions/sendCommandeEmail/index.ts
+++ b/supabase/functions/sendCommandeEmail/index.ts
@@ -30,6 +30,13 @@ serve(async (req) => {
     }),
   });
 
+  await supabase.from("emails_envoyés").insert({
+    commande_id: commande.id,
+    email: fournisseur.email,
+    statut: res.ok ? "succès" : "erreur",
+    mama_id: commande.mama_id,
+  });
+
   if (res.ok) return new Response("Email sent", { status: 200 });
   return new Response("Email failed", { status: 500 });
 });


### PR DESCRIPTION
## Summary
- record command email history in new `emails_envoyés` table with RLS
- log email send outcome in `sendCommandeEmail` edge function

## Testing
- `npm run lint`
- `npm test` *(fails: expected spy to be called with arguments)*

------
https://chatgpt.com/codex/tasks/task_e_6895b090d82c832d97c93b97ba8131a1