### PR TITLE
refactor: expose data in useCommandes

### DIFF
--- a/src/hooks/useCommandes.js
+++ b/src/hooks/useCommandes.js
@@ -5,7 +5,7 @@ import useAuth from "@/hooks/useAuth";
 
 export function useCommandes() {
   const { mama_id, user_id } = useAuth();
-  const [commandes, setCommandes] = useState([]);
+  const [data, setData] = useState([]);
   const [current, setCurrent] = useState(null);
   const [count, setCount] = useState(0);
   const [loading, setLoading] = useState(false);
@@ -34,7 +34,7 @@ export function useCommandes() {
       if (error) {
         console.error("❌ fetchCommandes", error.message);
         setError(error);
-        setCommandes([]);
+        setData([]);
         setCount(0);
         return { data: [], count: 0 };
       }
@@ -42,7 +42,7 @@ export function useCommandes() {
         ...c,
         total: (c.lignes || []).reduce((s, l) => s + Number(l.total_ligne || 0), 0),
       }));
-      setCommandes(rows);
+      setData(rows);
       setCount(count || 0);
       return { data: rows, count: count || 0 };
     },
@@ -65,12 +65,12 @@ export function useCommandes() {
       setLoading(false);
       if (error) {
         console.error("❌ fetchCommandeById", error.message);
-        setError(error);
-        setCurrent(null);
-        return null;
-      }
-      setCurrent(data);
-      return data;
+      setError(error);
+      setCurrent(null);
+      return null;
+    }
+    setCurrent(data);
+    return data;
     },
     [mama_id]
   );
@@ -145,7 +145,8 @@ export function useCommandes() {
   }
 
   return {
-    commandes,
+    data,
+    commandes: data,
     currentCommande: current,
     count,
     loading,

--- a/src/pages/commandes/Commandes.jsx
+++ b/src/pages/commandes/Commandes.jsx
@@ -7,7 +7,7 @@ import { useFournisseurs } from "@/hooks/useFournisseurs";
 
 export default function Commandes() {
   const { mama_id, role } = useAuth();
-  const { commandes, fetchCommandes, validateCommande, loading } = useCommandes();
+  const { data: commandes, fetchCommandes, validateCommande, loading } = useCommandes();
   const { fournisseurs, fetchFournisseurs } = useFournisseurs();
   const [filters, setFilters] = useState({ fournisseur: "", statut: "", debut: "", fin: "" });
 

--- a/test/CommandeForm.test.jsx
+++ b/test/CommandeForm.test.jsx
@@ -4,7 +4,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { vi } from 'vitest';
 
 vi.mock('@/hooks/useCommandes', () => ({
-  useCommandes: () => ({ commandes: [], loading: false, createCommande: vi.fn() }),
+  useCommandes: () => ({ data: [], commandes: [], loading: false, createCommande: vi.fn() }),
 }));
 vi.mock('@/hooks/useFournisseurs', () => ({ useFournisseurs: () => ({ fournisseurs: [], fetchFournisseurs: vi.fn() }) }));
 vi.mock('@/hooks/useProduitsFournisseur', () => ({ useProduitsFournisseur: () => ({ useProduitsDuFournisseur: () => ({ products: [], fetch: vi.fn() }) }) }));

--- a/test/Commandes.test.jsx
+++ b/test/Commandes.test.jsx
@@ -5,6 +5,7 @@ import { vi } from 'vitest';
 
 vi.mock('@/hooks/useCommandes', () => ({
   useCommandes: () => ({
+    data: [],
     commandes: [],
     loading: false,
     fetchCommandes: vi.fn().mockResolvedValue({ data: [], count: 0 }),


### PR DESCRIPTION
## Summary
- expose `data` array in `useCommandes`
- update commandes page to use `data`
- adjust tests for new hook return shape

## Testing
- `npm test` *(fails: Cannot find module '@testing-library/dom')*
- `npm run lint`
- `npm run build` *(fails: src/hooks/useEmailsEnvoyes.js (86:6): Expression expected)*

------
https://chatgpt.com/codex/tasks/task_e_6895daf33c48832db19529f96e18ece0