### PR TITLE
feat: replace mouvements with requisitions and update schema

### DIFF
--- a/FRONT_REFERENCES.json
+++ b/FRONT_REFERENCES.json
@@ -1,0 +1,2904 @@
+[
+  {
+    "type": "table",
+    "name": "achats",
+    "files": [
+      {
+        "file": "src/hooks/useAchats.js",
+        "line": 17
+      },
+      {
+        "file": "src/hooks/useAchats.js",
+        "line": 43
+      },
+      {
+        "file": "src/hooks/useAchats.js",
+        "line": 55
+      },
+      {
+        "file": "src/hooks/useAchats.js",
+        "line": 67
+      },
+      {
+        "file": "src/hooks/useAchats.js",
+        "line": 81
+      },
+      {
+        "file": "src/hooks/useFactures.js",
+        "line": 205
+      },
+      {
+        "file": "src/pages/factures/FactureForm.jsx",
+        "line": 266
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "alertes",
+    "files": [
+      {
+        "file": "src/pages/taches/Alertes.jsx",
+        "line": 17
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "alertes_rupture",
+    "files": [
+      {
+        "file": "src/hooks/useRuptureAlerts.js",
+        "line": 10
+      },
+      {
+        "file": "src/hooks/useRuptureAlerts.js",
+        "line": 26
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "api_keys",
+    "files": [
+      {
+        "file": "src/hooks/useApiKeys.js",
+        "line": 16
+      },
+      {
+        "file": "src/hooks/useApiKeys.js",
+        "line": 36
+      },
+      {
+        "file": "src/hooks/useApiKeys.js",
+        "line": 55
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "auth_double_facteur",
+    "files": [
+      {
+        "file": "src/hooks/useTwoFactorAuth.js",
+        "line": 16
+      },
+      {
+        "file": "src/hooks/useTwoFactorAuth.js",
+        "line": 41
+      },
+      {
+        "file": "src/hooks/useTwoFactorAuth.js",
+        "line": 52
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "bons_livraison",
+    "files": [
+      {
+        "file": "src/hooks/useBonsLivraison.js",
+        "line": 17
+      },
+      {
+        "file": "src/hooks/useBonsLivraison.js",
+        "line": 39
+      },
+      {
+        "file": "src/hooks/useBonsLivraison.js",
+        "line": 56
+      },
+      {
+        "file": "src/hooks/useBonsLivraison.js",
+        "line": 80
+      },
+      {
+        "file": "src/hooks/useFactures.js",
+        "line": 19
+      },
+      {
+        "file": "src/hooks/useFactures.js",
+        "line": 230
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "catalogue_updates",
+    "files": [
+      {
+        "file": "src/hooks/useFournisseurAPI.js",
+        "line": 112
+      },
+      {
+        "file": "src/pages/catalogue/CatalogueSyncViewer.jsx",
+        "line": 18
+      },
+      {
+        "file": "src/pages/catalogue/CatalogueSyncViewer.jsx",
+        "line": 43
+      },
+      {
+        "file": "src/pages/catalogue/CatalogueSyncViewer.jsx",
+        "line": 53
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "centres_de_cout",
+    "files": [
+      {
+        "file": "src/hooks/useCostCenters.js",
+        "line": 21
+      },
+      {
+        "file": "src/hooks/useCostCenters.js",
+        "line": 34
+      },
+      {
+        "file": "src/hooks/useCostCenters.js",
+        "line": 47
+      },
+      {
+        "file": "src/hooks/useCostCenters.js",
+        "line": 62
+      },
+      {
+        "file": "src/pages/parametrage/CentreCoutForm.jsx",
+        "line": 34
+      },
+      {
+        "file": "src/pages/parametrage/CentreCoutForm.jsx",
+        "line": 41
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "commande_lignes",
+    "files": [
+      {
+        "file": "src/hooks/useCommandes.js",
+        "line": 99
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "commandes",
+    "files": [
+      {
+        "file": "src/hooks/useCommandes.js",
+        "line": 19
+      },
+      {
+        "file": "src/hooks/useCommandes.js",
+        "line": 57
+      },
+      {
+        "file": "src/hooks/useCommandes.js",
+        "line": 82
+      },
+      {
+        "file": "src/hooks/useCommandes.js",
+        "line": 111
+      },
+      {
+        "file": "src/hooks/useCommandes.js",
+        "line": 139
+      },
+      {
+        "file": "src/hooks/useEmailsEnvoyes.js",
+        "line": 65
+      },
+      {
+        "file": "src/hooks/useFournisseurAPI.js",
+        "line": 138
+      },
+      {
+        "file": "src/hooks/useFournisseurAPI.js",
+        "line": 165
+      },
+      {
+        "file": "src/hooks/useFournisseurAPI.js",
+        "line": 185
+      },
+      {
+        "file": "src/hooks/useFournisseurAPI.js",
+        "line": 224
+      },
+      {
+        "file": "src/hooks/useFournisseurAPI.js",
+        "line": 253
+      },
+      {
+        "file": "src/pages/commandes/CommandesEnvoyees.jsx",
+        "line": 20
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "compta_mapping",
+    "files": [
+      {
+        "file": "src/hooks/useExportCompta.js",
+        "line": 57
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "consentements_utilisateur",
+    "files": [
+      {
+        "file": "src/hooks/useConsentements.js",
+        "line": 12
+      },
+      {
+        "file": "src/pages/parametrage/RGPDConsentForm.jsx",
+        "line": 30
+      }
+    ]
+  },
+  {
+    "type": "function",
+    "name": "consolidated_stats",
+    "files": [
+      {
+        "file": "src/hooks/useConsolidatedStats.js",
+        "line": 12
+      },
+      {
+        "file": "src/hooks/useReporting.js",
+        "line": 19
+      }
+    ]
+  },
+  {
+    "type": "function",
+    "name": "disable_two_fa",
+    "files": [
+      {
+        "file": "src/lib/loginUser.js",
+        "line": 106
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "documentation",
+    "files": [
+      {
+        "file": "src/context/HelpProvider.jsx",
+        "line": 40
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "documents",
+    "files": [
+      {
+        "file": "src/hooks/useDocuments.js",
+        "line": 17
+      },
+      {
+        "file": "src/hooks/useDocuments.js",
+        "line": 56
+      },
+      {
+        "file": "src/hooks/useDocuments.js",
+        "line": 94
+      },
+      {
+        "file": "src/hooks/useDocuments.js",
+        "line": 114
+      },
+      {
+        "file": "src/hooks/useDocuments.js",
+        "line": 131
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "emails_envoyes",
+    "files": [
+      {
+        "file": "src/hooks/useEmailsEnvoyes.js",
+        "line": 26
+      },
+      {
+        "file": "src/hooks/useEmailsEnvoyes.js",
+        "line": 57
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "etapes_onboarding",
+    "files": [
+      {
+        "file": "src/hooks/useOnboarding.js",
+        "line": 19
+      },
+      {
+        "file": "src/hooks/useOnboarding.js",
+        "line": 36
+      },
+      {
+        "file": "src/hooks/useOnboarding.js",
+        "line": 45
+      },
+      {
+        "file": "src/hooks/useOnboarding.js",
+        "line": 52
+      },
+      {
+        "file": "src/hooks/useOnboarding.js",
+        "line": 59
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "facture_lignes",
+    "files": [
+      {
+        "file": "src/hooks/useExportCompta.js",
+        "line": 18
+      },
+      {
+        "file": "src/hooks/useFactures.js",
+        "line": 175
+      },
+      {
+        "file": "src/hooks/useFactures.js",
+        "line": 276
+      },
+      {
+        "file": "src/hooks/useInvoiceItems.js",
+        "line": 18
+      },
+      {
+        "file": "src/hooks/useInvoiceItems.js",
+        "line": 35
+      },
+      {
+        "file": "src/hooks/useInvoiceItems.js",
+        "line": 60
+      },
+      {
+        "file": "src/hooks/useInvoiceItems.js",
+        "line": 75
+      },
+      {
+        "file": "src/hooks/useInvoiceItems.js",
+        "line": 87
+      },
+      {
+        "file": "src/pages/factures/FactureForm.jsx",
+        "line": 257
+      },
+      {
+        "file": "src/pages/fournisseurs/FournisseurDetail.jsx",
+        "line": 37
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "factures",
+    "files": [
+      {
+        "file": "src/hooks/useExport.js",
+        "line": 51
+      },
+      {
+        "file": "src/hooks/useFactures.js",
+        "line": 48
+      },
+      {
+        "file": "src/hooks/useFactures.js",
+        "line": 85
+      },
+      {
+        "file": "src/hooks/useFactures.js",
+        "line": 105
+      },
+      {
+        "file": "src/hooks/useFactures.js",
+        "line": 127
+      },
+      {
+        "file": "src/hooks/useFactures.js",
+        "line": 147
+      },
+      {
+        "file": "src/hooks/useFactures.js",
+        "line": 264
+      },
+      {
+        "file": "src/hooks/useFactures.js",
+        "line": 284
+      },
+      {
+        "file": "src/hooks/useFacturesAutocomplete.js",
+        "line": 15
+      },
+      {
+        "file": "src/hooks/useFournisseurAPI.js",
+        "line": 61
+      },
+      {
+        "file": "src/hooks/useInvoices.js",
+        "line": 20
+      },
+      {
+        "file": "src/hooks/useInvoices.js",
+        "line": 46
+      },
+      {
+        "file": "src/hooks/useInvoices.js",
+        "line": 65
+      },
+      {
+        "file": "src/hooks/useInvoices.js",
+        "line": 83
+      },
+      {
+        "file": "src/hooks/useInvoices.js",
+        "line": 96
+      },
+      {
+        "file": "src/hooks/useInvoices.js",
+        "line": 111
+      },
+      {
+        "file": "src/hooks/useInvoices.js",
+        "line": 126
+      },
+      {
+        "file": "src/pages/factures/FactureForm.jsx",
+        "line": 66
+      },
+      {
+        "file": "src/pages/factures/FactureForm.jsx",
+        "line": 152
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "familles",
+    "files": [
+      {
+        "file": "src/hooks/useFamilles.js",
+        "line": 10
+      },
+      {
+        "file": "src/hooks/useFamilles.js",
+        "line": 14
+      },
+      {
+        "file": "src/hooks/useFamilles.js",
+        "line": 35
+      },
+      {
+        "file": "src/hooks/useFamilles.js",
+        "line": 61
+      },
+      {
+        "file": "src/hooks/useFamilles.js",
+        "line": 84
+      },
+      {
+        "file": "src/hooks/useFamilles.js",
+        "line": 95
+      },
+      {
+        "file": "src/hooks/useFamilles.js",
+        "line": 120
+      },
+      {
+        "file": "src/hooks/useFamilles.js",
+        "line": 135
+      },
+      {
+        "file": "src/hooks/useFamillesWithSousFamilles.js",
+        "line": 17
+      },
+      {
+        "file": "src/hooks/useFamillesWithSousFamilles.js",
+        "line": 42
+      },
+      {
+        "file": "src/hooks/useFamillesWithSousFamilles.js",
+        "line": 51
+      },
+      {
+        "file": "src/hooks/useFamillesWithSousFamilles.js",
+        "line": 61
+      },
+      {
+        "file": "src/pages/CartePlats.jsx",
+        "line": 27
+      },
+      {
+        "file": "src/pages/parametrage/Familles.jsx",
+        "line": 54
+      },
+      {
+        "file": "src/pages/stats/StatsFiches.jsx",
+        "line": 30
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "feedback",
+    "files": [
+      {
+        "file": "src/hooks/useFeedback.js",
+        "line": 16
+      },
+      {
+        "file": "src/hooks/useFeedback.js",
+        "line": 37
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "fiche_cout_history",
+    "files": [
+      {
+        "file": "src/hooks/useFicheCoutHistory.js",
+        "line": 17
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "fiche_lignes",
+    "files": [
+      {
+        "file": "src/hooks/useFiches.js",
+        "line": 93
+      },
+      {
+        "file": "src/hooks/useFiches.js",
+        "line": 122
+      },
+      {
+        "file": "src/hooks/useFiches.js",
+        "line": 141
+      },
+      {
+        "file": "src/hooks/useFiches.js",
+        "line": 212
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "fiches",
+    "files": [
+      {
+        "file": "src/pages/simulation/SimulationForm.jsx",
+        "line": 19
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "fiches_techniques",
+    "files": [
+      {
+        "file": "src/hooks/useCarte.js",
+        "line": 16
+      },
+      {
+        "file": "src/hooks/useCarte.js",
+        "line": 37
+      },
+      {
+        "file": "src/hooks/useCarte.js",
+        "line": 50
+      },
+      {
+        "file": "src/hooks/useExport.js",
+        "line": 31
+      },
+      {
+        "file": "src/hooks/useFiches.js",
+        "line": 23
+      },
+      {
+        "file": "src/hooks/useFiches.js",
+        "line": 51
+      },
+      {
+        "file": "src/hooks/useFiches.js",
+        "line": 73
+      },
+      {
+        "file": "src/hooks/useFiches.js",
+        "line": 111
+      },
+      {
+        "file": "src/hooks/useFiches.js",
+        "line": 159
+      },
+      {
+        "file": "src/hooks/useFiches.js",
+        "line": 179
+      },
+      {
+        "file": "src/hooks/useFiches.js",
+        "line": 192
+      },
+      {
+        "file": "src/hooks/useFichesAutocomplete.js",
+        "line": 16
+      },
+      {
+        "file": "src/hooks/useFichesTechniques.js",
+        "line": 16
+      },
+      {
+        "file": "src/hooks/useFichesTechniques.js",
+        "line": 37
+      },
+      {
+        "file": "src/hooks/useFichesTechniques.js",
+        "line": 55
+      },
+      {
+        "file": "src/hooks/useFichesTechniques.js",
+        "line": 75
+      },
+      {
+        "file": "src/hooks/useStats.js",
+        "line": 17
+      },
+      {
+        "file": "src/pages/BarManager.jsx",
+        "line": 57
+      },
+      {
+        "file": "src/pages/CartePlats.jsx",
+        "line": 22
+      },
+      {
+        "file": "src/pages/costboisson/CostBoisson.jsx",
+        "line": 71
+      },
+      {
+        "file": "src/pages/stats/StatsFiches.jsx",
+        "line": 29
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "fournisseur_contacts",
+    "files": [
+      {
+        "file": "src/hooks/useFournisseurs.js",
+        "line": 66
+      },
+      {
+        "file": "src/hooks/useFournisseurs.js",
+        "line": 95
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "fournisseur_notes",
+    "files": [
+      {
+        "file": "src/hooks/useFournisseurNotes.js",
+        "line": 20
+      },
+      {
+        "file": "src/hooks/useFournisseurNotes.js",
+        "line": 39
+      },
+      {
+        "file": "src/hooks/useFournisseurNotes.js",
+        "line": 48
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "fournisseur_produits",
+    "files": [
+      {
+        "file": "src/hooks/useComparatif.js",
+        "line": 23
+      },
+      {
+        "file": "src/hooks/useFactures.js",
+        "line": 193
+      },
+      {
+        "file": "src/hooks/useFournisseurAPI.js",
+        "line": 90
+      },
+      {
+        "file": "src/hooks/useFournisseurAPI.js",
+        "line": 99
+      },
+      {
+        "file": "src/hooks/useProducts.js",
+        "line": 175
+      },
+      {
+        "file": "src/hooks/useProduitsFournisseur.js",
+        "line": 21
+      },
+      {
+        "file": "src/hooks/useProduitsFournisseur.js",
+        "line": 41
+      },
+      {
+        "file": "src/hooks/useProduitsFournisseur.js",
+        "line": 57
+      },
+      {
+        "file": "src/pages/catalogue/CatalogueSyncViewer.jsx",
+        "line": 31
+      },
+      {
+        "file": "src/pages/factures/FactureForm.jsx",
+        "line": 260
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "fournisseurs",
+    "files": [
+      {
+        "file": "src/hooks/useFournisseurs.js",
+        "line": 24
+      },
+      {
+        "file": "src/hooks/useFournisseurs.js",
+        "line": 60
+      },
+      {
+        "file": "src/hooks/useFournisseurs.js",
+        "line": 89
+      },
+      {
+        "file": "src/hooks/useFournisseurs.js",
+        "line": 116
+      },
+      {
+        "file": "src/hooks/useFournisseursAutocomplete.js",
+        "line": 15
+      },
+      {
+        "file": "src/hooks/useGlobalSearch.js",
+        "line": 19
+      },
+      {
+        "file": "src/pages/fournisseurs/FournisseurDetail.jsx",
+        "line": 47
+      },
+      {
+        "file": "src/utils/importExcelProduits.js",
+        "line": 67
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "fournisseurs_api_config",
+    "files": [
+      {
+        "file": "src/hooks/useFournisseurAPI.js",
+        "line": 14
+      },
+      {
+        "file": "src/hooks/useFournisseurApiConfig.js",
+        "line": 15
+      },
+      {
+        "file": "src/hooks/useFournisseurApiConfig.js",
+        "line": 33
+      },
+      {
+        "file": "src/hooks/useFournisseurApiConfig.js",
+        "line": 51
+      },
+      {
+        "file": "src/hooks/useFournisseurApiConfig.js",
+        "line": 67
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "gadgets",
+    "files": [
+      {
+        "file": "src/hooks/useDashboards.js",
+        "line": 54
+      },
+      {
+        "file": "src/hooks/useDashboards.js",
+        "line": 62
+      },
+      {
+        "file": "src/hooks/useDashboards.js",
+        "line": 86
+      },
+      {
+        "file": "src/hooks/useDashboards.js",
+        "line": 112
+      },
+      {
+        "file": "src/hooks/useGadgets.js",
+        "line": 59
+      },
+      {
+        "file": "src/hooks/useGadgets.js",
+        "line": 79
+      },
+      {
+        "file": "src/hooks/useGadgets.js",
+        "line": 101
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "groupes",
+    "files": [
+      {
+        "file": "src/pages/supervision/GroupeParamForm.jsx",
+        "line": 54
+      },
+      {
+        "file": "src/pages/supervision/GroupeParamForm.jsx",
+        "line": 67
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "guides_seen",
+    "files": [
+      {
+        "file": "src/context/HelpProvider.jsx",
+        "line": 53
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "help_articles",
+    "files": [
+      {
+        "file": "src/hooks/useAide.js",
+        "line": 17
+      },
+      {
+        "file": "src/hooks/useAide.js",
+        "line": 43
+      },
+      {
+        "file": "src/hooks/useAide.js",
+        "line": 64
+      },
+      {
+        "file": "src/hooks/useAide.js",
+        "line": 87
+      },
+      {
+        "file": "src/hooks/useHelpArticles.js",
+        "line": 13
+      },
+      {
+        "file": "src/hooks/useHelpArticles.js",
+        "line": 30
+      },
+      {
+        "file": "src/hooks/useHelpArticles.js",
+        "line": 44
+      },
+      {
+        "file": "src/hooks/useHelpArticles.js",
+        "line": 59
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "inventaire_zones",
+    "files": [
+      {
+        "file": "src/hooks/useInventaireZones.js",
+        "line": 17
+      },
+      {
+        "file": "src/hooks/useInventaireZones.js",
+        "line": 37
+      },
+      {
+        "file": "src/hooks/useInventaireZones.js",
+        "line": 53
+      },
+      {
+        "file": "src/hooks/useInventaireZones.js",
+        "line": 71
+      },
+      {
+        "file": "src/hooks/useInventaireZones.js",
+        "line": 87
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "inventaires",
+    "files": [
+      {
+        "file": "src/hooks/useExport.js",
+        "line": 37
+      },
+      {
+        "file": "src/hooks/useGraphiquesMultiZone.js",
+        "line": 25
+      },
+      {
+        "file": "src/hooks/useInventaireLignes.js",
+        "line": 12
+      },
+      {
+        "file": "src/hooks/useInventaires.js",
+        "line": 23
+      },
+      {
+        "file": "src/hooks/useInventaires.js",
+        "line": 76
+      },
+      {
+        "file": "src/hooks/useInventaires.js",
+        "line": 106
+      },
+      {
+        "file": "src/hooks/useInventaires.js",
+        "line": 133
+      },
+      {
+        "file": "src/hooks/useInventaires.js",
+        "line": 145
+      },
+      {
+        "file": "src/hooks/useStock.js",
+        "line": 56
+      },
+      {
+        "file": "src/hooks/useStock.js",
+        "line": 68
+      },
+      {
+        "file": "src/pages/Transferts.jsx",
+        "line": 52
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "journaux_utilisateur",
+    "files": [
+      {
+        "file": "src/hooks/useAuditLog.js",
+        "line": 10
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "lignes_bl",
+    "files": [
+      {
+        "file": "src/hooks/useBonsLivraison.js",
+        "line": 63
+      },
+      {
+        "file": "src/hooks/useFactures.js",
+        "line": 237
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "logs_activite",
+    "files": [
+      {
+        "file": "src/hooks/useLogs.js",
+        "line": 21
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "logs_securite",
+    "files": [
+      {
+        "file": "src/hooks/gadgets/useDerniersAcces.js",
+        "line": 17
+      },
+      {
+        "file": "src/hooks/useAuditLog.js",
+        "line": 26
+      },
+      {
+        "file": "src/hooks/useUsageStats.js",
+        "line": 34
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "mamas",
+    "files": [
+      {
+        "file": "src/context/AuthContext.jsx",
+        "line": 276
+      },
+      {
+        "file": "src/context/MultiMamaContext.jsx",
+        "line": 33
+      },
+      {
+        "file": "src/context/MultiMamaContext.jsx",
+        "line": 40
+      },
+      {
+        "file": "src/hooks/useMama.js",
+        "line": 16
+      },
+      {
+        "file": "src/hooks/useMama.js",
+        "line": 31
+      },
+      {
+        "file": "src/hooks/useMamaSettings.js",
+        "line": 28
+      },
+      {
+        "file": "src/hooks/useMamaSettings.js",
+        "line": 44
+      },
+      {
+        "file": "src/hooks/useMamas.js",
+        "line": 19
+      },
+      {
+        "file": "src/hooks/useMamas.js",
+        "line": 35
+      },
+      {
+        "file": "src/hooks/useMamas.js",
+        "line": 50
+      },
+      {
+        "file": "src/hooks/useMamas.js",
+        "line": 66
+      },
+      {
+        "file": "src/pages/auth/CreateMama.jsx",
+        "line": 27
+      },
+      {
+        "file": "src/pages/legal/Confidentialite.jsx",
+        "line": 15
+      },
+      {
+        "file": "src/pages/legal/MentionsLegales.jsx",
+        "line": 15
+      },
+      {
+        "file": "src/pages/parametrage/InvitationsEnAttente.jsx",
+        "line": 21
+      },
+      {
+        "file": "src/pages/parametrage/InviteUser.jsx",
+        "line": 27
+      },
+      {
+        "file": "src/pages/parametrage/InviteUser.jsx",
+        "line": 33
+      },
+      {
+        "file": "src/pages/parametrage/MamaForm.jsx",
+        "line": 39
+      },
+      {
+        "file": "src/pages/parametrage/MamaForm.jsx",
+        "line": 55
+      },
+      {
+        "file": "src/pages/parametrage/MamaForm.jsx",
+        "line": 64
+      },
+      {
+        "file": "src/pages/parametrage/Mamas.jsx",
+        "line": 32
+      },
+      {
+        "file": "src/pages/parametrage/Mamas.jsx",
+        "line": 44
+      },
+      {
+        "file": "src/pages/parametrage/PermissionsAdmin.jsx",
+        "line": 33
+      },
+      {
+        "file": "src/pages/supervision/GroupeParamForm.jsx",
+        "line": 25
+      },
+      {
+        "file": "src/pages/supervision/GroupeParamForm.jsx",
+        "line": 31
+      },
+      {
+        "file": "src/pages/supervision/GroupeParamForm.jsx",
+        "line": 62
+      },
+      {
+        "file": "src/pages/supervision/GroupeParamForm.jsx",
+        "line": 64
+      },
+      {
+        "file": "src/pages/supervision/GroupeParamForm.jsx",
+        "line": 75
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "menu_fiches",
+    "files": [
+      {
+        "file": "src/hooks/useMenus.js",
+        "line": 74
+      },
+      {
+        "file": "src/hooks/useMenus.js",
+        "line": 95
+      },
+      {
+        "file": "src/hooks/useMenus.js",
+        "line": 106
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "menu_groupe_lignes",
+    "files": [
+      {
+        "file": "src/hooks/useMenuGroupe.js",
+        "line": 32
+      },
+      {
+        "file": "src/hooks/useMenuGroupe.js",
+        "line": 70
+      },
+      {
+        "file": "src/hooks/useMenuGroupe.js",
+        "line": 79
+      },
+      {
+        "file": "src/hooks/useMenuGroupe.js",
+        "line": 84
+      },
+      {
+        "file": "src/hooks/useMenuGroupe.js",
+        "line": 119
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "menu_groupe_modele_lignes",
+    "files": [
+      {
+        "file": "src/hooks/useMenuGroupe.js",
+        "line": 105
+      },
+      {
+        "file": "src/hooks/useMenuGroupe.js",
+        "line": 132
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "menu_groupe_modeles",
+    "files": [
+      {
+        "file": "src/hooks/useMenuGroupe.js",
+        "line": 114
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "menu_groupes",
+    "files": [
+      {
+        "file": "src/hooks/useMenuGroupe.js",
+        "line": 12
+      },
+      {
+        "file": "src/hooks/useMenuGroupe.js",
+        "line": 26
+      },
+      {
+        "file": "src/hooks/useMenuGroupe.js",
+        "line": 51
+      },
+      {
+        "file": "src/hooks/useMenuGroupe.js",
+        "line": 60
+      },
+      {
+        "file": "src/hooks/useMenuGroupe.js",
+        "line": 94
+      },
+      {
+        "file": "src/hooks/useMenuGroupe.js",
+        "line": 98
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "menus",
+    "files": [
+      {
+        "file": "src/hooks/useMenus.js",
+        "line": 31
+      },
+      {
+        "file": "src/hooks/useMenus.js",
+        "line": 61
+      },
+      {
+        "file": "src/hooks/useMenus.js",
+        "line": 88
+      },
+      {
+        "file": "src/hooks/useMenus.js",
+        "line": 118
+      },
+      {
+        "file": "src/hooks/useMenus.js",
+        "line": 136
+      },
+      {
+        "file": "src/hooks/useMenus.js",
+        "line": 151
+      },
+      {
+        "file": "src/pages/menus/MenuPDF.jsx",
+        "line": 14
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "menus_jour",
+    "files": [
+      {
+        "file": "src/hooks/useMenuDuJour.js",
+        "line": 22
+      },
+      {
+        "file": "src/hooks/useMenuDuJour.js",
+        "line": 60
+      },
+      {
+        "file": "src/hooks/useMenuDuJour.js",
+        "line": 80
+      },
+      {
+        "file": "src/hooks/useMenuDuJour.js",
+        "line": 101
+      },
+      {
+        "file": "src/hooks/useMenuDuJour.js",
+        "line": 134
+      },
+      {
+        "file": "src/hooks/useMenuDuJour.js",
+        "line": 148
+      },
+      {
+        "file": "src/hooks/useMenuDuJour.js",
+        "line": 177
+      },
+      {
+        "file": "src/hooks/useMenuDuJour.js",
+        "line": 187
+      },
+      {
+        "file": "src/hooks/useMenuDuJour.js",
+        "line": 195
+      },
+      {
+        "file": "src/hooks/useMenuDuJour.js",
+        "line": 203
+      },
+      {
+        "file": "src/hooks/useMenuDuJour.js",
+        "line": 209
+      },
+      {
+        "file": "src/hooks/useMenuDuJour.js",
+        "line": 236
+      },
+      {
+        "file": "src/hooks/useMenuDuJour.js",
+        "line": 261
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "menus_jour_fiches",
+    "files": [
+      {
+        "file": "src/hooks/useMenuDuJour.js",
+        "line": 67
+      },
+      {
+        "file": "src/hooks/useMenuDuJour.js",
+        "line": 86
+      },
+      {
+        "file": "src/hooks/useMenuDuJour.js",
+        "line": 89
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "menus_jour_lignes",
+    "files": [
+      {
+        "file": "src/hooks/useMenuDuJour.js",
+        "line": 271
+      },
+      {
+        "file": "src/hooks/useMenuDuJour.js",
+        "line": 278
+      },
+      {
+        "file": "src/hooks/useMenuDuJour.js",
+        "line": 285
+      },
+      {
+        "file": "src/hooks/useMenuDuJour.js",
+        "line": 292
+      },
+      {
+        "file": "src/hooks/useMenuDuJour.js",
+        "line": 317
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "mouvements_centres_cout",
+    "files": [
+      {
+        "file": "src/hooks/useMouvementCostCenters.js",
+        "line": 18
+      },
+      {
+        "file": "src/hooks/useMouvementCostCenters.js",
+        "line": 38
+      },
+      {
+        "file": "src/hooks/useMouvementCostCenters.js",
+        "line": 51
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "notification_preferences",
+    "files": [
+      {
+        "file": "src/hooks/useNotifications.js",
+        "line": 116
+      },
+      {
+        "file": "src/hooks/useNotifications.js",
+        "line": 129
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "notifications",
+    "files": [
+      {
+        "file": "src/hooks/useNotifications.js",
+        "line": 22
+      },
+      {
+        "file": "src/hooks/useNotifications.js",
+        "line": 58
+      },
+      {
+        "file": "src/hooks/useNotifications.js",
+        "line": 81
+      },
+      {
+        "file": "src/hooks/useNotifications.js",
+        "line": 94
+      },
+      {
+        "file": "src/hooks/useNotifications.js",
+        "line": 105
+      },
+      {
+        "file": "src/hooks/useNotifications.js",
+        "line": 145
+      },
+      {
+        "file": "src/hooks/useNotifications.js",
+        "line": 159
+      },
+      {
+        "file": "src/hooks/useNotifications.js",
+        "line": 177
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "parametres_commandes",
+    "files": [
+      {
+        "file": "src/pages/parametrage/ParametresCommandes.jsx",
+        "line": 19
+      },
+      {
+        "file": "src/pages/parametrage/ParametresCommandes.jsx",
+        "line": 40
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "periodes_comptables",
+    "files": [
+      {
+        "file": "src/hooks/usePeriodes.js",
+        "line": 17
+      },
+      {
+        "file": "src/hooks/usePeriodes.js",
+        "line": 36
+      },
+      {
+        "file": "src/hooks/usePeriodes.js",
+        "line": 54
+      },
+      {
+        "file": "src/hooks/usePeriodes.js",
+        "line": 65
+      },
+      {
+        "file": "src/hooks/usePeriodes.js",
+        "line": 80
+      },
+      {
+        "file": "src/hooks/usePeriodes.js",
+        "line": 96
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "permissions",
+    "files": [
+      {
+        "file": "src/hooks/usePermissions.js",
+        "line": 20
+      },
+      {
+        "file": "src/hooks/usePermissions.js",
+        "line": 37
+      },
+      {
+        "file": "src/hooks/usePermissions.js",
+        "line": 50
+      },
+      {
+        "file": "src/hooks/usePermissions.js",
+        "line": 65
+      },
+      {
+        "file": "src/pages/parametrage/PermissionsForm.jsx",
+        "line": 33
+      },
+      {
+        "file": "src/pages/parametrage/PermissionsForm.jsx",
+        "line": 59
+      },
+      {
+        "file": "src/pages/parametrage/PermissionsForm.jsx",
+        "line": 69
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "pertes",
+    "files": [
+      {
+        "file": "src/hooks/usePertes.js",
+        "line": 18
+      },
+      {
+        "file": "src/hooks/usePertes.js",
+        "line": 39
+      },
+      {
+        "file": "src/hooks/usePertes.js",
+        "line": 55
+      },
+      {
+        "file": "src/hooks/usePertes.js",
+        "line": 73
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "planning_lignes",
+    "files": [
+      {
+        "file": "src/hooks/usePlanning.js",
+        "line": 58
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "planning_previsionnel",
+    "files": [
+      {
+        "file": "src/hooks/usePlanning.js",
+        "line": 10
+      },
+      {
+        "file": "src/hooks/usePlanning.js",
+        "line": 29
+      },
+      {
+        "file": "src/hooks/usePlanning.js",
+        "line": 44
+      },
+      {
+        "file": "src/hooks/usePlanning.js",
+        "line": 66
+      },
+      {
+        "file": "src/hooks/usePlanning.js",
+        "line": 79
+      },
+      {
+        "file": "src/hooks/usePlanning.js",
+        "line": 91
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "produits",
+    "files": [
+      {
+        "file": "src/components/produits/ModalImportProduits.jsx",
+        "line": 94
+      },
+      {
+        "file": "src/hooks/useEnrichedProducts.js",
+        "line": 16
+      },
+      {
+        "file": "src/hooks/useExport.js",
+        "line": 43
+      },
+      {
+        "file": "src/hooks/useGlobalSearch.js",
+        "line": 13
+      },
+      {
+        "file": "src/hooks/useInventaires.js",
+        "line": 54
+      },
+      {
+        "file": "src/hooks/useProducts.js",
+        "line": 32
+      },
+      {
+        "file": "src/hooks/useProducts.js",
+        "line": 106
+      },
+      {
+        "file": "src/hooks/useProducts.js",
+        "line": 124
+      },
+      {
+        "file": "src/hooks/useProducts.js",
+        "line": 141
+      },
+      {
+        "file": "src/hooks/useProducts.js",
+        "line": 158
+      },
+      {
+        "file": "src/hooks/useProducts.js",
+        "line": 237
+      },
+      {
+        "file": "src/hooks/useProduitsAutocomplete.js",
+        "line": 16
+      },
+      {
+        "file": "src/hooks/useRecommendations.js",
+        "line": 42
+      },
+      {
+        "file": "src/hooks/useStats.js",
+        "line": 16
+      },
+      {
+        "file": "src/hooks/useStock.js",
+        "line": 17
+      },
+      {
+        "file": "src/pages/Transferts.jsx",
+        "line": 45
+      },
+      {
+        "file": "src/pages/costboisson/CostBoisson.jsx",
+        "line": 63
+      },
+      {
+        "file": "src/pages/fournisseurs/comparatif/ComparatifPrix.jsx",
+        "line": 22
+      },
+      {
+        "file": "src/pages/mobile/MobileInventaire.jsx",
+        "line": 17
+      },
+      {
+        "file": "src/pages/mobile/MobileRequisition.jsx",
+        "line": 17
+      },
+      {
+        "file": "src/utils/exportExcelProduits.js",
+        "line": 30
+      },
+      {
+        "file": "src/utils/importExcelProduits.js",
+        "line": 68
+      },
+      {
+        "file": "src/utils/importExcelProduits.js",
+        "line": 159
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "produits_inventaire",
+    "files": [
+      {
+        "file": "src/hooks/useInventaireLignes.js",
+        "line": 33
+      },
+      {
+        "file": "src/hooks/useInventaireLignes.js",
+        "line": 64
+      },
+      {
+        "file": "src/hooks/useInventaireLignes.js",
+        "line": 85
+      },
+      {
+        "file": "src/hooks/useInventaireLignes.js",
+        "line": 104
+      },
+      {
+        "file": "src/hooks/useInventaireLignes.js",
+        "line": 115
+      },
+      {
+        "file": "src/hooks/useInventaires.js",
+        "line": 94
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "promotions",
+    "files": [
+      {
+        "file": "src/api/public/promotions.js",
+        "line": 29
+      },
+      {
+        "file": "src/hooks/usePromotions.js",
+        "line": 17
+      },
+      {
+        "file": "src/hooks/usePromotions.js",
+        "line": 39
+      },
+      {
+        "file": "src/hooks/usePromotions.js",
+        "line": 51
+      },
+      {
+        "file": "src/hooks/usePromotions.js",
+        "line": 65
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "rapports_generes",
+    "files": [
+      {
+        "file": "src/hooks/useLogs.js",
+        "line": 55
+      },
+      {
+        "file": "src/hooks/useLogs.js",
+        "line": 74
+      },
+      {
+        "file": "src/pages/supervision/Rapports.jsx",
+        "line": 45
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "regles_alertes",
+    "files": [
+      {
+        "file": "src/hooks/useAlerts.js",
+        "line": 16
+      },
+      {
+        "file": "src/hooks/useAlerts.js",
+        "line": 40
+      },
+      {
+        "file": "src/hooks/useAlerts.js",
+        "line": 54
+      },
+      {
+        "file": "src/hooks/useAlerts.js",
+        "line": 70
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "requisition_lignes",
+    "files": [
+      {
+        "file": "src/api/public/stock.js",
+        "line": 29
+      },
+      {
+        "file": "src/hooks/gadgets/useConsoMoyenne.js",
+        "line": 19
+      },
+      {
+        "file": "src/hooks/useDashboard.js",
+        "line": 60
+      },
+      {
+        "file": "src/hooks/useProducts.js",
+        "line": 213
+      },
+      {
+        "file": "src/hooks/useRequisitions.js",
+        "line": 111
+      },
+      {
+        "file": "src/hooks/useStats.js",
+        "line": 18
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "requisitions",
+    "files": [
+      {
+        "file": "src/hooks/useRequisitions.js",
+        "line": 36
+      },
+      {
+        "file": "src/hooks/useRequisitions.js",
+        "line": 61
+      },
+      {
+        "file": "src/hooks/useRequisitions.js",
+        "line": 84
+      },
+      {
+        "file": "src/hooks/useRequisitions.js",
+        "line": 119
+      },
+      {
+        "file": "src/hooks/useRequisitions.js",
+        "line": 135
+      },
+      {
+        "file": "src/pages/mobile/MobileRequisition.jsx",
+        "line": 31
+      },
+      {
+        "file": "src/pages/mobile/MobileRequisition.jsx",
+        "line": 42
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "roles",
+    "files": [
+      {
+        "file": "src/hooks/useRoles.js",
+        "line": 11
+      },
+      {
+        "file": "src/hooks/useRoles.js",
+        "line": 20
+      },
+      {
+        "file": "src/hooks/useRoles.js",
+        "line": 29
+      },
+      {
+        "file": "src/hooks/useUtilisateurs.js",
+        "line": 46
+      },
+      {
+        "file": "src/hooks/useUtilisateurs.js",
+        "line": 84
+      },
+      {
+        "file": "src/pages/parametrage/InvitationsEnAttente.jsx",
+        "line": 26
+      },
+      {
+        "file": "src/pages/parametrage/InviteUser.jsx",
+        "line": 41
+      },
+      {
+        "file": "src/pages/parametrage/Permissions.jsx",
+        "line": 29
+      },
+      {
+        "file": "src/pages/parametrage/PermissionsAdmin.jsx",
+        "line": 39
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "settings",
+    "files": [
+      {
+        "file": "src/hooks/useCostingCarte.js",
+        "line": 49
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "signalements",
+    "files": [
+      {
+        "file": "src/hooks/useSignalements.js",
+        "line": 17
+      },
+      {
+        "file": "src/hooks/useSignalements.js",
+        "line": 41
+      },
+      {
+        "file": "src/hooks/useSignalements.js",
+        "line": 74
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "sous_familles",
+    "files": [
+      {
+        "file": "src/components/parametrage/SousFamilleList.jsx",
+        "line": 25
+      },
+      {
+        "file": "src/components/parametrage/SousFamilleList.jsx",
+        "line": 42
+      },
+      {
+        "file": "src/components/parametrage/SousFamilleList.jsx",
+        "line": 56
+      },
+      {
+        "file": "src/components/parametrage/SousFamilleList.jsx",
+        "line": 71
+      },
+      {
+        "file": "src/components/parametrage/SousFamilleList.jsx",
+        "line": 86
+      },
+      {
+        "file": "src/hooks/useFamillesWithSousFamilles.js",
+        "line": 22
+      },
+      {
+        "file": "src/hooks/useFamillesWithSousFamilles.js",
+        "line": 72
+      },
+      {
+        "file": "src/hooks/useFamillesWithSousFamilles.js",
+        "line": 81
+      },
+      {
+        "file": "src/hooks/useFamillesWithSousFamilles.js",
+        "line": 91
+      },
+      {
+        "file": "src/hooks/useSousFamilles.js",
+        "line": 20
+      },
+      {
+        "file": "src/hooks/useSousFamilles.js",
+        "line": 42
+      },
+      {
+        "file": "src/hooks/useSousFamilles.js",
+        "line": 60
+      },
+      {
+        "file": "src/hooks/useSousFamilles.js",
+        "line": 76
+      },
+      {
+        "file": "src/pages/parametrage/Familles.jsx",
+        "line": 85
+      },
+      {
+        "file": "src/pages/parametrage/SousFamilles.jsx",
+        "line": 32
+      },
+      {
+        "file": "src/pages/parametrage/SousFamilles.jsx",
+        "line": 53
+      },
+      {
+        "file": "src/utils/importExcelProduits.js",
+        "line": 64
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "tableaux_de_bord",
+    "files": [
+      {
+        "file": "src/hooks/useDashboards.js",
+        "line": 16
+      },
+      {
+        "file": "src/hooks/useDashboards.js",
+        "line": 36
+      },
+      {
+        "file": "src/hooks/useGadgets.js",
+        "line": 15
+      },
+      {
+        "file": "src/hooks/useGadgets.js",
+        "line": 37
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "taches",
+    "files": [
+      {
+        "file": "src/hooks/gadgets/useTachesUrgentes.js",
+        "line": 20
+      },
+      {
+        "file": "src/hooks/useTaches.js",
+        "line": 81
+      },
+      {
+        "file": "src/hooks/useTaches.js",
+        "line": 113
+      },
+      {
+        "file": "src/hooks/useTaches.js",
+        "line": 139
+      },
+      {
+        "file": "src/hooks/useTaches.js",
+        "line": 145
+      },
+      {
+        "file": "src/hooks/useTasks.js",
+        "line": 16
+      },
+      {
+        "file": "src/hooks/useTasks.js",
+        "line": 34
+      },
+      {
+        "file": "src/hooks/useTasks.js",
+        "line": 53
+      },
+      {
+        "file": "src/hooks/useTasks.js",
+        "line": 73
+      },
+      {
+        "file": "src/hooks/useTasks.js",
+        "line": 90
+      },
+      {
+        "file": "src/hooks/useTasks.js",
+        "line": 109
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "templates_commandes",
+    "files": [
+      {
+        "file": "src/hooks/useTemplatesCommandes.js",
+        "line": 6
+      },
+      {
+        "file": "src/hooks/useTemplatesCommandes.js",
+        "line": 20
+      },
+      {
+        "file": "src/hooks/useTemplatesCommandes.js",
+        "line": 32
+      },
+      {
+        "file": "src/hooks/useTemplatesCommandes.js",
+        "line": 43
+      },
+      {
+        "file": "src/hooks/useTemplatesCommandes.js",
+        "line": 53
+      },
+      {
+        "file": "src/hooks/useTemplatesCommandes.js",
+        "line": 65
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "tooltips",
+    "files": [
+      {
+        "file": "src/context/HelpProvider.jsx",
+        "line": 24
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "transfert_lignes",
+    "files": [
+      {
+        "file": "src/hooks/useTransferts.js",
+        "line": 84
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "transferts",
+    "files": [
+      {
+        "file": "src/hooks/useTransferts.js",
+        "line": 27
+      },
+      {
+        "file": "src/hooks/useTransferts.js",
+        "line": 58
+      },
+      {
+        "file": "src/hooks/useTransferts.js",
+        "line": 102
+      },
+      {
+        "file": "src/pages/Transferts.jsx",
+        "line": 66
+      },
+      {
+        "file": "src/pages/Transferts.jsx",
+        "line": 195
+      },
+      {
+        "file": "src/pages/Transferts.jsx",
+        "line": 224
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "unites",
+    "files": [
+      {
+        "file": "src/hooks/useUnites.js",
+        "line": 10
+      },
+      {
+        "file": "src/hooks/useUnites.js",
+        "line": 26
+      },
+      {
+        "file": "src/hooks/useUnites.js",
+        "line": 47
+      },
+      {
+        "file": "src/hooks/useUnites.js",
+        "line": 70
+      },
+      {
+        "file": "src/hooks/useUnites.js",
+        "line": 81
+      },
+      {
+        "file": "src/hooks/useUnites.js",
+        "line": 106
+      },
+      {
+        "file": "src/hooks/useUnites.js",
+        "line": 121
+      },
+      {
+        "file": "src/pages/parametrage/Unites.jsx",
+        "line": 39
+      },
+      {
+        "file": "src/pages/parametrage/Unites.jsx",
+        "line": 50
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "usage_stats",
+    "files": [
+      {
+        "file": "src/hooks/useUsageStats.js",
+        "line": 10
+      },
+      {
+        "file": "src/hooks/useUsageStats.js",
+        "line": 21
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "user_mama_access",
+    "files": [
+      {
+        "file": "src/hooks/useConsolidation.js",
+        "line": 17
+      },
+      {
+        "file": "src/pages/consolidation/AccessMultiSites.jsx",
+        "line": 13
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "utilisateurs",
+    "files": [
+      {
+        "file": "src/context/AuthContext.jsx",
+        "line": 282
+      },
+      {
+        "file": "src/hooks/useRGPD.js",
+        "line": 10
+      },
+      {
+        "file": "src/hooks/useRGPD.js",
+        "line": 20
+      },
+      {
+        "file": "src/hooks/useUtilisateurs.js",
+        "line": 96
+      },
+      {
+        "file": "src/hooks/useUtilisateurs.js",
+        "line": 114
+      },
+      {
+        "file": "src/hooks/useUtilisateurs.js",
+        "line": 144
+      },
+      {
+        "file": "src/pages/auth/CreateMama.jsx",
+        "line": 33
+      },
+      {
+        "file": "src/pages/parametrage/InvitationsEnAttente.jsx",
+        "line": 32
+      },
+      {
+        "file": "src/pages/parametrage/InvitationsEnAttente.jsx",
+        "line": 52
+      },
+      {
+        "file": "src/pages/parametrage/InviteUser.jsx",
+        "line": 66
+      },
+      {
+        "file": "src/pages/parametrage/InviteUser.jsx",
+        "line": 78
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "utilisateurs_complets",
+    "files": [
+      {
+        "file": "src/context/AuthContext.jsx",
+        "line": 76
+      },
+      {
+        "file": "src/hooks/useUtilisateurs.js",
+        "line": 22
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "utilisateurs_taches",
+    "files": [
+      {
+        "file": "src/hooks/useTacheAssignation.js",
+        "line": 13
+      },
+      {
+        "file": "src/hooks/useTacheAssignation.js",
+        "line": 25
+      },
+      {
+        "file": "src/hooks/useTaches.js",
+        "line": 60
+      },
+      {
+        "file": "src/hooks/useTaches.js",
+        "line": 124
+      },
+      {
+        "file": "src/hooks/useTaches.js",
+        "line": 138
+      }
+    ]
+  },
+  {
+    "type": "view",
+    "name": "v_achats_mensuels",
+    "files": [
+      {
+        "file": "src/hooks/gadgets/useAchatsMensuels.js",
+        "line": 18
+      },
+      {
+        "file": "src/hooks/useAnalyse.js",
+        "line": 16
+      },
+      {
+        "file": "src/hooks/useReporting.js",
+        "line": 32
+      }
+    ]
+  },
+  {
+    "type": "view",
+    "name": "v_analytique_stock",
+    "files": [
+      {
+        "file": "src/hooks/useAnalytique.js",
+        "line": 16
+      },
+      {
+        "file": "src/hooks/useAnalytique.js",
+        "line": 35
+      },
+      {
+        "file": "src/hooks/useAnalytique.js",
+        "line": 51
+      },
+      {
+        "file": "src/hooks/useReporting.js",
+        "line": 39
+      },
+      {
+        "file": "src/hooks/useReporting.js",
+        "line": 64
+      }
+    ]
+  },
+  {
+    "type": "view",
+    "name": "v_besoins_previsionnels",
+    "files": [
+      {
+        "file": "src/hooks/useSimulation.js",
+        "line": 46
+      }
+    ]
+  },
+  {
+    "type": "view",
+    "name": "v_boissons",
+    "files": [
+      {
+        "file": "src/pages/costboisson/CostBoisson.jsx",
+        "line": 37
+      }
+    ]
+  },
+  {
+    "type": "view",
+    "name": "v_cons_achats_mensuels",
+    "files": [
+      {
+        "file": "src/hooks/useConsolidation.js",
+        "line": 54
+      }
+    ]
+  },
+  {
+    "type": "view",
+    "name": "v_cons_ecarts_inventaire",
+    "files": [
+      {
+        "file": "src/hooks/useConsolidation.js",
+        "line": 87
+      }
+    ]
+  },
+  {
+    "type": "view",
+    "name": "v_cons_foodcost_mensuel",
+    "files": [
+      {
+        "file": "src/hooks/useConsolidation.js",
+        "line": 76
+      }
+    ]
+  },
+  {
+    "type": "view",
+    "name": "v_cons_ventes_mensuelles",
+    "files": [
+      {
+        "file": "src/hooks/useConsolidation.js",
+        "line": 65
+      }
+    ]
+  },
+  {
+    "type": "view",
+    "name": "v_consolidation_mensuelle",
+    "files": [
+      {
+        "file": "src/hooks/useConsolidation.js",
+        "line": 34
+      }
+    ]
+  },
+  {
+    "type": "view",
+    "name": "v_cost_center_month",
+    "files": [
+      {
+        "file": "src/hooks/useReporting.js",
+        "line": 47
+      },
+      {
+        "file": "src/hooks/useReporting.js",
+        "line": 80
+      }
+    ]
+  },
+  {
+    "type": "view",
+    "name": "v_cost_center_monthly",
+    "files": [
+      {
+        "file": "src/hooks/useCostCenterMonthlyStats.js",
+        "line": 10
+      }
+    ]
+  },
+  {
+    "type": "view",
+    "name": "v_costing_carte",
+    "files": [
+      {
+        "file": "src/hooks/useCostingCarte.js",
+        "line": 22
+      }
+    ]
+  },
+  {
+    "type": "view",
+    "name": "v_ecarts_inventaire",
+    "files": [
+      {
+        "file": "src/hooks/useAnalyse.js",
+        "line": 61
+      },
+      {
+        "file": "src/hooks/useEcartsInventaire.js",
+        "line": 16
+      }
+    ]
+  },
+  {
+    "type": "view",
+    "name": "v_evolution_achats",
+    "files": [
+      {
+        "file": "src/hooks/gadgets/useEvolutionAchats.js",
+        "line": 21
+      },
+      {
+        "file": "src/hooks/useAnalyse.js",
+        "line": 32
+      }
+    ]
+  },
+  {
+    "type": "view",
+    "name": "v_fournisseurs_inactifs",
+    "files": [
+      {
+        "file": "src/hooks/useFournisseursInactifs.js",
+        "line": 12
+      }
+    ]
+  },
+  {
+    "type": "view",
+    "name": "v_me_classification",
+    "files": [
+      {
+        "file": "src/hooks/useMenuEngineering.js",
+        "line": 18
+      }
+    ]
+  },
+  {
+    "type": "view",
+    "name": "v_menu_du_jour_lignes_cout",
+    "files": [
+      {
+        "file": "src/hooks/useMenuDuJour.js",
+        "line": 249
+      }
+    ]
+  },
+  {
+    "type": "view",
+    "name": "v_menu_du_jour_mensuel",
+    "files": [
+      {
+        "file": "src/hooks/useMenuDuJour.js",
+        "line": 351
+      },
+      {
+        "file": "src/hooks/useMenuEngineering.js",
+        "line": 33
+      }
+    ]
+  },
+  {
+    "type": "view",
+    "name": "v_menu_du_jour_resume",
+    "files": [
+      {
+        "file": "src/hooks/useMenuDuJour.js",
+        "line": 224
+      }
+    ]
+  },
+  {
+    "type": "view",
+    "name": "v_menu_groupe_couts",
+    "files": [
+      {
+        "file": "src/hooks/useMenuGroupe.js",
+        "line": 42
+      }
+    ]
+  },
+  {
+    "type": "view",
+    "name": "v_menu_groupe_resume",
+    "files": [
+      {
+        "file": "src/hooks/useMenuGroupe.js",
+        "line": 37
+      }
+    ]
+  },
+  {
+    "type": "view",
+    "name": "v_performance_fiches",
+    "files": [
+      {
+        "file": "src/hooks/usePerformanceFiches.js",
+        "line": 15
+      }
+    ]
+  },
+  {
+    "type": "view",
+    "name": "v_pmp",
+    "files": [
+      {
+        "file": "src/hooks/useAnalyse.js",
+        "line": 48
+      },
+      {
+        "file": "src/hooks/useDashboard.js",
+        "line": 37
+      },
+      {
+        "file": "src/hooks/useProducts.js",
+        "line": 72
+      },
+      {
+        "file": "src/hooks/useProduitsInventaire.js",
+        "line": 30
+      },
+      {
+        "file": "src/hooks/useReporting.js",
+        "line": 36
+      }
+    ]
+  },
+  {
+    "type": "view",
+    "name": "v_products_last_price",
+    "files": [
+      {
+        "file": "src/hooks/useProducts.js",
+        "line": 74
+      }
+    ]
+  },
+  {
+    "type": "view",
+    "name": "v_produits_dernier_prix",
+    "files": [
+      {
+        "file": "src/api/public/produits.js",
+        "line": 30
+      },
+      {
+        "file": "src/hooks/gadgets/useAlerteStockFaible.js",
+        "line": 17
+      },
+      {
+        "file": "src/hooks/useDashboard.js",
+        "line": 32
+      },
+      {
+        "file": "src/hooks/useProduitsInventaire.js",
+        "line": 17
+      }
+    ]
+  },
+  {
+    "type": "view",
+    "name": "v_produits_utilises",
+    "files": [
+      {
+        "file": "src/hooks/gadgets/useProduitsUtilises.js",
+        "line": 19
+      }
+    ]
+  },
+  {
+    "type": "view",
+    "name": "v_reco_stockmort",
+    "files": [
+      {
+        "file": "src/hooks/useRecommendations.js",
+        "line": 11
+      }
+    ]
+  },
+  {
+    "type": "view",
+    "name": "v_reco_surcout",
+    "files": [
+      {
+        "file": "src/hooks/useRecommendations.js",
+        "line": 26
+      }
+    ]
+  },
+  {
+    "type": "view",
+    "name": "v_requisitions",
+    "files": [
+      {
+        "file": "src/hooks/useRequisitions.js",
+        "line": 11
+      }
+    ]
+  },
+  {
+    "type": "view",
+    "name": "v_stock_requisitionne",
+    "files": [
+      {
+        "file": "src/hooks/useStockRequisitionne.js",
+        "line": 14
+      }
+    ]
+  },
+  {
+    "type": "view",
+    "name": "v_stocks",
+    "files": [
+      {
+        "file": "src/hooks/useDashboard.js",
+        "line": 41
+      },
+      {
+        "file": "src/hooks/useProducts.js",
+        "line": 73
+      },
+      {
+        "file": "src/hooks/useProducts.js",
+        "line": 194
+      },
+      {
+        "file": "src/hooks/useProduitsInventaire.js",
+        "line": 34
+      },
+      {
+        "file": "src/hooks/useStock.js",
+        "line": 42
+      }
+    ]
+  },
+  {
+    "type": "view",
+    "name": "v_taches_assignees",
+    "files": [
+      {
+        "file": "src/hooks/useTaches.js",
+        "line": 16
+      },
+      {
+        "file": "src/hooks/useTaches.js",
+        "line": 41
+      }
+    ]
+  },
+  {
+    "type": "view",
+    "name": "v_tendance_prix_produit",
+    "files": [
+      {
+        "file": "src/hooks/usePriceTrends.js",
+        "line": 15
+      }
+    ]
+  },
+  {
+    "type": "view",
+    "name": "v_top_fournisseurs",
+    "files": [
+      {
+        "file": "src/hooks/gadgets/useTopFournisseurs.js",
+        "line": 18
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "validation_requests",
+    "files": [
+      {
+        "file": "src/hooks/useValidations.js",
+        "line": 16
+      },
+      {
+        "file": "src/hooks/useValidations.js",
+        "line": 36
+      },
+      {
+        "file": "src/hooks/useValidations.js",
+        "line": 51
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "ventes_boissons",
+    "files": [
+      {
+        "file": "src/pages/BarManager.jsx",
+        "line": 69
+      },
+      {
+        "file": "src/pages/costboisson/CostBoisson.jsx",
+        "line": 48
+      },
+      {
+        "file": "src/pages/costboisson/CostBoisson.jsx",
+        "line": 104
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "ventes_fiches",
+    "files": [
+      {
+        "file": "src/hooks/useMenuEngineering.js",
+        "line": 76
+      },
+      {
+        "file": "src/hooks/useMenuEngineering.js",
+        "line": 99
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "ventes_import_staging",
+    "files": [
+      {
+        "file": "src/hooks/useMenuEngineering.js",
+        "line": 61
+      },
+      {
+        "file": "src/hooks/useMenuEngineering.js",
+        "line": 82
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "zones_droits",
+    "files": [
+      {
+        "file": "src/hooks/useZoneRights.js",
+        "line": 10
+      },
+      {
+        "file": "src/hooks/useZoneRights.js",
+        "line": 23
+      },
+      {
+        "file": "src/hooks/useZoneRights.js",
+        "line": 31
+      }
+    ]
+  },
+  {
+    "type": "table",
+    "name": "zones_stock",
+    "files": [
+      {
+        "file": "src/hooks/useGraphiquesMultiZone.js",
+        "line": 17
+      },
+      {
+        "file": "src/hooks/useZones.js",
+        "line": 12
+      },
+      {
+        "file": "src/hooks/useZones.js",
+        "line": 30
+      },
+      {
+        "file": "src/hooks/useZones.js",
+        "line": 43
+      },
+      {
+        "file": "src/hooks/useZones.js",
+        "line": 51
+      },
+      {
+        "file": "src/hooks/useZones.js",
+        "line": 60
+      },
+      {
+        "file": "src/hooks/useZones.js",
+        "line": 76
+      },
+      {
+        "file": "src/hooks/useZonesStock.js",
+        "line": 6
+      },
+      {
+        "file": "src/hooks/useZonesStock.js",
+        "line": 17
+      },
+      {
+        "file": "src/hooks/useZonesStock.js",
+        "line": 32
+      }
+    ]
+  }
+]

--- a/SCHEMA_OBJECTS.json
+++ b/SCHEMA_OBJECTS.json
@@ -1,0 +1,546 @@
+[
+  {
+    "type": "table",
+    "name": "mamas"
+  },
+  {
+    "type": "table",
+    "name": "fournisseurs"
+  },
+  {
+    "type": "table",
+    "name": "produits"
+  },
+  {
+    "type": "table",
+    "name": "roles"
+  },
+  {
+    "type": "table",
+    "name": "utilisateurs"
+  },
+  {
+    "type": "table",
+    "name": "commandes"
+  },
+  {
+    "type": "table",
+    "name": "commande_lignes"
+  },
+  {
+    "type": "table",
+    "name": "templates_commandes"
+  },
+  {
+    "type": "table",
+    "name": "emails_envoyes"
+  },
+  {
+    "type": "table",
+    "name": "permissions"
+  },
+  {
+    "type": "table",
+    "name": "consentements_utilisateur"
+  },
+  {
+    "type": "table",
+    "name": "achats"
+  },
+  {
+    "type": "table",
+    "name": "alertes"
+  },
+  {
+    "type": "table",
+    "name": "api_keys"
+  },
+  {
+    "type": "table",
+    "name": "auth_double_facteur"
+  },
+  {
+    "type": "table",
+    "name": "bons_livraison"
+  },
+  {
+    "type": "table",
+    "name": "catalogue_updates"
+  },
+  {
+    "type": "table",
+    "name": "centres_de_cout"
+  },
+  {
+    "type": "table",
+    "name": "compta_mapping"
+  },
+  {
+    "type": "table",
+    "name": "documentation"
+  },
+  {
+    "type": "table",
+    "name": "documents"
+  },
+  {
+    "type": "table",
+    "name": "etapes_onboarding"
+  },
+  {
+    "type": "table",
+    "name": "facture_lignes"
+  },
+  {
+    "type": "table",
+    "name": "factures"
+  },
+  {
+    "type": "table",
+    "name": "familles"
+  },
+  {
+    "type": "table",
+    "name": "feedback"
+  },
+  {
+    "type": "table",
+    "name": "fiche_cout_history"
+  },
+  {
+    "type": "table",
+    "name": "fiche_lignes"
+  },
+  {
+    "type": "table",
+    "name": "fiches"
+  },
+  {
+    "type": "table",
+    "name": "fiches_techniques"
+  },
+  {
+    "type": "table",
+    "name": "fournisseur_contacts"
+  },
+  {
+    "type": "table",
+    "name": "fournisseur_notes"
+  },
+  {
+    "type": "table",
+    "name": "fournisseur_produits"
+  },
+  {
+    "type": "table",
+    "name": "fournisseurs_api_config"
+  },
+  {
+    "type": "table",
+    "name": "gadgets"
+  },
+  {
+    "type": "table",
+    "name": "groupes"
+  },
+  {
+    "type": "table",
+    "name": "guides_seen"
+  },
+  {
+    "type": "table",
+    "name": "help_articles"
+  },
+  {
+    "type": "table",
+    "name": "inventaire_zones"
+  },
+  {
+    "type": "table",
+    "name": "inventaires"
+  },
+  {
+    "type": "table",
+    "name": "produits_inventaire"
+  },
+  {
+    "type": "table",
+    "name": "journaux_utilisateur"
+  },
+  {
+    "type": "table",
+    "name": "lignes_bl"
+  },
+  {
+    "type": "table",
+    "name": "logs_securite"
+  },
+  {
+    "type": "table",
+    "name": "menu_fiches"
+  },
+  {
+    "type": "table",
+    "name": "menus"
+  },
+  {
+    "type": "table",
+    "name": "menus_groupes"
+  },
+  {
+    "type": "table",
+    "name": "menus_groupes_fiches"
+  },
+  {
+    "type": "table",
+    "name": "menus_jour"
+  },
+  {
+    "type": "table",
+    "name": "menus_jour_fiches"
+  },
+  {
+    "type": "table",
+    "name": "notification_preferences"
+  },
+  {
+    "type": "table",
+    "name": "notifications"
+  },
+  {
+    "type": "table",
+    "name": "parametres_commandes"
+  },
+  {
+    "type": "table",
+    "name": "periodes_comptables"
+  },
+  {
+    "type": "table",
+    "name": "pertes"
+  },
+  {
+    "type": "table",
+    "name": "planning_lignes"
+  },
+  {
+    "type": "table",
+    "name": "planning_previsionnel"
+  },
+  {
+    "type": "table",
+    "name": "promotions"
+  },
+  {
+    "type": "table",
+    "name": "regles_alertes"
+  },
+  {
+    "type": "table",
+    "name": "requisitions"
+  },
+  {
+    "type": "table",
+    "name": "requisition_lignes"
+  },
+  {
+    "type": "table",
+    "name": "signalements"
+  },
+  {
+    "type": "table",
+    "name": "sous_familles"
+  },
+  {
+    "type": "table",
+    "name": "stocks"
+  },
+  {
+    "type": "table",
+    "name": "tableaux_de_bord"
+  },
+  {
+    "type": "table",
+    "name": "taches"
+  },
+  {
+    "type": "table",
+    "name": "tooltips"
+  },
+  {
+    "type": "table",
+    "name": "transfert_lignes"
+  },
+  {
+    "type": "table",
+    "name": "transferts"
+  },
+  {
+    "type": "table",
+    "name": "unites"
+  },
+  {
+    "type": "table",
+    "name": "usage_stats"
+  },
+  {
+    "type": "table",
+    "name": "utilisateurs_taches"
+  },
+  {
+    "type": "table",
+    "name": "validation_requests"
+  },
+  {
+    "type": "table",
+    "name": "ventes_boissons"
+  },
+  {
+    "type": "table",
+    "name": "ventes_fiches_carte"
+  },
+  {
+    "type": "table",
+    "name": "zones_stock"
+  },
+  {
+    "type": "table",
+    "name": "zones_droits"
+  },
+  {
+    "type": "table",
+    "name": "menu_groupes"
+  },
+  {
+    "type": "table",
+    "name": "menu_groupe_lignes"
+  },
+  {
+    "type": "table",
+    "name": "menu_groupe_modeles"
+  },
+  {
+    "type": "table",
+    "name": "menu_groupe_modele_lignes"
+  },
+  {
+    "type": "view",
+    "name": "utilisateurs_complets"
+  },
+  {
+    "type": "view",
+    "name": "v_achats_mensuels"
+  },
+  {
+    "type": "view",
+    "name": "v_analytique_stock"
+  },
+  {
+    "type": "view",
+    "name": "v_besoins_previsionnels"
+  },
+  {
+    "type": "view",
+    "name": "v_boissons"
+  },
+  {
+    "type": "view",
+    "name": "v_cost_center_month"
+  },
+  {
+    "type": "view",
+    "name": "v_cost_center_monthly"
+  },
+  {
+    "type": "view",
+    "name": "v_ecarts_inventaire"
+  },
+  {
+    "type": "view",
+    "name": "v_evolution_achats"
+  },
+  {
+    "type": "view",
+    "name": "v_fournisseurs_inactifs"
+  },
+  {
+    "type": "view",
+    "name": "v_performance_fiches"
+  },
+  {
+    "type": "view",
+    "name": "v_pmp"
+  },
+  {
+    "type": "view",
+    "name": "v_products_last_price"
+  },
+  {
+    "type": "view",
+    "name": "v_produits_dernier_prix"
+  },
+  {
+    "type": "view",
+    "name": "v_produits_utilises"
+  },
+  {
+    "type": "view",
+    "name": "v_reco_stockmort"
+  },
+  {
+    "type": "view",
+    "name": "v_reco_surcout"
+  },
+  {
+    "type": "view",
+    "name": "v_requisitions"
+  },
+  {
+    "type": "view",
+    "name": "v_stock_requisitionne"
+  },
+  {
+    "type": "view",
+    "name": "suggestions_commandes"
+  },
+  {
+    "type": "view",
+    "name": "v_stocks"
+  },
+  {
+    "type": "view",
+    "name": "v_taches_assignees"
+  },
+  {
+    "type": "view",
+    "name": "v_tendance_prix_produit"
+  },
+  {
+    "type": "view",
+    "name": "v_top_fournisseurs"
+  },
+  {
+    "type": "view",
+    "name": "v_couts_fiches"
+  },
+  {
+    "type": "view",
+    "name": "v_menu_groupe_couts"
+  },
+  {
+    "type": "view",
+    "name": "v_menu_groupe_resume"
+  },
+  {
+    "type": "view",
+    "name": "v_costing_carte"
+  },
+  {
+    "type": "function",
+    "name": "trg_set_timestamp"
+  },
+  {
+    "type": "function",
+    "name": "current_user_mama_id"
+  },
+  {
+    "type": "function",
+    "name": "current_user_is_admin_or_manager"
+  },
+  {
+    "type": "function",
+    "name": "get_template_commande"
+  },
+  {
+    "type": "function",
+    "name": "create_utilisateur"
+  },
+  {
+    "type": "function",
+    "name": "calcul_ecarts_inventaire"
+  },
+  {
+    "type": "function",
+    "name": "fn_calc_budgets"
+  },
+  {
+    "type": "function",
+    "name": "can_access_zone"
+  },
+  {
+    "type": "function",
+    "name": "can_transfer"
+  },
+  {
+    "type": "function",
+    "name": "zone_is_cave_or_shop"
+  },
+  {
+    "type": "function",
+    "name": "advanced_stats"
+  },
+  {
+    "type": "function",
+    "name": "apply_stock_from_achat"
+  },
+  {
+    "type": "function",
+    "name": "calcul_ecarts_inventaire"
+  },
+  {
+    "type": "function",
+    "name": "compare_fiche"
+  },
+  {
+    "type": "function",
+    "name": "consolidated_stats"
+  },
+  {
+    "type": "function",
+    "name": "dashboard_stats"
+  },
+  {
+    "type": "function",
+    "name": "disable_two_fa"
+  },
+  {
+    "type": "function",
+    "name": "enable_two_fa"
+  },
+  {
+    "type": "function",
+    "name": "import_invoice"
+  },
+  {
+    "type": "function",
+    "name": "send_email_notification"
+  },
+  {
+    "type": "function",
+    "name": "send_notification_webhook"
+  },
+  {
+    "type": "function",
+    "name": "stats_achats_fournisseur"
+  },
+  {
+    "type": "function",
+    "name": "stats_achats_fournisseurs"
+  },
+  {
+    "type": "function",
+    "name": "stats_cost_centers"
+  },
+  {
+    "type": "function",
+    "name": "stats_multi_mamas"
+  },
+  {
+    "type": "function",
+    "name": "stats_rotation_produit"
+  },
+  {
+    "type": "function",
+    "name": "top_produits"
+  }
+]

--- a/db/POST_CONSOLIDATION_REPORT.md
+++ b/db/POST_CONSOLIDATION_REPORT.md
@@ -1,0 +1,28 @@
+# Post-Consolidation Report
+
+## Modules front corrigés
+- Remplacement des accès `mouvements` par `requisition_lignes` ou `v_stocks` dans les hooks principaux (`useStats`, `useDashboard`, `useProducts`, `useTransferts`, `useStock`, `useInventaires`, `useConsoMoyenne`, API stock).
+- Suppression des fonctions liées aux mouvements dans `useStock` et `useInventaires`.
+
+## Vues analytiques mises à jour
+- `v_stock_requisitionne` – quantités réquisitionnées sur 30 jours.
+- `v_produits_utilises` – comptage d'utilisation des produits.
+- `v_reco_stockmort` – achats sans utilisation sur 90 jours.
+- `v_reco_surcout` – comparaison dernier prix vs PMP.
+- `v_tendance_prix_produit` – tendance de prix sur 12 mois.
+- `v_top_fournisseurs` – montants d'achats sur 12 mois.
+- `v_analytique_stock` – valorisation par famille/sous-famille.
+- `v_besoins_previsionnels` – quantités à recommander.
+- `v_boissons` – fiches techniques avec coût par portion.
+- `v_cost_center_month` et `v_cost_center_monthly` – agrégats achats mensuels.
+- `v_performance_fiches` – marge par fiche.
+
+## TODO
+- Remplacer les appels restants à `mouvements_centres_cout`.
+- Implémenter une vraie logique de calcul pour les mouvements d'inventaire dans `InventaireForm`.
+- Compléter les vues de consolidation manquantes listées dans `VERIFY_GAPS.md`.
+
+## Étendre l'analytique ensuite
+- Ajouter des paramètres de période aux vues pour affiner les analyses.
+- Compléter les vues de cost center dès que les tables associées seront disponibles.
+- Optimiser les vues avec des index sur `achats` et `requisitions` pour les champs de date et `produit_id`.

--- a/db/VERIFY_GAPS.md
+++ b/db/VERIFY_GAPS.md
@@ -1,0 +1,130 @@
+# Vérification schéma vs Front
+
+## ✅ OK (présents)
+- achats
+- alertes
+- api_keys
+- auth_double_facteur
+- bons_livraison
+- catalogue_updates
+- centres_de_cout
+- commande_lignes
+- commandes
+- compta_mapping
+- consentements_utilisateur
+- consolidated_stats
+- disable_two_fa
+- documentation
+- documents
+- emails_envoyes
+- etapes_onboarding
+- facture_lignes
+- factures
+- familles
+- feedback
+- fiche_cout_history
+- fiche_lignes
+- fiches
+- fiches_techniques
+- fournisseur_contacts
+- fournisseur_notes
+- fournisseur_produits
+- fournisseurs
+- fournisseurs_api_config
+- gadgets
+- groupes
+- guides_seen
+- help_articles
+- inventaire_zones
+- inventaires
+- journaux_utilisateur
+- lignes_bl
+- logs_securite
+- mamas
+- menu_fiches
+- menu_groupe_lignes
+- menu_groupe_modele_lignes
+- menu_groupe_modeles
+- menu_groupes
+- menus
+- menus_jour
+- menus_jour_fiches
+- notification_preferences
+- notifications
+- parametres_commandes
+- periodes_comptables
+- permissions
+- pertes
+- planning_lignes
+- planning_previsionnel
+- produits
+- produits_inventaire
+- promotions
+- regles_alertes
+- requisition_lignes
+- requisitions
+- roles
+- signalements
+- sous_familles
+- tableaux_de_bord
+- taches
+- templates_commandes
+- tooltips
+- transfert_lignes
+- transferts
+- unites
+- usage_stats
+- utilisateurs
+- utilisateurs_complets
+- utilisateurs_taches
+- v_achats_mensuels
+- v_analytique_stock
+- v_besoins_previsionnels
+- v_boissons
+- v_cost_center_month
+- v_cost_center_monthly
+- v_costing_carte
+- v_ecarts_inventaire
+- v_evolution_achats
+- v_fournisseurs_inactifs
+- v_menu_groupe_couts
+- v_menu_groupe_resume
+- v_performance_fiches
+- v_pmp
+- v_products_last_price
+- v_produits_dernier_prix
+- v_produits_utilises
+- v_reco_stockmort
+- v_reco_surcout
+- v_requisitions
+- v_stock_requisitionne
+- v_stocks
+- v_taches_assignees
+- v_tendance_prix_produit
+- v_top_fournisseurs
+- validation_requests
+- ventes_boissons
+- zones_droits
+- zones_stock
+
+## ❌ Manquants (à créer côté SQL)
+- alertes_rupture (src/hooks/useRuptureAlerts.js:10, src/hooks/useRuptureAlerts.js:26)
+- logs_activite (src/hooks/useLogs.js:21)
+- menus_jour_lignes (src/hooks/useMenuDuJour.js:271, src/hooks/useMenuDuJour.js:278, src/hooks/useMenuDuJour.js:285, src/hooks/useMenuDuJour.js:292, src/hooks/useMenuDuJour.js:317)
+- rapports_generes (src/hooks/useLogs.js:55, src/hooks/useLogs.js:74, src/pages/supervision/Rapports.jsx:45)
+- settings (src/hooks/useCostingCarte.js:49)
+- user_mama_access (src/hooks/useConsolidation.js:17, src/pages/consolidation/AccessMultiSites.jsx:13)
+- v_cons_achats_mensuels (src/hooks/useConsolidation.js:54)
+- v_cons_ecarts_inventaire (src/hooks/useConsolidation.js:87)
+- v_cons_foodcost_mensuel (src/hooks/useConsolidation.js:76)
+- v_cons_ventes_mensuelles (src/hooks/useConsolidation.js:65)
+- v_consolidation_mensuelle (src/hooks/useConsolidation.js:34)
+- v_me_classification (src/hooks/useMenuEngineering.js:18)
+- v_menu_du_jour_lignes_cout (src/hooks/useMenuDuJour.js:249)
+- v_menu_du_jour_mensuel (src/hooks/useMenuDuJour.js:351, src/hooks/useMenuEngineering.js:33)
+- v_menu_du_jour_resume (src/hooks/useMenuDuJour.js:224)
+- ventes_fiches (src/hooks/useMenuEngineering.js:76, src/hooks/useMenuEngineering.js:99)
+- ventes_import_staging (src/hooks/useMenuEngineering.js:61, src/hooks/useMenuEngineering.js:82)
+
+## ⚠️ Appels legacy
+- mouvements_centres_cout (src/hooks/useMouvementCostCenters.js:18, src/hooks/useMouvementCostCenters.js:38, src/hooks/useMouvementCostCenters.js:51)

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "allocate:history": "node scripts/reallocate_history.js",
     "backup": "node scripts/backup_db.js",
     "test:manifest": "node scripts/validate_manifest_icons.cjs",
-    "deploy": "npm run build && npx netlify deploy --dir=dist --prod"
+    "deploy": "npm run build && npx netlify deploy --dir=dist --prod",
+    "check:schema": "node scripts/checkSchema.js",
+    "fix:imports": "node scripts/fixLegacyMouvements.js"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.14",

--- a/scripts/checkSchema.js
+++ b/scripts/checkSchema.js
@@ -1,0 +1,109 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+async function walk(dir, extensions, files = []) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await walk(full, extensions, files);
+    } else if (extensions.some(ext => entry.name.endsWith(ext))) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+function addRef(map, type, name, file, line) {
+  if (!map[name]) map[name] = { type, name, files: [] };
+  map[name].files.push({ file: path.relative(process.cwd(), file), line });
+}
+
+async function scanFront() {
+  const files = await walk(path.join(process.cwd(), 'src'), ['.js', '.jsx', '.ts', '.tsx']);
+  const refs = {};
+  const fromRegex = /supabase\s*\.from\(\s*['"]([^'"\)]+)['"]\s*\)/g;
+  const rpcRegex = /supabase\s*\.rpc\(\s*['"]([^'"\)]+)['"]\s*\)/g;
+  for (const file of files) {
+    const content = await fs.readFile(file, 'utf8');
+    let m;
+    while ((m = fromRegex.exec(content))) {
+      const before = content.slice(0, m.index);
+      const line = before.split(/\r?\n/).length;
+      const name = m[1];
+      const type = name.startsWith('v_') ? 'view' : 'table';
+      addRef(refs, type, name, file, line);
+    }
+    while ((m = rpcRegex.exec(content))) {
+      const before = content.slice(0, m.index);
+      const line = before.split(/\r?\n/).length;
+      const name = m[1];
+      addRef(refs, 'function', name, file, line);
+    }
+  }
+  const arr = Object.values(refs).sort((a, b) => a.name.localeCompare(b.name));
+  await fs.writeFile('FRONT_REFERENCES.json', JSON.stringify(arr, null, 2));
+  return arr;
+}
+
+async function parseSchema() {
+  const sql = await fs.readFile(path.join('db', 'full_setup_final.sql'), 'utf8');
+  const objs = [];
+  const tableRegex = /create table if not exists public\.([a-zA-Z0-9_]+)/gi;
+  const viewRegex = /create or replace view public\.([a-zA-Z0-9_]+)/gi;
+  const funcRegex = /create or replace function public\.([a-zA-Z0-9_]+)/gi;
+  let m;
+  while ((m = tableRegex.exec(sql))) objs.push({ type: 'table', name: m[1] });
+  while ((m = viewRegex.exec(sql))) objs.push({ type: 'view', name: m[1] });
+  while ((m = funcRegex.exec(sql))) objs.push({ type: 'function', name: m[1] });
+  await fs.writeFile('SCHEMA_OBJECTS.json', JSON.stringify(objs, null, 2));
+  return objs;
+}
+
+function diff(frontRefs, schemaObjs) {
+  const schemaMap = new Map(schemaObjs.map(o => [o.name, o.type]));
+  const ok = [];
+  const missing = [];
+  const legacy = [];
+  for (const ref of frontRefs) {
+    const exists = schemaMap.has(ref.name);
+    if (exists) {
+      ok.push(ref.name);
+    } else if (ref.name.includes('mouvement')) {
+      legacy.push(ref);
+    } else {
+      missing.push(ref);
+    }
+  }
+  return { ok, missing, legacy };
+}
+
+async function writeReport(result) {
+  let md = '# Vérification schéma vs Front\n\n';
+  md += '## ✅ OK (présents)\n';
+  result.ok.sort().forEach(name => {
+    md += `- ${name}\n`;
+  });
+  md += '\n## ❌ Manquants (à créer côté SQL)\n';
+  result.missing.forEach(r => {
+    const files = r.files.map(f => `${f.file}:${f.line}`).join(', ');
+    md += `- ${r.name} (${files})\n`;
+  });
+  md += '\n## ⚠️ Appels legacy\n';
+  result.legacy.forEach(r => {
+    const files = r.files.map(f => `${f.file}:${f.line}`).join(', ');
+    md += `- ${r.name} (${files})\n`;
+  });
+  await fs.writeFile(path.join('db', 'VERIFY_GAPS.md'), md);
+}
+
+(async () => {
+  const front = await scanFront();
+  const schema = await parseSchema();
+  const res = diff(front, schema);
+  await writeReport(res);
+  if (res.missing.length > 0) {
+    console.error('Missing schema objects detected');
+    process.exit(1);
+  }
+})();

--- a/scripts/fixLegacyMouvements.js
+++ b/scripts/fixLegacyMouvements.js
@@ -1,0 +1,31 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+async function walk(dir, files = []) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) await walk(full, files);
+    else if (/[jt]sx?$/.test(entry.name)) files.push(full);
+  }
+  return files;
+}
+
+(async () => {
+  const files = await walk(path.join(process.cwd(), 'src'));
+  const target = /supabase\.from\(['"]mouvements['"]\)/;
+  let patches = [];
+  for (const file of files) {
+    const txt = await fs.readFile(file, 'utf8');
+    if (target.test(txt)) {
+      const rel = path.relative(process.cwd(), file);
+      patches.push(`# File: ${rel}\n@@\n${txt.replace(target, "// TODO: remplacer mouvements")}\n`);
+    }
+  }
+  if (patches.length) {
+    await fs.writeFile('legacy_mouvements.patch', patches.join('\n'));
+    console.log('Patch suggestions written to legacy_mouvements.patch');
+  } else {
+    console.log('No legacy mouvements references found');
+  }
+})();

--- a/src/api/public/stock.js
+++ b/src/api/public/stock.js
@@ -27,12 +27,13 @@ router.get('/', async (req, res) => {
   try {
     if (!supabase) throw new Error('Missing Supabase credentials');
     let query = supabase
-      .from('mouvements')
-      .select('*')
-      .eq('mama_id', mama_id);
-    if (since) query = query.gte('date', since);
-    if (type) query = query.eq('type', type);
-    query = query.order(sortBy, { ascending: order !== 'desc' });
+      .from('requisition_lignes')
+      .select('quantite, produit_id, requisitions!inner(mama_id,date_requisition,statut)')
+      .eq('requisitions.mama_id', mama_id)
+      .eq('requisitions.statut', 'réalisée');
+    if (since) query = query.gte('requisitions.date_requisition', since);
+    if (type) void type; // les lignes de réquisition sont des sorties
+    query = query.order('requisitions.' + sortBy, { ascending: order !== 'desc' });
     const p = Math.max(parseInt(page, 10), 1);
     const l = Math.max(parseInt(limit, 10), 1);
     const start = (p - 1) * l;

--- a/src/components/inventaires/InventaireDetail.jsx
+++ b/src/components/inventaires/InventaireDetail.jsx
@@ -1,25 +1,16 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { useEffect, useState } from "react";
-import { useInventaires } from "@/hooks/useInventaires";
 import { Button } from "@/components/ui/button";
 import { saveAs } from "file-saver";
 import * as XLSX from "xlsx";
 import toast from "react-hot-toast";
 
 export default function InventaireDetail({ inventaire, onClose }) {
-  const { fetchMouvementsInventaire } = useInventaires();
-  const [mouvements, setMouvements] = useState([]);
-
-  useEffect(() => {
-    if (inventaire?.id) fetchMouvementsInventaire(inventaire.id).then(setMouvements);
-  }, [inventaire?.id]);
 
   // Export Excel
   const exportExcel = () => {
     const wb = XLSX.utils.book_new();
     const ws = XLSX.utils.json_to_sheet(inventaire.lignes || []);
     XLSX.utils.book_append_sheet(wb, ws, "LignesInventaire");
-    XLSX.utils.book_append_sheet(wb, XLSX.utils.json_to_sheet(mouvements), "Mouvements");
     const buf = XLSX.write(wb, { bookType: "xlsx", type: "array" });
     saveAs(new Blob([buf]), `inventaire_${inventaire.id}.xlsx`);
   };
@@ -67,33 +58,6 @@ export default function InventaireDetail({ inventaire, onClose }) {
                 </tr>
               )) : (
                 <tr><td colSpan={6} className="text-gray-400">Aucune ligne</td></tr>
-              )}
-            </tbody>
-          </table>
-        </div>
-        <div className="my-4">
-          <h3 className="font-bold mb-2">Mouvements liés</h3>
-          <table className="min-w-full bg-white/10 border border-white/20 rounded backdrop-blur-xl">
-            <thead>
-              <tr>
-                <th>Date</th>
-                <th>Produit</th>
-                <th>Type</th>
-                <th>Quantité</th>
-                <th>Stock après</th>
-              </tr>
-            </thead>
-            <tbody>
-              {mouvements.length > 0 ? mouvements.map((m, i) => (
-                <tr key={i}>
-                  <td>{m.date}</td>
-                  <td>{m.nom}</td>
-                  <td>{m.type}</td>
-                  <td>{m.quantite}</td>
-                  <td>{m.stock_apres}</td>
-                </tr>
-              )) : (
-                <tr><td colSpan={5} className="text-gray-400">Aucun mouvement</td></tr>
               )}
             </tbody>
           </table>

--- a/src/components/inventaires/InventaireForm.jsx
+++ b/src/components/inventaires/InventaireForm.jsx
@@ -15,7 +15,6 @@ export default function InventaireForm({ inventaire, onClose }) {
     addInventaire,
     editInventaire,
     clotureInventaire,
-    fetchMouvementsForPeriod,
     fetchLastClosedInventaire,
   } = useInventaires();
   const { products, fetchProducts } = useProducts();
@@ -44,8 +43,7 @@ export default function InventaireForm({ inventaire, onClose }) {
       }
         setDateDebut(date_debut);
         if (dateInventaire) {
-          const mouvements = await fetchMouvementsForPeriod(date_debut, dateInventaire);
-          setMouvementsProduits(mouvements);
+          // TODO: recompute mouvements via requisitions
         }
     }
     init();

--- a/src/hooks/gadgets/useConsoMoyenne.js
+++ b/src/hooks/gadgets/useConsoMoyenne.js
@@ -17,16 +17,16 @@ export default function useConsoMoyenne() {
       const start = new Date();
       start.setDate(start.getDate() - 7);
       const { data, error } = await supabase
-        .from('mouvements')
-        .select('date, quantite')
-        .eq('mama_id', mama_id)
-        .eq('type', 'sortie')
-        .gte('date', start.toISOString())
-        .order('date', { ascending: true });
+        .from('requisition_lignes')
+        .select('quantite, requisitions!inner(date_requisition,mama_id,statut)')
+        .eq('requisitions.mama_id', mama_id)
+        .eq('requisitions.statut', 'réalisée')
+        .gte('requisitions.date_requisition', start.toISOString())
+        .order('requisitions.date_requisition', { ascending: true });
       if (error) throw error;
       const daily = {};
       (data || []).forEach((m) => {
-        const d = m.date?.slice(0, 10);
+        const d = m.requisitions.date_requisition?.slice(0, 10);
         if (!daily[d]) daily[d] = 0;
         daily[d] += Number(m.quantite || 0);
       });

--- a/src/hooks/useInventaires.js
+++ b/src/hooks/useInventaires.js
@@ -45,20 +45,6 @@ export function useInventaires() {
     return cleaned;
   }
 
-  async function fetchMouvementsInventaire(inventaireId) {
-    if (!mama_id || !inventaireId) return [];
-    const { data, error } = await supabase
-      .from("mouvements")
-      .select("*")
-      .eq("inventaire_id", inventaireId)
-      .eq("mama_id", mama_id)
-      .order("date", { ascending: true });
-    if (error) {
-      setError(error);
-      return [];
-    }
-    return data || [];
-  }
 
   async function validateInventaireStock(inventaireId) {
     if (!mama_id || !inventaireId) return false;
@@ -173,7 +159,6 @@ export function useInventaires() {
     getInventaireById,
     deleteInventaire,
     reactivateInventaire,
-    fetchMouvementsInventaire,
     validateInventaireStock,
   };
 }

--- a/src/hooks/useProducts.js
+++ b/src/hooks/useProducts.js
@@ -211,17 +211,22 @@ export function useProducts() {
     async (productId) => {
       if (!mama_id) return [];
       const { data, error } = await supabase
-        .from('mouvements')
-        .select('id,date,type,quantite')
+        .from('requisition_lignes')
+        .select('quantite, requisitions!inner(date_requisition, mama_id, statut)')
         .eq('produit_id', productId)
-        .eq('mama_id', mama_id)
-        .order('date', { ascending: false });
+        .eq('requisitions.mama_id', mama_id)
+        .eq('requisitions.statut', 'réalisée')
+        .order('requisitions.date_requisition', { ascending: false });
       if (error) {
         setError(error);
         toast.error(error.message);
         return [];
       }
-      return data || [];
+      return (data || []).map(m => ({
+        date: m.requisitions.date_requisition,
+        type: 'sortie',
+        quantite: m.quantite,
+      }));
     },
     [mama_id]
   );

--- a/src/hooks/useStats.js
+++ b/src/hooks/useStats.js
@@ -15,7 +15,11 @@ export function useStats() {
     const queries = [
       supabase.from("produits").select("id").eq("mama_id", mama_id),
       supabase.from("fiches_techniques").select("cout_total").eq("mama_id", mama_id),
-      supabase.from("mouvements").select("quantite").eq("mama_id", mama_id),
+      supabase
+        .from("requisition_lignes")
+        .select("quantite, requisitions!inner(mama_id, statut)")
+        .eq("requisitions.mama_id", mama_id)
+        .eq("requisitions.statut", "réalisée"),
     ];
 
     const [products, fiches, mouvements] = await Promise.all(queries.map((q) => q));
@@ -24,7 +28,8 @@ export function useStats() {
       totalProduits: products.data?.length || 0,
       totalFiches: fiches.data?.length || 0,
       coutTotalFiches: fiches.data?.reduce((a, f) => a + (f.cout_total || 0), 0) || 0,
-      mouvementsTotal: mouvements.data?.reduce((a, m) => a + (m.quantite || 0), 0) || 0,
+      mouvementsTotal:
+        mouvements.data?.reduce((a, m) => a + (m.quantite || 0), 0) || 0,
     });
 
     setLoading(false);

--- a/src/hooks/useStock.js
+++ b/src/hooks/useStock.js
@@ -76,25 +76,6 @@ export function useStock() {
     [mama_id, user_id]
   );
 
-  const createMouvement = useCallback(
-    async (payload) => {
-      if (!mama_id) return null;
-      const toInsert = { ...payload, mama_id, auteur_id: user_id };
-      if (payload.motif) {
-        toInsert.commentaire = payload.motif;
-        delete toInsert.motif;
-      }
-      const { data, error } = await supabase
-        .from("mouvements")
-        .insert([toInsert])
-        .select()
-        .single();
-      if (error) return null;
-      return data;
-    },
-    [mama_id, user_id]
-  );
-
   return {
     stocks,
     loading,
@@ -104,6 +85,5 @@ export function useStock() {
     getStockTheorique,
     getInventaires,
     createInventaire,
-    createMouvement,
   };
 }

--- a/src/hooks/useTransferts.js
+++ b/src/hooks/useTransferts.js
@@ -89,35 +89,7 @@ export function useTransferts() {
       setLoading(false);
       return { error: err2 };
     }
-    const mouvements = [];
-    lignesInsert.forEach((l) => {
-      mouvements.push({
-        mama_id,
-        produit_id: l.produit_id,
-        quantite: Number(l.quantite),
-        type: "sortie_transfert",
-        date,
-        transfert_id: tr.id,
-        auteur_id: user_id,
-      });
-      mouvements.push({
-        mama_id,
-        produit_id: l.produit_id,
-        quantite: Number(l.quantite),
-        type: "entree_transfert",
-        date,
-        transfert_id: tr.id,
-        auteur_id: user_id,
-      });
-    });
-    const { error: err3 } = await supabase
-      .from("mouvements")
-      .insert(mouvements);
     setLoading(false);
-    if (err3) {
-      setError(err3);
-      return { error: err3 };
-    }
     setTransferts((t) => [{ ...tr, lignes: lignesInsert }, ...t]);
     return { data: tr };
   }

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -391,7 +391,7 @@ export default function Router() {
           />
           <Route
             path="/transferts"
-            element={<ProtectedRoute moduleKey="mouvements"><StockTransferts /></ProtectedRoute>}
+            element={<ProtectedRoute moduleKey="transferts"><StockTransferts /></ProtectedRoute>}
           />
           <Route
             path="/stock/alertes"


### PR DESCRIPTION
## Summary
- add schema check utility and legacy mouvements fixer
- replace mouvements usage with requisition-based queries
- implement minimal analytical SQL views and generate verification files

## Testing
- `node scripts/checkSchema.js` *(fails: Missing schema objects detected)*
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_689762d478a0832d907d4b18968c1dff