### PR TITLE
chore: align vitest with react 18

### DIFF
--- a/REPORTS/TEST_ENV_FIX.md
+++ b/REPORTS/TEST_ENV_FIX.md
@@ -1,0 +1,12 @@
+# Test environment fix
+
+## Files renamed from .js to .jsx
+- None
+
+## Files patched with pragma or React import
+- None
+
+## Key versions
+- react 18.3.1
+- @vitejs/plugin-react 4.3.1
+- vitest 1.6.0

--- a/audit-mamastock.txt
+++ b/audit-mamastock.txt
@@ -578,7 +578,7 @@ TwoFactorSetup.jsx : configuration de la double authentification
 - Dockerfile multi-stage avec Node 18 pour builder puis servir `dist`
 - `supabase/config.toml` expose l'API locale sur le port 54321
 - `.github/workflows/ci.yml` exécute lint, tests et e2e sur Node 18
-- `vite.config.js` active le plugin PWA pour générer le service worker
+- `vite.config.ts` active le plugin PWA pour générer le service worker
 - `src/lib/supabase.js` déclare les variables Node `process.env` pour ESLint
 
 

--- a/test/vite.config.test.js
+++ b/test/vite.config.test.js
@@ -3,6 +3,6 @@ import fs from 'fs';
 import { test, expect } from 'vitest';
 
 test('vite config includes VitePWA', () => {
-  const content = fs.readFileSync('vite.config.js', 'utf8');
+  const content = fs.readFileSync('vite.config.ts', 'utf8');
   expect(content).toMatch(/VitePWA/);
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,5 @@
     },
     "types": ["vitest/globals", "node"]
   },
-  "include": ["src", "test", "vitest.config.ts"]
+  "include": ["src", "test", "vitest.config.ts", "vite.config.ts"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,8 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
-import { VitePWA } from 'vite-plugin-pwa';
-import path from 'path';
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import { VitePWA } from "vite-plugin-pwa";
+import path from "node:path";
 
 export default defineConfig({
   plugins: [
@@ -42,13 +42,7 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './src'), // 👈 définit @ comme racine de /src
+      "@": path.resolve(__dirname, "./src"), // 👈 définit @ comme racine de /src
     },
-  },
-  test: {
-    globals: true,
-    environment: 'jsdom',
-    setupFiles: './vitest.setup.js',
-    exclude: ['e2e/**', 'node_modules/**'],
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,9 @@
 import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
 import path from "node:path";
 
 export default defineConfig({
+  plugins: [react()],
   test: {
     environment: "jsdom",
     globals: true,


### PR DESCRIPTION
## Summary
- switch vite config to TypeScript and keep react plugin
- load react plugin in vitest config for JSX tests
- document test env fix

## Testing
- `npm test` *(fails: MenuGroupes.test.jsx, useInvoiceOcr.test.js, StockDetail.test.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68984e507c20832d9b99e2df63adae79