### PR TITLE
fix: include mama_id when creating commande lines

### DIFF
--- a/src/hooks/useCommandes.js
+++ b/src/hooks/useCommandes.js
@@ -91,8 +91,14 @@ export function useCommandes() {
       return { error };
     }
     if (lignes.length) {
-      const toInsert = lignes.map((l) => ({ ...l, commande_id: data.id }));
-      const { error: lineErr } = await supabase.from("commande_lignes").insert(toInsert);
+      const toInsert = lignes.map((l) => ({
+        ...l,
+        commande_id: data.id,
+        mama_id,
+      }));
+      const { error: lineErr } = await supabase
+        .from("commande_lignes")
+        .insert(toInsert);
       if (lineErr) console.error("❌ commande lignes", lineErr.message);
     }
     return { data };


### PR DESCRIPTION
## Summary
- include mama_id on commande line insertions to satisfy RLS policies

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68962a9678fc832dbc028d711bcd2512