### PR TITLE
feat(menu): add menu du jour module

### DIFF
--- a/access_rights_generated.json
+++ b/access_rights_generated.json
@@ -119,6 +119,12 @@
     "edit": false,
     "delete": false
   },
+  "menu_du_jour": {
+    "view": false,
+    "create": false,
+    "edit": false,
+    "delete": false
+  },
   "menu_groupe": {
     "view": false,
     "create": false,

--- a/access_rights_template.json
+++ b/access_rights_template.json
@@ -47,6 +47,12 @@
     "edit": false,
     "delete": false
   },
+  "menu_du_jour": {
+    "view": false,
+    "create": false,
+    "edit": false,
+    "delete": false
+  },
   "menu_groupe": {
     "view": false,
     "create": false,

--- a/router_mapping.json
+++ b/router_mapping.json
@@ -68,6 +68,14 @@
     "module": "menus"
   },
   {
+    "route": "/menu",
+    "module": "menu_du_jour"
+  },
+  {
+    "route": "/menu/:date",
+    "module": "menu_du_jour"
+  },
+  {
     "route": "/menu-groupes",
     "module": "menu_groupe"
   },

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -40,6 +40,7 @@ export default function Sidebar() {
             <div className="ml-4 flex flex-col gap-1 mt-1">
               {has("fiches_techniques") && <Link to="/fiches">Fiches</Link>}
               {has("menus") && <Link to="/menus">Menus</Link>}
+              {has("menu_du_jour") && <Link to="/menu">Menu du jour</Link>}
             </div>
           </details>
         )}

--- a/src/layout/Sidebar.jsx
+++ b/src/layout/Sidebar.jsx
@@ -128,6 +128,7 @@ export default function Sidebar() {
       items: [
         { module: "fiches_techniques", to: "/fiches", label: "Fiches", icon: <ChefHat size={16} /> },
         { module: "menus", to: "/menus", label: "Menus", icon: <MenuIcon size={16} /> },
+        { module: "menu_du_jour", to: "/menu", label: "Menu du jour", icon: <MenuIcon size={16} /> },
         { module: "menu_groupe", to: "/menu-groupes", label: "Menu Groupe", icon: <MenuIcon size={16} /> },
         { module: "carte", to: "/carte", label: "Carte", icon: <BookOpen size={16} /> },
         { module: "recettes", to: "/recettes", label: "Recettes", icon: <BookOpen size={16} /> },

--- a/src/pages/menu/MenuDuJour.jsx
+++ b/src/pages/menu/MenuDuJour.jsx
@@ -1,0 +1,54 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { useMenuDuJour } from "@/hooks/useMenuDuJour";
+
+function getMonday(date) {
+  const d = new Date(date);
+  const day = d.getDay();
+  const diff = d.getDate() - day + (day === 0 ? -6 : 1);
+  d.setDate(diff);
+  return d.toISOString().slice(0, 10);
+}
+
+export default function MenuDuJour() {
+  const { fetchWeek } = useMenuDuJour();
+  const [startDate, setStartDate] = useState(getMonday(new Date()));
+  const [resume, setResume] = useState([]);
+
+  useEffect(() => {
+    fetchWeek({ startDate }).then(setResume);
+  }, [startDate, fetchWeek]);
+
+  const changeWeek = (delta) => {
+    const d = new Date(startDate);
+    d.setDate(d.getDate() + delta * 7);
+    setStartDate(getMonday(d));
+  };
+
+  const days = Array.from({ length: 7 }).map((_, i) => {
+    const d = new Date(startDate);
+    d.setDate(d.getDate() + i);
+    const iso = d.toISOString().slice(0, 10);
+    const info = resume.find((r) => r.date_menu === iso) || {};
+    return { date: iso, info };
+  });
+
+  return (
+    <div className="p-4">
+      <div className="flex justify-between items-center mb-4">
+        <button onClick={() => changeWeek(-1)}>&lt;</button>
+        <h1 className="text-xl font-bold">Menu du jour</h1>
+        <button onClick={() => changeWeek(1)}>&gt;</button>
+      </div>
+      <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-7 gap-4">
+        {days.map(({ date, info }) => (
+          <Link key={date} to={`/menu/${date}`} className="border p-2 rounded hover:bg-gray-50">
+            <div className="font-semibold">{date}</div>
+            <div className="text-sm mt-1">Coût: {info.cout_total ? info.cout_total.toFixed(2) : "-"} €</div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/menu/MenuDuJourJour.jsx
+++ b/src/pages/menu/MenuDuJourJour.jsx
@@ -1,0 +1,75 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { useMenuDuJour } from "@/hooks/useMenuDuJour";
+
+const categories = ["entree", "plat", "dessert", "boisson"];
+
+export default function MenuDuJourJour() {
+  const { date } = useParams();
+  const { fetchDay, createOrUpdateMenu } = useMenuDuJour();
+  const [lignes, setLignes] = useState([]);
+
+  useEffect(() => {
+    fetchDay(date).then(({ lignes }) => setLignes(lignes || []));
+  }, [date, fetchDay]);
+
+  const addLine = () => {
+    setLignes([...lignes, { categorie: "entree", fiche_id: "", portions: 1 }]);
+  };
+
+  const updateLine = (idx, field, value) => {
+    setLignes(lignes.map((l, i) => (i === idx ? { ...l, [field]: value } : l)));
+  };
+
+  const removeLine = (idx) => {
+    setLignes(lignes.filter((_, i) => i !== idx));
+  };
+
+  const save = async () => {
+    await createOrUpdateMenu(date, lignes);
+  };
+
+  const total = lignes.reduce((s, l) => s + Number(l.cout_ligne_total || 0), 0);
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Menu du {date}</h1>
+      <div className="mb-4">Coût total: {total.toFixed(2)} €</div>
+      <button onClick={addLine} className="mb-4 border px-2 py-1 rounded">Ajouter une fiche</button>
+      {lignes.map((l, idx) => (
+        <div key={idx} className="border p-2 mb-2 rounded">
+          <div className="flex gap-2 mb-2">
+            <select
+              value={l.categorie}
+              onChange={(e) => updateLine(idx, "categorie", e.target.value)}
+              className="border px-1"
+            >
+              {categories.map((c) => (
+                <option key={c} value={c}>{c}</option>
+              ))}
+            </select>
+            <input
+              type="text"
+              placeholder="fiche_id"
+              value={l.fiche_id}
+              onChange={(e) => updateLine(idx, "fiche_id", e.target.value)}
+              className="border px-1 flex-1"
+            />
+            <input
+              type="number"
+              value={l.portions}
+              onChange={(e) => updateLine(idx, "portions", e.target.value)}
+              className="border w-20 px-1"
+            />
+            <button onClick={() => removeLine(idx)} className="text-red-500">X</button>
+          </div>
+          {l.cout_par_portion && (
+            <div className="text-sm">{l.cout_par_portion.toFixed(2)} € / portion</div>
+          )}
+        </div>
+      ))}
+      <button onClick={save} className="mt-4 border px-3 py-1 rounded">Sauvegarder</button>
+    </div>
+  );
+}

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -36,6 +36,8 @@ const Menus = lazyWithPreload(() => import("@/pages/menus/Menus.jsx"));
 const MenuGroupes = lazyWithPreload(() => import("@/pages/menus/MenuGroupes.jsx"));
 const MenuGroupeForm = lazyWithPreload(() => import("@/pages/menus/MenuGroupeForm.jsx"));
 const MenuGroupeDetail = lazyWithPreload(() => import("@/pages/menus/MenuGroupeDetail.jsx"));
+const MenuDuJourPlanning = lazyWithPreload(() => import("@/pages/menu/MenuDuJour.jsx"));
+const MenuDuJourJour = lazyWithPreload(() => import("@/pages/menu/MenuDuJourJour.jsx"));
 const Produits = lazyWithPreload(() => import("@/pages/produits/Produits.jsx"));
 const ProduitDetail = lazyWithPreload(() => import("@/pages/produits/ProduitDetail.jsx"));
 const ProduitForm = lazyWithPreload(() => import("@/pages/produits/ProduitForm.jsx"));
@@ -144,6 +146,8 @@ export const routePreloadMap = {
   '/promotions': Promotions.preload,
   '/fiches': Fiches.preload,
   '/menus': Menus.preload,
+  '/menu': MenuDuJourPlanning.preload,
+  '/menu/:date': MenuDuJourJour.preload,
   '/menu-groupes': MenuGroupes.preload,
   '/menu-groupes/nouveau': MenuGroupeForm.preload,
   '/menu-groupes/:id': MenuGroupeDetail.preload,
@@ -304,6 +308,14 @@ export default function Router() {
           <Route
             path="/menus"
             element={<ProtectedRoute moduleKey="menus"><Menus /></ProtectedRoute>}
+          />
+          <Route
+            path="/menu"
+            element={<ProtectedRoute moduleKey="menu_du_jour"><MenuDuJourPlanning /></ProtectedRoute>}
+          />
+          <Route
+            path="/menu/:date"
+            element={<ProtectedRoute moduleKey="menu_du_jour"><MenuDuJourJour /></ProtectedRoute>}
           />
           <Route
             path="/menu-groupes"

--- a/supabase/migrations/20240326000000_menu_du_jour.sql
+++ b/supabase/migrations/20240326000000_menu_du_jour.sql
@@ -1,0 +1,108 @@
+-- Menu du jour module
+
+-- Table des menus par jour
+create table if not exists menus_jour (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid not null references mamas(id) on delete cascade,
+  date_menu date not null,
+  titre text,
+  note text,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now(),
+  unique (mama_id, date_menu)
+);
+
+-- Lignes de menu (fiches techniques)
+create table if not exists menus_jour_lignes (
+  id uuid primary key default gen_random_uuid(),
+  menu_id uuid not null references menus_jour(id) on delete cascade,
+  mama_id uuid not null,
+  categorie text not null check (categorie in ('entree','plat','dessert','boisson')),
+  fiche_id uuid not null references fiches_techniques(id) on delete restrict,
+  portions numeric not null default 1,
+  prix_unitaire_snapshot numeric,
+  created_at timestamptz default now()
+);
+
+-- Favoris pour rechargement rapide
+create table if not exists menus_favoris (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid not null references mamas(id) on delete cascade,
+  nom text not null,
+  categorie text check (categorie in ('entree','plat','dessert','boisson')),
+  fiche_id uuid not null references fiches_techniques(id) on delete restrict,
+  portions_default numeric default 1,
+  actif boolean default true,
+  created_at timestamptz default now()
+);
+
+-- Indexes
+create index if not exists idx_menus_jour_mama_date on menus_jour(mama_id, date_menu);
+create index if not exists idx_menus_jour_lignes_menu on menus_jour_lignes(menu_id);
+create index if not exists idx_menus_jour_lignes_fiche on menus_jour_lignes(fiche_id);
+
+-- Enable RLS
+alter table menus_jour enable row level security;
+alter table menus_jour_lignes enable row level security;
+alter table menus_favoris enable row level security;
+
+-- Policies
+create policy menus_jour_all on menus_jour
+  for all using (mama_id = current_user_mama_id())
+  with check (mama_id = current_user_mama_id());
+
+create policy menus_jour_lignes_all on menus_jour_lignes
+  for all using (mama_id = current_user_mama_id())
+  with check (mama_id = current_user_mama_id());
+
+create policy menus_favoris_all on menus_favoris
+  for all using (mama_id = current_user_mama_id())
+  with check (mama_id = current_user_mama_id());
+
+-- Grants
+grant select, insert, update, delete on menus_jour, menus_jour_lignes, menus_favoris to authenticated;
+
+-- Views de coûts
+create or replace view v_menu_du_jour_lignes_cout as
+select
+  l.id,
+  l.menu_id,
+  l.mama_id,
+  l.categorie,
+  l.fiche_id,
+  l.portions,
+  cf.cout as cout_total_fiche,
+  cf.portions as portions_fiche,
+  (cf.cout / nullif(cf.portions,0)) as cout_par_portion,
+  ((cf.cout / nullif(cf.portions,0)) * l.portions) as cout_ligne_total
+from menus_jour_lignes l
+join v_couts_fiches cf on cf.fiche_id = l.fiche_id
+where l.mama_id = cf.mama_id;
+
+create or replace view v_menu_du_jour_resume as
+with lignes as (
+  select menu_id, categorie, sum(cout_ligne_total) as cout_categorie
+  from v_menu_du_jour_lignes_cout
+  group by menu_id, categorie
+)
+select
+  m.id as menu_id,
+  m.mama_id,
+  m.date_menu,
+  coalesce(sum(l.cout_categorie) filter (where l.categorie='entree'),0) as cout_entrees,
+  coalesce(sum(l.cout_categorie) filter (where l.categorie='plat'),0) as cout_plats,
+  coalesce(sum(l.cout_categorie) filter (where l.categorie='dessert'),0) as cout_desserts,
+  coalesce(sum(l.cout_categorie) filter (where l.categorie='boisson'),0) as cout_boissons,
+  coalesce(sum(l.cout_categorie),0) as cout_total
+from menus_jour m
+left join lignes l on l.menu_id = m.id
+group by m.id, m.mama_id, m.date_menu;
+
+create or replace view v_menu_du_jour_mensuel as
+select
+  mama_id,
+  date_trunc('month', date_menu)::date as mois,
+  sum(cout_total) as cout_total_mois
+from v_menu_du_jour_resume
+group by mama_id, date_trunc('month', date_menu);
+


### PR DESCRIPTION
## Summary
- add SQL schema for daily menus and cost views
- introduce menu du jour hook with planning helpers
- create menu du jour planning and day pages with routing and sidebar links

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896e9a6f3a0832d836456e302870f0a