### PR TITLE
fix: ensure fetchCommandeById returns data/error object

### DIFF
--- a/src/hooks/useCommandes.js
+++ b/src/hooks/useCommandes.js
@@ -51,7 +51,7 @@ export function useCommandes() {
 
   const fetchCommandeById = useCallback(
     async (id) => {
-      if (!id || !mama_id) return null;
+      if (!id || !mama_id) return { data: null, error: null };
       setLoading(true);
       setError(null);
       const { data, error } = await supabase
@@ -65,12 +65,12 @@ export function useCommandes() {
       setLoading(false);
       if (error) {
         console.error("❌ fetchCommandeById", error.message);
-      setError(error);
-      setCurrent(null);
-      return null;
-    }
-    setCurrent(data);
-    return data;
+        setError(error);
+        setCurrent(null);
+        return { data: null, error };
+      }
+      setCurrent(data);
+      return { data, error: null };
     },
     [mama_id]
   );

--- a/src/pages/emails/EmailsEnvoyes.jsx
+++ b/src/pages/emails/EmailsEnvoyes.jsx
@@ -67,7 +67,7 @@ export default function EmailsEnvoyes() {
 
   const handleViewPDF = async (commandeId) => {
     try {
-      const commande = await fetchCommandeById(commandeId);
+      const { data: commande } = await fetchCommandeById(commandeId);
       if (!commande) throw new Error();
       let template = null;
       if (commande.template_id) {


### PR DESCRIPTION
## Summary
- return `{ data, error }` from `fetchCommandeById`
- adapt email PDF viewer to new fetch signature

## Testing
- `npm test` *(fails: An update to FournisseurApiSettingsForm inside a test was not wrapped in act(...), fetchPlanning err, Erreur chargement produits : Oops, Erreur stats_cost_centers: { message: 'bad' }, An update to AuthProvider inside a test was not wrapped in act(...), Erreur consolidated_stats: { message: 'bad' }, and more)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895df274348832dae3274d82d7bbfcd