### PR TITLE
chore: remove unused React imports

### DIFF
--- a/REPORTS/LINT_FIXES.md
+++ b/REPORTS/LINT_FIXES.md
@@ -1,16 +1,16 @@
-# Lint Fixes Report
+# Lint fixes
 
 ## Fichiers modifiés
-- .eslintrc.cjs
-- src/api/public/index.js
-- src/api/shared/supabaseEnv.js
-- src/lib/supabase.js
-- src/pages/aide/AideForm.jsx
-- src/pages/documents/DocumentForm.jsx
+- `src/pages/surcouts/Surcouts.jsx` : suppression de l'import React inutilisé.
+- `src/router.jsx` : suppression de l'import `NotFound` inutilisé.
+- `src/components/LiquidBackground/BubblesParticles.jsx` : suppression de l'import React inutilisé.
+- `src/components/LiquidBackground/LiquidBackground.jsx` : suppression de l'import React inutilisé.
+- `src/components/LiquidBackground/WavesBackground.jsx` : suppression de l'import React inutilisé.
 
-## Règles encore en "warn"
-- react-hooks/exhaustive-deps
-- no-unused-vars
+## Règles encore en *warn*
+- `react-hooks/exhaustive-deps` : de nombreuses dépendances manquantes dans `useEffect` nécessitent une revue fonctionnelle.
+- `no-unused-vars` : quelques variables non utilisées subsistent (ex. `Button`).
 
-## TODO
-- Aucun refactor lourd requis.
+## TODO / Refactors
+- Vérifier les dépendances des hooks pour éviter les effets oubliés.
+- Nettoyer les imports inutilisés restants, notamment les composants ou helpers non utilisés.

--- a/src/components/LiquidBackground/BubblesParticles.jsx
+++ b/src/components/LiquidBackground/BubblesParticles.jsx
@@ -1,5 +1,4 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import React from 'react';
 
 export default function BubblesParticles({
   count = 12,

--- a/src/components/LiquidBackground/LiquidBackground.jsx
+++ b/src/components/LiquidBackground/LiquidBackground.jsx
@@ -1,5 +1,4 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import React from 'react';
 import BubblesParticles from './BubblesParticles';
 
 export default function LiquidBackground({

--- a/src/components/LiquidBackground/WavesBackground.jsx
+++ b/src/components/LiquidBackground/WavesBackground.jsx
@@ -1,5 +1,4 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import React from 'react';
 
 export default function WavesBackground({ className = '' }) {
   return (

--- a/src/pages/surcouts/Surcouts.jsx
+++ b/src/pages/surcouts/Surcouts.jsx
@@ -1,5 +1,4 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import React from "react";
 import GlassCard from "@/components/ui/GlassCard";
 
 export default function Surcouts() {

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -17,7 +17,6 @@ import Blocked from "@/pages/auth/Blocked";
 import OnboardingUtilisateur from "@/pages/onboarding/OnboardingUtilisateur";
 import AuthDebug from "@/pages/debug/AuthDebug";
 import AccessExample from "@/pages/debug/AccessExample";
-import NotFound from "@/pages/NotFound";
 import ProtectedRoute from "@/components/ProtectedRoute";
 
 const Dashboard = lazyWithPreload(() => import("@/pages/Dashboard.jsx"));


### PR DESCRIPTION
## Summary
- remove unused React and other imports from several components
- document lint warnings in REPORTS/LINT_FIXES.md

## Testing
- `npm run lint`
- `npm run lint:fix`


------
https://chatgpt.com/codex/tasks/task_e_68977c75cd40832dafb25e6e17f54999