### PR TITLE
feat(db): add famille to costing view

### DIFF
--- a/db/full_setup_final.sql
+++ b/db/full_setup_final.sql
@@ -2557,6 +2557,7 @@ select
   f.id as fiche_id,
   f.nom,
   f.type,
+  f.famille,
   f.actif,
   cf.cout,
   cf.portions,

--- a/supabase/migrations/20240521000000_costing_carte.sql
+++ b/supabase/migrations/20240521000000_costing_carte.sql
@@ -1,0 +1,28 @@
+-- View: v_costing_carte
+create or replace view public.v_costing_carte as
+select
+  f.mama_id,
+  f.id as fiche_id,
+  f.nom,
+  f.type,
+  f.famille,
+  f.actif,
+  cf.cout,
+  cf.portions,
+  case 
+    when cf.portions is null or cf.portions = 0 then null
+    else cf.cout / cf.portions
+  end as cout_par_portion,
+  f.prix_vente,
+  (coalesce(f.prix_vente,0) - coalesce(cf.cout / nullif(cf.portions,0),0)) as marge_euro,
+  case
+    when f.prix_vente is null or f.prix_vente = 0 then null
+    else round(((coalesce(f.prix_vente,0) - coalesce(cf.cout / nullif(cf.portions,0),0)) / f.prix_vente) * 100, 2)
+  end as marge_pct,
+  case
+    when f.prix_vente is null or f.prix_vente = 0 then null
+    else round((coalesce(cf.cout / nullif(cf.portions,0),0) / f.prix_vente) * 100, 2)
+  end as food_cost_pct
+from public.fiches_techniques f
+left join public.v_couts_fiches cf 
+  on cf.fiche_id = f.id and cf.mama_id = f.mama_id;


### PR DESCRIPTION
## Summary
- expose fiche family in v_costing_carte view
- add migration for costing carte view

## Testing
- `npx vitest run test/useCostingCarte.test.jsx`
- `npx vitest run test/CostingCarte.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_6896ed6bc74c832db69cb43a22e0348c