### PR TITLE
feat(commandes): add stateful hook and routing

### DIFF
--- a/src/pages/commandes/CommandeDetail.jsx
+++ b/src/pages/commandes/CommandeDetail.jsx
@@ -25,12 +25,11 @@ async function generateCommandePDFBase64(commande, template, fournisseur) {
 
 export default function CommandeDetail() {
   const { id } = useParams();
-  const { fetchCommandeById } = useCommandes();
-  const [commande, setCommande] = useState(null);
+  const { currentCommande: commande, fetchCommandeById, loading } = useCommandes();
   const [template, setTemplate] = useState(null);
 
   useEffect(() => {
-    fetchCommandeById(id).then(data => setCommande(data));
+    fetchCommandeById(id);
   }, [id, fetchCommandeById]);
 
   useEffect(() => {
@@ -44,7 +43,7 @@ export default function CommandeDetail() {
     }
   }, [commande]);
 
-  if (!commande) return <div>Chargement...</div>;
+  if (loading || !commande) return <div>Chargement...</div>;
 
   const fournisseur = commande.fournisseur;
 

--- a/src/pages/commandes/Commandes.jsx
+++ b/src/pages/commandes/Commandes.jsx
@@ -7,15 +7,14 @@ import { useFournisseurs } from "@/hooks/useFournisseurs";
 
 export default function Commandes() {
   const { mama_id, role } = useAuth();
-  const { fetchCommandes, validateCommande } = useCommandes();
+  const { commandes, fetchCommandes, validateCommande, loading } = useCommandes();
   const { fournisseurs, fetchFournisseurs } = useFournisseurs();
   const [filters, setFilters] = useState({ fournisseur: "", statut: "", debut: "", fin: "" });
-  const [rows, setRows] = useState([]);
 
   useEffect(() => { fetchFournisseurs({ limit: 1000 }); }, [fetchFournisseurs]);
   useEffect(() => {
     if (!mama_id) return;
-    fetchCommandes({ ...filters }).then(({ data }) => setRows(data));
+    fetchCommandes({ ...filters });
   }, [mama_id, filters, fetchCommandes]);
 
   return (
@@ -84,21 +83,27 @@ export default function Commandes() {
             </tr>
           </thead>
           <tbody>
-            {rows.map(c => (
-              <tr key={c.id} className="border-b border-white/10">
-                <td>{c.reference}</td>
-                <td>{c.fournisseur?.nom || '-'}</td>
-                <td>{c.date_commande}</td>
-                <td>{c.statut}</td>
-                <td>{c.total || 0}</td>
-                <td className="space-x-2">
-                  <Link to={`/commandes/${c.id}`}>Voir</Link>
-                  {role === 'admin' && c.statut === 'brouillon' && (
-                    <button onClick={() => validateCommande(c.id)}>Valider</button>
-                  )}
-                </td>
+            {loading ? (
+              <tr>
+                <td colSpan={6}>Chargement...</td>
               </tr>
-            ))}
+            ) : (
+              commandes.map((c) => (
+                <tr key={c.id} className="border-b border-white/10">
+                  <td>{c.reference}</td>
+                  <td>{c.fournisseur?.nom || '-'}</td>
+                  <td>{c.date_commande}</td>
+                  <td>{c.statut}</td>
+                  <td>{c.total || 0}</td>
+                  <td className="space-x-2">
+                    <Link to={`/commandes/${c.id}`}>Voir</Link>
+                    {role === 'admin' && c.statut === 'brouillon' && (
+                      <button onClick={() => validateCommande(c.id)}>Valider</button>
+                    )}
+                  </td>
+                </tr>
+              ))
+            )}
           </tbody>
         </table>
       </div>

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -81,6 +81,8 @@ const FournisseurApiSettingsForm = lazyWithPreload(() => import("@/pages/fournis
 const ApiFournisseurs = lazyWithPreload(() => import("@/pages/fournisseurs/ApiFournisseurs.jsx"));
 const CatalogueSyncViewer = lazyWithPreload(() => import("@/pages/catalogue/CatalogueSyncViewer.jsx"));
 const CommandesEnvoyees = lazyWithPreload(() => import("@/pages/commandes/CommandesEnvoyees.jsx"));
+const CommandeForm = lazyWithPreload(() => import("@/pages/commandes/CommandeForm.jsx"));
+const CommandeDetail = lazyWithPreload(() => import("@/pages/commandes/CommandeDetail.jsx"));
 const EmailsEnvoyes = lazyWithPreload(() => import("@/pages/emails/EmailsEnvoyes.jsx"));
 const SimulationPlanner = lazyWithPreload(() => import("@/pages/planning/SimulationPlanner.jsx"));
 const Commandes = lazyWithPreload(() => import("@/pages/commandes/Commandes.jsx"));
@@ -126,6 +128,10 @@ export const routePreloadMap = {
   '/documents': Documents.preload,
   '/notifications': NotificationsInbox.preload,
   '/emails/envoyes': EmailsEnvoyes.preload,
+  '/commandes': Commandes.preload,
+  '/commandes/envoyees': CommandesEnvoyees.preload,
+  '/commandes/nouvelle': CommandeForm.preload,
+  '/commandes/:id': CommandeDetail.preload,
   '/planning': Planning.preload,
   '/planning/simulation': SimulationPlanner.preload,
   '/taches': Taches.preload,
@@ -392,6 +398,14 @@ export default function Router() {
           <Route
             path="/commandes/envoyees"
             element={<ProtectedRoute moduleKey="fournisseurs"><CommandesEnvoyees /></ProtectedRoute>}
+          />
+          <Route
+            path="/commandes/nouvelle"
+            element={<ProtectedRoute moduleKey="fournisseurs"><CommandeForm /></ProtectedRoute>}
+          />
+          <Route
+            path="/commandes/:id"
+            element={<ProtectedRoute moduleKey="fournisseurs"><CommandeDetail /></ProtectedRoute>}
           />
           <Route
             path="/emails/envoyes"

--- a/test/CommandeForm.test.jsx
+++ b/test/CommandeForm.test.jsx
@@ -3,7 +3,9 @@ import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { vi } from 'vitest';
 
-vi.mock('@/hooks/useCommandes', () => ({ useCommandes: () => ({ createCommande: vi.fn() }) }));
+vi.mock('@/hooks/useCommandes', () => ({
+  useCommandes: () => ({ commandes: [], loading: false, createCommande: vi.fn() }),
+}));
 vi.mock('@/hooks/useFournisseurs', () => ({ useFournisseurs: () => ({ fournisseurs: [], fetchFournisseurs: vi.fn() }) }));
 vi.mock('@/hooks/useProduitsFournisseur', () => ({ useProduitsFournisseur: () => ({ useProduitsDuFournisseur: () => ({ products: [], fetch: vi.fn() }) }) }));
 vi.mock('@/hooks/useAuth', () => ({ default: () => ({ role: 'admin' }) }));

--- a/test/Commandes.test.jsx
+++ b/test/Commandes.test.jsx
@@ -3,7 +3,14 @@ import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { vi } from 'vitest';
 
-vi.mock('@/hooks/useCommandes', () => ({ useCommandes: () => ({ fetchCommandes: vi.fn().mockResolvedValue({ data: [], count: 0 }), validateCommande: vi.fn() }) }));
+vi.mock('@/hooks/useCommandes', () => ({
+  useCommandes: () => ({
+    commandes: [],
+    loading: false,
+    fetchCommandes: vi.fn().mockResolvedValue({ data: [], count: 0 }),
+    validateCommande: vi.fn(),
+  }),
+}));
 vi.mock('@/hooks/useFournisseurs', () => ({ useFournisseurs: () => ({ fournisseurs: [], fetchFournisseurs: vi.fn() }) }));
 vi.mock('@/hooks/useAuth', () => ({ default: () => ({ mama_id: 'm1', role: 'admin' }) }));
 


### PR DESCRIPTION
## Summary
- refactor useCommandes hook to expose state, loading and error handling
- update Commandes pages to leverage stateful hook and improve loading UX
- add missing CommandeForm and CommandeDetail routes with preload mapping

## Testing
- `npm test` *(fails: Cannot find module '@testing-library/dom')*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895d86fcce0832d9a9cb762be667c14