### PR TITLE
Expose named useAuth hook for compatibility

### DIFF
--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -2,10 +2,12 @@
 import { useContext } from 'react';
 import { AuthContext } from '@/context/AuthContext';
 
-export default function useAuth() {
+export function useAuth() {
   const context = useContext(AuthContext);
   if (context === undefined || context === null) {
     throw new Error('useAuth must be used within AuthProvider');
   }
   return context;
 }
+
+export default useAuth;


### PR DESCRIPTION
## Summary
- expose `useAuth` both as named and default export

## Testing
- `npm run lint` *(fails: A form label must be associated with a control)*
- `npm test` *(fails: Cannot destructure property 'mamaId' of '__vite_ssr_import_2__.useAuth(...)' as it is null)*
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_68988da476c4832d86835f3c411aec1b