### PR TITLE
fix: add label associations and guard fournisseur requests

### DIFF
--- a/REPORTS/COMPAT_PASS.md
+++ b/REPORTS/COMPAT_PASS.md
@@ -1,0 +1,23 @@
+# Compatibilité MamaStock
+
+## Colonnes ajoutées
+- Aucune
+
+## FKs créées
+- Aucune
+
+## Vues recréées
+- Aucune
+
+## Policies/Triggers ajoutés
+- Aucun
+
+## Tables supprimées
+- Aucune
+
+## Fichiers front modifiés
+- `src/components/fournisseurs/FournisseurFormModal.jsx`
+- `src/components/dashboard/GadgetConfigForm.jsx`
+- `src/components/dashboard/PeriodFilter.jsx`
+- `src/components/ui/InputField.jsx`
+- `src/hooks/useFournisseurs.js`

--- a/src/components/dashboard/GadgetConfigForm.jsx
+++ b/src/components/dashboard/GadgetConfigForm.jsx
@@ -47,8 +47,8 @@ export default function GadgetConfigForm({ gadget, onSave, onCancel }) {
       <form onSubmit={handleSubmit} className="space-y-4">
       <InputField label="Nom" value={nom} onChange={(e) => setNom(e.target.value)} required />
       <div>
-        <label className="block text-sm text-white mb-1">Type</label>
-        <select className="form-select w-full" value={type} onChange={(e) => setType(e.target.value)}>
+        <label htmlFor="type" className="block text-sm text-white mb-1">Type</label>
+        <select id="type" className="form-select w-full" value={type} onChange={(e) => setType(e.target.value)}>
           <option value="indicator">Indicateur</option>
           <option value="line">Line</option>
           <option value="bar">Bar</option>
@@ -57,8 +57,9 @@ export default function GadgetConfigForm({ gadget, onSave, onCancel }) {
         </select>
       </div>
       <div>
-        <label className="block text-sm text-white mb-1">Configuration (JSON)</label>
+        <label htmlFor="config" className="block text-sm text-white mb-1">Configuration (JSON)</label>
         <textarea
+          id="config"
           className="form-textarea w-full font-mono"
           rows="4"
           value={config}

--- a/src/components/dashboard/PeriodFilter.jsx
+++ b/src/components/dashboard/PeriodFilter.jsx
@@ -22,24 +22,22 @@ export default function PeriodFilter({ onChange, initialStart, initialEnd }) {
 
   return (
     <div className="flex gap-2 items-center">
-      <label>
-        Du :
-        <input
-          type="date"
-          value={start}
-          onChange={e => update(e.target.value, end)}
-          className="form-input"
-        />
-      </label>
-      <label>
-        Au :
-        <input
-          type="date"
-          value={end}
-          onChange={e => update(start, e.target.value)}
-          className="form-input"
-        />
-      </label>
+      <label htmlFor="period-start">Du :</label>
+      <input
+        id="period-start"
+        type="date"
+        value={start}
+        onChange={e => update(e.target.value, end)}
+        className="form-input"
+      />
+      <label htmlFor="period-end">Au :</label>
+      <input
+        id="period-end"
+        type="date"
+        value={end}
+        onChange={e => update(start, e.target.value)}
+        className="form-input"
+      />
       <button
         className="btn btn-sm"
         onClick={() => update(getToday(), getToday())}

--- a/src/components/fournisseurs/FournisseurFormModal.jsx
+++ b/src/components/fournisseurs/FournisseurFormModal.jsx
@@ -61,30 +61,29 @@ export default function FournisseurFormModal({ fournisseur, onClose }) {
    >
       <h3 className="text-xl font-bold mb-2">{fournisseur ? "Modifier" : "Ajouter"} un fournisseur</h3>
       <div>
-        <label>Nom</label>
-        <input className="form-input w-full" name="nom" value={form.nom} onChange={handleChange} required />
+        <label htmlFor="nom">Nom</label>
+        <input id="nom" className="form-input w-full" name="nom" value={form.nom} onChange={handleChange} required />
       </div>
       <div>
-        <label>Email</label>
-        <input className="form-input w-full" name="email" value={form.email} onChange={handleChange} type="email" />
+        <label htmlFor="email">Email</label>
+        <input id="email" className="form-input w-full" name="email" value={form.email} onChange={handleChange} type="email" />
       </div>
       <div>
-        <label>Téléphone</label>
-        <input className="form-input w-full" name="tel" type="tel" value={form.tel} onChange={handleChange} />
+        <label htmlFor="tel">Téléphone</label>
+        <input id="tel" className="form-input w-full" name="tel" type="tel" value={form.tel} onChange={handleChange} />
       </div>
       <div>
-        <label>Contact</label>
-        <input className="form-input w-full" name="contact" value={form.contact} onChange={handleChange} />
+        <label htmlFor="contact">Contact</label>
+        <input id="contact" className="form-input w-full" name="contact" value={form.contact} onChange={handleChange} />
       </div>
-      <div>
-        <label className="flex items-center gap-2">
-          <input
-            type="checkbox"
-            checked={form.actif}
-            onChange={e => setForm(f => ({ ...f, actif: e.target.checked }))}
-          />
-          Actif
-        </label>
+      <div className="flex items-center gap-2">
+        <input
+          id="actif"
+          type="checkbox"
+          checked={form.actif}
+          onChange={e => setForm(f => ({ ...f, actif: e.target.checked }))}
+        />
+        <label htmlFor="actif">Actif</label>
       </div>
       <div className="flex gap-2 justify-end">
         <Button type="button" variant="outline" onClick={onClose} disabled={loading}>Annuler</Button>

--- a/src/components/ui/InputField.jsx
+++ b/src/components/ui/InputField.jsx
@@ -6,12 +6,19 @@ export default function InputField({
   error,
   className = "",
   inputClass = "",
+  id,
   ...props
 }) {
+  const inputId = id || props.name || label?.toString().toLowerCase().replace(/\s+/g, '-');
   return (
     <div className={`mb-4 ${className}`}>
-      <label className="block text-sm text-white/90 mb-1">{label}</label>
+      {label && (
+        <label htmlFor={inputId} className="block text-sm text-white/90 mb-1">
+          {label}
+        </label>
+      )}
       <input
+        id={inputId}
         value={value}
         onChange={onChange}
         className={`input w-full ${error ? "border-red-500" : "border-white/20"} ${inputClass}`}

--- a/src/hooks/useFournisseurs.js
+++ b/src/hooks/useFournisseurs.js
@@ -18,7 +18,7 @@ export function useFournisseurs() {
   // 1. Charger les fournisseurs (filtrage par mama_id automatiquement)
   const fetchFournisseurs = useCallback(
     async ({ search = "", actif = null, page = 1, limit = 20 } = {}) => {
-      if (!mama_id) return [];
+      if (loading || !mama_id) return [];
       setLoading(true);
       setError(null);
       let query = supabase
@@ -48,12 +48,12 @@ export function useFournisseurs() {
       }
       return data || [];
     },
-    [mama_id]
+    [mama_id, loading]
   );
 
   // 2. Ajouter un fournisseur
   async function createFournisseur(fournisseur) {
-    if (!mama_id) return;
+    if (loading || !mama_id) return;
     setLoading(true);
     setError(null);
     const { nom, actif = true, tel, email, contact } = fournisseur;
@@ -82,7 +82,7 @@ export function useFournisseurs() {
 
   // 3. Modifier un fournisseur
   async function updateFournisseur(id, updateFields) {
-    if (!mama_id) return;
+    if (loading || !mama_id) return;
     setLoading(true);
     setError(null);
     const { tel, email, contact, ...fields } = updateFields;
@@ -110,7 +110,7 @@ export function useFournisseurs() {
 
   // 4. Désactiver un fournisseur (soft delete)
   async function disableFournisseur(id) {
-    if (!mama_id) return;
+    if (loading || !mama_id) return;
     setLoading(true);
     setError(null);
     const { error } = await supabase


### PR DESCRIPTION
## Summary
- add missing `htmlFor` and IDs to supplier and dashboard forms
- ensure generic InputField and fournisseur hooks handle loading/mama checks
- document compatibility report

## Testing
- `npm install`
- `npm run lint --fix` *(fails: A form label must be associated with a control)*
- `npm test` *(fails: vitest mock errors, hook functions undefined)*
- `npm run build` *(fails: Identifier `loading` has already been declared in useZonesStock.js)*

------
https://chatgpt.com/codex/tasks/task_e_6899b5dc03c0832d90cd3f24543a78c5