### PR TITLE
refactor: cleanup React imports, hooks deps, and forwardRef optimizations

### DIFF
--- a/src/components/ui/LanguageSelector.jsx
+++ b/src/components/ui/LanguageSelector.jsx
@@ -1,25 +1,36 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { forwardRef, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
-export default function LanguageSelector() {
+const LanguageSelector = forwardRef(function LanguageSelector(
+  { className = "px-2 py-1 text-sm rounded-md bg-mamastock-gold text-black", ...props },
+  ref
+) {
   const { i18n, t } = useTranslation();
 
-  const changeLanguage = e => {
-    const lng = e.target.value;
-    i18n.changeLanguage(lng);
-    localStorage.setItem('lang', lng);
-  };
+  const changeLanguage = useCallback(
+    e => {
+      const lng = e.target.value;
+      i18n.changeLanguage(lng);
+      localStorage.setItem('lang', lng);
+    },
+    [i18n]
+  );
 
   return (
     <select
+      ref={ref}
       onChange={changeLanguage}
       value={i18n.language}
-      className="px-2 py-1 text-sm rounded-md bg-mamastock-gold text-black"
+      className={className}
       aria-label={t('language')}
+      {...props}
     >
       <option value="fr">🇫🇷 {t('french')}</option>
       <option value="en">🇬🇧 {t('english')}</option>
       <option value="es">🇪🇸 {t('spanish')}</option>
     </select>
   );
-}
+});
+
+export default LanguageSelector;

--- a/src/layout/Navbar.jsx
+++ b/src/layout/Navbar.jsx
@@ -1,5 +1,5 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useTranslation } from 'react-i18next';
 import useAuth from "@/hooks/useAuth";
 import { useGlobalSearch } from "@/hooks/useGlobalSearch";
@@ -11,9 +11,9 @@ export default function Navbar() {
   const [term, setTerm] = useState("");
   const { results, search } = useGlobalSearch();
   const [dark, setDark] = useState(false);
-  const toggleSidebar = () => {
+  const toggleSidebar = useCallback(() => {
     document.dispatchEvent(new CustomEvent('toggle-sidebar'));
-  };
+  }, []);
 
   useEffect(() => {
     if (localStorage.theme === 'dark') {
@@ -22,21 +22,21 @@ export default function Navbar() {
     }
   }, []);
 
-  const toggleDark = () => {
+  const toggleDark = useCallback(() => {
     const html = document.documentElement;
     const isDark = html.classList.toggle('dark');
     localStorage.theme = isDark ? 'dark' : 'light';
     setDark(isDark);
-  };
+  }, []);
 
-  const handleLogout = async () => {
+  const handleLogout = useCallback(async () => {
     const confirmLogout = window.confirm(
       "Voulez-vous vraiment vous déconnecter ?"
     );
     if (!confirmLogout) return;
 
     window.location.href = "/logout";
-  };
+  }, []);
 
   return (
     <nav className="glass-panel border-b border-white/10 backdrop-blur-xl text-white px-6 py-4 flex items-center justify-between shadow-md text-shadow">

--- a/test/CommandeForm.test.jsx
+++ b/test/CommandeForm.test.jsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { vi } from 'vitest';
 

--- a/test/Commandes.test.jsx
+++ b/test/Commandes.test.jsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { vi } from 'vitest';
 

--- a/test/ComparatifPrix.test.jsx
+++ b/test/ComparatifPrix.test.jsx
@@ -1,6 +1,5 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 import { vi, beforeEach } from 'vitest';
 
 vi.mock('@/hooks/useAuth', () => ({

--- a/test/CostingCarte.test.jsx
+++ b/test/CostingCarte.test.jsx
@@ -1,6 +1,5 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { render, screen, fireEvent } from '@testing-library/react'
-import React from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import { vi, test, expect } from 'vitest'
 

--- a/test/Feedback.test.jsx
+++ b/test/Feedback.test.jsx
@@ -1,6 +1,5 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { render, screen, fireEvent, act } from '@testing-library/react';
-import React from 'react';
 import { vi } from 'vitest';
 
 let hook;

--- a/test/FournisseurApiConfigs.test.jsx
+++ b/test/FournisseurApiConfigs.test.jsx
@@ -1,7 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import React from 'react';
 import { vi } from 'vitest';
 
 let hook;

--- a/test/FournisseurFormModal.test.jsx
+++ b/test/FournisseurFormModal.test.jsx
@@ -1,6 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { fireEvent } from '@testing-library/react';
-import React from 'react';
 import { vi } from 'vitest';
 
 const create = vi.fn();

--- a/test/Fournisseurs.test.jsx
+++ b/test/Fournisseurs.test.jsx
@@ -1,7 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { render, screen } from '@testing-library/react';
 import { fireEvent } from '@testing-library/react';
-import React from 'react';
 import { vi } from 'vitest';
 
 let mockHook;

--- a/test/ImportFactures.test.jsx
+++ b/test/ImportFactures.test.jsx
@@ -1,6 +1,5 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { render, screen, fireEvent, act } from '@testing-library/react';
-import React from 'react';
 import { vi } from 'vitest';
 
 let hook;

--- a/test/InventaireDetail.test.jsx
+++ b/test/InventaireDetail.test.jsx
@@ -1,6 +1,5 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 import { vi } from 'vitest';
 
 let mockGet;

--- a/test/InventaireForm.test.jsx
+++ b/test/InventaireForm.test.jsx
@@ -1,6 +1,5 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { render, screen, fireEvent, act } from '@testing-library/react';
-import React from 'react';
 import { vi } from 'vitest';
 
 let mockCreate;

--- a/test/InventaireZones.test.jsx
+++ b/test/InventaireZones.test.jsx
@@ -1,6 +1,5 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { render, screen, fireEvent, act } from '@testing-library/react';
-import React from 'react';
 import { vi } from 'vitest';
 
 let mockHook;

--- a/test/Planning.test.jsx
+++ b/test/Planning.test.jsx
@@ -1,6 +1,5 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { render, screen, fireEvent, act } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { vi } from 'vitest';
 

--- a/test/PrixFournisseurs.test.jsx
+++ b/test/PrixFournisseurs.test.jsx
@@ -1,6 +1,5 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { render, screen } from '@testing-library/react';
-import React from 'react';
 import { vi } from 'vitest';
 
 import PrixFournisseurs from '@/pages/fournisseurs/comparatif/PrixFournisseurs.jsx';

--- a/test/ProduitForm.test.jsx
+++ b/test/ProduitForm.test.jsx
@@ -1,6 +1,5 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { render, screen } from '@testing-library/react';
-import React from 'react';
 import { vi } from 'vitest';
 
 let mockHook;

--- a/test/Produits.test.jsx
+++ b/test/Produits.test.jsx
@@ -1,7 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { render, screen } from '@testing-library/react';
 import { fireEvent } from '@testing-library/react';
-import React from 'react';
 import { vi } from 'vitest';
 
 let mockHook;

--- a/test/ZonesPage.test.jsx
+++ b/test/ZonesPage.test.jsx
@@ -1,6 +1,5 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { render, screen, fireEvent, act } from '@testing-library/react';
-import React from 'react';
 import { vi } from 'vitest';
 
 let mockHook;

--- a/test/authRole.test.jsx
+++ b/test/authRole.test.jsx
@@ -1,5 +1,4 @@
 import { renderHook, waitFor } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { vi } from 'vitest';
 import { AuthProvider } from '../src/context/AuthContext.jsx';

--- a/test/router.test.jsx
+++ b/test/router.test.jsx
@@ -1,7 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import React from 'react';
 import { vi, beforeEach } from 'vitest';
 import RouterConfig from '../src/router.jsx';
 

--- a/test/useAuthRole.test.jsx
+++ b/test/useAuthRole.test.jsx
@@ -1,5 +1,4 @@
 import { renderHook, waitFor } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { vi } from 'vitest';
 import { AuthProvider } from '../src/context/AuthContext.jsx';


### PR DESCRIPTION
## Summary
- remove legacy default React imports in tests
- wrap navigation handlers with useCallback for stable deps
- add forwardRef and memoized language change handler

## Testing
- `npm run lint` *(fails: ESLint couldn't find the plugin "eslint-plugin-react")*
- `npm run lint:fix` *(fails: ESLint couldn't find the plugin "eslint-plugin-react")*
- `npm run test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68978bd4fdd8832d961f8f11198b4d90