### PR TITLE
feat: add core menu engineering hook

### DIFF
--- a/src/hooks/useMenuEngineering.js
+++ b/src/hooks/useMenuEngineering.js
@@ -1,114 +1,117 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { useState, useCallback } from 'react'
-import { supabase } from '@/lib/supabase'
-import useAuth from '@/hooks/useAuth'
+import { useState, useCallback } from 'react';
+import { supabase } from '@/lib/supabase';
+import useAuth from '@/hooks/useAuth';
 
 export function useMenuEngineering() {
-  const { mama_id } = useAuth()
-  const [data, setData] = useState([])
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState(null)
+  const { mama_id } = useAuth();
+  const [metrics, setMetrics] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
 
-  const fetchData = useCallback(
-    async (periode, { famille, actif } = {}) => {
-      if (!mama_id) return []
-      setLoading(true)
-      setError(null)
+  const fetchMetrics = useCallback(
+    async ({ dateStart, dateEnd, type, actif } = {}) => {
+      if (!mama_id) return { rows: [], foodCost: null };
+      setLoading(true);
+      setError(null);
       try {
         let query = supabase
-          .from('v_menu_engineering')
+          .from('v_me_classification')
           .select('*')
-          .eq('mama_id', mama_id)
-          .eq('periode', periode)
-          .order('nom')
-        if (famille) query = query.eq('famille', famille)
-        if (actif !== '' && actif !== undefined) query = query.eq('actif', actif === 'actif')
+          .eq('mama_id', mama_id);
+        if (dateStart) query = query.gte('debut', dateStart);
+        if (dateEnd) query = query.lte('fin', dateEnd);
+        if (type) query = query.eq('fiche_type', type);
+        if (actif !== undefined) query = query.eq('actif', actif);
 
-        const { data: fiches, error } = await query
-        if (error) throw error
+        const { data: rows, error: qError } = await query;
+        if (qError) throw qError;
 
-        const rows = (fiches || []).map(f => {
-          const cout = f.cout_portion ?? 0
-          const p = f.prix_vente ?? 0
-          const qty = f.ventes ?? 0
-          const pop = f.popularite ?? 0
-          const foodCost = p > 0 ? (cout / p) * 100 : null
-          const marge = p > 0 ? ((p - cout) / p) * 100 : 0
-          const margeEuro = p - cout
-          const ca = p * qty
-          return {
-            ...f,
-            prix_vente: p,
-            cout_portion: cout,
-            ventes: qty,
-            popularite: pop,
-            foodCost,
-            marge,
-            margeEuro,
-            ca,
-            x: pop * 100,
-            y: marge,
-          }
-        })
+        let foodCost = null;
+        if (dateStart) {
+          const month = dateStart.slice(0, 7);
+          const { data: fcData, error: fcError } = await supabase
+            .from('v_menu_du_jour_mensuel')
+            .select('food_cost_avg')
+            .eq('mama_id', mama_id)
+            .eq('mois', month)
+            .maybeSingle();
+          if (fcError) throw fcError;
+          foodCost = fcData?.food_cost_avg ?? null;
+        }
 
-        const medPop = median(rows.map(r => r.ventes))
-        const medMarge = median(rows.map(r => r.marge))
-        rows.forEach(r => {
-          if (r.ventes >= medPop && r.marge >= medMarge) r.classement = 'Star'
-          else if (r.ventes >= medPop && r.marge < medMarge) r.classement = 'Horse'
-          else if (r.ventes < medPop && r.marge >= medMarge) r.classement = 'Puzzle'
-          else r.classement = 'Dog'
-          r.score_calc = Math.round(r.marge + r.popularite * 100)
-        })
-        setData(rows)
-        return rows
+        setMetrics(rows || []);
+        return { rows: rows || [], foodCost };
       } catch (e) {
-        setError(e)
-        setData([])
-        return []
+        setError(e);
+        setMetrics([]);
+        return { rows: [], foodCost: null };
       } finally {
-        setLoading(false)
+        setLoading(false);
       }
     },
     [mama_id]
-  )
+  );
 
-  const median = arr => {
-    const s = [...arr].sort((a, b) => a - b)
-    return s.length ? s[Math.floor(s.length / 2)] : 0
-  }
-
-  const saveVente = useCallback(
-    async (fiche_id, periode, ventes) => {
-      if (!mama_id) return
-      const { data: existing } = await supabase
-        .from('ventes_fiches_carte')
-        .select('id')
-        .eq('fiche_id', fiche_id)
-        .eq('periode', periode)
+  const commitImport = useCallback(async () => {
+    if (!mama_id) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const { data: staged, error: stError } = await supabase
+        .from('ventes_import_staging')
+        .select('id, fiche_id, date_vente, quantite, prix_vente_unitaire')
         .eq('mama_id', mama_id)
-        .maybeSingle()
-      let error
-      if (existing) {
-        const res = await supabase
-          .from('ventes_fiches_carte')
-          .update({ ventes })
-          .eq('id', existing.id)
-          .eq('mama_id', mama_id)
-        error = res.error
-      } else {
-        const res = await supabase
-          .from('ventes_fiches_carte')
-          .insert({ fiche_id, periode, ventes, mama_id })
-        error = res.error
-      }
-      if (error) {
-        setError(error)
-        throw error
+        .eq('statut', 'mapped');
+      if (stError) throw stError;
+      if (!staged?.length) return;
+
+      const toInsert = staged.map((r) => ({
+        mama_id,
+        fiche_id: r.fiche_id,
+        date_vente: r.date_vente,
+        quantite: r.quantite,
+        prix_vente_unitaire: r.prix_vente_unitaire,
+      }));
+      const { error: insError } = await supabase
+        .from('ventes_fiches')
+        .insert(toInsert);
+      if (insError) throw insError;
+
+      const ids = staged.map((r) => r.id);
+      const { error: updError } = await supabase
+        .from('ventes_import_staging')
+        .update({ statut: 'imported' })
+        .in('id', ids);
+      if (updError) throw updError;
+    } catch (e) {
+      setError(e);
+      throw e;
+    } finally {
+      setLoading(false);
+    }
+  }, [mama_id]);
+
+  const upsertManual = useCallback(
+    async ({ fiche_id, date_vente, quantite, prix_vente_unitaire }) => {
+      if (!mama_id) return;
+      setError(null);
+      const { error: upError } = await supabase
+        .from('ventes_fiches')
+        .upsert(
+          [{ mama_id, fiche_id, date_vente, quantite, prix_vente_unitaire }],
+          { onConflict: 'mama_id,fiche_id,date_vente' }
+        );
+      if (upError) {
+        setError(upError);
+        throw upError;
       }
     },
     [mama_id]
-  )
+  );
 
-  return { data, loading, error, fetchData, saveVente }
+  return { metrics, loading, error, fetchMetrics, commitImport, upsertManual };
 }
+
+export default useMenuEngineering;
+


### PR DESCRIPTION
## Summary
- implement useMenuEngineering hook with fetchMetrics, commitImport and upsertManual
- cover new menu engineering behaviors with tests

## Testing
- `npm test test/useMenuEngineering.test.js test/MenuEngineering.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_6896e2126bc4832da72ecda68263fb55