### PR TITLE
feat: view and resend sent emails with PDF

### DIFF
--- a/src/hooks/useEmailsEnvoyes.js
+++ b/src/hooks/useEmailsEnvoyes.js
@@ -2,9 +2,11 @@
 import { useState } from "react";
 import { supabase } from "@/lib/supabase";
 import useAuth from "@/hooks/useAuth";
+import { pdf } from "@react-pdf/renderer";
+import CommandePDF from "@/components/pdf/CommandePDF";
 
 export function useEmailsEnvoyes() {
-  const { mama_id } = useAuth();
+  const { mama_id, role } = useAuth();
   const [emails, setEmails] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
@@ -48,5 +50,59 @@ export function useEmailsEnvoyes() {
     return { data: data || [], count: count || 0 };
   }
 
-  return { emails, loading, error, fetchEmails };
+  async function resendEmail(id) {
+    if (!mama_id) return { error: "mama_id manquant" };
+    if (role !== "admin") return { error: "Accès refusé" };
+
+    const { data: record, error: recErr } = await supabase
+      .from("emails_envoyes")
+      .select("id, commande_id, email, mama_id")
+      .eq("id", id)
+      .eq("mama_id", mama_id)
+      .single();
+    if (recErr || !record) return { error: recErr || "Email introuvable" };
+
+    const { data: commande, error: cmdErr } = await supabase
+      .from("commandes")
+      .select(
+        "*, fournisseur:fournisseur_id(id, nom, email), lignes:commande_lignes(*, produit:produit_id(id, nom))"
+      )
+      .eq("id", record.commande_id)
+      .eq("mama_id", mama_id)
+      .single();
+    if (cmdErr || !commande) return { error: cmdErr || "Commande introuvable" };
+
+    let template = null;
+    if (commande.template_id) {
+      const { data: tpl } = await supabase
+        .from("templates_commandes")
+        .select("*")
+        .eq("id", commande.template_id)
+        .single();
+      template = tpl || null;
+    }
+
+    const blob = await pdf(
+      <CommandePDF commande={commande} template={template} fournisseur={commande.fournisseur} />,
+    ).toBlob();
+
+    const base64 = await new Promise((resolve) => {
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        resolve(reader.result.split(",")[1]);
+      };
+      reader.readAsDataURL(blob);
+    });
+
+    const fournisseur = { ...commande.fournisseur, email: record.email };
+
+    const { error: sendErr } = await supabase.functions.invoke("sendCommandeEmail", {
+      body: { commande, fournisseur, pdfBase64: base64 },
+    });
+    if (sendErr) return { error: sendErr };
+
+    return { data: true };
+  }
+
+  return { emails, loading, error, fetchEmails, resendEmail };
 }


### PR DESCRIPTION
## Summary
- allow viewing and resending command emails from EmailsEnvoyes
- add resendEmail hook to regenerate PDF and send email again

## Testing
- `npm run lint`
- `npm test` *(fails: backup_db.test.js, public_api.test.js, reallocate_history.test.js, weekly_report.test.js, export_accounting.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_6895b4a068a8832db57f456c2cb0846d