### PR TITLE
feat: implement requisitions module

### DIFF
--- a/src/pages/requisitions/RequisitionDetail.jsx
+++ b/src/pages/requisitions/RequisitionDetail.jsx
@@ -30,7 +30,7 @@ function RequisitionDetailPage() {
           <strong>Statut :</strong> {requisition.statut}
         </div>
         <div>
-          <strong>Date :</strong> {requisition.date_demande}
+          <strong>Date :</strong> {requisition.date_requisition}
         </div>
         <div>
           <strong>Zone :</strong> Cave
@@ -48,8 +48,8 @@ function RequisitionDetailPage() {
                   alt=""
                   className="w-6 h-6 rounded object-cover"
                 />
-                <span>
-                  {l.produit?.nom || l.produit_id} - {l.quantite_demandee} {l.unite?.nom || ""} (stock {l.stock_theorique_avant} → {l.stock_theorique_apres})
+              <span>
+                  {l.produit?.nom || l.produit_id} - {l.quantite} {l.unite || ""}
                 </span>
               </li>
             ))}

--- a/src/pages/requisitions/Requisitions.jsx
+++ b/src/pages/requisitions/Requisitions.jsx
@@ -54,7 +54,7 @@ export default function Requisitions() {
     const ws = XLSX.utils.json_to_sheet(
       filtered.map(r => ({
         Numero: r.numero,
-        Date: r.date_demande,
+        Date: r.date_requisition,
         Statut: r.statut,
         Zone: zones.find(z => z.id === r.zone_id)?.nom || "-",
       }))
@@ -74,7 +74,7 @@ export default function Requisitions() {
       head: [["Numero", "Date", "Statut", "Zone"]],
       body: filtered.map(r => [
         r.numero,
-        r.date_demande,
+        r.date_requisition,
         r.statut,
         zones.find(z => z.id === r.zone_id)?.nom || "-",
       ]),
@@ -170,7 +170,7 @@ export default function Requisitions() {
             {filtered.map(r => (
               <tr key={r.id}>
                 <td className="px-2 py-1">{r.numero}</td>
-                <td className="px-2 py-1">{r.date_demande}</td>
+                <td className="px-2 py-1">{r.date_requisition}</td>
                 <td className="px-2 py-1">{r.statut}</td>
                 <td className="px-2 py-1">{zones.find(z => z.id === r.zone_id)?.nom || '-'}</td>
               </tr>

--- a/test/useRequisitions.test.js
+++ b/test/useRequisitions.test.js
@@ -31,7 +31,6 @@ test('getRequisitions applies filters', async () => {
   await act(async () => {
     await result.current.getRequisitions({
       statut: 'draft',
-      utilisateur: 'u2',
       produit: 'p1',
       debut: '2025-01-01',
       fin: '2025-01-31',
@@ -39,20 +38,19 @@ test('getRequisitions applies filters', async () => {
     });
   });
   expect(fromMock).toHaveBeenCalledWith('requisitions');
-  expect(query.select).toHaveBeenCalledWith('*, lignes:requisition_lignes(produit_id, unite_id)', { count: 'exact' });
+  expect(query.select).toHaveBeenCalledWith('*, lignes:requisition_lignes(produit_id, unite, quantite)', { count: 'exact' });
   expect(query.eq).toHaveBeenCalledWith('mama_id', 'm1');
   expect(query.eq).toHaveBeenCalledWith('actif', true);
   expect(query.eq).toHaveBeenCalledWith('statut', 'draft');
-  expect(query.eq).toHaveBeenCalledWith('utilisateur_id', 'u2');
-  expect(query.gte).toHaveBeenCalledWith('date_demande', '2025-01-01');
-  expect(query.lte).toHaveBeenCalledWith('date_demande', '2025-01-31');
+  expect(query.gte).toHaveBeenCalledWith('date_requisition', '2025-01-01');
+  expect(query.lte).toHaveBeenCalledWith('date_requisition', '2025-01-31');
   expect(query.range).toHaveBeenCalledWith(10, 19);
 });
 
 test('createRequisition inserts header and lines', async () => {
   const { result } = renderHook(() => useRequisitions());
   await act(async () => {
-    await result.current.createRequisition({ zone_id: 'z1', lignes: [{ produit_id: 'p1', quantite_demandee: 2, unite_id: 'u9' }] });
+    await result.current.createRequisition({ zone_id: 'z1', lignes: [{ produit_id: 'p1', quantite: 2, unite: 'kg' }] });
   });
   expect(fromMock).toHaveBeenCalledWith('requisitions');
   expect(query.insert).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- define requisitions and requisition_lignes tables with RLS and suggestions view
- adapt hook and pages to new requisition fields
- update tests for new requisition API

## Testing
- `npm test` *(fails: test/backup_db.test.js, test/public_api.test.js, test/reallocate_history.test.js, test/weekly_report.test.js, test/export_accounting.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_689656ad01a8832d879166e955af3aed