### PR TITLE
feat: add emails envoyes module

### DIFF
--- a/access_rights_generated.json
+++ b/access_rights_generated.json
@@ -232,5 +232,11 @@
     "create": false,
     "edit": false,
     "delete": false
+  },
+  "emails_envoyes": {
+    "view": false,
+    "create": false,
+    "edit": false,
+    "delete": false
   }
 }

--- a/access_rights_template.json
+++ b/access_rights_template.json
@@ -233,5 +233,11 @@
     "edit": false,
     "delete": false
   },
-    
+  "emails_envoyes": {
+    "view": false,
+    "create": false,
+    "edit": false,
+    "delete": false
+  }
+
 }

--- a/router_mapping.json
+++ b/router_mapping.json
@@ -292,6 +292,10 @@
     "module": "licences"
   },
   {
+    "route": "/emails/envoyes",
+    "module": "emails_envoyes"
+  },
+  {
     "route": "/logs",
     "module": "logs"
   },

--- a/src/config/modules.js
+++ b/src/config/modules.js
@@ -37,4 +37,5 @@ export const MODULES = [
   { label: "Paramétrage", key: "parametrage" },
   { label: "Feedback", key: "feedback" },
   { label: "Logs", key: "logs" },
+  { label: "Emails envoyés", key: "emails_envoyes" },
 ];

--- a/src/hooks/useEmailsEnvoyes.js
+++ b/src/hooks/useEmailsEnvoyes.js
@@ -1,0 +1,52 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { useState } from "react";
+import { supabase } from "@/lib/supabase";
+import useAuth from "@/hooks/useAuth";
+
+export function useEmailsEnvoyes() {
+  const { mama_id } = useAuth();
+  const [emails, setEmails] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  async function fetchEmails({
+    statut,
+    email,
+    date_start,
+    date_end,
+    commande_id,
+    page = 1,
+    limit = 50,
+  } = {}) {
+    if (!mama_id) return { data: [], count: 0 };
+    setLoading(true);
+    setError(null);
+    let query = supabase
+      .from("emails_envoyes")
+      .select(
+        "id, commande_id, email, statut, envoye_le, commandes:commande_id(reference)",
+        { count: "exact" }
+      )
+      .eq("mama_id", mama_id)
+      .order("envoye_le", { ascending: false })
+      .range((page - 1) * limit, page * limit - 1);
+
+    if (statut) query = query.eq("statut", statut);
+    if (email) query = query.ilike("email", `%${email}%`);
+    if (commande_id) query = query.eq("commande_id", commande_id);
+    if (date_start) query = query.gte("envoye_le", date_start);
+    if (date_end) query = query.lte("envoye_le", date_end);
+
+    const { data, error, count } = await query;
+    setLoading(false);
+    if (error) {
+      setError(error);
+      setEmails([]);
+      return { data: [], count: 0 };
+    }
+    setEmails(Array.isArray(data) ? data : []);
+    return { data: data || [], count: count || 0 };
+  }
+
+  return { emails, loading, error, fetchEmails };
+}

--- a/src/layout/Sidebar.jsx
+++ b/src/layout/Sidebar.jsx
@@ -25,6 +25,7 @@ import {
   HelpCircle,
   Gift,
   Bell,
+  Mail,
   MessageCircle,
   Plug,
 } from "lucide-react";
@@ -105,6 +106,7 @@ export default function Sidebar() {
       title: "Notifications",
       items: [
         { module: "notifications", to: "/notifications", label: "Notifications", icon: <Bell size={16} /> },
+        { module: "emails_envoyes", to: "/emails/envoyes", label: "Emails envoyés", icon: <Mail size={16} /> },
       ],
     },
     {

--- a/src/pages/emails/EmailsEnvoyes.jsx
+++ b/src/pages/emails/EmailsEnvoyes.jsx
@@ -1,0 +1,169 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { useEmailsEnvoyes } from "@/hooks/useEmailsEnvoyes";
+import useAuth from "@/hooks/useAuth";
+import TableContainer from "@/components/ui/TableContainer";
+import GlassCard from "@/components/ui/GlassCard";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import PaginationFooter from "@/components/ui/PaginationFooter";
+import { Badge } from "@/components/ui/badge";
+import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import * as XLSX from "xlsx";
+import { saveAs } from "file-saver";
+
+export default function EmailsEnvoyes() {
+  const { mama_id, loading: authLoading } = useAuth();
+  const { emails, fetchEmails, loading, error } = useEmailsEnvoyes();
+  const [page, setPage] = useState(1);
+  const [pages, setPages] = useState(1);
+  const [statut, setStatut] = useState("");
+  const [email, setEmail] = useState("");
+  const [commande, setCommande] = useState("");
+  const [start, setStart] = useState("");
+  const [end, setEnd] = useState("");
+
+  useEffect(() => {
+    if (!authLoading && mama_id) load();
+  }, [authLoading, mama_id, page]);
+
+  async function load() {
+    const { count } = await fetchEmails({
+      statut: statut || undefined,
+      email: email || undefined,
+      commande_id: commande || undefined,
+      date_start: start || undefined,
+      date_end: end || undefined,
+      page,
+    });
+    setPages(Math.max(1, Math.ceil((count || 0) / 50)));
+  }
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setPage(1);
+    await load();
+  };
+
+  const exportExcel = () => {
+    const rows = emails.map((e) => ({
+      envoye_le: e.envoye_le,
+      email: e.email,
+      commande: e.commandes?.reference || e.commande_id,
+      statut: e.statut,
+    }));
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, XLSX.utils.json_to_sheet(rows), "Emails");
+    const buf = XLSX.write(wb, { bookType: "xlsx", type: "array" });
+    saveAs(new Blob([buf]), "emails-envoyes.xlsx");
+  };
+
+  if (authLoading) return <LoadingSpinner message="Chargement..." />;
+  if (!mama_id) return null;
+
+  return (
+    <div className="p-6 space-y-4 container mx-auto text-sm">
+      <h1 className="text-2xl font-bold">Emails envoyés</h1>
+      <GlassCard title="Filtrer" className="mb-4">
+        <form onSubmit={handleSubmit} className="flex flex-wrap gap-2 items-end">
+          <select
+            value={statut}
+            onChange={(e) => setStatut(e.target.value)}
+            className="border rounded px-2 py-1 text-black"
+          >
+            <option value="">Tous</option>
+            <option value="success">Succès</option>
+            <option value="error">Erreur</option>
+          </select>
+          <Input
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-40"
+          />
+          <Input
+            placeholder="Commande"
+            value={commande}
+            onChange={(e) => setCommande(e.target.value)}
+            className="w-32"
+          />
+          <Input
+            type="date"
+            value={start}
+            onChange={(e) => setStart(e.target.value)}
+          />
+          <Input
+            type="date"
+            value={end}
+            onChange={(e) => setEnd(e.target.value)}
+          />
+          <Button type="submit" className="text-sm">
+            Filtrer
+          </Button>
+          <Button type="button" className="text-sm" onClick={exportExcel}>
+            Exporter Excel
+          </Button>
+        </form>
+      </GlassCard>
+
+      {loading ? (
+        <LoadingSpinner message="Chargement..." />
+      ) : error ? (
+        <div className="text-red-600">{error.message || error}</div>
+      ) : (
+        <>
+          <TableContainer>
+            <table className="min-w-full text-xs md:table">
+              <thead className="hidden md:table-header-group">
+                <tr>
+                  <th className="px-2 py-1">Date d'envoi</th>
+                  <th className="px-2 py-1">Email</th>
+                  <th className="px-2 py-1">Commande</th>
+                  <th className="px-2 py-1">Statut</th>
+                </tr>
+              </thead>
+              <tbody>
+                {emails.map((e) => (
+                  <tr
+                    key={e.id}
+                    className="border-b border-white/10 md:table-row block md:border-0 mb-2 md:mb-0"
+                  >
+                    <td className="px-2 py-1 md:border-none block md:table-cell">
+                      <span className="md:hidden font-semibold">Date: </span>
+                      {new Date(e.envoye_le).toLocaleString()}
+                    </td>
+                    <td className="px-2 py-1 md:border-none block md:table-cell break-all">
+                      <span className="md:hidden font-semibold">Email: </span>
+                      {e.email}
+                    </td>
+                    <td className="px-2 py-1 md:border-none block md:table-cell">
+                      <span className="md:hidden font-semibold">Commande: </span>
+                      <Link
+                        to={`/commandes/${e.commande_id}`}
+                        className="underline text-mamastockGold"
+                      >
+                        {e.commandes?.reference || e.commande_id}
+                      </Link>
+                    </td>
+                    <td className="px-2 py-1 md:border-none block md:table-cell">
+                      <span className="md:hidden font-semibold">Statut: </span>
+                      <Badge color={e.statut === "success" ? "green" : "red"}>
+                        {e.statut === "success" ? "Succès" : "Erreur"}
+                      </Badge>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </TableContainer>
+          <PaginationFooter
+            page={page}
+            pages={pages}
+            onPageChange={(p) => setPage(p)}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -81,6 +81,7 @@ const FournisseurApiSettingsForm = lazyWithPreload(() => import("@/pages/fournis
 const ApiFournisseurs = lazyWithPreload(() => import("@/pages/fournisseurs/ApiFournisseurs.jsx"));
 const CatalogueSyncViewer = lazyWithPreload(() => import("@/pages/catalogue/CatalogueSyncViewer.jsx"));
 const CommandesEnvoyees = lazyWithPreload(() => import("@/pages/commandes/CommandesEnvoyees.jsx"));
+const EmailsEnvoyes = lazyWithPreload(() => import("@/pages/emails/EmailsEnvoyes.jsx"));
 const SimulationPlanner = lazyWithPreload(() => import("@/pages/planning/SimulationPlanner.jsx"));
 const Commandes = lazyWithPreload(() => import("@/pages/commandes/Commandes.jsx"));
 const Planning = lazyWithPreload(() => import("@/pages/Planning.jsx"));
@@ -124,6 +125,7 @@ export const routePreloadMap = {
   '/bons-livraison': BonsLivraison.preload,
   '/documents': Documents.preload,
   '/notifications': NotificationsInbox.preload,
+  '/emails/envoyes': EmailsEnvoyes.preload,
   '/planning': Planning.preload,
   '/planning/simulation': SimulationPlanner.preload,
   '/taches': Taches.preload,
@@ -390,6 +392,10 @@ export default function Router() {
           <Route
             path="/commandes/envoyees"
             element={<ProtectedRoute moduleKey="fournisseurs"><CommandesEnvoyees /></ProtectedRoute>}
+          />
+          <Route
+            path="/emails/envoyes"
+            element={<ProtectedRoute moduleKey="emails_envoyes"><EmailsEnvoyes /></ProtectedRoute>}
           />
           <Route
             path="/planning"

--- a/test/useEmailsEnvoyes.test.js
+++ b/test/useEmailsEnvoyes.test.js
@@ -1,0 +1,65 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { renderHook, act } from '@testing-library/react';
+import { vi, beforeEach, test, expect } from 'vitest';
+
+const final = { then: (fn) => fn({ data: [{ id: 'e1' }], count: 1, error: null }) };
+const selectMock = vi.fn(() => builder);
+const eqMock = vi.fn(() => builder);
+const ilikeMock = vi.fn(() => builder);
+const gteMock = vi.fn(() => builder);
+const lteMock = vi.fn(() => builder);
+const orderMock = vi.fn(() => builder);
+const rangeMock = vi.fn(() => builder);
+const builder = {
+  select: (...args) => { selectMock(...args); return builder; },
+  eq: (...args) => { eqMock(...args); return builder; },
+  ilike: (...args) => { ilikeMock(...args); return builder; },
+  gte: (...args) => { gteMock(...args); return builder; },
+  lte: (...args) => { lteMock(...args); return builder; },
+  order: (...args) => { orderMock(...args); return builder; },
+  range: (...args) => { rangeMock(...args); return builder; },
+  then: final.then,
+};
+
+const fromMock = vi.fn(() => builder);
+
+vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
+vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1' }) }));
+
+let useEmailsEnvoyes;
+
+beforeEach(async () => {
+  ({ useEmailsEnvoyes } = await import('@/hooks/useEmailsEnvoyes'));
+  fromMock.mockClear();
+  selectMock.mockClear();
+  eqMock.mockClear();
+  ilikeMock.mockClear();
+  gteMock.mockClear();
+  lteMock.mockClear();
+  orderMock.mockClear();
+  rangeMock.mockClear();
+});
+
+test('fetchEmails queries emails_envoyes with filters', async () => {
+  const { result } = renderHook(() => useEmailsEnvoyes());
+  await act(async () => {
+    await result.current.fetchEmails({
+      statut: 'success',
+      email: 'test',
+      commande_id: 'c1',
+      date_start: '2024-01-01',
+      date_end: '2024-01-02',
+    });
+  });
+  expect(fromMock).toHaveBeenCalledWith('emails_envoyes');
+  expect(selectMock).toHaveBeenCalled();
+  expect(eqMock).toHaveBeenCalledWith('mama_id', 'm1');
+  expect(orderMock).toHaveBeenCalledWith('envoye_le', { ascending: false });
+  expect(rangeMock).toHaveBeenCalledWith(0, 49);
+  expect(eqMock).toHaveBeenCalledWith('statut', 'success');
+  expect(ilikeMock).toHaveBeenCalledWith('email', '%test%');
+  expect(eqMock).toHaveBeenCalledWith('commande_id', 'c1');
+  expect(gteMock).toHaveBeenCalledWith('envoye_le', '2024-01-01');
+  expect(lteMock).toHaveBeenCalledWith('envoye_le', '2024-01-02');
+  expect(result.current.emails).toEqual([{ id: 'e1' }]);
+});


### PR DESCRIPTION
## Summary
- add hook and page to list sent emails with filters and export
- expose Emails envoyés in router, modules, sidebar and access rights
- add unit test for emails hook

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module '@testing-library/dom')*


------
https://chatgpt.com/codex/tasks/task_e_6895b1b72840832dbfe8ad89333840a9