### PR TITLE
feat: add front/back schema analyzer

### DIFF
--- a/REPORTS/FRONT_BACK_ALIGN.json
+++ b/REPORTS/FRONT_BACK_ALIGN.json
@@ -1,0 +1,1766 @@
+{
+  "missing": {
+    "tables": [
+      "requisitions!inner",
+      "utilisateur:utilisateurs!logs_securite_utilisateur_id_fkey",
+      "fournisseur:fournisseur_id",
+      "produit:produit_id",
+      "lignes:lignes_bl!bl_id",
+      "lignes:commande_lignes",
+      "unite:unite_id",
+      "gadgets:gadgets!tableau_id",
+      "famille:familles!fk_produits_famille",
+      "sous_famille:sous_familles!fk_produits_sous_famille",
+      "liaisons:fournisseur_produits!fournisseur_produits_produit_id_fkey",
+      "fournisseur:fournisseurs!fk_fournisseur_produits_fournisseur_id",
+      "lignes:produits_inventaire!inventaire_id",
+      "fournisseur_produits:fournisseur_produits!fournisseur_produits_produit_id_fkey",
+      "lignes:facture_lignes!facture_id",
+      "factures:facture_id",
+      "famille:familles!fiches_techniques_famille_id_fkey",
+      "lignes:fiche_lignes!fiche_id",
+      "lignes:v_fiche_lignes_complete!fiche_id",
+      "sous_fiche:sous_fiche_id",
+      "contact:fournisseur_contacts",
+      "zones_stock",
+      "zone:inventaire_zones!inventaires_zone_id_fkey",
+      "produit:produits!produits_inventaire_produit_id_fkey",
+      "produit:produits!facture_lignes_produit_id_fkey",
+      "famille:familles",
+      "utilisateurs:user_id",
+      "mamas",
+      "fiches:menus_jour_fiches",
+      "fiche:fiches_techniques",
+      "resume:v_menu_groupe_resume",
+      "fiches:menu_fiches",
+      "fiche: fiches",
+      "mouvements_centres_cout",
+      "centres_de_cout:cost_center_id",
+      "lignes:planning_lignes!planning_id",
+      "main_fournisseur:fournisseur_id",
+      "produit:produits!fournisseur_produits_produit_id_fkey",
+      "lignes:requisition_lignes",
+      "lignes:requisition_lignes!requisition_id",
+      "assigned:utilisateurs!taches_assigned_to_fkey",
+      "zone_source:zones_stock!fk_transferts_zone_source_id",
+      "zone_destination:zones_stock!fk_transferts_zone_dest_id",
+      "lignes:transfert_lignes",
+      "produit:produits",
+      "utilisateurs_complets",
+      "zones_droits!inner"
+    ],
+    "columns": {
+      "promotions": [
+        "*"
+      ],
+      "logs_securite": [
+        "utilisateur_id",
+        "description",
+        "count:id"
+      ],
+      "taches": [
+        "titre",
+        "date_echeance",
+        "*"
+      ],
+      "achats": [
+        "*"
+      ],
+      "help_articles": [
+        "*"
+      ],
+      "regles_alertes": [
+        "*"
+      ],
+      "api_keys": [
+        "*"
+      ],
+      "bons_livraison": [
+        "numero_bl",
+        "date_reception",
+        "commentaire",
+        "actif",
+        "fournisseur_id",
+        "*"
+      ],
+      "fiches_techniques": [
+        "*",
+        "nom",
+        "cout_par_portion",
+        "actif",
+        "cout_total"
+      ],
+      "commandes": [
+        "*"
+      ],
+      "fournisseur_produits": [
+        "*",
+        "derniere_livraison:date_livraison"
+      ],
+      "consentements_utilisateur": [
+        "*"
+      ],
+      "centres_de_cout": [
+        "*"
+      ],
+      "tableaux_de_bord": [
+        "*",
+        "liste_gadgets_json"
+      ],
+      "gadgets": [
+        "ordre"
+      ],
+      "documents": [
+        "*",
+        "fichier_url",
+        "url"
+      ],
+      "produits": [
+        "sous_famille_id",
+        "*",
+        "tva",
+        "dernier_prix"
+      ],
+      "inventaires": [
+        "*",
+        "date"
+      ],
+      "factures": [
+        "*",
+        "numero",
+        "date_facture",
+        "fournisseur_id",
+        "total_ttc",
+        "statut"
+      ],
+      "facture_lignes": [
+        "quantite",
+        "prix",
+        "tva",
+        "facture_id",
+        "prix_unitaire",
+        "*"
+      ],
+      "compta_mapping": [
+        "cle",
+        "compte"
+      ],
+      "familles": [
+        "*"
+      ],
+      "sous_familles": [
+        "*"
+      ],
+      "feedback": [
+        "*"
+      ],
+      "fiche_cout_history": [
+        "*"
+      ],
+      "fournisseurs_api_config": [
+        "*"
+      ],
+      "fournisseur_notes": [
+        "*"
+      ],
+      "fournisseurs": [
+        "actif"
+      ],
+      "produits_inventaire": [
+        "*"
+      ],
+      "inventaire_zones": [
+        "*"
+      ],
+      "logs_activite": [
+        "*"
+      ],
+      "rapports_generes": [
+        "*"
+      ],
+      "menus_jour": [
+        "*",
+        "date",
+        "categorie",
+        "fiche_id",
+        "portions"
+      ],
+      "menu_groupes": [
+        "*"
+      ],
+      "menu_groupe_lignes": [
+        "*"
+      ],
+      "menu_groupe_modele_lignes": [
+        "*"
+      ],
+      "menus": [
+        "*"
+      ],
+      "notifications": [
+        "*"
+      ],
+      "notification_preferences": [
+        "*"
+      ],
+      "etapes_onboarding": [
+        "etape",
+        "statut"
+      ],
+      "periodes_comptables": [
+        "*"
+      ],
+      "permissions": [
+        "*"
+      ],
+      "pertes": [
+        "*"
+      ],
+      "planning_previsionnel": [
+        "*"
+      ],
+      "requisitions": [
+        "*"
+      ],
+      "roles": [
+        "*"
+      ],
+      "alertes_rupture": [
+        "*"
+      ],
+      "signalements": [
+        "*"
+      ],
+      "templates_commandes": [
+        "*"
+      ],
+      "transferts": [
+        "date_transfert",
+        "motif"
+      ],
+      "auth_double_facteur": [
+        "enabled",
+        "secret"
+      ],
+      "usage_stats": [
+        "module",
+        "count:id",
+        "timestamp"
+      ],
+      "validation_requests": [
+        "*"
+      ],
+      "v_produits_par_zone": [
+        "*"
+      ],
+      "zones_droits": [
+        "*"
+      ]
+    },
+    "views": [
+      "v_achats_mensuels",
+      "v_costing_carte",
+      "v_menu_du_jour_lignes_cout"
+    ],
+    "functions": [
+      "advanced_stats",
+      "suggest_cost_centers",
+      "merge_familles",
+      "reorder_familles",
+      "log_action"
+    ]
+  },
+  "mismatch": {
+    "fks": [
+      {
+        "from": {
+          "table": "templates_commandes",
+          "columns": [
+            "mama_id"
+          ]
+        },
+        "to": {
+          "table": "mamas",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      {
+        "from": {
+          "table": "inventaires",
+          "columns": [
+            "mama_id"
+          ]
+        },
+        "to": {
+          "table": "mamas",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      {
+        "from": {
+          "table": "produits_inventaire",
+          "columns": [
+            "mama_id"
+          ]
+        },
+        "to": {
+          "table": "mamas",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      {
+        "from": {
+          "table": "periodes_comptables",
+          "columns": [
+            "mama_id"
+          ]
+        },
+        "to": {
+          "table": "mamas",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      {
+        "from": {
+          "table": "requisitions",
+          "columns": [
+            "mama_id"
+          ]
+        },
+        "to": {
+          "table": "mamas",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      {
+        "from": {
+          "table": "requisitions",
+          "columns": [
+            "zone_id"
+          ]
+        },
+        "to": {
+          "table": "zones_stock",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      {
+        "from": {
+          "table": "menu_groupe_lignes",
+          "columns": [
+            "menu_groupe_id"
+          ]
+        },
+        "to": {
+          "table": "menu_groupes",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      {
+        "from": {
+          "table": "menu_groupe_modeles",
+          "columns": [
+            "mama_id"
+          ]
+        },
+        "to": {
+          "table": "mamas",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      {
+        "from": {
+          "table": "settings",
+          "columns": [
+            "mama_id"
+          ]
+        },
+        "to": {
+          "table": "mamas",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      {
+        "from": {
+          "table": "user_mama_access",
+          "columns": [
+            "mama_id"
+          ]
+        },
+        "to": {
+          "table": "mamas",
+          "columns": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "policies": [],
+    "views": []
+  },
+  "unused": {
+    "tables": [
+      "emails_envoyes",
+      "alertes",
+      "documentation",
+      "fiches",
+      "groupes",
+      "guides_seen",
+      "menus_groupes",
+      "menus_groupes_fiches",
+      "parametres_commandes",
+      "stocks",
+      "tooltips",
+      "ventes_boissons",
+      "ventes_fiches_carte"
+    ],
+    "views": [
+      "v_boissons",
+      "suggestions_commandes",
+      "v_couts_fiches"
+    ],
+    "functions": [
+      "current_user_mama_id",
+      "current_user_is_admin_or_manager",
+      "current_user_is_admin",
+      "calcul_ecarts_inventaire",
+      "can_transfer",
+      "zone_is_cave_or_shop",
+      "compare_fiche",
+      "stats_multi_mamas",
+      "sync_pivot_from_produits",
+      "sync_produits_from_pivot",
+      "safe_delete_zone"
+    ]
+  },
+  "sqlIndex": {
+    "tables": {
+      "fournisseurs": {
+        "columns": [
+          "id",
+          "mama_id",
+          "nom",
+          "contact",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "produits": {
+        "columns": [
+          "id",
+          "mama_id",
+          "nom",
+          "fournisseur_id",
+          "unite_id",
+          "famille_id",
+          "stock_reel",
+          "stock_min",
+          "pmp",
+          "actif",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "roles": {
+        "columns": [
+          "id",
+          "nom",
+          "description",
+          "access_rights",
+          "actif",
+          "mama_id",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "utilisateurs": {
+        "columns": [
+          "id",
+          "nom",
+          "email",
+          "auth_id",
+          "role_id",
+          "mama_id",
+          "access_rights",
+          "actif",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "commandes": {
+        "columns": [
+          "id",
+          "mama_id",
+          "fournisseur_id",
+          "reference",
+          "date_commande",
+          "statut",
+          "commentaire",
+          "envoyee_at",
+          "created_at",
+          "updated_at",
+          "date_livraison_prevue",
+          "montant_total",
+          "bl_id",
+          "facture_id"
+        ]
+      },
+      "commande_lignes": {
+        "columns": [
+          "id",
+          "commande_id",
+          "produit_id",
+          "mama_id",
+          "quantite",
+          "unite",
+          "prix_achat",
+          "total_ligne",
+          "suggestion",
+          "commentaire"
+        ]
+      },
+      "templates_commandes": {
+        "columns": [
+          "id",
+          "mama_id",
+          "nom",
+          "fournisseur_id",
+          "logo_url",
+          "entete",
+          "pied_page",
+          "adresse_livraison",
+          "contact_nom",
+          "contact_tel",
+          "contact_email",
+          "conditions_generales",
+          "champs_visibles",
+          "actif",
+          "created_at",
+          "updated_at",
+          "unique"
+        ]
+      },
+      "emails_envoyes": {
+        "columns": [
+          "id",
+          "commande_id",
+          "email",
+          "statut",
+          "envoye_le",
+          "mama_id"
+        ]
+      },
+      "permissions": {
+        "columns": [
+          "id",
+          "role_id",
+          "module",
+          "droit",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "consentements_utilisateur": {
+        "columns": [
+          "id",
+          "utilisateur_id",
+          "user_id",
+          "mama_id",
+          "type_consentement",
+          "consentement",
+          "date_consentement"
+        ]
+      },
+      "achats": {
+        "columns": []
+      },
+      "alertes": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "api_keys": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "auth_double_facteur": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "bons_livraison": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "catalogue_updates": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "centres_de_cout": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "compta_mapping": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "documentation": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "documents": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "etapes_onboarding": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "facture_lignes": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "factures": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "familles": {
+        "columns": [
+          "id",
+          "mama_id",
+          "nom",
+          "actif",
+          "created_at"
+        ]
+      },
+      "feedback": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "fiche_cout_history": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "fiche_lignes": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "fiches": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "fiches_techniques": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "fournisseur_contacts": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "fournisseur_notes": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "fournisseur_produits": {
+        "columns": [
+          "id",
+          "mama_id",
+          "produit_id",
+          "fournisseur_id",
+          "prix_achat",
+          "date_livraison",
+          "created_at"
+        ]
+      },
+      "fournisseurs_api_config": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "gadgets": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "groupes": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "guides_seen": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "help_articles": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "inventaire_zones": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "inventaires": {
+        "columns": [
+          "id",
+          "mama_id",
+          "date_inventaire",
+          "zone_id",
+          "periode_id",
+          "commentaire",
+          "actif",
+          "created_at"
+        ]
+      },
+      "produits_inventaire": {
+        "columns": [
+          "id",
+          "inventaire_id",
+          "produit_id",
+          "quantite_theorique",
+          "quantite_reelle",
+          "unite",
+          "ecart",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "journaux_utilisateur": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "lignes_bl": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "logs_securite": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "menu_fiches": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "menus": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "menus_groupes": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "menus_groupes_fiches": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "menus_jour": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "menus_jour_fiches": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "notification_preferences": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "notifications": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "parametres_commandes": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "periodes_comptables": {
+        "columns": [
+          "id",
+          "mama_id",
+          "debut",
+          "fin",
+          "actif",
+          "cloturee",
+          "created_at"
+        ]
+      },
+      "pertes": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "planning_lignes": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "planning_previsionnel": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "promotions": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "regles_alertes": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "requisitions": {
+        "columns": [
+          "id",
+          "mama_id",
+          "date_requisition",
+          "zone_id",
+          "statut",
+          "commentaire",
+          "created_at",
+          "updated_at",
+          "actif"
+        ]
+      },
+      "requisition_lignes": {
+        "columns": [
+          "id",
+          "requisition_id",
+          "produit_id",
+          "quantite",
+          "unite",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "signalements": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "sous_familles": {
+        "columns": [
+          "id",
+          "mama_id",
+          "famille_id",
+          "nom",
+          "actif",
+          "created_at"
+        ]
+      },
+      "stocks": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "tableaux_de_bord": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "taches": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "tooltips": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "transfert_lignes": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "transferts": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "unites": {
+        "columns": [
+          "id",
+          "mama_id",
+          "nom",
+          "actif",
+          "created_at"
+        ]
+      },
+      "usage_stats": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "utilisateurs_taches": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "validation_requests": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "ventes_boissons": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "ventes_fiches_carte": {
+        "columns": [
+          "id",
+          "mama_id",
+          "created_at"
+        ]
+      },
+      "zones_droits": {
+        "columns": []
+      },
+      "menu_groupes": {
+        "columns": []
+      },
+      "menu_groupe_lignes": {
+        "columns": [
+          "id",
+          "menu_groupe_id",
+          "mama_id",
+          "categorie",
+          "fiche_id",
+          "portions_par_personne",
+          "position",
+          "created_at"
+        ]
+      },
+      "menu_groupe_modeles": {
+        "columns": [
+          "id",
+          "mama_id",
+          "nom",
+          "actif",
+          "created_at"
+        ]
+      },
+      "menu_groupe_modele_lignes": {
+        "columns": [
+          "id",
+          "modele_id",
+          "mama_id",
+          "categorie",
+          "fiche_id",
+          "portions_par_personne",
+          "position",
+          "created_at"
+        ]
+      },
+      "alertes_rupture": {
+        "columns": []
+      },
+      "logs_activite": {
+        "columns": [
+          "id",
+          "mama_id",
+          "user_id",
+          "type",
+          "module",
+          "description",
+          "donnees",
+          "ip_address",
+          "user_agent",
+          "critique",
+          "date_log"
+        ]
+      },
+      "menus_jour_lignes": {
+        "columns": [
+          "id",
+          "menu_id",
+          "mama_id",
+          "categorie",
+          "fiche_id",
+          "portions",
+          "prix_unitaire_snapshot",
+          "created_at"
+        ]
+      },
+      "rapports_generes": {
+        "columns": [
+          "id",
+          "mama_id",
+          "module",
+          "type",
+          "periode_debut",
+          "periode_fin",
+          "date_generation",
+          "chemin_fichier",
+          "created_by"
+        ]
+      },
+      "settings": {
+        "columns": [
+          "id",
+          "mama_id",
+          "objectif_marge_pct",
+          "objectif_food_cost_pct",
+          "primary_color",
+          "secondary_color",
+          "dark_mode",
+          "logo_url",
+          "created_at"
+        ]
+      },
+      "user_mama_access": {
+        "columns": [
+          "id",
+          "user_id",
+          "mama_id",
+          "role",
+          "created_at",
+          "unique"
+        ]
+      },
+      "ventes_fiches": {
+        "columns": [
+          "id",
+          "mama_id",
+          "fiche_id",
+          "date_vente",
+          "quantite",
+          "prix_vente_unitaire",
+          "created_at",
+          "unique"
+        ]
+      },
+      "ventes_import_staging": {
+        "columns": [
+          "id",
+          "mama_id",
+          "fiche_id",
+          "date_vente",
+          "quantite",
+          "prix_vente_unitaire",
+          "statut",
+          "created_at"
+        ]
+      },
+      "produits_zones": {
+        "columns": []
+      }
+    },
+    "views": {
+      "v_analytique_stock": {
+        "columns": []
+      },
+      "v_besoins_previsionnels": {
+        "columns": []
+      },
+      "v_boissons": {
+        "columns": []
+      },
+      "v_cost_center_month": {
+        "columns": []
+      },
+      "v_cost_center_monthly": {
+        "columns": []
+      },
+      "v_ecarts_inventaire": {
+        "columns": []
+      },
+      "v_evolution_achats": {
+        "columns": []
+      },
+      "v_fournisseurs_inactifs": {
+        "columns": []
+      },
+      "v_performance_fiches": {
+        "columns": []
+      },
+      "v_pmp": {
+        "columns": []
+      },
+      "v_products_last_price": {
+        "columns": []
+      },
+      "v_produits_dernier_prix": {
+        "columns": []
+      },
+      "v_produits_utilises": {
+        "columns": []
+      },
+      "v_reco_stockmort": {
+        "columns": []
+      },
+      "v_reco_surcout": {
+        "columns": []
+      },
+      "v_requisitions": {
+        "columns": []
+      },
+      "v_stock_requisitionne": {
+        "columns": []
+      },
+      "suggestions_commandes": {
+        "columns": []
+      },
+      "v_stocks": {
+        "columns": []
+      },
+      "v_taches_assignees": {
+        "columns": []
+      },
+      "v_tendance_prix_produit": {
+        "columns": []
+      },
+      "v_top_fournisseurs": {
+        "columns": []
+      },
+      "v_couts_fiches": {
+        "columns": []
+      },
+      "v_menu_groupe_couts": {
+        "columns": []
+      },
+      "v_menu_groupe_resume": {
+        "columns": []
+      },
+      "v_menu_du_jour_resume": {
+        "columns": []
+      },
+      "v_menu_du_jour_mensuel": {
+        "columns": []
+      },
+      "v_cons_achats_mensuels": {
+        "columns": []
+      },
+      "v_cons_ventes_mensuelles": {
+        "columns": []
+      },
+      "v_cons_foodcost_mensuel": {
+        "columns": []
+      },
+      "v_cons_ecarts_inventaire": {
+        "columns": []
+      },
+      "v_consolidation_mensuelle": {
+        "columns": []
+      },
+      "v_me_classification": {
+        "columns": []
+      },
+      "v_produits_par_zone": {
+        "columns": [
+          "mama_id",
+          "produit_id",
+          "produit_nom",
+          "zone_id",
+          "zone_nom",
+          "zone_type",
+          "unite_id",
+          "stock_reel",
+          "stock_min"
+        ]
+      }
+    },
+    "functions": [
+      {
+        "name": "current_user_mama_id",
+        "args": 0
+      },
+      {
+        "name": "current_user_is_admin_or_manager",
+        "args": 0
+      },
+      {
+        "name": "current_user_is_admin",
+        "args": 0
+      },
+      {
+        "name": "get_template_commande",
+        "args": 2
+      },
+      {
+        "name": "create_utilisateur",
+        "args": 4
+      },
+      {
+        "name": "calcul_ecarts_inventaire",
+        "args": 0
+      },
+      {
+        "name": "fn_calc_budgets",
+        "args": 2
+      },
+      {
+        "name": "can_transfer",
+        "args": 2
+      },
+      {
+        "name": "zone_is_cave_or_shop",
+        "args": 1
+      },
+      {
+        "name": "apply_stock_from_achat",
+        "args": 0
+      },
+      {
+        "name": "compare_fiche",
+        "args": 0
+      },
+      {
+        "name": "consolidated_stats",
+        "args": 0
+      },
+      {
+        "name": "dashboard_stats",
+        "args": 0
+      },
+      {
+        "name": "disable_two_fa",
+        "args": 0
+      },
+      {
+        "name": "enable_two_fa",
+        "args": 0
+      },
+      {
+        "name": "import_invoice",
+        "args": 0
+      },
+      {
+        "name": "send_email_notification",
+        "args": 0
+      },
+      {
+        "name": "send_notification_webhook",
+        "args": 0
+      },
+      {
+        "name": "stats_achats_fournisseur",
+        "args": 2
+      },
+      {
+        "name": "stats_achats_fournisseurs",
+        "args": 1
+      },
+      {
+        "name": "stats_cost_centers",
+        "args": 0
+      },
+      {
+        "name": "stats_multi_mamas",
+        "args": 0
+      },
+      {
+        "name": "stats_rotation_produit",
+        "args": 0
+      },
+      {
+        "name": "top_produits",
+        "args": 4
+      },
+      {
+        "name": "sync_pivot_from_produits",
+        "args": 0
+      },
+      {
+        "name": "sync_produits_from_pivot",
+        "args": 0
+      },
+      {
+        "name": "move_zone_products",
+        "args": 4
+      },
+      {
+        "name": "copy_zone_products",
+        "args": 4
+      },
+      {
+        "name": "merge_zone_products",
+        "args": 3
+      },
+      {
+        "name": "safe_delete_zone",
+        "args": 3
+      }
+    ],
+    "fks": [
+      {
+        "from": {
+          "table": "templates_commandes",
+          "columns": [
+            "mama_id"
+          ]
+        },
+        "to": {
+          "table": "mamas",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      {
+        "from": {
+          "table": "templates_commandes",
+          "columns": [
+            "fournisseur_id"
+          ]
+        },
+        "to": {
+          "table": "fournisseurs",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      {
+        "from": {
+          "table": "inventaires",
+          "columns": [
+            "mama_id"
+          ]
+        },
+        "to": {
+          "table": "mamas",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      {
+        "from": {
+          "table": "inventaires",
+          "columns": [
+            "zone_id"
+          ]
+        },
+        "to": {
+          "table": "inventaire_zones",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      {
+        "from": {
+          "table": "inventaires",
+          "columns": [
+            "periode_id"
+          ]
+        },
+        "to": {
+          "table": "periodes_comptables",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      {
+        "from": {
+          "table": "produits_inventaire",
+          "columns": [
+            "inventaire_id"
+          ]
+        },
+        "to": {
+          "table": "inventaires",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      {
+        "from": {
+          "table": "produits_inventaire",
+          "columns": [
+            "produit_id"
+          ]
+        },
+        "to": {
+          "table": "produits",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      {
+        "from": {
+          "table": "produits_inventaire",
+          "columns": [
+            "mama_id"
+          ]
+        },
+        "to": {
+          "table": "mamas",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      {
+        "from": {
+          "table": "periodes_comptables",
+          "columns": [
+            "mama_id"
+          ]
+        },
+        "to": {
+          "table": "mamas",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      {
+        "from": {
+          "table": "requisitions",
+          "columns": [
+            "mama_id"
+          ]
+        },
+        "to": {
+          "table": "mamas",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      {
+        "from": {
+          "table": "requisitions",
+          "columns": [
+            "zone_id"
+          ]
+        },
+        "to": {
+          "table": "zones_stock",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      {
+        "from": {
+          "table": "requisition_lignes",
+          "columns": [
+            "requisition_id"
+          ]
+        },
+        "to": {
+          "table": "requisitions",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      {
+        "from": {
+          "table": "requisition_lignes",
+          "columns": [
+            "produit_id"
+          ]
+        },
+        "to": {
+          "table": "produits",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      {
+        "from": {
+          "table": "menu_groupe_lignes",
+          "columns": [
+            "menu_groupe_id"
+          ]
+        },
+        "to": {
+          "table": "menu_groupes",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      {
+        "from": {
+          "table": "menu_groupe_lignes",
+          "columns": [
+            "fiche_id"
+          ]
+        },
+        "to": {
+          "table": "fiches_techniques",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      {
+        "from": {
+          "table": "menu_groupe_modeles",
+          "columns": [
+            "mama_id"
+          ]
+        },
+        "to": {
+          "table": "mamas",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      {
+        "from": {
+          "table": "menu_groupe_modele_lignes",
+          "columns": [
+            "modele_id"
+          ]
+        },
+        "to": {
+          "table": "menu_groupe_modeles",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      {
+        "from": {
+          "table": "menu_groupe_modele_lignes",
+          "columns": [
+            "fiche_id"
+          ]
+        },
+        "to": {
+          "table": "fiches_techniques",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      {
+        "from": {
+          "table": "menus_jour_lignes",
+          "columns": [
+            "menu_id"
+          ]
+        },
+        "to": {
+          "table": "menus_jour",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      {
+        "from": {
+          "table": "menus_jour_lignes",
+          "columns": [
+            "fiche_id"
+          ]
+        },
+        "to": {
+          "table": "fiches_techniques",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      {
+        "from": {
+          "table": "settings",
+          "columns": [
+            "mama_id"
+          ]
+        },
+        "to": {
+          "table": "mamas",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      {
+        "from": {
+          "table": "user_mama_access",
+          "columns": [
+            "mama_id"
+          ]
+        },
+        "to": {
+          "table": "mamas",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      {
+        "from": {
+          "table": "ventes_fiches",
+          "columns": [
+            "fiche_id"
+          ]
+        },
+        "to": {
+          "table": "fiches_techniques",
+          "columns": [
+            "id"
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/REPORTS/FRONT_BACK_ALIGN.md
+++ b/REPORTS/FRONT_BACK_ALIGN.md
@@ -1,0 +1,171 @@
+# Front / Back Alignment
+
+## Missing
+### Tables
+- requisitions!inner
+- utilisateur:utilisateurs!logs_securite_utilisateur_id_fkey
+- fournisseur:fournisseur_id
+- produit:produit_id
+- lignes:lignes_bl!bl_id
+- lignes:commande_lignes
+- unite:unite_id
+- gadgets:gadgets!tableau_id
+- famille:familles!fk_produits_famille
+- sous_famille:sous_familles!fk_produits_sous_famille
+- liaisons:fournisseur_produits!fournisseur_produits_produit_id_fkey
+- fournisseur:fournisseurs!fk_fournisseur_produits_fournisseur_id
+- lignes:produits_inventaire!inventaire_id
+- fournisseur_produits:fournisseur_produits!fournisseur_produits_produit_id_fkey
+- lignes:facture_lignes!facture_id
+- factures:facture_id
+- famille:familles!fiches_techniques_famille_id_fkey
+- lignes:fiche_lignes!fiche_id
+- lignes:v_fiche_lignes_complete!fiche_id
+- sous_fiche:sous_fiche_id
+- contact:fournisseur_contacts
+- zones_stock
+- zone:inventaire_zones!inventaires_zone_id_fkey
+- produit:produits!produits_inventaire_produit_id_fkey
+- produit:produits!facture_lignes_produit_id_fkey
+- famille:familles
+- utilisateurs:user_id
+- mamas
+- fiches:menus_jour_fiches
+- fiche:fiches_techniques
+- resume:v_menu_groupe_resume
+- fiches:menu_fiches
+- fiche: fiches
+- mouvements_centres_cout
+- centres_de_cout:cost_center_id
+- lignes:planning_lignes!planning_id
+- main_fournisseur:fournisseur_id
+- produit:produits!fournisseur_produits_produit_id_fkey
+- lignes:requisition_lignes
+- lignes:requisition_lignes!requisition_id
+- assigned:utilisateurs!taches_assigned_to_fkey
+- zone_source:zones_stock!fk_transferts_zone_source_id
+- zone_destination:zones_stock!fk_transferts_zone_dest_id
+- lignes:transfert_lignes
+- produit:produits
+- utilisateurs_complets
+- zones_droits!inner
+
+### Views
+- v_achats_mensuels
+- v_costing_carte
+- v_menu_du_jour_lignes_cout
+
+### Columns
+- promotions: *
+- logs_securite: utilisateur_id, description, count:id
+- taches: titre, date_echeance, *
+- achats: *
+- help_articles: *
+- regles_alertes: *
+- api_keys: *
+- bons_livraison: numero_bl, date_reception, commentaire, actif, fournisseur_id, *
+- fiches_techniques: *, nom, cout_par_portion, actif, cout_total
+- commandes: *
+- fournisseur_produits: *, derniere_livraison:date_livraison
+- consentements_utilisateur: *
+- centres_de_cout: *
+- tableaux_de_bord: *, liste_gadgets_json
+- gadgets: ordre
+- documents: *, fichier_url, url
+- produits: sous_famille_id, *, tva, dernier_prix
+- inventaires: *, date
+- factures: *, numero, date_facture, fournisseur_id, total_ttc, statut
+- facture_lignes: quantite, prix, tva, facture_id, prix_unitaire, *
+- compta_mapping: cle, compte
+- familles: *
+- sous_familles: *
+- feedback: *
+- fiche_cout_history: *
+- fournisseurs_api_config: *
+- fournisseur_notes: *
+- fournisseurs: actif
+- produits_inventaire: *
+- inventaire_zones: *
+- logs_activite: *
+- rapports_generes: *
+- menus_jour: *, date, categorie, fiche_id, portions
+- menu_groupes: *
+- menu_groupe_lignes: *
+- menu_groupe_modele_lignes: *
+- menus: *
+- notifications: *
+- notification_preferences: *
+- etapes_onboarding: etape, statut
+- periodes_comptables: *
+- permissions: *
+- pertes: *
+- planning_previsionnel: *
+- requisitions: *
+- roles: *
+- alertes_rupture: *
+- signalements: *
+- templates_commandes: *
+- transferts: date_transfert, motif
+- auth_double_facteur: enabled, secret
+- usage_stats: module, count:id, timestamp
+- validation_requests: *
+- v_produits_par_zone: *
+- zones_droits: *
+
+### Functions
+- advanced_stats
+- suggest_cost_centers
+- merge_familles
+- reorder_familles
+- log_action
+
+## Mismatch
+### Foreign Keys
+- templates_commandes(mama_id) -> mamas(id)
+- inventaires(mama_id) -> mamas(id)
+- produits_inventaire(mama_id) -> mamas(id)
+- periodes_comptables(mama_id) -> mamas(id)
+- requisitions(mama_id) -> mamas(id)
+- requisitions(zone_id) -> zones_stock(id)
+- menu_groupe_lignes(menu_groupe_id) -> menu_groupes(id)
+- menu_groupe_modeles(mama_id) -> mamas(id)
+- settings(mama_id) -> mamas(id)
+- user_mama_access(mama_id) -> mamas(id)
+
+### Policies
+
+### Views
+
+## Unused
+### Tables
+- emails_envoyes
+- alertes
+- documentation
+- fiches
+- groupes
+- guides_seen
+- menus_groupes
+- menus_groupes_fiches
+- parametres_commandes
+- stocks
+- tooltips
+- ventes_boissons
+- ventes_fiches_carte
+
+### Views
+- v_boissons
+- suggestions_commandes
+- v_couts_fiches
+
+### Functions
+- current_user_mama_id
+- current_user_is_admin_or_manager
+- current_user_is_admin
+- calcul_ecarts_inventaire
+- can_transfer
+- zone_is_cave_or_shop
+- compare_fiche
+- stats_multi_mamas
+- sync_pivot_from_produits
+- sync_produits_from_pivot
+- safe_delete_zone

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "schema:repair": "node scripts/repairSchema.js",
     "schema:repair:apply": "SCHEMA_APPLY=1 node scripts/repairSchema.js",
     "fix:fe": "node scripts/fixFrontend.js",
-    "fix:fe:write": "node scripts/fixFrontend.js --write"
+    "fix:fe:write": "node scripts/fixFrontend.js --write",
+    "schema:analyze": "node scripts/analyzeFrontBackend.js"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.14",

--- a/scripts/analyzeFrontBackend.js
+++ b/scripts/analyzeFrontBackend.js
@@ -1,0 +1,410 @@
+import fs from 'fs/promises';
+import glob from 'glob';
+import { promisify } from 'util';
+import recast from 'recast';
+import * as babelParser from '@babel/parser';
+
+const globAsync = promisify(glob);
+
+const parser = {
+  parse(source) {
+    return babelParser.parse(source, {
+      sourceType: 'module',
+      plugins: ['jsx', 'typescript'],
+    });
+  },
+};
+
+function isMember(node, name) {
+  return (
+    node.callee &&
+    node.callee.type === 'MemberExpression' &&
+    !node.callee.computed &&
+    node.callee.property.name === name
+  );
+}
+
+function findTableRecursive(obj) {
+  if (!obj) return null;
+  if (obj.type === 'CallExpression') {
+    const callee = obj.callee;
+    if (
+      callee.type === 'MemberExpression' &&
+      !callee.computed &&
+      callee.property.name === 'from'
+    ) {
+      const arg = obj.arguments[0];
+      if (arg && arg.type === 'StringLiteral') return arg.value;
+    }
+    return findTableRecursive(callee.object);
+  } else if (obj.type === 'MemberExpression') {
+    return findTableRecursive(obj.object);
+  }
+  return null;
+}
+
+function parseSelect(str, base) {
+  const result = { [base]: new Set() };
+  const stack = [base];
+  let token = '';
+  for (let i = 0; i < str.length; i++) {
+    const c = str[i];
+    if (c === '(') {
+      const table = token.trim();
+      if (table) {
+        if (!result[table]) result[table] = new Set();
+        stack.push(table);
+      }
+      token = '';
+    } else if (c === ')') {
+      if (token.trim()) result[stack[stack.length - 1]].add(token.trim());
+      token = '';
+      if (stack.length > 1) stack.pop();
+    } else if (c === ',') {
+      if (token.trim()) result[stack[stack.length - 1]].add(token.trim());
+      token = '';
+    } else {
+      token += c;
+    }
+  }
+  if (token.trim()) result[stack[stack.length - 1]].add(token.trim());
+  return result;
+}
+
+async function scanFront() {
+  const files = await globAsync('src/**/*.{js,jsx,ts,tsx}', {
+    ignore: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/.next/**',
+      '**/build/**',
+      '**/test/**',
+      '**/__mocks__/**',
+    ],
+  });
+  const tables = {};
+  const functions = new Set();
+
+  const ensureTable = name => {
+    if (!tables[name]) tables[name] = { columns: new Set() };
+  };
+
+  for (const file of files) {
+    const code = await fs.readFile(file, 'utf8');
+    let ast;
+    try {
+      ast = recast.parse(code, { parser });
+    } catch (e) {
+      console.warn('Parse error in', file, e.message);
+      continue;
+    }
+    recast.types.visit(ast, {
+      visitCallExpression(path) {
+        const node = path.node;
+        if (isMember(node, 'rpc')) {
+          const arg = node.arguments[0];
+          if (arg && arg.type === 'StringLiteral') functions.add(arg.value);
+        }
+        if (isMember(node, 'from')) {
+          const arg = node.arguments[0];
+          if (arg && arg.type === 'StringLiteral') ensureTable(arg.value);
+        }
+        if (isMember(node, 'select')) {
+          const table = findTableRecursive(node.callee.object);
+          const arg = node.arguments[0];
+          if (table) ensureTable(table);
+          if (arg && arg.type === 'StringLiteral' && table) {
+            const map = parseSelect(arg.value, table);
+            for (const [tbl, cols] of Object.entries(map)) {
+              ensureTable(tbl);
+              cols.forEach(c => tables[tbl].columns.add(c));
+            }
+          }
+        }
+        this.traverse(path);
+      },
+    });
+  }
+  return { tables, functions: Array.from(functions) };
+}
+
+function splitStatements(sql) {
+  const statements = [];
+  let current = '';
+  let tag = null;
+  for (let i = 0; i < sql.length; i++) {
+    const ch = sql[i];
+    if (tag) {
+      if (sql.startsWith(tag, i)) {
+        current += tag;
+        i += tag.length - 1;
+        tag = null;
+      } else {
+        current += ch;
+      }
+      continue;
+    }
+    if (ch === '$') {
+      const m = sql.slice(i).match(/^\$[^$]*\$/);
+      if (m) {
+        tag = m[0];
+        current += tag;
+        i += tag.length - 1;
+        continue;
+      }
+    }
+    if (ch === ';') {
+      if (current.trim()) statements.push(current.trim());
+      current = '';
+    } else {
+      current += ch;
+    }
+  }
+  if (current.trim()) statements.push(current.trim());
+  return statements;
+}
+
+function splitComma(str) {
+  const parts = [];
+  let current = '';
+  let depth = 0;
+  for (let i = 0; i < str.length; i++) {
+    const c = str[i];
+    if (c === '(') depth++;
+    if (c === ')') depth--;
+    if (c === ',' && depth === 0) {
+      parts.push(current.trim());
+      current = '';
+    } else {
+      current += c;
+    }
+  }
+  if (current.trim()) parts.push(current.trim());
+  return parts;
+}
+
+function parseCreateTable(stmt, index) {
+  const m = stmt.match(/create\s+table\s+(?:if\s+not\s+exists\s+)?(?:public\.)?([a-zA-Z0-9_]+)/i);
+  if (!m) return;
+  const name = m[1];
+  if (!index.tables[name]) index.tables[name] = { columns: new Set() };
+  const body = stmt.slice(stmt.indexOf('(') + 1, stmt.lastIndexOf(')'));
+  const parts = splitComma(body);
+  for (const p of parts) {
+    const colMatch = p.match(/^"?([a-zA-Z0-9_]+)"?/);
+    if (!colMatch) continue;
+    const col = colMatch[1];
+    if (/^constraint/i.test(p) || /foreign key/i.test(p)) {
+      const fkMatch = p.match(/foreign key\s*\(([^)]+)\)\s*references\s+(?:public\.)?([a-zA-Z0-9_]+)\s*\(([^)]+)\)/i);
+      if (fkMatch) {
+        const fromCols = fkMatch[1].split(',').map(s => s.trim());
+        const toTable = fkMatch[2];
+        const toCols = fkMatch[3].split(',').map(s => s.trim());
+        index.fks.push({ from: { table: name, columns: fromCols }, to: { table: toTable, columns: toCols } });
+      }
+      continue;
+    }
+    index.tables[name].columns.add(col);
+    if (p.includes('references')) {
+      const refMatch = p.match(/references\s+(?:public\.)?([a-zA-Z0-9_]+)\s*\(([^)]+)\)/i);
+      if (refMatch) {
+        const toTable = refMatch[1];
+        const toCols = refMatch[2].split(',').map(s => s.trim());
+        index.fks.push({ from: { table: name, columns: [col] }, to: { table: toTable, columns: toCols } });
+      }
+    }
+  }
+}
+
+function parseAlterTable(stmt, index) {
+  const m = stmt.match(/alter\s+table\s+(?:if\s+exists\s+)?(?:public\.)?([a-zA-Z0-9_]+)/i);
+  if (!m) return;
+  const name = m[1];
+  if (!index.tables[name]) index.tables[name] = { columns: new Set() };
+  if (/add\s+column/i.test(stmt)) {
+    const c = stmt.match(/add\s+column\s+(?:if\s+not\s+exists\s+)?"?([a-zA-Z0-9_]+)"?/i);
+    if (c) index.tables[name].columns.add(c[1]);
+  }
+  if (/foreign key/i.test(stmt)) {
+    const fkMatch = stmt.match(/foreign key\s*\(([^)]+)\)\s*references\s+(?:public\.)?([a-zA-Z0-9_]+)\s*\(([^)]+)\)/i);
+    if (fkMatch) {
+      const fromCols = fkMatch[1].split(',').map(s => s.trim());
+      const toTable = fkMatch[2];
+      const toCols = fkMatch[3].split(',').map(s => s.trim());
+      index.fks.push({ from: { table: name, columns: fromCols }, to: { table: toTable, columns: toCols } });
+    }
+  }
+}
+
+function parseCreateView(stmt, index) {
+  const m = stmt.match(/create\s+(?:or\s+replace\s+)?view\s+(?:public\.)?([a-zA-Z0-9_]+)(?:\s*\(([^)]+)\))?/i);
+  if (!m) return;
+  const name = m[1];
+  const cols = m[2] ? m[2].split(',').map(s => s.trim()) : [];
+  index.views[name] = { columns: new Set(cols) };
+}
+
+function parseCreateFunction(stmt, index) {
+  const m = stmt.match(/create\s+(?:or\s+replace\s+)?function\s+(?:public\.)?([a-zA-Z0-9_]+)\s*\(([^)]*)\)/i);
+  if (!m) return;
+  const name = m[1];
+  const params = m[2].trim();
+  const args = params ? params.split(',').filter(s => s.trim()).length : 0;
+  index.functions[name] = args;
+}
+
+async function indexSQL() {
+  const candidates = [
+    'db/full_setup_final.sql',
+    'db/full_setup_fixed.sql',
+    'full_setup_final.sql',
+    'full_setup.sql',
+  ];
+  let sqlFile = null;
+  for (const p of candidates) {
+    try {
+      await fs.access(p);
+      sqlFile = p;
+      break;
+    } catch {}
+  }
+  if (!sqlFile) throw new Error('SQL reference file not found');
+  const sql = await fs.readFile(sqlFile, 'utf8');
+  const statements = splitStatements(sql);
+  const index = { tables: {}, views: {}, functions: {}, fks: [] };
+  for (const stmt of statements) {
+    const lower = stmt.toLowerCase();
+    if (lower.startsWith('create table')) parseCreateTable(stmt, index);
+    else if (lower.startsWith('alter table')) parseAlterTable(stmt, index);
+    else if (lower.startsWith('create view') || lower.startsWith('create or replace view')) parseCreateView(stmt, index);
+    else if (lower.startsWith('create function') || lower.startsWith('create or replace function')) parseCreateFunction(stmt, index);
+  }
+  return { index, sqlFile };
+}
+
+function compare(front, sqlIndex) {
+  const missing = { tables: [], columns: {}, views: [], functions: [] };
+  const mismatch = { fks: [], policies: [], views: [] };
+  const unused = { tables: [], views: [], functions: [] };
+
+  const frontTables = Object.keys(front.tables);
+  for (const t of frontTables) {
+    if (sqlIndex.tables[t]) {
+      for (const col of front.tables[t].columns) {
+        if (!sqlIndex.tables[t].columns.has(col)) {
+          if (!missing.columns[t]) missing.columns[t] = [];
+          missing.columns[t].push(col);
+        }
+      }
+    } else if (sqlIndex.views[t]) {
+      const viewCols = sqlIndex.views[t].columns;
+      for (const col of front.tables[t].columns) {
+        if (viewCols.size && !viewCols.has(col)) {
+          if (!missing.columns[t]) missing.columns[t] = [];
+          missing.columns[t].push(col);
+        }
+      }
+    } else {
+      if (t.startsWith('v_')) missing.views.push(t);
+      else missing.tables.push(t);
+    }
+  }
+
+  for (const fn of front.functions) {
+    if (!sqlIndex.functions.find(f => f.name === fn)) missing.functions.push(fn);
+  }
+
+  const used = new Set(frontTables);
+  for (const t of Object.keys(sqlIndex.tables)) {
+    if (!used.has(t)) unused.tables.push(t);
+  }
+  for (const v of Object.keys(sqlIndex.views)) {
+    if (!used.has(v)) unused.views.push(v);
+  }
+  for (const fn of sqlIndex.functions) {
+    if (!front.functions.includes(fn.name)) unused.functions.push(fn.name);
+  }
+
+  for (const fk of sqlIndex.fks) {
+    const src = sqlIndex.tables[fk.from.table];
+    const dst = sqlIndex.tables[fk.to.table];
+    const srcOk = src && fk.from.columns.every(c => src.columns.has(c));
+    const dstOk = dst && fk.to.columns.every(c => dst.columns.has(c));
+    if (!srcOk || !dstOk) mismatch.fks.push(fk);
+  }
+
+  return { missing, mismatch, unused };
+}
+
+function formatReportJSON(res, sqlIndex) {
+  const tables = {};
+  for (const [t, obj] of Object.entries(sqlIndex.tables)) {
+    tables[t] = { columns: Array.from(obj.columns) };
+  }
+  const views = {};
+  for (const [v, obj] of Object.entries(sqlIndex.views)) {
+    views[v] = { columns: Array.from(obj.columns) };
+  }
+  const functions = Object.entries(sqlIndex.functions).map(([name, args]) => ({ name, args }));
+  const fks = sqlIndex.fks;
+  return { ...res, sqlIndex: { tables, views, functions, fks } };
+}
+
+function formatReportMD(res) {
+  let md = '# Front / Back Alignment\n\n';
+  md += '## Missing\n';
+  md += '### Tables\n';
+  res.missing.tables.forEach(t => { md += `- ${t}\n`; });
+  md += '\n### Views\n';
+  res.missing.views.forEach(v => { md += `- ${v}\n`; });
+  md += '\n### Columns\n';
+  for (const [t, cols] of Object.entries(res.missing.columns)) {
+    md += `- ${t}: ${cols.join(', ')}\n`;
+  }
+  md += '\n### Functions\n';
+  res.missing.functions.forEach(f => { md += `- ${f}\n`; });
+  md += '\n## Mismatch\n';
+  md += '### Foreign Keys\n';
+  res.mismatch.fks.forEach(fk => {
+    md += `- ${fk.from.table}(${fk.from.columns.join(',')}) -> ${fk.to.table}(${fk.to.columns.join(',')})\n`;
+  });
+  md += '\n### Policies\n';
+  res.mismatch.policies.forEach(p => { md += `- ${p}\n`; });
+  md += '\n### Views\n';
+  res.mismatch.views.forEach(v => { md += `- ${v}\n`; });
+  md += '\n## Unused\n';
+  md += '### Tables\n';
+  res.unused.tables.forEach(t => { md += `- ${t}\n`; });
+  md += '\n### Views\n';
+  res.unused.views.forEach(v => { md += `- ${v}\n`; });
+  md += '\n### Functions\n';
+  res.unused.functions.forEach(f => { md += `- ${f}\n`; });
+  return md;
+}
+
+async function main() {
+  const front = await scanFront();
+  const { index } = await indexSQL();
+  const res = compare(front, {
+    tables: Object.fromEntries(Object.entries(index.tables).map(([k, v]) => [k, { columns: new Set(v.columns) }])),
+    views: Object.fromEntries(Object.entries(index.views).map(([k, v]) => [k, { columns: new Set(v.columns) }])),
+    functions: Object.entries(index.functions).map(([name, args]) => ({ name, args })),
+    fks: index.fks,
+  });
+  const json = formatReportJSON(res, {
+    tables: index.tables,
+    views: index.views,
+    functions: index.functions,
+    fks: index.fks,
+  });
+  await fs.mkdir('REPORTS', { recursive: true });
+  await fs.writeFile('REPORTS/FRONT_BACK_ALIGN.json', JSON.stringify(json, null, 2));
+  const md = formatReportMD(res);
+  await fs.writeFile('REPORTS/FRONT_BACK_ALIGN.md', md);
+}
+
+main().catch(e => {
+  console.error(e);
+  process.exit(1);
+});
+


### PR DESCRIPTION
## Summary
- add analyzer script to compare front-end supabase usage with SQL schema and generate alignment reports
- wire analyzer as `npm run schema:analyze` for quick execution

## Testing
- `npm run schema:analyze`
- `npm test` *(fails: useNotifications is not a function, no default export on hooks mocks, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_6899bf9158a0832dafe77bd55d4bcb44