### PR TITLE
feat: add error handling for template hooks

### DIFF
--- a/src/hooks/useTemplatesCommandes.js
+++ b/src/hooks/useTemplatesCommandes.js
@@ -14,32 +14,50 @@ export async function getTemplatesCommandesActifs() {
 export default function useTemplatesCommandes() {
   const [templates, setTemplates] = useState([]);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
 
   const fetchTemplates = async () => {
     setLoading(true);
-    const { data } = await supabase
+    setError(null);
+    const { data, error } = await supabase
       .from("templates_commandes")
       .select("*")
       .order("nom");
-    setTemplates(data || []);
+    if (error) {
+      setError(error);
+      setTemplates([]);
+    } else {
+      setTemplates(data || []);
+    }
     setLoading(false);
+    return { data, error };
   };
 
-  const saveTemplate = async template => {
+  const saveTemplate = async (template) => {
+    setError(null);
     const { error } = await supabase
       .from("templates_commandes")
       .upsert(template)
       .select();
-    if (!error) fetchTemplates();
+    if (error) {
+      setError(error);
+    } else {
+      fetchTemplates();
+    }
     return { error };
   };
 
   const toggleActif = async (id, actif) => {
+    setError(null);
     const { error } = await supabase
       .from("templates_commandes")
       .update({ actif })
       .eq("id", id);
-    if (!error) fetchTemplates();
+    if (error) {
+      setError(error);
+    } else {
+      fetchTemplates();
+    }
     return { error };
   };
 
@@ -47,5 +65,13 @@ export default function useTemplatesCommandes() {
     fetchTemplates();
   }, []);
 
-  return { templates, loading, fetchTemplates, saveTemplate, toggleActif };
+  return {
+    data: templates,
+    templates,
+    loading,
+    error,
+    fetchTemplates,
+    saveTemplate,
+    toggleActif,
+  };
 }

--- a/src/pages/parametrage/TemplatesCommandes.jsx
+++ b/src/pages/parametrage/TemplatesCommandes.jsx
@@ -5,7 +5,7 @@ import TemplateCommandeForm from "./TemplateCommandeForm";
 import { Button } from "@/components/ui/button";
 
 export default function TemplatesCommandes() {
-  const { templates, loading, toggleActif } = useTemplatesCommandes();
+  const { templates, loading, error, toggleActif } = useTemplatesCommandes();
   const [selected, setSelected] = useState(null);
 
   return (
@@ -15,6 +15,7 @@ export default function TemplatesCommandes() {
       <Button onClick={() => setSelected({})}>➕ Nouveau modèle</Button>
 
       {loading && <p>Chargement...</p>}
+      {error && <p className="text-red-500">{error.message || error}</p>}
 
       <div className="space-y-2 mt-4">
         {templates.map(tpl => (


### PR DESCRIPTION
## Summary
- return error state from `useTemplatesCommandes` and expose data consistently
- show template loading errors in `TemplatesCommandes` page

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module '@testing-library/dom')*

------
https://chatgpt.com/codex/tasks/task_e_6895dc786d58832dac9efe8a324a3151