### PR TITLE
feat: manage order templates

### DIFF
--- a/src/components/pdf/CommandePDF.jsx
+++ b/src/components/pdf/CommandePDF.jsx
@@ -1,19 +1,32 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { Document, Page, Text, View, StyleSheet } from "@react-pdf/renderer";
+import { Document, Page, Text, View, StyleSheet, Image } from "@react-pdf/renderer";
 
 const styles = StyleSheet.create({
   page: { padding: 30, fontSize: 11 },
   section: { marginBottom: 10 },
   title: { fontSize: 16, marginBottom: 10, fontWeight: "bold" },
   ligne: { flexDirection: "row", justifyContent: "space-between", marginBottom: 3 },
+  logo: { width: 80, height: 40, marginBottom: 10 },
 });
 
 export default function CommandePDF({ commande, template, fournisseur }) {
   return (
     <Document>
       <Page size="A4" style={styles.page}>
+        {template?.logo_url && <Image src={template.logo_url} style={styles.logo} />}
+        {template?.entete && (
+          <View style={styles.section}>
+            <Text>{template.entete}</Text>
+          </View>
+        )}
         <View style={styles.section}>
           <Text style={styles.title}>Commande Fournisseur</Text>
+          {template?.champs_visibles?.ref_commande && (
+            <Text>Réf : {commande.reference}</Text>
+          )}
+          {template?.champs_visibles?.date_livraison && commande.date_livraison_prevue && (
+            <Text>Date livraison : {commande.date_livraison_prevue}</Text>
+          )}
           <Text>Fournisseur : {fournisseur?.nom}</Text>
           <Text>Email : {fournisseur?.email}</Text>
         </View>
@@ -35,12 +48,21 @@ export default function CommandePDF({ commande, template, fournisseur }) {
           <View style={styles.section}>
             <Text style={styles.title}>Adresse de livraison</Text>
             <Text>{template.adresse_livraison}</Text>
+            {template.contact_nom && <Text>Contact: {template.contact_nom}</Text>}
+            {template.contact_tel && <Text>Téléphone: {template.contact_tel}</Text>}
+            {template.contact_email && <Text>Email: {template.contact_email}</Text>}
           </View>
         )}
 
-        {template?.pied_de_page && (
+        {template?.pied_page && (
           <View style={styles.section}>
-            <Text>{template.pied_de_page}</Text>
+            <Text>{template.pied_page}</Text>
+          </View>
+        )}
+
+        {template?.conditions_generales && (
+          <View style={styles.section}>
+            <Text>{template.conditions_generales}</Text>
           </View>
         )}
       </Page>

--- a/src/hooks/useEmailsEnvoyes.js
+++ b/src/hooks/useEmailsEnvoyes.js
@@ -72,15 +72,13 @@ export function useEmailsEnvoyes() {
       .single();
     if (cmdErr || !commande) return { error: cmdErr || "Commande introuvable" };
 
-    let template = null;
-    if (commande.template_id) {
-      const { data: tpl } = await supabase
-        .from("templates_commandes")
-        .select("*")
-        .eq("id", commande.template_id)
-        .single();
-      template = tpl || null;
-    }
+    const { data: tpl } = await supabase
+      .rpc("get_template_commande", {
+        p_mama: mama_id,
+        p_fournisseur: commande.fournisseur_id,
+      })
+      .single();
+    const template = tpl || null;
 
     const blob = await pdf(
       <CommandePDF commande={commande} template={template} fournisseur={commande.fournisseur} />,

--- a/src/pages/commandes/CommandeDetail.jsx
+++ b/src/pages/commandes/CommandeDetail.jsx
@@ -4,6 +4,7 @@ import { useParams } from "react-router-dom";
 import { PDFDownloadLink, pdf } from "@react-pdf/renderer";
 import { supabase } from "@/lib/supabase";
 import { useCommandes } from "@/hooks/useCommandes";
+import { useTemplatesCommandes } from "@/hooks/useTemplatesCommandes";
 import CommandePDF from "@/components/pdf/CommandePDF";
 import { Button } from "@/components/ui/button";
 import toast from "react-hot-toast";
@@ -26,6 +27,7 @@ async function generateCommandePDFBase64(commande, template, fournisseur) {
 export default function CommandeDetail() {
   const { id } = useParams();
   const { currentCommande: commande, fetchCommandeById, loading } = useCommandes();
+  const { getTemplateForFournisseur } = useTemplatesCommandes();
   const [template, setTemplate] = useState(null);
 
   useEffect(() => {
@@ -33,15 +35,12 @@ export default function CommandeDetail() {
   }, [id, fetchCommandeById]);
 
   useEffect(() => {
-    if (commande?.template_id) {
-      supabase
-        .from("templates_commandes")
-        .select("*")
-        .eq("id", commande.template_id)
-        .single()
-        .then(({ data }) => setTemplate(data || null));
+    if (commande?.fournisseur_id) {
+      getTemplateForFournisseur(commande.fournisseur_id).then(({ data }) =>
+        setTemplate(data || null)
+      );
     }
-  }, [commande]);
+  }, [commande, getTemplateForFournisseur]);
 
   if (loading || !commande) return <div>Chargement...</div>;
 

--- a/src/pages/commandes/CommandeForm.jsx
+++ b/src/pages/commandes/CommandeForm.jsx
@@ -23,7 +23,7 @@ export default function CommandeForm() {
   const [templateId, setTemplateId] = useState("");
   const [form, setForm] = useState({
     adresse_livraison: "",
-    pied_de_page: "",
+    pied_page: "",
     champs_visibles: {},
   });
 
@@ -57,7 +57,7 @@ export default function CommandeForm() {
       setForm(prev => ({
         ...prev,
         adresse_livraison: tpl.adresse_livraison || "",
-        pied_de_page: tpl.pied_de_page || "",
+        pied_page: tpl.pied_page || "",
         champs_visibles: tpl.champs_visibles || {},
       }));
     }
@@ -69,7 +69,7 @@ export default function CommandeForm() {
       fournisseur_id: fournisseurId,
       template_id: templateId || undefined,
       adresse_livraison: form.adresse_livraison,
-      pied_de_page: form.pied_de_page,
+      pied_page: form.pied_page,
       champs_visibles: form.champs_visibles,
       lignes: lignes.map(l => ({
         produit_id: l.produit_id,
@@ -129,13 +129,13 @@ export default function CommandeForm() {
           />
         </div>
       )}
-      {form.champs_visibles?.pied_de_page !== false && (
+      {form.champs_visibles?.pied_page !== false && (
         <div>
           <label className="block font-medium">Pied de page</label>
           <textarea
             className="input"
-            value={form.pied_de_page}
-            onChange={e => setForm(prev => ({ ...prev, pied_de_page: e.target.value }))}
+            value={form.pied_page}
+            onChange={e => setForm(prev => ({ ...prev, pied_page: e.target.value }))}
           />
         </div>
       )}

--- a/src/pages/emails/EmailsEnvoyes.jsx
+++ b/src/pages/emails/EmailsEnvoyes.jsx
@@ -69,15 +69,13 @@ export default function EmailsEnvoyes() {
     try {
       const { data: commande } = await fetchCommandeById(commandeId);
       if (!commande) throw new Error();
-      let template = null;
-      if (commande.template_id) {
-        const { data: tpl } = await supabase
-          .from("templates_commandes")
-          .select("*")
-          .eq("id", commande.template_id)
-          .single();
-        template = tpl || null;
-      }
+      const { data: tpl } = await supabase
+        .rpc("get_template_commande", {
+          p_mama: mama_id,
+          p_fournisseur: commande.fournisseur_id,
+        })
+        .single();
+      const template = tpl || null;
       const blob = await pdf(
         <CommandePDF commande={commande} template={template} fournisseur={commande.fournisseur} />,
       ).toBlob();

--- a/src/pages/parametrage/TemplateCommandeForm.jsx
+++ b/src/pages/parametrage/TemplateCommandeForm.jsx
@@ -1,91 +1,163 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import React, { useState } from "react";
-import useTemplatesCommandes from "@/hooks/useTemplatesCommandes";
+import { supabase } from "@/lib/supabase";
+import { useTemplatesCommandes } from "@/hooks/useTemplatesCommandes";
 import { Button } from "@/components/ui/button";
 
-export default function TemplateCommandeForm({ template, onClose }) {
-  const { saveTemplate } = useTemplatesCommandes();
+export default function TemplateCommandeForm({ template = {}, onClose, fournisseurs = [] }) {
+  const { createTemplate, updateTemplate } = useTemplatesCommandes();
   const [nom, setNom] = useState(template.nom || "");
+  const [fournisseurId, setFournisseurId] = useState(template.fournisseur_id || "");
+  const [logoUrl, setLogoUrl] = useState(template.logo_url || "");
+  const [entete, setEntete] = useState(template.entete || "");
+  const [pied, setPied] = useState(template.pied_page || "");
   const [adresse, setAdresse] = useState(template.adresse_livraison || "");
-  const [pied, setPied] = useState(template.pied_de_page || "");
+  const [contactNom, setContactNom] = useState(template.contact_nom || "");
+  const [contactTel, setContactTel] = useState(template.contact_tel || "");
+  const [contactEmail, setContactEmail] = useState(template.contact_email || "");
+  const [conditions, setConditions] = useState(template.conditions_generales || "");
   const [champs, setChamps] = useState(
-    template.champs_visibles || {
-      reference: true,
-      date: true,
-      zone: true,
-      fournisseur: true,
-      quantite: true,
-      prix: true,
-      commentaire: true,
-    }
+    template.champs_visibles || { ref_commande: true, date_livraison: true }
   );
+  const [actif, setActif] = useState(template.actif ?? true);
 
-  const toggleChamp = champ => {
-    setChamps(prev => ({ ...prev, [champ]: !prev[champ] }));
+  const handleLogoUpload = async (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const path = `templates/${Date.now()}-${file.name}`;
+    const { error } = await supabase.storage.from("public").upload(path, file);
+    if (!error) {
+      const { data } = supabase.storage.from("public").getPublicUrl(path);
+      setLogoUrl(data.publicUrl);
+    }
   };
 
-  const save = async () => {
+  const toggleChamp = (champ) => {
+    setChamps((prev) => ({ ...prev, [champ]: !prev[champ] }));
+  };
+
+  const handleSubmit = async () => {
     const payload = {
-      ...template,
       nom,
+      fournisseur_id: fournisseurId || null,
+      logo_url: logoUrl,
+      entete,
+      pied_page: pied,
       adresse_livraison: adresse,
-      pied_de_page: pied,
+      contact_nom: contactNom,
+      contact_tel: contactTel,
+      contact_email: contactEmail,
+      conditions_generales: conditions,
       champs_visibles: champs,
+      actif,
     };
-    await saveTemplate(payload);
+    if (template.id) await updateTemplate(template.id, payload);
+    else await createTemplate(payload);
     onClose();
   };
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-30 flex items-center justify-center z-50">
-      <div className="bg-white p-6 rounded-lg max-w-lg w-full max-h-[90vh] overflow-auto">
-        <h2 className="text-lg font-bold mb-4">
+      <div className="bg-white p-6 rounded-lg max-w-2xl w-full max-h-[90vh] overflow-auto space-y-3">
+        <h2 className="text-lg font-bold">
           {template.id ? "Modifier" : "Créer"} un template
         </h2>
 
-        <label className="block text-sm font-medium">Nom</label>
-        <input
-          className="w-full border p-1 mb-3"
-          value={nom}
-          onChange={e => setNom(e.target.value)}
-        />
-
-        <label className="block text-sm font-medium">Adresse de livraison</label>
-        <textarea
-          className="w-full border p-1 mb-3"
-          value={adresse}
-          onChange={e => setAdresse(e.target.value)}
-        />
-
-        <label className="block text-sm font-medium">Pied de page</label>
-        <textarea
-          className="w-full border p-1 mb-3"
-          value={pied}
-          onChange={e => setPied(e.target.value)}
-        />
-
-        <label className="block text-sm font-medium">Champs à afficher</label>
-        <div className="grid grid-cols-2 gap-2 text-sm mb-4">
-          {Object.keys(champs).map(champ => (
-            <label key={champ}>
-              <input
-                type="checkbox"
-                checked={champs[champ]}
-                onChange={() => toggleChamp(champ)}
-                className="mr-1"
-              />
-              {champ}
-            </label>
-          ))}
+        <div>
+          <label className="block text-sm font-medium">Nom</label>
+          <input className="w-full border p-1" value={nom} onChange={(e) => setNom(e.target.value)} />
         </div>
 
-        <div className="flex justify-end gap-2">
+        <div>
+          <label className="block text-sm font-medium">Fournisseur</label>
+          <select
+            className="w-full border p-1"
+            value={fournisseurId}
+            onChange={(e) => setFournisseurId(e.target.value)}
+          >
+            <option value="">Générique</option>
+            {fournisseurs.map((f) => (
+              <option key={f.id} value={f.id}>
+                {f.nom}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium">Logo</label>
+          <input type="file" onChange={handleLogoUpload} className="mb-1" />
+          {logoUrl && <img src={logoUrl} alt="logo" className="h-16" />}
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium">En-tête</label>
+          <textarea className="w-full border p-1" value={entete} onChange={(e) => setEntete(e.target.value)} />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium">Pied de page</label>
+          <textarea className="w-full border p-1" value={pied} onChange={(e) => setPied(e.target.value)} />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium">Adresse de livraison</label>
+          <textarea className="w-full border p-1" value={adresse} onChange={(e) => setAdresse(e.target.value)} />
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-2">
+          <div>
+            <label className="block text-sm font-medium">Contact nom</label>
+            <input className="w-full border p-1" value={contactNom} onChange={(e) => setContactNom(e.target.value)} />
+          </div>
+          <div>
+            <label className="block text-sm font-medium">Contact tel</label>
+            <input className="w-full border p-1" value={contactTel} onChange={(e) => setContactTel(e.target.value)} />
+          </div>
+          <div>
+            <label className="block text-sm font-medium">Contact email</label>
+            <input className="w-full border p-1" value={contactEmail} onChange={(e) => setContactEmail(e.target.value)} />
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium">Conditions générales</label>
+          <textarea
+            className="w-full border p-1"
+            value={conditions}
+            onChange={(e) => setConditions(e.target.value)}
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium">Champs visibles</label>
+          <div className="grid grid-cols-2 gap-2 text-sm">
+            {Object.keys(champs).map((champ) => (
+              <label key={champ} className="flex items-center gap-1">
+                <input
+                  type="checkbox"
+                  checked={champs[champ]}
+                  onChange={() => toggleChamp(champ)}
+                />
+                {champ}
+              </label>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <input type="checkbox" checked={actif} onChange={(e) => setActif(e.target.checked)} />
+          <span>Actif</span>
+        </div>
+
+        <div className="flex justify-end gap-2 pt-2">
           <Button variant="ghost" onClick={onClose}>
             Annuler
           </Button>
-          <Button onClick={save}>Enregistrer</Button>
+          <Button onClick={handleSubmit}>Enregistrer</Button>
         </div>
       </div>
     </div>
   );
 }
+

--- a/src/pages/parametrage/TemplatesCommandes.jsx
+++ b/src/pages/parametrage/TemplatesCommandes.jsx
@@ -1,53 +1,111 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import React, { useState } from "react";
-import useTemplatesCommandes from "@/hooks/useTemplatesCommandes";
+import React, { useEffect, useState } from "react";
+import { useTemplatesCommandes } from "@/hooks/useTemplatesCommandes";
+import { useFournisseurs } from "@/hooks/useFournisseurs";
 import TemplateCommandeForm from "./TemplateCommandeForm";
 import { Button } from "@/components/ui/button";
 
 export default function TemplatesCommandes() {
-  const { templates, loading, error, toggleActif } = useTemplatesCommandes();
+  const { fetchTemplates, deleteTemplate } = useTemplatesCommandes();
+  const { fournisseurs, fetchFournisseurs } = useFournisseurs();
+  const [templates, setTemplates] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
   const [selected, setSelected] = useState(null);
+  const [fournisseurId, setFournisseurId] = useState("");
+
+  useEffect(() => {
+    fetchFournisseurs({ limit: 1000 });
+  }, [fetchFournisseurs]);
+
+  const load = async () => {
+    setLoading(true);
+    const { data, error } = await fetchTemplates({ fournisseur_id: fournisseurId || undefined });
+    if (error) setError(error);
+    setTemplates(data || []);
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    load();
+  }, [fournisseurId]);
+
+  const handleDelete = async (id) => {
+    if (!window.confirm("Supprimer ce modèle ?")) return;
+    await deleteTemplate(id);
+    load();
+  };
 
   return (
     <div className="p-4">
       <h1 className="text-xl font-bold mb-4">Templates de commandes</h1>
 
-      <Button onClick={() => setSelected({})}>➕ Nouveau modèle</Button>
+      <div className="flex flex-wrap items-center gap-2 mb-4">
+        <Button onClick={() => setSelected({})}>➕ Nouveau modèle</Button>
+        <select
+          className="border px-2 py-1 rounded text-black"
+          value={fournisseurId}
+          onChange={(e) => setFournisseurId(e.target.value)}
+        >
+          <option value="">Tous les fournisseurs</option>
+          {fournisseurs.map((f) => (
+            <option key={f.id} value={f.id}>
+              {f.nom}
+            </option>
+          ))}
+        </select>
+      </div>
 
       {loading && <p>Chargement...</p>}
-      {error && <p className="text-red-500">{error.message || error}</p>}
+      {error && <p className="text-red-500">{error.message}</p>}
 
-      <div className="space-y-2 mt-4">
-        {templates.map(tpl => (
-          <div
-            key={tpl.id}
-            className="border p-2 rounded flex flex-col sm:flex-row justify-between"
-          >
-            <div>
-              <strong>{tpl.nom}</strong>
-              {!tpl.actif && (
-                <span className="ml-2 text-red-500">[Inactif]</span>
-              )}
-            </div>
-            <div className="flex gap-2 mt-2 sm:mt-0">
-              <Button onClick={() => setSelected(tpl)}>✏️ Modifier</Button>
-              <Button
-                variant="destructive"
-                onClick={() => toggleActif(tpl.id, !tpl.actif)}
-              >
-                {tpl.actif ? "Désactiver" : "Réactiver"}
-              </Button>
-            </div>
-          </div>
-        ))}
-      </div>
+      <table className="w-full text-sm border-collapse">
+        <thead>
+          <tr className="border-b text-left">
+            <th className="p-2">Nom</th>
+            <th className="p-2">Fournisseur</th>
+            <th className="p-2">Actif</th>
+            <th className="p-2">Date MAJ</th>
+            <th className="p-2" />
+          </tr>
+        </thead>
+        <tbody>
+          {templates.map((tpl) => (
+            <tr key={tpl.id} className="border-b">
+              <td className="p-2">{tpl.nom}</td>
+              <td className="p-2">{tpl.fournisseur ? tpl.fournisseur.nom : "Générique"}</td>
+              <td className="p-2">{tpl.actif ? "Oui" : "Non"}</td>
+              <td className="p-2">
+                {tpl.updated_at ? new Date(tpl.updated_at).toLocaleDateString() : ""}
+              </td>
+              <td className="p-2 flex gap-2">
+                <Button size="sm" onClick={() => setSelected(tpl)}>
+                  Modifier
+                </Button>
+                <Button
+                  size="sm"
+                  variant="destructive"
+                  onClick={() => handleDelete(tpl.id)}
+                >
+                  Supprimer
+                </Button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
 
       {selected && (
         <TemplateCommandeForm
           template={selected}
-          onClose={() => setSelected(null)}
+          fournisseurs={fournisseurs}
+          onClose={() => {
+            setSelected(null);
+            load();
+          }}
         />
       )}
     </div>
   );
 }
+

--- a/test/useTemplatesCommandes.test.js
+++ b/test/useTemplatesCommandes.test.js
@@ -1,0 +1,40 @@
+import { vi, beforeEach, test, expect } from "vitest";
+
+const query = {
+  select: vi.fn(() => query),
+  eq: vi.fn(() => query),
+  order: vi.fn(() => query),
+};
+const fromMock = vi.fn(() => query);
+const rpcMock = vi.fn();
+
+vi.mock("@/lib/supabase", () => ({ supabase: { from: fromMock, rpc: rpcMock } }));
+vi.mock("@/hooks/useAuth", () => ({ default: () => ({ mama_id: "m1" }) }));
+
+let useTemplatesCommandes;
+
+beforeEach(async () => {
+  ({ useTemplatesCommandes } = await import("@/hooks/useTemplatesCommandes"));
+  fromMock.mockClear();
+  rpcMock.mockClear();
+  Object.values(query).forEach((fn) => fn.mockClear && fn.mockClear());
+  rpcMock.mockResolvedValue({ data: { id: "t1" }, error: null });
+});
+
+test("fetchTemplates applies filter", async () => {
+  const { fetchTemplates } = useTemplatesCommandes();
+  await fetchTemplates({ fournisseur_id: "f1" });
+  expect(fromMock).toHaveBeenCalledWith("templates_commandes");
+  expect(query.eq).toHaveBeenCalledWith("mama_id", "m1");
+  expect(query.eq).toHaveBeenCalledWith("fournisseur_id", "f1");
+});
+
+test("getTemplateForFournisseur calls rpc", async () => {
+  const { getTemplateForFournisseur } = useTemplatesCommandes();
+  await getTemplateForFournisseur("f1");
+  expect(rpcMock).toHaveBeenCalledWith("get_template_commande", {
+    p_mama: "m1",
+    p_fournisseur: "f1",
+  });
+});
+


### PR DESCRIPTION
## Summary
- expand `templates_commandes` table with supplier-specific settings and RLS
- add hook and UI to manage order templates and fetch by supplier
- integrate template retrieval into command PDF/email generation

## Testing
- `npm test` *(fails: supabase.from(...).select(...).eq(...).eq is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6896e285fda0832dabe5af5b8d70ec23