### PR TITLE
feat: build consolidated Supabase SQL

### DIFF
--- a/REPORTS/SQL_BUILD_SUMMARY.md
+++ b/REPORTS/SQL_BUILD_SUMMARY.md
@@ -1,0 +1,252 @@
+# SQL Build Summary
+
+## Columns added for FKs
+- public.produits.zone_id -> public.zones_stock(id)
+- public.fournisseurs.mama_id -> public.mamas(id)
+- public.produits.mama_id -> public.mamas(id)
+- public.produits.fournisseur_id -> public.fournisseurs(id)
+- public.produits.unite_id -> public.unites(id)
+- public.produits.famille_id -> public.familles(id)
+- public.produits.sous_famille_id -> public.sous_familles(id)
+- public.roles.mama_id -> public.mamas(id)
+- public.utilisateurs.mama_id -> public.mamas(id)
+- public.utilisateurs.role_id -> public.roles(id)
+- public.commandes.mama_id -> public.mamas(id)
+- public.commandes.fournisseur_id -> public.fournisseurs(id)
+- public.commandes.created_by -> public.utilisateurs(id)
+- public.commandes.validated_by -> public.utilisateurs(id)
+- public.commande_lignes.commande_id -> public.commandes(id)
+- public.commande_lignes.produit_id -> public.produits(id)
+- public.commande_lignes.mama_id -> public.mamas(id)
+- public.templates_commandes.mama_id -> public.mamas(id)
+- public.templates_commandes.fournisseur_id -> public.fournisseurs(id)
+- public.emails_envoyes.commande_id -> public.commandes(id)
+- public.emails_envoyes.mama_id -> public.mamas(id)
+- public.permissions.role_id -> public.roles(id)
+- public.permissions.mama_id -> public.mamas(id)
+- public.consentements_utilisateur.utilisateur_id -> public.utilisateurs(id)
+- public.consentements_utilisateur.mama_id -> public.mamas(id)
+- public.achats.mama_id -> public.mamas(id)
+- public.achats.produit_id -> public.produits(id)
+- public.achats.fournisseur_id -> public.fournisseurs(id)
+- public.alertes.mama_id -> public.mamas(id)
+- public.api_keys.mama_id -> public.mamas(id)
+- public.auth_double_facteur.mama_id -> public.mamas(id)
+- public.bons_livraison.mama_id -> public.mamas(id)
+- public.catalogue_updates.mama_id -> public.mamas(id)
+- public.centres_de_cout.mama_id -> public.mamas(id)
+- public.compta_mapping.mama_id -> public.mamas(id)
+- public.documentation.mama_id -> public.mamas(id)
+- public.documents.mama_id -> public.mamas(id)
+- public.etapes_onboarding.mama_id -> public.mamas(id)
+- public.facture_lignes.mama_id -> public.mamas(id)
+- public.factures.mama_id -> public.mamas(id)
+- public.familles.mama_id -> public.mamas(id)
+- public.feedback.mama_id -> public.mamas(id)
+- public.fiche_cout_history.mama_id -> public.mamas(id)
+- public.fiche_lignes.mama_id -> public.mamas(id)
+- public.fiches.mama_id -> public.mamas(id)
+- public.fiches_techniques.mama_id -> public.mamas(id)
+- public.fournisseur_contacts.mama_id -> public.mamas(id)
+- public.fournisseur_notes.mama_id -> public.mamas(id)
+- public.fournisseur_produits.mama_id -> public.mamas(id)
+- public.fournisseur_produits.produit_id -> public.produits(id)
+- public.fournisseur_produits.fournisseur_id -> public.fournisseurs(id)
+- public.fournisseurs_api_config.mama_id -> public.mamas(id)
+- public.gadgets.mama_id -> public.mamas(id)
+- public.groupes.mama_id -> public.mamas(id)
+- public.guides_seen.mama_id -> public.mamas(id)
+- public.help_articles.mama_id -> public.mamas(id)
+- public.inventaire_zones.mama_id -> public.mamas(id)
+- public.journaux_utilisateur.mama_id -> public.mamas(id)
+- public.lignes_bl.mama_id -> public.mamas(id)
+- public.logs_securite.mama_id -> public.mamas(id)
+- public.menu_fiches.mama_id -> public.mamas(id)
+- public.menus.mama_id -> public.mamas(id)
+- public.menus_groupes.mama_id -> public.mamas(id)
+- public.menus_groupes_fiches.mama_id -> public.mamas(id)
+- public.menus_jour.mama_id -> public.mamas(id)
+- public.menus_jour_fiches.mama_id -> public.mamas(id)
+- public.notification_preferences.mama_id -> public.mamas(id)
+- public.notifications.mama_id -> public.mamas(id)
+- public.parametres_commandes.mama_id -> public.mamas(id)
+- public.pertes.mama_id -> public.mamas(id)
+- public.planning_lignes.mama_id -> public.mamas(id)
+- public.planning_previsionnel.mama_id -> public.mamas(id)
+- public.promotions.mama_id -> public.mamas(id)
+- public.regles_alertes.mama_id -> public.mamas(id)
+- public.signalements.mama_id -> public.mamas(id)
+- public.sous_familles.mama_id -> public.mamas(id)
+- public.sous_familles.famille_id -> public.familles(id)
+- public.stocks.mama_id -> public.mamas(id)
+- public.tableaux_de_bord.mama_id -> public.mamas(id)
+- public.taches.mama_id -> public.mamas(id)
+- public.tooltips.mama_id -> public.mamas(id)
+- public.transfert_lignes.mama_id -> public.mamas(id)
+- public.transferts.mama_id -> public.mamas(id)
+- public.unites.mama_id -> public.mamas(id)
+- public.usage_stats.mama_id -> public.mamas(id)
+- public.utilisateurs_taches.mama_id -> public.mamas(id)
+- public.validation_requests.mama_id -> public.mamas(id)
+- public.ventes_boissons.mama_id -> public.mamas(id)
+- public.ventes_fiches_carte.mama_id -> public.mamas(id)
+
+## Policies wrapped
+- requisitions_select on public.requisitions
+- requisitions_insert on public.requisitions
+- requisitions_update on public.requisitions
+- requisitions_delete on public.requisitions
+- requisition_lignes_select on public.requisition_lignes
+- requisition_lignes_insert on public.requisition_lignes
+- requisition_lignes_update on public.requisition_lignes
+- requisition_lignes_delete on public.requisition_lignes
+- zones_stock_select on public.zones_stock
+- zones_stock_admin_iud on public.zones_stock
+- zones_droits_admin_all on public.zones_droits
+- alertes_rupture_all on public.alertes_rupture
+- logs_activite_all on public.logs_activite
+- menus_jour_lignes_all on public.menus_jour_lignes
+- rapports_generes_all on public.rapports_generes
+- settings_all on public.settings
+- user_mama_access_select on public.user_mama_access
+- user_mama_access_modify on public.user_mama_access
+- ventes_fiches_all on public.ventes_fiches
+- ventes_import_staging_all on public.ventes_import_staging
+
+## Constraints wrapped
+- fk_produits_zone_id
+- fk_fournisseurs_mama_id
+- fk_produits_mama_id
+- fk_produits_fournisseur_id
+- fk_produits_unite_id
+- fk_produits_famille_id
+- fk_produits_sous_famille_id
+- fk_roles_mama_id
+- fk_utilisateurs_mama_id
+- fk_utilisateurs_role_id
+- fk_commandes_mama_id
+- fk_commandes_fournisseur_id
+- fk_commandes_created_by
+- fk_commandes_validated_by
+- fk_commande_lignes_commande_id
+- fk_commande_lignes_produit_id
+- fk_commande_lignes_mama_id
+- fk_templates_commandes_mama_id
+- fk_templates_commandes_fournisseur_id
+- fk_emails_envoyes_commande_id
+- fk_emails_envoyes_mama_id
+- fk_permissions_role_id
+- fk_permissions_mama_id
+- fk_consentements_utilisateur_utilisateur_id
+- fk_consentements_utilisateur_mama_id
+- fk_achats_mama_id
+- fk_achats_produit_id
+- fk_achats_fournisseur_id
+- fk_alertes_mama_id
+- fk_api_keys_mama_id
+- fk_auth_double_facteur_mama_id
+- fk_bons_livraison_mama_id
+- fk_catalogue_updates_mama_id
+- fk_centres_de_cout_mama_id
+- fk_compta_mapping_mama_id
+- fk_documentation_mama_id
+- fk_documents_mama_id
+- fk_etapes_onboarding_mama_id
+- fk_facture_lignes_mama_id
+- fk_factures_mama_id
+- fk_familles_mama_id
+- fk_feedback_mama_id
+- fk_fiche_cout_history_mama_id
+- fk_fiche_lignes_mama_id
+- fk_fiches_mama_id
+- fk_fiches_techniques_mama_id
+- fk_fournisseur_contacts_mama_id
+- fk_fournisseur_notes_mama_id
+- fk_fournisseur_produits_mama_id
+- fk_fournisseur_produits_produit_id
+- fk_fournisseur_produits_fournisseur_id
+- fk_fournisseurs_api_config_mama_id
+- fk_gadgets_mama_id
+- fk_groupes_mama_id
+- fk_guides_seen_mama_id
+- fk_help_articles_mama_id
+- fk_inventaire_zones_mama_id
+- fk_journaux_utilisateur_mama_id
+- fk_lignes_bl_mama_id
+- fk_logs_securite_mama_id
+- fk_menu_fiches_mama_id
+- fk_menus_mama_id
+- fk_menus_groupes_mama_id
+- fk_menus_groupes_fiches_mama_id
+- fk_menus_jour_mama_id
+- fk_menus_jour_fiches_mama_id
+- fk_notification_preferences_mama_id
+- fk_notifications_mama_id
+- fk_parametres_commandes_mama_id
+- fk_pertes_mama_id
+- fk_planning_lignes_mama_id
+- fk_planning_previsionnel_mama_id
+- fk_promotions_mama_id
+- fk_regles_alertes_mama_id
+- fk_signalements_mama_id
+- fk_sous_familles_mama_id
+- fk_sous_familles_famille_id
+- fk_stocks_mama_id
+- fk_tableaux_de_bord_mama_id
+- fk_taches_mama_id
+- fk_tooltips_mama_id
+- fk_transfert_lignes_mama_id
+- fk_transferts_mama_id
+- fk_unites_mama_id
+- fk_usage_stats_mama_id
+- fk_utilisateurs_taches_mama_id
+- fk_validation_requests_mama_id
+- fk_ventes_boissons_mama_id
+- fk_ventes_fiches_carte_mama_id
+
+## Views touched
+- public.v_analytique_stock
+- public.v_besoins_previsionnels
+- public.v_boissons
+- public.v_cost_center_month
+- public.v_cost_center_monthly
+- public.v_ecarts_inventaire
+- public.v_evolution_achats
+- public.v_fournisseurs_inactifs
+- public.v_performance_fiches
+- public.v_pmp
+- public.v_products_last_price
+- public.v_produits_dernier_prix
+- public.v_produits_utilises
+- public.v_reco_stockmort
+- public.v_reco_surcout
+- public.v_requisitions
+- public.v_stock_requisitionne
+- public.suggestions_commandes
+- public.v_stocks
+- public.v_taches_assignees
+- public.v_tendance_prix_produit
+- public.v_top_fournisseurs
+- public.v_couts_fiches
+- public.v_menu_groupe_couts
+- public.v_menu_groupe_resume
+- public.v_menu_du_jour_resume
+- public.v_menu_du_jour_mensuel
+- public.v_cons_achats_mensuels
+- public.v_cons_ventes_mensuelles
+- public.v_cons_foodcost_mensuel
+- public.v_cons_ecarts_inventaire
+- public.v_consolidation_mensuelle
+- public.v_me_classification
+- public.v_produits_par_zone
+
+## Functions aliased/stubbed
+None
+
+## Execution order
+EXTENSIONS -> FUNCTIONS -> TABLES -> ADDCOLUMNS -> INDEXES -> TRIGGERS -> RLS_ENABLE -> POLICIES -> GRANTS -> VIEWS -> OTHER
+
+## Cleanup suggestions
+- Views: v_boissons, suggestions_commandes, v_couts_fiches
+- Functions: current_user_mama_id, current_user_is_admin_or_manager, current_user_is_admin, calcul_ecarts_inventaire, can_transfer, zone_is_cave_or_shop, compare_fiche, stats_multi_mamas, sync_pivot_from_produits, sync_produits_from_pivot, safe_delete_zone
+- Tables: emails_envoyes, alertes, documentation, fiches, groupes, guides_seen, menus_groupes, menus_groupes_fiches, parametres_commandes, stocks, tooltips, ventes_boissons, ventes_fiches_carte

--- a/db/full_setup_ONE.sql
+++ b/db/full_setup_ONE.sql
@@ -1,0 +1,5572 @@
+create extension if not exists "pg_net";
+
+create or replace function public.current_user_mama_id()
+returns uuid
+language sql stable as $$
+  select u.mama_id from public.utilisateurs u where u.auth_id = auth.uid();
+$$;
+
+create or replace function public.current_user_is_admin_or_manager()
+returns boolean
+language sql stable as $$
+  select exists (
+    select 1 from public.utilisateurs u
+    join public.roles r on r.id = u.role_id
+    where u.auth_id = auth.uid()
+      and r.nom in ('admin','manager')
+  );
+$$;
+
+create or replace function public.current_user_is_admin()
+returns boolean
+language sql stable as $$
+  select public.current_user_is_admin_or_manager() and exists (
+    select 1 from public.utilisateurs u
+    join public.roles r on r.id = u.role_id
+    where u.auth_id = auth.uid() and r.nom = 'admin'
+  );
+$$;
+
+create or replace function public.get_template_commande(p_mama uuid, p_fournisseur uuid)
+returns setof public.templates_commandes
+language sql security definer as $$
+  select *
+  from public.templates_commandes
+  where mama_id = p_mama
+    and actif = true
+    and (fournisseur_id = p_fournisseur or fournisseur_id is null)
+  order by fournisseur_id nulls last
+  limit 1;
+$$;
+
+create or replace function public.create_utilisateur(
+  p_email text,
+  p_nom text,
+  p_role_id uuid,
+  p_mama_id uuid
+) returns json
+language plpgsql
+security definer as $$
+declare
+  v_auth_id uuid;
+  v_password text;
+begin
+  if exists(select 1 from auth.users where lower(email) = lower(p_email)) then
+    raise exception 'email exists';
+  end if;
+  v_password := encode(gen_random_bytes(9), 'base64');
+  insert into auth.users(email, encrypted_password)
+  values (p_email, crypt(v_password, gen_salt('bf'))) returning id into v_auth_id;
+  insert into public.utilisateurs(nom, email, auth_id, role_id, mama_id, actif)
+  values(p_nom, p_email, v_auth_id, p_role_id, p_mama_id, true);
+  perform net.http_post(
+    url => 'https://example.com/send',
+    body => jsonb_build_object('email', p_email, 'password', v_password)
+  );
+  return json_build_object('success', true);
+exception when others then
+  return json_build_object('success', false, 'error', SQLERRM);
+end;$$;
+
+create or replace function public.calcul_ecarts_inventaire(p_date date, p_zone text, mama_id_param uuid)
+returns table(produit text, stock_theorique numeric, stock_reel numeric, ecart numeric, motif text)
+language plpgsql as $$
+begin
+  raise notice 'TODO';
+  return;
+end;
+$$;
+
+create or replace function public.fn_calc_budgets(mama_id_param uuid, periode_param text)
+returns table(famille text, ecart_pct numeric)
+language plpgsql as $$
+begin
+  raise notice 'TODO';
+  return;
+end;
+$$;
+
+create or replace function public.can_transfer(p_src uuid, p_dst uuid)
+returns boolean
+language sql stable security definer
+as $$
+  select
+    (select public.can_access_zone(p_src, 'transfert')) and
+    (select public.can_access_zone(p_dst, 'transfert'));
+$$;
+
+create or replace function public.zone_is_cave_or_shop(p_zone uuid)
+returns boolean
+language sql stable security definer
+as $$
+  select exists(
+    select 1 from public.zones_stock z
+    where z.id = p_zone
+      and z.type in ('cave','shop')
+  );
+$$;
+
+create or replace function public.apply_stock_from_achat()
+returns void
+language plpgsql as $$
+begin
+  raise notice 'TODO';
+  return;
+end;
+$$;
+
+create or replace function public.calcul_ecarts_inventaire()
+returns void
+language plpgsql as $$
+begin
+  raise notice 'TODO';
+  return;
+end;
+$$;
+
+create or replace function public.compare_fiche()
+returns void
+language plpgsql as $$
+begin
+  raise notice 'TODO';
+  return;
+end;
+$$;
+
+create or replace function public.consolidated_stats()
+returns void
+language plpgsql as $$
+begin
+  raise notice 'TODO';
+  return;
+end;
+$$;
+
+create or replace function public.dashboard_stats()
+returns void
+language plpgsql as $$
+begin
+  raise notice 'TODO';
+  return;
+end;
+$$;
+
+create or replace function public.disable_two_fa()
+returns void
+language plpgsql as $$
+begin
+  raise notice 'TODO';
+  return;
+end;
+$$;
+
+create or replace function public.enable_two_fa()
+returns void
+language plpgsql as $$
+begin
+  raise notice 'TODO';
+  return;
+end;
+$$;
+
+create or replace function public.import_invoice()
+returns void
+language plpgsql as $$
+begin
+  raise notice 'TODO';
+  return;
+end;
+$$;
+
+create or replace function public.send_email_notification()
+returns void
+language plpgsql as $$
+begin
+  raise notice 'TODO';
+  return;
+end;
+$$;
+
+create or replace function public.send_notification_webhook()
+returns void
+language plpgsql as $$
+begin
+  raise notice 'TODO';
+  return;
+end;
+$$;
+
+create or replace function public.stats_achats_fournisseur(mama_id_param uuid, fournisseur_id_param uuid)
+returns table(mois date, total_achats numeric)
+language sql as $$
+  select
+    date_trunc('month', date_achat)::date as mois,
+    sum(quantite * prix) as total_achats
+  from public.achats
+  where mama_id = mama_id_param
+    and fournisseur_id = fournisseur_id_param
+    and actif = true
+  group by date_trunc('month', date_achat)::date
+  order by mois;
+$$;
+
+create or replace function public.stats_achats_fournisseurs(mama_id_param uuid)
+returns table(mois date, total_achats numeric)
+language sql as $$
+  select
+    date_trunc('month', date_achat)::date as mois,
+    sum(quantite * prix) as total_achats
+  from public.achats
+  where mama_id = mama_id_param
+    and actif = true
+  group by date_trunc('month', date_achat)::date
+  order by mois;
+$$;
+
+create or replace function public.stats_cost_centers()
+returns void
+language plpgsql as $$
+begin
+  raise notice 'TODO';
+  return;
+end;
+$$;
+
+create or replace function public.stats_multi_mamas()
+returns void
+language plpgsql as $$
+begin
+  raise notice 'TODO';
+  return;
+end;
+$$;
+
+create or replace function public.stats_rotation_produit()
+returns void
+language plpgsql as $$
+begin
+  raise notice 'TODO';
+  return;
+end;
+$$;
+
+create or replace function public.top_produits(
+  mama_id_param uuid,
+  debut_param date,
+  fin_param date,
+  limit_param integer
+)
+returns table(produit_id uuid, nom text, total numeric)
+language sql as $$
+  select
+    rl.produit_id,
+    p.nom,
+    sum(rl.quantite) as total
+  from public.requisition_lignes rl
+  join public.requisitions r on r.id = rl.requisition_id
+  join public.produits p on p.id = rl.produit_id
+  where r.mama_id = mama_id_param
+    and r.statut = 'réalisée'
+    and (debut_param is null or r.date_requisition >= debut_param)
+    and (fin_param is null or r.date_requisition <= fin_param)
+  group by rl.produit_id, p.nom
+  order by total desc
+  limit coalesce(limit_param, 10);
+$$;
+
+create or replace function public.sync_pivot_from_produits() returns trigger as $$
+begin
+  if new.zone_id is null then
+    return new;
+  end if;
+
+  insert into public.produits_zones(mama_id, produit_id, zone_id, actif)
+  values (new.mama_id, new.id, new.zone_id, true)
+  on conflict (mama_id, produit_id, zone_id)
+  do update set actif = true, updated_at = now();
+
+  update public.produits_zones
+    set actif = false, updated_at = now()
+  where mama_id = new.mama_id
+    and produit_id = new.id
+    and zone_id <> new.zone_id
+    and actif is true;
+
+  return new;
+end $$ language plpgsql;
+
+create or replace function public.sync_produits_from_pivot() returns trigger as $$
+begin
+  if new.actif is true then
+    update public.produits p
+      set zone_id = new.zone_id, updated_at = now()
+    where p.id = new.produit_id
+      and p.mama_id = new.mama_id
+      and (p.zone_id is distinct from new.zone_id);
+  end if;
+  return new;
+end $$ language plpgsql;
+
+create or replace function public.move_zone_products(
+  p_mama uuid,
+  p_src_zone uuid,
+  p_dst_zone uuid,
+  p_keep_quantities boolean default true
+) returns json language plpgsql security definer as $$
+declare v_cnt int := 0;
+begin
+  perform 1 from public.zones_stock z where z.id in (p_src_zone, p_dst_zone) and z.mama_id = p_mama;
+  if not found then raise exception 'zones_invalides'; end if;
+
+  insert into public.produits_zones(mama_id, produit_id, zone_id, stock_reel, stock_min, actif)
+  select p_mama, pz.produit_id, p_dst_zone,
+         case when p_keep_quantities then pz.stock_reel else 0 end,
+         pz.stock_min, true
+  from public.produits_zones pz
+  where pz.mama_id = p_mama and pz.zone_id = p_src_zone
+  on conflict (mama_id, produit_id, zone_id)
+  do update set
+    stock_reel = excluded.stock_reel,
+    stock_min = excluded.stock_min,
+    actif = true,
+    updated_at = now();
+
+  get diagnostics v_cnt = row_count;
+
+  update public.produits_zones
+    set actif = false, updated_at = now()
+  where mama_id = p_mama and zone_id = p_src_zone;
+
+  return json_build_object('moved', v_cnt);
+end $$;
+
+create or replace function public.copy_zone_products(
+  p_mama uuid,
+  p_src_zone uuid,
+  p_dst_zone uuid,
+  p_with_quantities boolean default false
+) returns json language plpgsql security definer as $$
+declare v_cnt int := 0;
+begin
+  insert into public.produits_zones(mama_id, produit_id, zone_id, stock_reel, stock_min, actif)
+  select p_mama, pz.produit_id, p_dst_zone,
+         case when p_with_quantities then pz.stock_reel else 0 end,
+         pz.stock_min, true
+  from public.produits_zones pz
+  where pz.mama_id = p_mama and pz.zone_id = p_src_zone
+  on conflict (mama_id, produit_id, zone_id)
+  do update set
+    stock_reel = case when excluded.stock_reel is not null then excluded.stock_reel else public.produits_zones.stock_reel end,
+    stock_min   = excluded.stock_min,
+    actif = true,
+    updated_at = now();
+  get diagnostics v_cnt = row_count;
+  return json_build_object('copied', v_cnt);
+end $$;
+
+create or replace function public.merge_zone_products(
+  p_mama uuid,
+  p_src_zone uuid,
+  p_dst_zone uuid
+) returns json language plpgsql security definer as $$
+declare v_cnt int := 0;
+begin
+  insert into public.produits_zones(mama_id, produit_id, zone_id, stock_reel, stock_min, actif)
+  select p_mama, pz.produit_id, p_dst_zone, pz.stock_reel, pz.stock_min, true
+  from public.produits_zones pz
+  where pz.mama_id = p_mama and pz.zone_id = p_src_zone
+  on conflict (mama_id, produit_id, zone_id)
+  do update set
+    stock_reel = coalesce(public.produits_zones.stock_reel,0) + coalesce(excluded.stock_reel,0),
+    stock_min  = greatest(public.produits_zones.stock_min, excluded.stock_min),
+    actif = true,
+    updated_at = now();
+  get diagnostics v_cnt = row_count;
+  update public.produits_zones set actif=false, updated_at=now()
+  where mama_id=p_mama and zone_id=p_src_zone;
+  return json_build_object('merged', v_cnt);
+end $$;
+
+create or replace function public.safe_delete_zone(
+  p_mama uuid,
+  p_zone uuid,
+  p_reassign_to uuid default null
+) returns json language plpgsql security definer as $$
+declare v_cnt int := 0;
+begin
+  if p_reassign_to is not null then
+    perform public.move_zone_products(p_mama, p_zone, p_reassign_to, true);
+  end if;
+
+  if exists(select 1 from public.produits_zones where mama_id=p_mama and zone_id=p_zone and actif=true) then
+    raise exception 'zone_has_products';
+  end if;
+
+  delete from public.zones_stock where id = p_zone and mama_id = p_mama;
+  get diagnostics v_cnt = row_count;
+  return json_build_object('deleted', v_cnt);
+end $$;
+
+create table if not exists public.fournisseurs (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid not null,
+  nom text not null,
+  contact text,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+create table if not exists public.produits (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid not null,
+  nom text not null,
+  fournisseur_id uuid,
+  unite_id uuid,
+  famille_id uuid,
+  stock_reel numeric default 0,
+  stock_min numeric default 0,
+  pmp numeric default 0,
+  actif boolean default true,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+create table if not exists public.roles (
+  id uuid primary key default gen_random_uuid(),
+  nom text not null,
+  description text,
+  access_rights jsonb default '{}'::jsonb,
+  actif boolean default true,
+  mama_id uuid not null,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+create table if not exists public.utilisateurs (
+  id uuid primary key default gen_random_uuid(),
+  nom text not null,
+  email text not null,
+  auth_id uuid unique,
+  role_id uuid,
+  mama_id uuid not null,
+  access_rights jsonb default '{}'::jsonb,
+  actif boolean default true,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+create table if not exists public.commandes (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid not null,
+  fournisseur_id uuid,
+  reference text,
+  date_commande date default current_date,
+  statut text default 'brouillon' check (statut in ('brouillon','validée','envoyée')),
+  commentaire text,
+  envoyee_at timestamptz,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now(),
+  date_livraison_prevue date,
+  montant_total numeric(12,2),
+  bl_id uuid,
+  facture_id uuid
+);
+
+create table if not exists public.commande_lignes (
+  id uuid primary key default gen_random_uuid(),
+  commande_id uuid not null,
+  produit_id uuid not null,
+  mama_id uuid not null,
+  quantite numeric,
+  unite text,
+  prix_achat numeric,
+  total_ligne numeric generated always as (coalesce(quantite,0) * coalesce(prix_achat,0)) stored,
+  suggestion boolean default false,
+  commentaire text
+);
+
+create table if not exists public.templates_commandes (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid not null references public.mamas(id) on delete cascade,
+  nom text not null,
+  fournisseur_id uuid references public.fournisseurs(id) on delete set null,
+  logo_url text,
+  entete text,
+  pied_page text,
+  adresse_livraison text,
+  contact_nom text,
+  contact_tel text,
+  contact_email text,
+  conditions_generales text,
+  champs_visibles jsonb default '{}'::jsonb,
+  actif boolean default true,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now(),
+  unique (mama_id, nom, fournisseur_id)
+);
+
+create table if not exists public.emails_envoyes (
+  id uuid primary key default gen_random_uuid(),
+  commande_id uuid not null,
+  email text not null,
+  statut text not null default 'en_attente' check (statut in ('en_attente','succès','erreur')),
+  envoye_le timestamptz not null default now(),
+  mama_id uuid not null
+);
+
+create table if not exists public.permissions (
+  id uuid primary key default gen_random_uuid(),
+  role_id uuid not null,
+  module text not null,
+  droit text not null,
+  mama_id uuid not null,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.consentements_utilisateur (
+  id uuid primary key default gen_random_uuid(),
+  utilisateur_id uuid not null,
+  user_id uuid,
+  mama_id uuid not null,
+  type_consentement text not null,
+  consentement boolean not null,
+  date_consentement timestamptz default now()
+);
+
+create table if not exists public.alertes (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.api_keys (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.auth_double_facteur (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.bons_livraison (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.catalogue_updates (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.centres_de_cout (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.compta_mapping (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.documentation (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.documents (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.etapes_onboarding (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.facture_lignes (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.factures (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.familles (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid not null,
+  nom text not null,
+  actif boolean default true,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.feedback (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.fiche_cout_history (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.fiche_lignes (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.fiches (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.fiches_techniques (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.fournisseur_contacts (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.fournisseur_notes (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.fournisseur_produits (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid not null,
+  produit_id uuid not null,
+  fournisseur_id uuid not null,
+  prix_achat numeric,
+  date_livraison date,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.fournisseurs_api_config (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.gadgets (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.groupes (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.guides_seen (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.help_articles (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.inventaire_zones (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.inventaires (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid references public.mamas(id),
+  date_inventaire date not null,
+  zone_id uuid references public.inventaire_zones(id),
+  periode_id uuid references public.periodes_comptables(id),
+  commentaire text,
+  actif boolean default true,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.produits_inventaire (
+  id uuid primary key default gen_random_uuid(),
+  inventaire_id uuid references public.inventaires(id) on delete cascade,
+  produit_id uuid references public.produits(id),
+  quantite_theorique numeric,
+  quantite_reelle numeric,
+  unite text,
+  ecart numeric generated always as (coalesce(quantite_reelle,0) - coalesce(quantite_theorique,0)) stored,
+  mama_id uuid references public.mamas(id),
+  created_at timestamptz default now()
+);
+
+create table if not exists public.journaux_utilisateur (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.lignes_bl (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.logs_securite (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.menu_fiches (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.menus (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.menus_groupes (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.menus_groupes_fiches (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.menus_jour (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.menus_jour_fiches (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.notification_preferences (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.notifications (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.parametres_commandes (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.periodes_comptables (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid references public.mamas(id),
+  debut date not null,
+  fin date not null,
+  actif boolean default true,
+  cloturee boolean default false,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.pertes (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.planning_lignes (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.planning_previsionnel (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.promotions (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.regles_alertes (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.requisitions (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid references public.mamas(id),
+  date_requisition date not null,
+  zone_id uuid references public.zones_stock(id),
+  statut text check (statut in ('brouillon','faite','réalisée')) default 'brouillon',
+  commentaire text,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now(),
+  actif boolean default true
+);
+
+create table if not exists public.requisition_lignes (
+  id uuid primary key default gen_random_uuid(),
+  requisition_id uuid references public.requisitions(id) on delete cascade,
+  produit_id uuid references public.produits(id),
+  quantite numeric,
+  unite text,
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.signalements (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.sous_familles (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid not null,
+  famille_id uuid not null,
+  nom text not null,
+  actif boolean default true,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.stocks (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.tableaux_de_bord (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.taches (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.tooltips (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.transfert_lignes (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.transferts (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.unites (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid not null,
+  nom text not null,
+  actif boolean default true,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.usage_stats (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.utilisateurs_taches (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.validation_requests (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.ventes_boissons (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.ventes_fiches_carte (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.menu_groupe_lignes (
+  id uuid primary key default gen_random_uuid(),
+  menu_groupe_id uuid not null references public.menu_groupes(id) on delete cascade,
+  mama_id uuid not null,
+  categorie text not null check (categorie in ('aperitif','entree','plat','dessert','boisson')),
+  fiche_id uuid not null references public.fiches_techniques(id) on delete restrict,
+  portions_par_personne numeric not null default 1,
+  position integer,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.menu_groupe_modeles (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid not null references public.mamas(id) on delete cascade,
+  nom text not null,
+  actif boolean default true,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.menu_groupe_modele_lignes (
+  id uuid primary key default gen_random_uuid(),
+  modele_id uuid not null references public.menu_groupe_modeles(id) on delete cascade,
+  mama_id uuid not null,
+  categorie text not null check (categorie in ('aperitif','entree','plat','dessert','boisson')),
+  fiche_id uuid not null references public.fiches_techniques(id) on delete restrict,
+  portions_par_personne numeric not null default 1,
+  position integer,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.logs_activite (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid not null,
+  user_id uuid,
+  type text,
+  module text,
+  description text,
+  donnees jsonb default '{}'::jsonb,
+  ip_address text,
+  user_agent text,
+  critique boolean default false,
+  date_log timestamptz default now()
+);
+
+create table if not exists public.menus_jour_lignes (
+  id uuid primary key default gen_random_uuid(),
+  menu_id uuid not null references public.menus_jour(id) on delete cascade,
+  mama_id uuid not null,
+  categorie text not null check (categorie in ('entree','plat','dessert','boisson')),
+  fiche_id uuid not null references public.fiches_techniques(id) on delete restrict,
+  portions numeric not null default 1,
+  prix_unitaire_snapshot numeric,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.rapports_generes (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid not null,
+  module text,
+  type text,
+  periode_debut date,
+  periode_fin date,
+  date_generation timestamptz default now(),
+  chemin_fichier text,
+  created_by uuid
+);
+
+create table if not exists public.settings (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid not null references public.mamas(id) on delete cascade,
+  objectif_marge_pct numeric,
+  objectif_food_cost_pct numeric,
+  primary_color text,
+  secondary_color text,
+  dark_mode boolean,
+  logo_url text,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.user_mama_access (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null,
+  mama_id uuid not null references public.mamas(id) on delete cascade,
+  role text default 'viewer' check (role in ('viewer','manager','admin')),
+  created_at timestamptz default now(),
+  unique (user_id, mama_id)
+);
+
+create table if not exists public.ventes_fiches (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid not null,
+  fiche_id uuid not null references public.fiches_techniques(id) on delete cascade,
+  date_vente date not null,
+  quantite numeric not null default 0,
+  prix_vente_unitaire numeric,
+  created_at timestamptz default now(),
+  unique (mama_id, fiche_id, date_vente)
+);
+
+create table if not exists public.ventes_import_staging (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid not null,
+  fiche_id uuid,
+  date_vente date,
+  quantite numeric,
+  prix_vente_unitaire numeric,
+  statut text default 'pending',
+  created_at timestamptz default now()
+);
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='produits' and column_name='zone_id'
+  ) then
+    alter table public.produits add column zone_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_produits_zone_id'
+  ) then
+    alter table public.produits add constraint fk_produits_zone_id foreign key (zone_id) references public.zones_stock(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='fournisseurs' and column_name='mama_id'
+  ) then
+    alter table public.fournisseurs add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_fournisseurs_mama_id'
+  ) then
+    alter table public.fournisseurs add constraint fk_fournisseurs_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='produits' and column_name='mama_id'
+  ) then
+    alter table public.produits add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_produits_mama_id'
+  ) then
+    alter table public.produits add constraint fk_produits_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='produits' and column_name='fournisseur_id'
+  ) then
+    alter table public.produits add column fournisseur_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_produits_fournisseur_id'
+  ) then
+    alter table public.produits add constraint fk_produits_fournisseur_id foreign key (fournisseur_id) references public.fournisseurs(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='produits' and column_name='unite_id'
+  ) then
+    alter table public.produits add column unite_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_produits_unite_id'
+  ) then
+    alter table public.produits add constraint fk_produits_unite_id foreign key (unite_id) references public.unites(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='produits' and column_name='famille_id'
+  ) then
+    alter table public.produits add column famille_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_produits_famille_id'
+  ) then
+    alter table public.produits add constraint fk_produits_famille_id foreign key (famille_id) references public.familles(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='produits' and column_name='sous_famille_id'
+  ) then
+    alter table public.produits add column sous_famille_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_produits_sous_famille_id'
+  ) then
+    alter table public.produits add constraint fk_produits_sous_famille_id foreign key (sous_famille_id) references public.sous_familles(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='roles' and column_name='mama_id'
+  ) then
+    alter table public.roles add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_roles_mama_id'
+  ) then
+    alter table public.roles add constraint fk_roles_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='utilisateurs' and column_name='mama_id'
+  ) then
+    alter table public.utilisateurs add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_utilisateurs_mama_id'
+  ) then
+    alter table public.utilisateurs add constraint fk_utilisateurs_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='utilisateurs' and column_name='role_id'
+  ) then
+    alter table public.utilisateurs add column role_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_utilisateurs_role_id'
+  ) then
+    alter table public.utilisateurs add constraint fk_utilisateurs_role_id foreign key (role_id) references public.roles(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='commandes' and column_name='mama_id'
+  ) then
+    alter table public.commandes add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_commandes_mama_id'
+  ) then
+    alter table public.commandes add constraint fk_commandes_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='commandes' and column_name='fournisseur_id'
+  ) then
+    alter table public.commandes add column fournisseur_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_commandes_fournisseur_id'
+  ) then
+    alter table public.commandes add constraint fk_commandes_fournisseur_id foreign key (fournisseur_id) references public.fournisseurs(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='commandes' and column_name='created_by'
+  ) then
+    alter table public.commandes add column created_by uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_commandes_created_by'
+  ) then
+    alter table public.commandes add constraint fk_commandes_created_by foreign key (created_by) references public.utilisateurs(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='commandes' and column_name='validated_by'
+  ) then
+    alter table public.commandes add column validated_by uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_commandes_validated_by'
+  ) then
+    alter table public.commandes add constraint fk_commandes_validated_by foreign key (validated_by) references public.utilisateurs(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='commande_lignes' and column_name='commande_id'
+  ) then
+    alter table public.commande_lignes add column commande_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_commande_lignes_commande_id'
+  ) then
+    alter table public.commande_lignes add constraint fk_commande_lignes_commande_id foreign key (commande_id) references public.commandes(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='commande_lignes' and column_name='produit_id'
+  ) then
+    alter table public.commande_lignes add column produit_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_commande_lignes_produit_id'
+  ) then
+    alter table public.commande_lignes add constraint fk_commande_lignes_produit_id foreign key (produit_id) references public.produits(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='commande_lignes' and column_name='mama_id'
+  ) then
+    alter table public.commande_lignes add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_commande_lignes_mama_id'
+  ) then
+    alter table public.commande_lignes add constraint fk_commande_lignes_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='templates_commandes' and column_name='mama_id'
+  ) then
+    alter table public.templates_commandes add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_templates_commandes_mama_id'
+  ) then
+    alter table public.templates_commandes add constraint fk_templates_commandes_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='templates_commandes' and column_name='fournisseur_id'
+  ) then
+    alter table public.templates_commandes add column fournisseur_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_templates_commandes_fournisseur_id'
+  ) then
+    alter table public.templates_commandes add constraint fk_templates_commandes_fournisseur_id foreign key (fournisseur_id) references public.fournisseurs(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='emails_envoyes' and column_name='commande_id'
+  ) then
+    alter table public.emails_envoyes add column commande_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_emails_envoyes_commande_id'
+  ) then
+    alter table public.emails_envoyes add constraint fk_emails_envoyes_commande_id foreign key (commande_id) references public.commandes(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='emails_envoyes' and column_name='mama_id'
+  ) then
+    alter table public.emails_envoyes add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_emails_envoyes_mama_id'
+  ) then
+    alter table public.emails_envoyes add constraint fk_emails_envoyes_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='permissions' and column_name='role_id'
+  ) then
+    alter table public.permissions add column role_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_permissions_role_id'
+  ) then
+    alter table public.permissions add constraint fk_permissions_role_id foreign key (role_id) references public.roles(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='permissions' and column_name='mama_id'
+  ) then
+    alter table public.permissions add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_permissions_mama_id'
+  ) then
+    alter table public.permissions add constraint fk_permissions_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='consentements_utilisateur' and column_name='utilisateur_id'
+  ) then
+    alter table public.consentements_utilisateur add column utilisateur_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_consentements_utilisateur_utilisateur_id'
+  ) then
+    alter table public.consentements_utilisateur add constraint fk_consentements_utilisateur_utilisateur_id foreign key (utilisateur_id) references public.utilisateurs(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='consentements_utilisateur' and column_name='mama_id'
+  ) then
+    alter table public.consentements_utilisateur add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_consentements_utilisateur_mama_id'
+  ) then
+    alter table public.consentements_utilisateur add constraint fk_consentements_utilisateur_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='achats' and column_name='mama_id'
+  ) then
+    alter table public.achats add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_achats_mama_id'
+  ) then
+    alter table public.achats add constraint fk_achats_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='achats' and column_name='produit_id'
+  ) then
+    alter table public.achats add column produit_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_achats_produit_id'
+  ) then
+    alter table public.achats add constraint fk_achats_produit_id foreign key (produit_id) references public.produits(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='achats' and column_name='fournisseur_id'
+  ) then
+    alter table public.achats add column fournisseur_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_achats_fournisseur_id'
+  ) then
+    alter table public.achats add constraint fk_achats_fournisseur_id foreign key (fournisseur_id) references public.fournisseurs(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='alertes' and column_name='mama_id'
+  ) then
+    alter table public.alertes add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_alertes_mama_id'
+  ) then
+    alter table public.alertes add constraint fk_alertes_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='api_keys' and column_name='mama_id'
+  ) then
+    alter table public.api_keys add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_api_keys_mama_id'
+  ) then
+    alter table public.api_keys add constraint fk_api_keys_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='auth_double_facteur' and column_name='mama_id'
+  ) then
+    alter table public.auth_double_facteur add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_auth_double_facteur_mama_id'
+  ) then
+    alter table public.auth_double_facteur add constraint fk_auth_double_facteur_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='bons_livraison' and column_name='mama_id'
+  ) then
+    alter table public.bons_livraison add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_bons_livraison_mama_id'
+  ) then
+    alter table public.bons_livraison add constraint fk_bons_livraison_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='catalogue_updates' and column_name='mama_id'
+  ) then
+    alter table public.catalogue_updates add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_catalogue_updates_mama_id'
+  ) then
+    alter table public.catalogue_updates add constraint fk_catalogue_updates_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='centres_de_cout' and column_name='mama_id'
+  ) then
+    alter table public.centres_de_cout add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_centres_de_cout_mama_id'
+  ) then
+    alter table public.centres_de_cout add constraint fk_centres_de_cout_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='compta_mapping' and column_name='mama_id'
+  ) then
+    alter table public.compta_mapping add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_compta_mapping_mama_id'
+  ) then
+    alter table public.compta_mapping add constraint fk_compta_mapping_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='documentation' and column_name='mama_id'
+  ) then
+    alter table public.documentation add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_documentation_mama_id'
+  ) then
+    alter table public.documentation add constraint fk_documentation_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='documents' and column_name='mama_id'
+  ) then
+    alter table public.documents add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_documents_mama_id'
+  ) then
+    alter table public.documents add constraint fk_documents_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='etapes_onboarding' and column_name='mama_id'
+  ) then
+    alter table public.etapes_onboarding add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_etapes_onboarding_mama_id'
+  ) then
+    alter table public.etapes_onboarding add constraint fk_etapes_onboarding_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='facture_lignes' and column_name='mama_id'
+  ) then
+    alter table public.facture_lignes add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_facture_lignes_mama_id'
+  ) then
+    alter table public.facture_lignes add constraint fk_facture_lignes_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='factures' and column_name='mama_id'
+  ) then
+    alter table public.factures add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_factures_mama_id'
+  ) then
+    alter table public.factures add constraint fk_factures_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='familles' and column_name='mama_id'
+  ) then
+    alter table public.familles add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_familles_mama_id'
+  ) then
+    alter table public.familles add constraint fk_familles_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='feedback' and column_name='mama_id'
+  ) then
+    alter table public.feedback add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_feedback_mama_id'
+  ) then
+    alter table public.feedback add constraint fk_feedback_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='fiche_cout_history' and column_name='mama_id'
+  ) then
+    alter table public.fiche_cout_history add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_fiche_cout_history_mama_id'
+  ) then
+    alter table public.fiche_cout_history add constraint fk_fiche_cout_history_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='fiche_lignes' and column_name='mama_id'
+  ) then
+    alter table public.fiche_lignes add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_fiche_lignes_mama_id'
+  ) then
+    alter table public.fiche_lignes add constraint fk_fiche_lignes_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='fiches' and column_name='mama_id'
+  ) then
+    alter table public.fiches add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_fiches_mama_id'
+  ) then
+    alter table public.fiches add constraint fk_fiches_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='fiches_techniques' and column_name='mama_id'
+  ) then
+    alter table public.fiches_techniques add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_fiches_techniques_mama_id'
+  ) then
+    alter table public.fiches_techniques add constraint fk_fiches_techniques_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='fournisseur_contacts' and column_name='mama_id'
+  ) then
+    alter table public.fournisseur_contacts add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_fournisseur_contacts_mama_id'
+  ) then
+    alter table public.fournisseur_contacts add constraint fk_fournisseur_contacts_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='fournisseur_notes' and column_name='mama_id'
+  ) then
+    alter table public.fournisseur_notes add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_fournisseur_notes_mama_id'
+  ) then
+    alter table public.fournisseur_notes add constraint fk_fournisseur_notes_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='fournisseur_produits' and column_name='mama_id'
+  ) then
+    alter table public.fournisseur_produits add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_fournisseur_produits_mama_id'
+  ) then
+    alter table public.fournisseur_produits add constraint fk_fournisseur_produits_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='fournisseur_produits' and column_name='produit_id'
+  ) then
+    alter table public.fournisseur_produits add column produit_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_fournisseur_produits_produit_id'
+  ) then
+    alter table public.fournisseur_produits add constraint fk_fournisseur_produits_produit_id foreign key (produit_id) references public.produits(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='fournisseur_produits' and column_name='fournisseur_id'
+  ) then
+    alter table public.fournisseur_produits add column fournisseur_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_fournisseur_produits_fournisseur_id'
+  ) then
+    alter table public.fournisseur_produits add constraint fk_fournisseur_produits_fournisseur_id foreign key (fournisseur_id) references public.fournisseurs(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='fournisseurs_api_config' and column_name='mama_id'
+  ) then
+    alter table public.fournisseurs_api_config add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_fournisseurs_api_config_mama_id'
+  ) then
+    alter table public.fournisseurs_api_config add constraint fk_fournisseurs_api_config_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='gadgets' and column_name='mama_id'
+  ) then
+    alter table public.gadgets add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_gadgets_mama_id'
+  ) then
+    alter table public.gadgets add constraint fk_gadgets_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='groupes' and column_name='mama_id'
+  ) then
+    alter table public.groupes add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_groupes_mama_id'
+  ) then
+    alter table public.groupes add constraint fk_groupes_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='guides_seen' and column_name='mama_id'
+  ) then
+    alter table public.guides_seen add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_guides_seen_mama_id'
+  ) then
+    alter table public.guides_seen add constraint fk_guides_seen_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='help_articles' and column_name='mama_id'
+  ) then
+    alter table public.help_articles add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_help_articles_mama_id'
+  ) then
+    alter table public.help_articles add constraint fk_help_articles_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='inventaire_zones' and column_name='mama_id'
+  ) then
+    alter table public.inventaire_zones add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_inventaire_zones_mama_id'
+  ) then
+    alter table public.inventaire_zones add constraint fk_inventaire_zones_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='journaux_utilisateur' and column_name='mama_id'
+  ) then
+    alter table public.journaux_utilisateur add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_journaux_utilisateur_mama_id'
+  ) then
+    alter table public.journaux_utilisateur add constraint fk_journaux_utilisateur_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='lignes_bl' and column_name='mama_id'
+  ) then
+    alter table public.lignes_bl add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_lignes_bl_mama_id'
+  ) then
+    alter table public.lignes_bl add constraint fk_lignes_bl_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='logs_securite' and column_name='mama_id'
+  ) then
+    alter table public.logs_securite add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_logs_securite_mama_id'
+  ) then
+    alter table public.logs_securite add constraint fk_logs_securite_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='menu_fiches' and column_name='mama_id'
+  ) then
+    alter table public.menu_fiches add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_menu_fiches_mama_id'
+  ) then
+    alter table public.menu_fiches add constraint fk_menu_fiches_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='menus' and column_name='mama_id'
+  ) then
+    alter table public.menus add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_menus_mama_id'
+  ) then
+    alter table public.menus add constraint fk_menus_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='menus_groupes' and column_name='mama_id'
+  ) then
+    alter table public.menus_groupes add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_menus_groupes_mama_id'
+  ) then
+    alter table public.menus_groupes add constraint fk_menus_groupes_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='menus_groupes_fiches' and column_name='mama_id'
+  ) then
+    alter table public.menus_groupes_fiches add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_menus_groupes_fiches_mama_id'
+  ) then
+    alter table public.menus_groupes_fiches add constraint fk_menus_groupes_fiches_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='menus_jour' and column_name='mama_id'
+  ) then
+    alter table public.menus_jour add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_menus_jour_mama_id'
+  ) then
+    alter table public.menus_jour add constraint fk_menus_jour_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='menus_jour_fiches' and column_name='mama_id'
+  ) then
+    alter table public.menus_jour_fiches add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_menus_jour_fiches_mama_id'
+  ) then
+    alter table public.menus_jour_fiches add constraint fk_menus_jour_fiches_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='notification_preferences' and column_name='mama_id'
+  ) then
+    alter table public.notification_preferences add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_notification_preferences_mama_id'
+  ) then
+    alter table public.notification_preferences add constraint fk_notification_preferences_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='notifications' and column_name='mama_id'
+  ) then
+    alter table public.notifications add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_notifications_mama_id'
+  ) then
+    alter table public.notifications add constraint fk_notifications_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='parametres_commandes' and column_name='mama_id'
+  ) then
+    alter table public.parametres_commandes add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_parametres_commandes_mama_id'
+  ) then
+    alter table public.parametres_commandes add constraint fk_parametres_commandes_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='pertes' and column_name='mama_id'
+  ) then
+    alter table public.pertes add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_pertes_mama_id'
+  ) then
+    alter table public.pertes add constraint fk_pertes_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='planning_lignes' and column_name='mama_id'
+  ) then
+    alter table public.planning_lignes add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_planning_lignes_mama_id'
+  ) then
+    alter table public.planning_lignes add constraint fk_planning_lignes_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='planning_previsionnel' and column_name='mama_id'
+  ) then
+    alter table public.planning_previsionnel add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_planning_previsionnel_mama_id'
+  ) then
+    alter table public.planning_previsionnel add constraint fk_planning_previsionnel_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='promotions' and column_name='mama_id'
+  ) then
+    alter table public.promotions add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_promotions_mama_id'
+  ) then
+    alter table public.promotions add constraint fk_promotions_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='regles_alertes' and column_name='mama_id'
+  ) then
+    alter table public.regles_alertes add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_regles_alertes_mama_id'
+  ) then
+    alter table public.regles_alertes add constraint fk_regles_alertes_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='signalements' and column_name='mama_id'
+  ) then
+    alter table public.signalements add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_signalements_mama_id'
+  ) then
+    alter table public.signalements add constraint fk_signalements_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='sous_familles' and column_name='mama_id'
+  ) then
+    alter table public.sous_familles add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_sous_familles_mama_id'
+  ) then
+    alter table public.sous_familles add constraint fk_sous_familles_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='sous_familles' and column_name='famille_id'
+  ) then
+    alter table public.sous_familles add column famille_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_sous_familles_famille_id'
+  ) then
+    alter table public.sous_familles add constraint fk_sous_familles_famille_id foreign key (famille_id) references public.familles(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='stocks' and column_name='mama_id'
+  ) then
+    alter table public.stocks add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_stocks_mama_id'
+  ) then
+    alter table public.stocks add constraint fk_stocks_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='tableaux_de_bord' and column_name='mama_id'
+  ) then
+    alter table public.tableaux_de_bord add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_tableaux_de_bord_mama_id'
+  ) then
+    alter table public.tableaux_de_bord add constraint fk_tableaux_de_bord_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='taches' and column_name='mama_id'
+  ) then
+    alter table public.taches add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_taches_mama_id'
+  ) then
+    alter table public.taches add constraint fk_taches_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='tooltips' and column_name='mama_id'
+  ) then
+    alter table public.tooltips add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_tooltips_mama_id'
+  ) then
+    alter table public.tooltips add constraint fk_tooltips_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='transfert_lignes' and column_name='mama_id'
+  ) then
+    alter table public.transfert_lignes add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_transfert_lignes_mama_id'
+  ) then
+    alter table public.transfert_lignes add constraint fk_transfert_lignes_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='transferts' and column_name='mama_id'
+  ) then
+    alter table public.transferts add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_transferts_mama_id'
+  ) then
+    alter table public.transferts add constraint fk_transferts_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='unites' and column_name='mama_id'
+  ) then
+    alter table public.unites add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_unites_mama_id'
+  ) then
+    alter table public.unites add constraint fk_unites_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='usage_stats' and column_name='mama_id'
+  ) then
+    alter table public.usage_stats add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_usage_stats_mama_id'
+  ) then
+    alter table public.usage_stats add constraint fk_usage_stats_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='utilisateurs_taches' and column_name='mama_id'
+  ) then
+    alter table public.utilisateurs_taches add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_utilisateurs_taches_mama_id'
+  ) then
+    alter table public.utilisateurs_taches add constraint fk_utilisateurs_taches_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='validation_requests' and column_name='mama_id'
+  ) then
+    alter table public.validation_requests add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_validation_requests_mama_id'
+  ) then
+    alter table public.validation_requests add constraint fk_validation_requests_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='ventes_boissons' and column_name='mama_id'
+  ) then
+    alter table public.ventes_boissons add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_ventes_boissons_mama_id'
+  ) then
+    alter table public.ventes_boissons add constraint fk_ventes_boissons_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='ventes_fiches_carte' and column_name='mama_id'
+  ) then
+    alter table public.ventes_fiches_carte add column mama_id uuid;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname='fk_ventes_fiches_carte_mama_id'
+  ) then
+    alter table public.ventes_fiches_carte add constraint fk_ventes_fiches_carte_mama_id foreign key (mama_id) references public.mamas(id);
+  end if;
+end$$;
+
+create index if not exists idx_produits_zone_id on public.produits(zone_id);
+
+create index if not exists idx_produits_mama_id on public.produits(mama_id);
+
+create index if not exists idx_produits_fournisseur_id on public.produits(fournisseur_id);
+
+create index if not exists idx_produits_unite_id on public.produits(unite_id);
+
+create index if not exists idx_produits_famille_id on public.produits(famille_id);
+
+create index if not exists idx_produits_sous_famille_id on public.produits(sous_famille_id);
+
+create index if not exists idx_roles_mama_id on public.roles(mama_id);
+
+create index if not exists idx_utilisateurs_mama_id on public.utilisateurs(mama_id);
+
+create index if not exists idx_commandes_mama_id on public.commandes(mama_id);
+
+create index if not exists idx_commandes_fournisseur_id on public.commandes(fournisseur_id);
+
+create index if not exists idx_commande_lignes_commande_id on public.commande_lignes(commande_id);
+
+create index if not exists idx_commande_lignes_mama_id on public.commande_lignes(mama_id);
+
+create index if not exists idx_templates_cmd_mama on public.templates_commandes(mama_id);
+
+create index if not exists idx_templates_cmd_fournisseur on public.templates_commandes(fournisseur_id);
+
+create unique index if not exists uq_templates_cmd_mama_nom_generic on public.templates_commandes(mama_id, nom) where fournisseur_id is null;
+
+create index if not exists idx_emails_envoyes_commande on public.emails_envoyes(commande_id);
+
+create index if not exists idx_emails_envoyes_mama_id on public.emails_envoyes(mama_id);
+
+create index if not exists idx_permissions_role_id on public.permissions(role_id);
+
+create index if not exists idx_permissions_mama_id on public.permissions(mama_id);
+
+create index if not exists idx_consentements_utilisateur_mama_id on public.consentements_utilisateur(mama_id);
+
+create index if not exists idx_achats_mama_id on public.achats(mama_id);
+
+create index if not exists idx_achats_produit_id on public.achats(produit_id);
+
+create index if not exists idx_achats_fournisseur_id on public.achats(fournisseur_id);
+
+create index if not exists idx_achats_date on public.achats(date_achat);
+
+create index if not exists idx_alertes_mama_id on public.alertes(mama_id);
+
+create index if not exists idx_api_keys_mama_id on public.api_keys(mama_id);
+
+create index if not exists idx_auth_double_facteur_mama_id on public.auth_double_facteur(mama_id);
+
+create index if not exists idx_bons_livraison_mama_id on public.bons_livraison(mama_id);
+
+create index if not exists idx_catalogue_updates_mama_id on public.catalogue_updates(mama_id);
+
+create index if not exists idx_centres_de_cout_mama_id on public.centres_de_cout(mama_id);
+
+create index if not exists idx_compta_mapping_mama_id on public.compta_mapping(mama_id);
+
+create index if not exists idx_documentation_mama_id on public.documentation(mama_id);
+
+create index if not exists idx_documents_mama_id on public.documents(mama_id);
+
+create index if not exists idx_etapes_onboarding_mama_id on public.etapes_onboarding(mama_id);
+
+create index if not exists idx_facture_lignes_mama_id on public.facture_lignes(mama_id);
+
+create index if not exists idx_factures_mama_id on public.factures(mama_id);
+
+create index if not exists idx_familles_mama_id on public.familles(mama_id);
+
+create index if not exists idx_feedback_mama_id on public.feedback(mama_id);
+
+create index if not exists idx_fiche_cout_history_mama_id on public.fiche_cout_history(mama_id);
+
+create index if not exists idx_fiche_lignes_mama_id on public.fiche_lignes(mama_id);
+
+create index if not exists idx_fiches_mama_id on public.fiches(mama_id);
+
+create index if not exists idx_fiches_techniques_mama_id on public.fiches_techniques(mama_id);
+
+create index if not exists idx_fournisseur_contacts_mama_id on public.fournisseur_contacts(mama_id);
+
+create index if not exists idx_fournisseur_notes_mama_id on public.fournisseur_notes(mama_id);
+
+create index if not exists idx_fournisseur_produits_mama_id on public.fournisseur_produits(mama_id);
+
+create index if not exists idx_fournisseur_produits_produit_id on public.fournisseur_produits(produit_id);
+
+create index if not exists idx_fournisseur_produits_fournisseur_id on public.fournisseur_produits(fournisseur_id);
+
+create index if not exists idx_fournisseurs_api_config_mama_id on public.fournisseurs_api_config(mama_id);
+
+create index if not exists idx_gadgets_mama_id on public.gadgets(mama_id);
+
+create index if not exists idx_groupes_mama_id on public.groupes(mama_id);
+
+create index if not exists idx_guides_seen_mama_id on public.guides_seen(mama_id);
+
+create index if not exists idx_help_articles_mama_id on public.help_articles(mama_id);
+
+create index if not exists idx_inventaire_zones_mama_id on public.inventaire_zones(mama_id);
+
+create index if not exists idx_inventaires_mama_id on public.inventaires(mama_id);
+
+create index if not exists idx_inventaires_periode_id on public.inventaires(periode_id);
+
+create index if not exists idx_produits_inventaire_mama_id on public.produits_inventaire(mama_id);
+
+create index if not exists idx_produits_inventaire_inventaire_id on public.produits_inventaire(inventaire_id);
+
+create index if not exists idx_journaux_utilisateur_mama_id on public.journaux_utilisateur(mama_id);
+
+create index if not exists idx_lignes_bl_mama_id on public.lignes_bl(mama_id);
+
+create index if not exists idx_logs_securite_mama_id on public.logs_securite(mama_id);
+
+create index if not exists idx_menu_fiches_mama_id on public.menu_fiches(mama_id);
+
+create index if not exists idx_menus_mama_id on public.menus(mama_id);
+
+create index if not exists idx_menus_groupes_mama_id on public.menus_groupes(mama_id);
+
+create index if not exists idx_menus_groupes_fiches_mama_id on public.menus_groupes_fiches(mama_id);
+
+create index if not exists idx_menus_jour_mama_id on public.menus_jour(mama_id);
+
+create index if not exists idx_menus_jour_fiches_mama_id on public.menus_jour_fiches(mama_id);
+
+create index if not exists idx_notification_preferences_mama_id on public.notification_preferences(mama_id);
+
+create index if not exists idx_notifications_mama_id on public.notifications(mama_id);
+
+create index if not exists idx_parametres_commandes_mama_id on public.parametres_commandes(mama_id);
+
+create index if not exists idx_periodes_comptables_mama_id on public.periodes_comptables(mama_id);
+
+create index if not exists idx_pertes_mama_id on public.pertes(mama_id);
+
+create index if not exists idx_planning_lignes_mama_id on public.planning_lignes(mama_id);
+
+create index if not exists idx_planning_previsionnel_mama_id on public.planning_previsionnel(mama_id);
+
+create index if not exists idx_promotions_mama_id on public.promotions(mama_id);
+
+create index if not exists idx_regles_alertes_mama_id on public.regles_alertes(mama_id);
+
+create index if not exists idx_requisitions_mama_id on public.requisitions(mama_id);
+
+create index if not exists idx_requisitions_zone on public.requisitions(zone_id);
+
+create index if not exists idx_requisition_lignes_requisition on public.requisition_lignes(requisition_id);
+
+create index if not exists idx_requisition_lignes_mama_id on public.requisition_lignes(mama_id);
+
+create index if not exists idx_signalements_mama_id on public.signalements(mama_id);
+
+create index if not exists idx_sous_familles_mama_id on public.sous_familles(mama_id);
+
+create index if not exists idx_stocks_mama_id on public.stocks(mama_id);
+
+create index if not exists idx_tableaux_de_bord_mama_id on public.tableaux_de_bord(mama_id);
+
+create index if not exists idx_taches_mama_id on public.taches(mama_id);
+
+create index if not exists idx_tooltips_mama_id on public.tooltips(mama_id);
+
+create index if not exists idx_transfert_lignes_mama_id on public.transfert_lignes(mama_id);
+
+create index if not exists idx_transferts_mama_id on public.transferts(mama_id);
+
+create index if not exists idx_unites_mama_id on public.unites(mama_id);
+
+create index if not exists idx_usage_stats_mama_id on public.usage_stats(mama_id);
+
+create index if not exists idx_utilisateurs_taches_mama_id on public.utilisateurs_taches(mama_id);
+
+create index if not exists idx_validation_requests_mama_id on public.validation_requests(mama_id);
+
+create index if not exists idx_ventes_boissons_mama_id on public.ventes_boissons(mama_id);
+
+create index if not exists idx_ventes_fiches_carte_mama_id on public.ventes_fiches_carte(mama_id);
+
+create index if not exists idx_zones_mama_pos on public.zones_stock(mama_id, position);
+
+create index if not exists idx_zones_parent on public.zones_stock(parent_id);
+
+create index if not exists idx_zones_droits_zone on public.zones_droits(zone_id);
+
+create index if not exists idx_zones_droits_user on public.zones_droits(user_id);
+
+create index if not exists idx_menu_groupes_mama on public.menu_groupes(mama_id);
+
+create index if not exists idx_menu_groupe_lignes_menu on public.menu_groupe_lignes(menu_groupe_id);
+
+create index if not exists idx_menu_groupe_lignes_fiche on public.menu_groupe_lignes(fiche_id);
+
+create index if not exists idx_menu_groupe_modeles_mama on public.menu_groupe_modeles(mama_id);
+
+create index if not exists idx_menu_groupe_modele_lignes_modele on public.menu_groupe_modele_lignes(modele_id);
+
+create index if not exists idx_alertes_rupture_mama on public.alertes_rupture(mama_id);
+
+create index if not exists idx_logs_activite_mama on public.logs_activite(mama_id, date_log desc);
+
+create index if not exists idx_menus_jour_lignes_menu on public.menus_jour_lignes(menu_id);
+
+create index if not exists idx_menus_jour_lignes_fiche on public.menus_jour_lignes(fiche_id);
+
+create index if not exists idx_rapports_generes_mama on public.rapports_generes(mama_id);
+
+create index if not exists idx_settings_mama on public.settings(mama_id);
+
+create index if not exists idx_ventes_fiches_mama on public.ventes_fiches(mama_id);
+
+create index if not exists idx_vis_mama on public.ventes_import_staging(mama_id);
+
+create index if not exists idx_pz_mama on public.produits_zones(mama_id);
+
+create index if not exists idx_pz_zone on public.produits_zones(zone_id);
+
+create index if not exists idx_pz_prod on public.produits_zones(produit_id);
+
+alter table public.fournisseurs enable row level security;
+
+alter table public.produits enable row level security;
+
+alter table public.roles enable row level security;
+
+alter table public.utilisateurs enable row level security;
+
+alter table public.commandes enable row level security;
+
+alter table public.commande_lignes enable row level security;
+
+alter table public.templates_commandes enable row level security;
+
+alter table public.emails_envoyes enable row level security;
+
+alter table public.permissions enable row level security;
+
+alter table public.consentements_utilisateur enable row level security;
+
+alter table public.achats enable row level security;
+
+alter table public.alertes enable row level security;
+
+alter table public.api_keys enable row level security;
+
+alter table public.auth_double_facteur enable row level security;
+
+alter table public.bons_livraison enable row level security;
+
+alter table public.catalogue_updates enable row level security;
+
+alter table public.centres_de_cout enable row level security;
+
+alter table public.compta_mapping enable row level security;
+
+alter table public.documentation enable row level security;
+
+alter table public.documents enable row level security;
+
+alter table public.etapes_onboarding enable row level security;
+
+alter table public.facture_lignes enable row level security;
+
+alter table public.factures enable row level security;
+
+alter table public.familles enable row level security;
+
+alter table public.feedback enable row level security;
+
+alter table public.fiche_cout_history enable row level security;
+
+alter table public.fiche_lignes enable row level security;
+
+alter table public.fiches enable row level security;
+
+alter table public.fiches_techniques enable row level security;
+
+alter table public.fournisseur_contacts enable row level security;
+
+alter table public.fournisseur_notes enable row level security;
+
+alter table public.fournisseur_produits enable row level security;
+
+alter table public.fournisseurs_api_config enable row level security;
+
+alter table public.gadgets enable row level security;
+
+alter table public.groupes enable row level security;
+
+alter table public.guides_seen enable row level security;
+
+alter table public.help_articles enable row level security;
+
+alter table public.inventaire_zones enable row level security;
+
+alter table public.inventaires enable row level security;
+
+alter table public.produits_inventaire enable row level security;
+
+alter table public.journaux_utilisateur enable row level security;
+
+alter table public.lignes_bl enable row level security;
+
+alter table public.logs_securite enable row level security;
+
+alter table public.menu_fiches enable row level security;
+
+alter table public.menus enable row level security;
+
+alter table public.menus_groupes enable row level security;
+
+alter table public.menus_groupes_fiches enable row level security;
+
+alter table public.menus_jour enable row level security;
+
+alter table public.menus_jour_fiches enable row level security;
+
+alter table public.notification_preferences enable row level security;
+
+alter table public.notifications enable row level security;
+
+alter table public.parametres_commandes enable row level security;
+
+alter table public.periodes_comptables enable row level security;
+
+alter table public.pertes enable row level security;
+
+alter table public.planning_lignes enable row level security;
+
+alter table public.planning_previsionnel enable row level security;
+
+alter table public.promotions enable row level security;
+
+alter table public.regles_alertes enable row level security;
+
+alter table public.requisitions enable row level security;
+
+alter table public.requisition_lignes enable row level security;
+
+alter table public.signalements enable row level security;
+
+alter table public.sous_familles enable row level security;
+
+alter table public.stocks enable row level security;
+
+alter table public.tableaux_de_bord enable row level security;
+
+alter table public.taches enable row level security;
+
+alter table public.tooltips enable row level security;
+
+alter table public.transfert_lignes enable row level security;
+
+alter table public.transferts enable row level security;
+
+alter table public.unites enable row level security;
+
+alter table public.usage_stats enable row level security;
+
+alter table public.utilisateurs_taches enable row level security;
+
+alter table public.validation_requests enable row level security;
+
+alter table public.ventes_boissons enable row level security;
+
+alter table public.ventes_fiches_carte enable row level security;
+
+alter table public.zones_droits enable row level security;
+
+alter table public.menu_groupes enable row level security;
+
+alter table public.menu_groupe_lignes enable row level security;
+
+alter table public.menu_groupe_modeles enable row level security;
+
+alter table public.menu_groupe_modele_lignes enable row level security;
+
+alter table public.alertes_rupture enable row level security;
+
+alter table public.logs_activite enable row level security;
+
+alter table public.menus_jour_lignes enable row level security;
+
+alter table public.rapports_generes enable row level security;
+
+alter table public.settings enable row level security;
+
+alter table public.user_mama_access enable row level security;
+
+alter table public.ventes_fiches enable row level security;
+
+alter table public.ventes_import_staging enable row level security;
+
+alter table public.produits_zones enable row level security;
+
+alter table if exists public.fournisseurs enable row level security;
+
+alter table if exists public.produits enable row level security;
+
+alter table if exists public.roles enable row level security;
+
+alter table if exists public.utilisateurs enable row level security;
+
+alter table if exists public.commandes enable row level security;
+
+alter table if exists public.commande_lignes enable row level security;
+
+alter table if exists public.templates_commandes enable row level security;
+
+alter table if exists public.emails_envoyes enable row level security;
+
+alter table if exists public.permissions enable row level security;
+
+alter table if exists public.consentements_utilisateur enable row level security;
+
+alter table if exists public.achats enable row level security;
+
+alter table if exists public.alertes enable row level security;
+
+alter table if exists public.api_keys enable row level security;
+
+alter table if exists public.auth_double_facteur enable row level security;
+
+alter table if exists public.bons_livraison enable row level security;
+
+alter table if exists public.catalogue_updates enable row level security;
+
+alter table if exists public.centres_de_cout enable row level security;
+
+alter table if exists public.compta_mapping enable row level security;
+
+alter table if exists public.documentation enable row level security;
+
+alter table if exists public.documents enable row level security;
+
+alter table if exists public.etapes_onboarding enable row level security;
+
+alter table if exists public.facture_lignes enable row level security;
+
+alter table if exists public.factures enable row level security;
+
+alter table if exists public.familles enable row level security;
+
+alter table if exists public.feedback enable row level security;
+
+alter table if exists public.fiche_cout_history enable row level security;
+
+alter table if exists public.fiche_lignes enable row level security;
+
+alter table if exists public.fiches enable row level security;
+
+alter table if exists public.fiches_techniques enable row level security;
+
+alter table if exists public.fournisseur_contacts enable row level security;
+
+alter table if exists public.fournisseur_notes enable row level security;
+
+alter table if exists public.fournisseur_produits enable row level security;
+
+alter table if exists public.fournisseurs_api_config enable row level security;
+
+alter table if exists public.gadgets enable row level security;
+
+alter table if exists public.groupes enable row level security;
+
+alter table if exists public.guides_seen enable row level security;
+
+alter table if exists public.help_articles enable row level security;
+
+alter table if exists public.inventaire_zones enable row level security;
+
+alter table if exists public.inventaires enable row level security;
+
+alter table if exists public.produits_inventaire enable row level security;
+
+alter table if exists public.journaux_utilisateur enable row level security;
+
+alter table if exists public.lignes_bl enable row level security;
+
+alter table if exists public.logs_securite enable row level security;
+
+alter table if exists public.menu_fiches enable row level security;
+
+alter table if exists public.menus enable row level security;
+
+alter table if exists public.menus_groupes enable row level security;
+
+alter table if exists public.menus_groupes_fiches enable row level security;
+
+alter table if exists public.menus_jour enable row level security;
+
+alter table if exists public.menus_jour_fiches enable row level security;
+
+alter table if exists public.notification_preferences enable row level security;
+
+alter table if exists public.notifications enable row level security;
+
+alter table if exists public.parametres_commandes enable row level security;
+
+alter table if exists public.periodes_comptables enable row level security;
+
+alter table if exists public.pertes enable row level security;
+
+alter table if exists public.planning_lignes enable row level security;
+
+alter table if exists public.planning_previsionnel enable row level security;
+
+alter table if exists public.promotions enable row level security;
+
+alter table if exists public.regles_alertes enable row level security;
+
+alter table if exists public.requisitions enable row level security;
+
+alter table if exists public.requisition_lignes enable row level security;
+
+alter table if exists public.signalements enable row level security;
+
+alter table if exists public.sous_familles enable row level security;
+
+alter table if exists public.stocks enable row level security;
+
+alter table if exists public.tableaux_de_bord enable row level security;
+
+alter table if exists public.taches enable row level security;
+
+alter table if exists public.tooltips enable row level security;
+
+alter table if exists public.transfert_lignes enable row level security;
+
+alter table if exists public.transferts enable row level security;
+
+alter table if exists public.unites enable row level security;
+
+alter table if exists public.usage_stats enable row level security;
+
+alter table if exists public.utilisateurs_taches enable row level security;
+
+alter table if exists public.validation_requests enable row level security;
+
+alter table if exists public.ventes_boissons enable row level security;
+
+alter table if exists public.ventes_fiches_carte enable row level security;
+
+alter table if exists public.zones_droits enable row level security;
+
+alter table if exists public.menu_groupes enable row level security;
+
+alter table if exists public.menu_groupe_lignes enable row level security;
+
+alter table if exists public.menu_groupe_modeles enable row level security;
+
+alter table if exists public.menu_groupe_modele_lignes enable row level security;
+
+alter table if exists public.alertes_rupture enable row level security;
+
+alter table if exists public.logs_activite enable row level security;
+
+alter table if exists public.menus_jour_lignes enable row level security;
+
+alter table if exists public.rapports_generes enable row level security;
+
+alter table if exists public.settings enable row level security;
+
+alter table if exists public.user_mama_access enable row level security;
+
+alter table if exists public.ventes_fiches enable row level security;
+
+alter table if exists public.ventes_import_staging enable row level security;
+
+alter table if exists public.produits_zones enable row level security;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname='public'
+      and tablename='requisitions'
+      and policyname='requisitions_select'
+  ) then
+    create policy requisitions_select on public.requisitions for select using (mama_id = current_user_mama_id());
+;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname='public'
+      and tablename='requisitions'
+      and policyname='requisitions_insert'
+  ) then
+    create policy requisitions_insert on public.requisitions for insert with check (
+  mama_id = current_user_mama_id()
+  and exists (
+    select 1 from public.zones_stock z
+    where z.id = zone_id and z.mama_id = mama_id and z.type in ('cave','shop')
+  )
+);
+;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname='public'
+      and tablename='requisitions'
+      and policyname='requisitions_update'
+  ) then
+    create policy requisitions_update on public.requisitions for update using (mama_id = current_user_mama_id());
+;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname='public'
+      and tablename='requisitions'
+      and policyname='requisitions_delete'
+  ) then
+    create policy requisitions_delete on public.requisitions for delete using (mama_id = current_user_mama_id());
+;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname='public'
+      and tablename='requisition_lignes'
+      and policyname='requisition_lignes_select'
+  ) then
+    create policy requisition_lignes_select on public.requisition_lignes for select using (mama_id = current_user_mama_id());
+;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname='public'
+      and tablename='requisition_lignes'
+      and policyname='requisition_lignes_insert'
+  ) then
+    create policy requisition_lignes_insert on public.requisition_lignes for insert with check (mama_id = current_user_mama_id());
+;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname='public'
+      and tablename='requisition_lignes'
+      and policyname='requisition_lignes_update'
+  ) then
+    create policy requisition_lignes_update on public.requisition_lignes for update using (mama_id = current_user_mama_id());
+;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname='public'
+      and tablename='requisition_lignes'
+      and policyname='requisition_lignes_delete'
+  ) then
+    create policy requisition_lignes_delete on public.requisition_lignes for delete using (mama_id = current_user_mama_id());
+;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname='public'
+      and tablename='zones_stock'
+      and policyname='zones_stock_select'
+  ) then
+    create policy zones_stock_select on public.zones_stock for select using (
+    mama_id = current_user_mama_id()
+    and exists (
+      select 1 from public.zones_droits zd
+      where zd.zone_id = zones_stock.id
+        and zd.user_id = auth.uid()
+        and zd.lecture = true
+        and zd.mama_id = zones_stock.mama_id
+    )
+  );
+;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname='public'
+      and tablename='zones_stock'
+      and policyname='zones_stock_admin_iud'
+  ) then
+    create policy zones_stock_admin_iud on public.zones_stock for all using (mama_id = current_user_mama_id() and current_user_is_admin_or_manager())
+  with check (mama_id = current_user_mama_id() and current_user_is_admin_or_manager());
+;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname='public'
+      and tablename='zones_droits'
+      and policyname='zones_droits_admin_all'
+  ) then
+    create policy zones_droits_admin_all on public.zones_droits for all using (mama_id = current_user_mama_id() and current_user_is_admin())
+  with check (mama_id = current_user_mama_id() and current_user_is_admin());
+;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname='public'
+      and tablename='alertes_rupture'
+      and policyname='alertes_rupture_all'
+  ) then
+    create policy alertes_rupture_all on public.alertes_rupture for all using (mama_id = current_user_mama_id()) with check (mama_id = current_user_mama_id());
+;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname='public'
+      and tablename='logs_activite'
+      and policyname='logs_activite_all'
+  ) then
+    create policy logs_activite_all on public.logs_activite for all using (mama_id = current_user_mama_id()) with check (mama_id = current_user_mama_id());
+;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname='public'
+      and tablename='menus_jour_lignes'
+      and policyname='menus_jour_lignes_all'
+  ) then
+    create policy menus_jour_lignes_all on public.menus_jour_lignes for all using (mama_id = current_user_mama_id()) with check (mama_id = current_user_mama_id());
+;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname='public'
+      and tablename='rapports_generes'
+      and policyname='rapports_generes_all'
+  ) then
+    create policy rapports_generes_all on public.rapports_generes for all using (mama_id = current_user_mama_id()) with check (mama_id = current_user_mama_id());
+;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname='public'
+      and tablename='settings'
+      and policyname='settings_all'
+  ) then
+    create policy settings_all on public.settings for all using (mama_id = current_user_mama_id()) with check (mama_id = current_user_mama_id());
+;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname='public'
+      and tablename='user_mama_access'
+      and policyname='user_mama_access_select'
+  ) then
+    create policy user_mama_access_select on public.user_mama_access for select using (user_id = auth.uid());
+;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname='public'
+      and tablename='user_mama_access'
+      and policyname='user_mama_access_modify'
+  ) then
+    create policy user_mama_access_modify on public.user_mama_access for all using (current_user_is_admin()) with check (current_user_is_admin());
+;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname='public'
+      and tablename='ventes_fiches'
+      and policyname='ventes_fiches_all'
+  ) then
+    create policy ventes_fiches_all on public.ventes_fiches for all using (mama_id = current_user_mama_id()) with check (mama_id = current_user_mama_id());
+;
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname='public'
+      and tablename='ventes_import_staging'
+      and policyname='ventes_import_staging_all'
+  ) then
+    create policy ventes_import_staging_all on public.ventes_import_staging for all using (mama_id = current_user_mama_id()) with check (mama_id = current_user_mama_id());
+;
+  end if;
+end$$;
+
+create policy if not exists pz_select on public.produits_zones
+  for select using (mama_id = current_user_mama_id());
+
+create policy if not exists pz_iud on public.produits_zones
+  for all using (mama_id = current_user_mama_id())
+  with check (mama_id = current_user_mama_id());
+
+grant execute on function public.get_template_commande(uuid, uuid) to authenticated;
+
+grant execute on function public.current_user_mama_id() to authenticated;
+
+grant execute on function public.current_user_is_admin_or_manager() to authenticated;
+
+grant execute on function public.current_user_is_admin() to authenticated;
+
+grant select, insert, update, delete on public.fournisseurs to authenticated;
+
+grant select, insert, update, delete on public.produits to authenticated;
+
+grant select, insert, update on public.roles to authenticated;
+
+grant select, insert, update on public.utilisateurs to authenticated;
+
+grant select, insert, update, delete on public.commandes to authenticated;
+
+grant select, insert, update, delete on public.commande_lignes to authenticated;
+
+grant select, insert, update, delete on public.templates_commandes to authenticated;
+
+grant select, insert, update, delete on public.emails_envoyes to authenticated;
+
+grant select, insert, update on public.permissions to authenticated;
+
+grant select on public.utilisateurs_complets to authenticated;
+
+grant select, insert, update, delete on public.consentements_utilisateur to authenticated;
+
+grant execute on function public.create_utilisateur(text, text, uuid, uuid) to authenticated;
+
+grant execute on function public.calcul_ecarts_inventaire(date, text, uuid) to authenticated;
+
+grant execute on function public.fn_calc_budgets(uuid, text) to authenticated;
+
+grant select, insert, update, delete on public.achats to authenticated;
+
+grant select, insert, update, delete on public.alertes to authenticated;
+
+grant select, insert, update, delete on public.api_keys to authenticated;
+
+grant select, insert, update, delete on public.auth_double_facteur to authenticated;
+
+grant select, insert, update, delete on public.bons_livraison to authenticated;
+
+grant select, insert, update, delete on public.catalogue_updates to authenticated;
+
+grant select, insert, update, delete on public.centres_de_cout to authenticated;
+
+grant select, insert, update, delete on public.compta_mapping to authenticated;
+
+grant select, insert, update, delete on public.documentation to authenticated;
+
+grant select, insert, update, delete on public.documents to authenticated;
+
+grant select, insert, update, delete on public.etapes_onboarding to authenticated;
+
+grant select, insert, update, delete on public.facture_lignes to authenticated;
+
+grant select, insert, update, delete on public.factures to authenticated;
+
+grant select, insert, update, delete on public.familles to authenticated;
+
+grant select, insert, update, delete on public.feedback to authenticated;
+
+grant select, insert, update, delete on public.fiche_cout_history to authenticated;
+
+grant select, insert, update, delete on public.fiche_lignes to authenticated;
+
+grant select, insert, update, delete on public.fiches to authenticated;
+
+grant select, insert, update, delete on public.fiches_techniques to authenticated;
+
+grant select, insert, update, delete on public.fournisseur_contacts to authenticated;
+
+grant select, insert, update, delete on public.fournisseur_notes to authenticated;
+
+grant select, insert, update, delete on public.fournisseur_produits to authenticated;
+
+grant select, insert, update, delete on public.fournisseurs_api_config to authenticated;
+
+grant select, insert, update, delete on public.gadgets to authenticated;
+
+grant select, insert, update, delete on public.groupes to authenticated;
+
+grant select, insert, update, delete on public.guides_seen to authenticated;
+
+grant select, insert, update, delete on public.help_articles to authenticated;
+
+grant select, insert, update, delete on public.inventaire_zones to authenticated;
+
+grant select, insert, update, delete on public.inventaires to authenticated;
+
+grant select, insert, update, delete on public.produits_inventaire to authenticated;
+
+grant select, insert, update, delete on public.journaux_utilisateur to authenticated;
+
+grant select, insert, update, delete on public.lignes_bl to authenticated;
+
+grant select, insert, update, delete on public.logs_securite to authenticated;
+
+grant select, insert, update, delete on public.menu_fiches to authenticated;
+
+grant select, insert, update, delete on public.menus to authenticated;
+
+grant select, insert, update, delete on public.menus_groupes to authenticated;
+
+grant select, insert, update, delete on public.menus_groupes_fiches to authenticated;
+
+grant select, insert, update, delete on public.menus_jour to authenticated;
+
+grant select, insert, update, delete on public.menus_jour_fiches to authenticated;
+
+grant select, insert, update, delete on public.notification_preferences to authenticated;
+
+grant select, insert, update, delete on public.notifications to authenticated;
+
+grant select, insert, update, delete on public.parametres_commandes to authenticated;
+
+grant select, insert, update, delete on public.periodes_comptables to authenticated;
+
+grant select, insert, update, delete on public.pertes to authenticated;
+
+grant select, insert, update, delete on public.planning_lignes to authenticated;
+
+grant select, insert, update, delete on public.planning_previsionnel to authenticated;
+
+grant select, insert, update, delete on public.promotions to authenticated;
+
+grant select, insert, update, delete on public.regles_alertes to authenticated;
+
+grant select, insert, update, delete on public.requisitions to authenticated;
+
+grant select, insert, update, delete on public.requisition_lignes to authenticated;
+
+grant select, insert, update, delete on public.signalements to authenticated;
+
+grant select, insert, update, delete on public.sous_familles to authenticated;
+
+grant select, insert, update, delete on public.stocks to authenticated;
+
+grant select, insert, update, delete on public.tableaux_de_bord to authenticated;
+
+grant select, insert, update, delete on public.taches to authenticated;
+
+grant select, insert, update, delete on public.tooltips to authenticated;
+
+grant select, insert, update, delete on public.transfert_lignes to authenticated;
+
+grant select, insert, update, delete on public.transferts to authenticated;
+
+grant select, insert, update, delete on public.unites to authenticated;
+
+grant select, insert, update, delete on public.usage_stats to authenticated;
+
+grant select, insert, update, delete on public.utilisateurs_taches to authenticated;
+
+grant select, insert, update, delete on public.validation_requests to authenticated;
+
+grant select, insert, update, delete on public.ventes_boissons to authenticated;
+
+grant select, insert, update, delete on public.ventes_fiches_carte to authenticated;
+
+grant select, insert, update, delete on public.zones_stock, public.zones_droits to authenticated;
+
+grant select on public.v_achats_mensuels to authenticated;
+
+grant select on public.v_analytique_stock to authenticated;
+
+grant select on public.v_besoins_previsionnels to authenticated;
+
+grant select on public.v_boissons to authenticated;
+
+grant select on public.v_cost_center_month to authenticated;
+
+grant select on public.v_cost_center_monthly to authenticated;
+
+grant select on public.v_evolution_achats to authenticated;
+
+grant select on public.v_pmp to authenticated;
+
+grant select on public.v_produits_dernier_prix to authenticated;
+
+grant select on public.v_stocks to authenticated;
+
+grant select on public.v_products_last_price to authenticated;
+
+grant select on public.v_fournisseurs_inactifs to authenticated;
+
+grant select on public.v_produits_utilises to authenticated;
+
+grant select on public.v_reco_stockmort to authenticated;
+
+grant select on public.v_reco_surcout to authenticated;
+
+grant select on public.v_stock_requisitionne to authenticated;
+
+grant select on public.v_taches_assignees to authenticated;
+
+grant select on public.v_tendance_prix_produit to authenticated;
+
+grant select on public.v_top_fournisseurs to authenticated;
+
+grant select on public.v_couts_fiches to authenticated;
+
+grant select on public.v_performance_fiches to authenticated;
+
+grant execute on function public.advanced_stats() to authenticated;
+
+grant execute on function public.apply_stock_from_achat() to authenticated;
+
+grant execute on function public.calcul_ecarts_inventaire() to authenticated;
+
+grant execute on function public.compare_fiche() to authenticated;
+
+grant execute on function public.consolidated_stats() to authenticated;
+
+grant execute on function public.dashboard_stats() to authenticated;
+
+grant execute on function public.disable_two_fa() to authenticated;
+
+grant execute on function public.enable_two_fa() to authenticated;
+
+grant execute on function public.import_invoice() to authenticated;
+
+grant execute on function public.send_email_notification() to authenticated;
+
+grant execute on function public.send_notification_webhook() to authenticated;
+
+grant execute on function public.stats_achats_fournisseur(uuid, uuid) to authenticated;
+
+grant execute on function public.stats_achats_fournisseurs(uuid) to authenticated;
+
+grant execute on function public.stats_cost_centers() to authenticated;
+
+grant execute on function public.stats_multi_mamas() to authenticated;
+
+grant execute on function public.stats_rotation_produit() to authenticated;
+
+grant execute on function public.top_produits(uuid, date, date, integer) to authenticated;
+
+grant select, insert, update, delete on public.menu_groupes to authenticated;
+
+grant select, insert, update, delete on public.menu_groupe_lignes to authenticated;
+
+grant select, insert, update, delete on public.menu_groupe_modeles to authenticated;
+
+grant select, insert, update, delete on public.menu_groupe_modele_lignes to authenticated;
+
+grant select, insert, update, delete on public.alertes_rupture to authenticated;
+
+grant select, insert on public.logs_activite to authenticated;
+
+grant select, insert, update, delete on public.menus_jour_lignes to authenticated;
+
+grant select, insert on public.rapports_generes to authenticated;
+
+grant select, insert, update on public.settings to authenticated;
+
+grant select, insert, update, delete on public.user_mama_access to authenticated;
+
+grant select, insert, update, delete on public.ventes_fiches to authenticated;
+
+grant select, insert, update, delete on public.ventes_import_staging to authenticated;
+
+grant execute on function public.log_action(uuid, text, text, text, jsonb, boolean) to authenticated;
+
+grant select, insert, update, delete on public.produits_zones to authenticated;
+
+grant select on public.v_produits_par_zone to authenticated;
+
+grant execute on function public.move_zone_products(uuid,uuid,uuid,boolean) to authenticated;
+
+grant execute on function public.copy_zone_products(uuid,uuid,uuid,boolean) to authenticated;
+
+grant execute on function public.merge_zone_products(uuid,uuid,uuid) to authenticated;
+
+grant execute on function public.safe_delete_zone(uuid,uuid,uuid) to authenticated;
+
+grant select, insert, update, delete on table public.fournisseurs to authenticated;
+
+grant select, insert, update, delete on table public.produits to authenticated;
+
+grant select, insert, update, delete on table public.roles to authenticated;
+
+grant select, insert, update, delete on table public.utilisateurs to authenticated;
+
+grant select, insert, update, delete on table public.commandes to authenticated;
+
+grant select, insert, update, delete on table public.commande_lignes to authenticated;
+
+grant select, insert, update, delete on table public.templates_commandes to authenticated;
+
+grant select, insert, update, delete on table public.emails_envoyes to authenticated;
+
+grant select, insert, update, delete on table public.permissions to authenticated;
+
+grant select, insert, update, delete on table public.consentements_utilisateur to authenticated;
+
+grant select, insert, update, delete on table public.achats to authenticated;
+
+grant select, insert, update, delete on table public.alertes to authenticated;
+
+grant select, insert, update, delete on table public.api_keys to authenticated;
+
+grant select, insert, update, delete on table public.auth_double_facteur to authenticated;
+
+grant select, insert, update, delete on table public.bons_livraison to authenticated;
+
+grant select, insert, update, delete on table public.catalogue_updates to authenticated;
+
+grant select, insert, update, delete on table public.centres_de_cout to authenticated;
+
+grant select, insert, update, delete on table public.compta_mapping to authenticated;
+
+grant select, insert, update, delete on table public.documentation to authenticated;
+
+grant select, insert, update, delete on table public.documents to authenticated;
+
+grant select, insert, update, delete on table public.etapes_onboarding to authenticated;
+
+grant select, insert, update, delete on table public.facture_lignes to authenticated;
+
+grant select, insert, update, delete on table public.factures to authenticated;
+
+grant select, insert, update, delete on table public.familles to authenticated;
+
+grant select, insert, update, delete on table public.feedback to authenticated;
+
+grant select, insert, update, delete on table public.fiche_cout_history to authenticated;
+
+grant select, insert, update, delete on table public.fiche_lignes to authenticated;
+
+grant select, insert, update, delete on table public.fiches to authenticated;
+
+grant select, insert, update, delete on table public.fiches_techniques to authenticated;
+
+grant select, insert, update, delete on table public.fournisseur_contacts to authenticated;
+
+grant select, insert, update, delete on table public.fournisseur_notes to authenticated;
+
+grant select, insert, update, delete on table public.fournisseur_produits to authenticated;
+
+grant select, insert, update, delete on table public.fournisseurs_api_config to authenticated;
+
+grant select, insert, update, delete on table public.gadgets to authenticated;
+
+grant select, insert, update, delete on table public.groupes to authenticated;
+
+grant select, insert, update, delete on table public.guides_seen to authenticated;
+
+grant select, insert, update, delete on table public.help_articles to authenticated;
+
+grant select, insert, update, delete on table public.inventaire_zones to authenticated;
+
+grant select, insert, update, delete on table public.inventaires to authenticated;
+
+grant select, insert, update, delete on table public.produits_inventaire to authenticated;
+
+grant select, insert, update, delete on table public.journaux_utilisateur to authenticated;
+
+grant select, insert, update, delete on table public.lignes_bl to authenticated;
+
+grant select, insert, update, delete on table public.logs_securite to authenticated;
+
+grant select, insert, update, delete on table public.menu_fiches to authenticated;
+
+grant select, insert, update, delete on table public.menus to authenticated;
+
+grant select, insert, update, delete on table public.menus_groupes to authenticated;
+
+grant select, insert, update, delete on table public.menus_groupes_fiches to authenticated;
+
+grant select, insert, update, delete on table public.menus_jour to authenticated;
+
+grant select, insert, update, delete on table public.menus_jour_fiches to authenticated;
+
+grant select, insert, update, delete on table public.notification_preferences to authenticated;
+
+grant select, insert, update, delete on table public.notifications to authenticated;
+
+grant select, insert, update, delete on table public.parametres_commandes to authenticated;
+
+grant select, insert, update, delete on table public.periodes_comptables to authenticated;
+
+grant select, insert, update, delete on table public.pertes to authenticated;
+
+grant select, insert, update, delete on table public.planning_lignes to authenticated;
+
+grant select, insert, update, delete on table public.planning_previsionnel to authenticated;
+
+grant select, insert, update, delete on table public.promotions to authenticated;
+
+grant select, insert, update, delete on table public.regles_alertes to authenticated;
+
+grant select, insert, update, delete on table public.requisitions to authenticated;
+
+grant select, insert, update, delete on table public.requisition_lignes to authenticated;
+
+grant select, insert, update, delete on table public.signalements to authenticated;
+
+grant select, insert, update, delete on table public.sous_familles to authenticated;
+
+grant select, insert, update, delete on table public.stocks to authenticated;
+
+grant select, insert, update, delete on table public.tableaux_de_bord to authenticated;
+
+grant select, insert, update, delete on table public.taches to authenticated;
+
+grant select, insert, update, delete on table public.tooltips to authenticated;
+
+grant select, insert, update, delete on table public.transfert_lignes to authenticated;
+
+grant select, insert, update, delete on table public.transferts to authenticated;
+
+grant select, insert, update, delete on table public.unites to authenticated;
+
+grant select, insert, update, delete on table public.usage_stats to authenticated;
+
+grant select, insert, update, delete on table public.utilisateurs_taches to authenticated;
+
+grant select, insert, update, delete on table public.validation_requests to authenticated;
+
+grant select, insert, update, delete on table public.ventes_boissons to authenticated;
+
+grant select, insert, update, delete on table public.ventes_fiches_carte to authenticated;
+
+grant select, insert, update, delete on table public.zones_droits to authenticated;
+
+grant select, insert, update, delete on table public.menu_groupes to authenticated;
+
+grant select, insert, update, delete on table public.menu_groupe_lignes to authenticated;
+
+grant select, insert, update, delete on table public.menu_groupe_modeles to authenticated;
+
+grant select, insert, update, delete on table public.menu_groupe_modele_lignes to authenticated;
+
+grant select, insert, update, delete on table public.alertes_rupture to authenticated;
+
+grant select, insert, update, delete on table public.logs_activite to authenticated;
+
+grant select, insert, update, delete on table public.menus_jour_lignes to authenticated;
+
+grant select, insert, update, delete on table public.rapports_generes to authenticated;
+
+grant select, insert, update, delete on table public.settings to authenticated;
+
+grant select, insert, update, delete on table public.user_mama_access to authenticated;
+
+grant select, insert, update, delete on table public.ventes_fiches to authenticated;
+
+grant select, insert, update, delete on table public.ventes_import_staging to authenticated;
+
+grant select, insert, update, delete on table public.produits_zones to authenticated;
+
+grant execute on function public.apply_stock_from_achat() to authenticated;
+
+grant execute on function public.consolidated_stats() to authenticated;
+
+grant execute on function public.dashboard_stats() to authenticated;
+
+grant execute on function public.disable_two_fa() to authenticated;
+
+grant execute on function public.enable_two_fa() to authenticated;
+
+grant execute on function public.import_invoice() to authenticated;
+
+grant execute on function public.send_email_notification() to authenticated;
+
+grant execute on function public.send_notification_webhook() to authenticated;
+
+grant execute on function public.stats_cost_centers() to authenticated;
+
+grant execute on function public.stats_rotation_produit() to authenticated;
+
+create or replace view public.v_analytique_stock as
+select
+  p.famille_id,
+  p.sous_famille_id,
+  s.mama_id,
+  sum(s.stock) as quantite,
+  sum(s.stock * coalesce(vplp.dernier_prix,0)) as valeur
+from public.v_stocks s
+join public.produits p on p.id = s.produit_id and p.mama_id = s.mama_id
+left join public.v_products_last_price vplp on vplp.produit_id = s.produit_id and vplp.mama_id = s.mama_id
+group by p.famille_id, p.sous_famille_id, s.mama_id;
+
+create or replace view public.v_besoins_previsionnels as
+select
+  p.mama_id,
+  p.id as produit_id,
+  greatest(p.stock_min - coalesce(s.stock,0),0) as quantite
+from public.produits p
+left join public.v_stocks s on s.produit_id = p.id and s.mama_id = p.mama_id;
+
+create or replace view public.v_boissons as
+select
+  f.id,
+  f.mama_id,
+  f.created_at,
+  cf.cout / nullif(cf.portions,0) as cout_portion
+from public.fiches_techniques f
+left join public.v_couts_fiches cf on cf.fiche_id = f.id and cf.mama_id = f.mama_id;
+
+create or replace view public.v_cost_center_month as
+select
+  null::uuid as cost_center_id,
+  null::text as nom,
+  date_trunc('month', a.date_achat)::date as mois,
+  sum(a.quantite * a.prix) as valeur,
+  a.mama_id
+from public.achats a
+where a.actif is true
+group by a.mama_id, date_trunc('month', a.date_achat)::date;
+
+create or replace view public.v_cost_center_monthly as
+select
+  date_trunc('month', a.date_achat)::date as mois,
+  null::text as nom,
+  null::uuid as cost_center_id,
+  sum(a.quantite * a.prix) as valeur,
+  a.mama_id
+from public.achats a
+where a.actif is true
+group by a.mama_id, date_trunc('month', a.date_achat)::date;
+
+create or replace view public.v_ecarts_inventaire as
+select i.periode_id,
+       i.zone_id,
+       sum(p.ecart) as ecart_total
+from public.inventaires i
+join public.produits_inventaire p on p.inventaire_id = i.id
+where i.actif is true
+group by i.periode_id, i.zone_id;
+
+create or replace view public.v_evolution_achats as
+select
+  mama_id,
+  date_trunc('month', date_achat)::date as mois,
+  sum(quantite * prix) as montant
+from public.achats
+where actif = true
+group by mama_id, date_trunc('month', date_achat)::date
+order by mois;
+
+create or replace view public.v_fournisseurs_inactifs as
+select f.id, f.mama_id, f.nom, f.contact, false::boolean as actif
+from public.fournisseurs f
+where false;
+
+create or replace view public.v_performance_fiches as
+select
+  f.id as fiche_id,
+  f.mama_id,
+  cf.cout / nullif(cf.portions,0) as cout_par_portion,
+  f.prix_vente,
+  (f.prix_vente - cf.cout / nullif(cf.portions,0)) as marge
+from public.fiches_techniques f
+left join public.v_couts_fiches cf on cf.fiche_id = f.id and cf.mama_id = f.mama_id;
+
+create or replace view public.v_pmp as
+select
+  mama_id,
+  produit_id,
+  sum(prix * quantite) / nullif(sum(quantite),0) as pmp
+from public.achats
+where actif = true
+group by mama_id, produit_id;
+
+create or replace view public.v_products_last_price as
+select
+  p.id as produit_id,
+  p.mama_id,
+  p.famille_id,
+  p.unite_id,
+  (
+    select a.prix
+    from public.achats a
+    where a.produit_id=p.id and a.mama_id=p.mama_id and a.actif is true
+    order by a.date_achat desc
+    limit 1
+  ) as dernier_prix
+from public.produits p;
+
+create or replace view public.v_produits_dernier_prix as
+select
+  p.id,
+  p.id as produit_id,
+  p.mama_id,
+  p.nom,
+  p.unite_id,
+  p.famille_id,
+  p.sous_famille_id,
+  p.stock_reel,
+  p.stock_min,
+  p.actif,
+  (
+    select a.prix
+    from public.achats a
+    where a.produit_id = p.id
+      and a.mama_id = p.mama_id
+      and a.actif = true
+    order by a.date_achat desc
+    limit 1
+  ) as dernier_prix
+from public.produits p;
+
+create or replace view public.v_produits_utilises as
+select x.mama_id,
+       x.produit_id,
+       count(*) as usage_count
+from (
+  select r.mama_id, rl.produit_id
+  from public.requisition_lignes rl
+  join public.requisitions r on r.id = rl.requisition_id
+  where r.statut = 'réalisée'
+  union all
+  select f.mama_id, fl.produit_id
+  from public.fiche_lignes fl
+  join public.fiches_techniques f on f.id = fl.fiche_id
+) x
+group by x.mama_id, x.produit_id;
+
+create or replace view public.v_reco_stockmort as
+with achats as (
+  select produit_id, mama_id
+  from public.achats
+  where actif is true
+    and date_achat >= now() - interval '90 days'
+  group by produit_id, mama_id
+),
+requis as (
+  select rl.produit_id, r.mama_id, sum(rl.quantite) as q
+  from public.requisition_lignes rl
+  join public.requisitions r on r.id = rl.requisition_id
+  where r.statut = 'réalisée'
+    and r.date_requisition >= now() - interval '90 days'
+  group by rl.produit_id, r.mama_id
+)
+select p.id as produit_id, p.mama_id, p.nom
+from public.produits p
+join achats a on a.produit_id = p.id and a.mama_id = p.mama_id
+left join requis r on r.produit_id = p.id and r.mama_id = p.mama_id
+where coalesce(r.q,0) = 0;
+
+create or replace view public.v_reco_surcout as
+select p.id as produit_id,
+       p.mama_id,
+       p.nom,
+       vplp.dernier_prix,
+       p.pmp,
+       case
+         when p.pmp > 0 and vplp.dernier_prix > p.pmp
+           then (vplp.dernier_prix - p.pmp) / p.pmp * 100
+         else null
+       end as variation_pct
+from public.produits p
+join public.v_products_last_price vplp on vplp.produit_id = p.id and vplp.mama_id = p.mama_id
+where p.pmp > 0 and vplp.dernier_prix > p.pmp;
+
+create or replace view public.v_requisitions as
+select r.id,
+       r.mama_id,
+       r.date_requisition,
+       r.zone_id,
+       r.statut,
+       r.commentaire,
+       r.created_at,
+       r.updated_at,
+       r.actif
+from public.requisitions r;
+
+create or replace view public.v_stock_requisitionne as
+select
+  r.mama_id,
+  rl.produit_id,
+  sum(rl.quantite) as quantite_30j
+from public.requisition_lignes rl
+join public.requisitions r on r.id = rl.requisition_id
+where r.statut in ('faite','réalisée')
+  and r.date_requisition >= now() - interval '30 days'
+group by r.mama_id, rl.produit_id;
+
+create or replace view public.suggestions_commandes as
+select rl.produit_id,
+       sum(rl.quantite) as quantite_totale,
+       p.stock_reel,
+       p.stock_min,
+       (p.stock_reel - sum(rl.quantite)) as stock_projection
+from public.requisition_lignes rl
+join public.requisitions r on r.id = rl.requisition_id
+join public.produits p on p.id = rl.produit_id
+where r.statut = 'faite'
+group by rl.produit_id, p.stock_reel, p.stock_min
+having (p.stock_reel - sum(rl.quantite)) < p.stock_min;
+
+create or replace view public.v_stocks as
+with base as (
+  select p.id produit_id, p.mama_id, 0::numeric as stock from public.produits p
+),
+achats as (
+  select a.produit_id, a.mama_id, sum(a.quantite) as q
+  from public.achats a
+  where a.actif is true
+  group by 1,2
+),
+transferts_plus as (
+  select tl.produit_id, t.mama_id, sum(tl.quantite) as q
+  from public.transferts t
+  join public.transfert_lignes tl on tl.transfert_id = t.id
+  group by 1,2
+),
+requis_moins as (
+  select rl.produit_id, r.mama_id, sum(rl.quantite) as q
+  from public.requisition_lignes rl
+  join public.requisitions r on r.id = rl.requisition_id
+  where r.statut = 'réalisée'
+  group by 1,2
+)
+select
+  b.mama_id, b.produit_id,
+  coalesce(a.q,0) + coalesce(tp.q,0) - coalesce(rm.q,0) as stock
+from base b
+left join achats a on a.produit_id=b.produit_id and a.mama_id=b.mama_id
+left join transferts_plus tp on tp.produit_id=b.produit_id and tp.mama_id=b.mama_id
+left join requis_moins rm on rm.produit_id=b.produit_id and rm.mama_id=b.mama_id;
+
+create or replace view public.v_taches_assignees as
+select t.id as tache_id, t.mama_id, null::uuid as utilisateur_id, null::text as utilisateur_nom
+from public.taches t;
+
+create or replace view public.v_tendance_prix_produit as
+select
+  a.mama_id,
+  a.produit_id,
+  to_char(a.date_achat, 'YYYY-MM') as mois,
+  avg(a.prix) as prix_moyen
+from public.achats a
+where a.actif is true
+  and a.date_achat >= date_trunc('month', now()) - interval '11 months'
+group by a.mama_id, a.produit_id, to_char(a.date_achat, 'YYYY-MM');
+
+create or replace view public.v_top_fournisseurs as
+select
+  a.mama_id,
+  a.fournisseur_id,
+  sum(a.prix * a.quantite) as montant
+from public.achats a
+where a.actif is true
+  and a.date_achat >= current_date - interval '12 months'
+group by a.mama_id, a.fournisseur_id;
+
+create or replace view public.v_couts_fiches as
+select
+  f.id as fiche_id,
+  f.mama_id,
+  1::numeric as portions,
+  coalesce(sum(vplp.dernier_prix * coalesce(fl.quantite,0)),0) as cout
+from public.fiches_techniques f
+left join public.fiche_lignes fl on fl.mama_id=f.mama_id and fl.fiche_id=f.id
+left join public.v_products_last_price vplp on vplp.produit_id=fl.produit_id and vplp.mama_id=f.mama_id
+group by f.id, f.mama_id;
+
+create or replace view public.v_menu_groupe_couts as
+select
+  l.id as ligne_id,
+  l.menu_groupe_id,
+  l.mama_id,
+  l.categorie,
+  l.fiche_id,
+  l.portions_par_personne,
+  cf.cout as cout_total_fiche,
+  cf.portions as portions_fiche,
+  (cf.cout / nullif(cf.portions,0)) as cout_par_portion_fiche,
+  ((cf.cout / nullif(cf.portions,0)) * l.portions_par_personne) as cout_par_personne_ligne
+from public.menu_groupe_lignes l
+join public.v_couts_fiches cf on cf.fiche_id = l.fiche_id and cf.mama_id = l.mama_id;
+
+create or replace view public.v_menu_groupe_resume as
+with couts as (
+  select menu_groupe_id, sum(cout_par_personne_ligne) as cout_par_personne
+  from public.v_menu_groupe_couts
+  group by menu_groupe_id
+)
+select
+  mg.id as menu_groupe_id,
+  mg.mama_id,
+  mg.nom,
+  mg.prix_vente_personne,
+  coalesce(c.cout_par_personne,0) as cout_par_personne,
+  (mg.prix_vente_personne - coalesce(c.cout_par_personne,0)) as marge_par_personne,
+  case
+    when mg.prix_vente_personne is null or mg.prix_vente_personne = 0 then null
+    else round((mg.prix_vente_personne - coalesce(c.cout_par_personne,0)) / mg.prix_vente_personne * 100, 2)
+  end as marge_pct
+from public.menu_groupes mg
+left join couts c on c.menu_groupe_id = mg.id;
+
+create or replace view public.v_menu_du_jour_resume as
+with lignes as (
+  select menu_id, categorie, sum(cout_ligne_total) as cout_categorie
+  from public.v_menu_du_jour_lignes_cout
+  group by menu_id, categorie
+)
+select
+  m.id as menu_id,
+  m.mama_id,
+  m.date_menu,
+  coalesce(sum(l.cout_categorie) filter (where l.categorie='entree'),0) as cout_entrees,
+  coalesce(sum(l.cout_categorie) filter (where l.categorie='plat'),0) as cout_plats,
+  coalesce(sum(l.cout_categorie) filter (where l.categorie='dessert'),0) as cout_desserts,
+  coalesce(sum(l.cout_categorie) filter (where l.categorie='boisson'),0) as cout_boissons,
+  coalesce(sum(l.cout_categorie),0) as cout_total
+from public.menus_jour m
+left join lignes l on l.menu_id = m.id
+group by m.id, m.mama_id, m.date_menu;
+
+create or replace view public.v_menu_du_jour_mensuel as
+select
+  mama_id,
+  date_trunc('month', date_menu)::date as mois,
+  avg(cout_total) as food_cost_avg,
+  sum(cout_total) as cout_total_mois
+from public.v_menu_du_jour_resume
+group by mama_id, date_trunc('month', date_menu);
+
+create or replace view public.v_cons_achats_mensuels as
+select
+  cl.mama_id,
+  date_trunc('month', c.date_commande)::date as mois,
+  sum(coalesce(cl.quantite,0) * coalesce(cl.prix_achat,0)) as achats_total
+from public.commande_lignes cl
+join public.commandes c on c.id = cl.commande_id and c.mama_id = cl.mama_id
+where cl.mama_id = current_user_mama_id()
+group by cl.mama_id, date_trunc('month', c.date_commande);
+
+create or replace view public.v_cons_ventes_mensuelles as
+select
+  mama_id,
+  date_trunc('month', date_vente)::date as mois,
+  sum(coalesce(quantite,0) * coalesce(prix_vente_unitaire,0)) as ca_total,
+  sum(coalesce(quantite,0)) as ventes_total
+from public.ventes_fiches
+where mama_id = current_user_mama_id()
+group by mama_id, date_trunc('month', date_vente);
+
+create or replace view public.v_cons_foodcost_mensuel as
+select
+  mama_id,
+  mois,
+  cout_total_mois as menu_foodcost_total
+from public.v_menu_du_jour_mensuel
+where mama_id = current_user_mama_id();
+
+create or replace view public.v_cons_ecarts_inventaire as
+select
+  mama_id,
+  date_trunc('month', date_inventaire)::date as mois,
+  sum(abs(coalesce(ecart_valorise,0))) as ecart_valorise_total
+from public.v_ecarts_inventaire
+where mama_id = current_user_mama_id()
+group by mama_id, date_trunc('month', date_inventaire);
+
+create or replace view public.v_consolidation_mensuelle as
+select
+  mid.mama_id,
+  mid.mois,
+  coalesce(a.achats_total,0) as achats_total,
+  coalesce(v.ca_total,0) as ca_total,
+  coalesce(v.ventes_total,0) as ventes_total,
+  coalesce(f.menu_foodcost_total,0) as menu_foodcost_total,
+  null::numeric as marge_pct_moy,
+  coalesce(i.ecart_valorise_total,0) as ecart_valorise_total
+from (
+  select mama_id, mois from public.v_cons_achats_mensuels
+  union
+  select mama_id, mois from public.v_cons_ventes_mensuelles
+  union
+  select mama_id, mois from public.v_cons_foodcost_mensuel
+  union
+  select mama_id, mois from public.v_cons_ecarts_inventaire
+) mid
+left join public.v_cons_achats_mensuels a on a.mama_id=mid.mama_id and a.mois=mid.mois
+left join public.v_cons_ventes_mensuelles v on v.mama_id=mid.mama_id and v.mois=mid.mois
+left join public.v_cons_foodcost_mensuel f on f.mama_id=mid.mama_id and f.mois=mid.mois
+left join public.v_cons_ecarts_inventaire i on i.mama_id=mid.mama_id and i.mois=mid.mois;
+
+create or replace view public.v_me_classification as
+select
+  ft.mama_id,
+  ft.id as fiche_id,
+  ft.nom,
+  ft.type as fiche_type,
+  ft.actif,
+  current_date as debut,
+  current_date as fin,
+  null::numeric as ventes,
+  null::numeric as cout_portion,
+  null::numeric as prix_vente,
+  null::numeric as marge,
+  null::numeric as score_calc,
+  null::text as classement,
+  null::numeric as x,
+  null::numeric as y
+from public.fiches_techniques ft
+where 1=0;
+
+create or replace view public.v_produits_par_zone (
+  mama_id, produit_id, produit_nom, zone_id, zone_nom, zone_type, unite_id, stock_reel, stock_min
+) as
+with base as (
+  select
+    p.mama_id,
+    p.id as produit_id,
+    p.nom as produit_nom,
+    coalesce(pz.zone_id, p.zone_id) as zone_id,
+    p.unite_id,
+    p.stock_reel,
+    p.stock_min
+  from public.produits p
+  left join lateral (
+    select zone_id
+    from public.produits_zones z
+    where z.produit_id = p.id and z.mama_id = p.mama_id and z.actif = true
+    limit 1
+  ) pz on true
+)
+select
+  b.mama_id,
+  b.produit_id,
+  b.produit_nom,
+  z.id as zone_id,
+  z.nom as zone_nom,
+  z.type as zone_type,
+  b.unite_id,
+  b.stock_reel,
+  b.stock_min
+from base b
+left join public.zones_stock z on z.id = b.zone_id
+where b.zone_id is not null;
+
+-- Consolidated Supabase schema for MamaStock
+-- Generated by merging all SQL definitions
+
+-- 1. Extensions
+create extension if not exists "pgcrypto";
+
+-- 2. Tables
+create table if not exists public.mamas (
+  id uuid primary key default gen_random_uuid(),
+  nom text not null,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+-- FK safety for produits
+do $$ begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='produits' and column_name='sous_famille_id'
+  ) then
+    alter table public.produits add column sous_famille_id uuid;
+  end if;
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='produits' and column_name='zone_id'
+  ) then
+    alter table public.produits add column zone_id uuid;
+  end if;
+end $$;
+
+-- FK safety for commandes
+do $$ begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='commandes' and column_name='created_by'
+  ) then
+    alter table public.commandes add column created_by uuid;
+  end if;
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema='public' and table_name='commandes' and column_name='validated_by'
+  ) then
+    alter table public.commandes add column validated_by uuid;
+  end if;
+end $$;
+
+-- 4. Indexes
+create index if not exists idx_fournisseurs_mama_id on public.fournisseurs(mama_id);
+
+-- 5. Functions
+create or replace function public.trg_set_timestamp() returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+-- 6. Triggers
+do $$ begin
+  if not exists (select 1 from pg_trigger where tgname = 'trg_roles_updated_at') then
+    create trigger trg_roles_updated_at
+    before update on public.roles
+    for each row execute procedure public.trg_set_timestamp();
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_trigger where tgname = 'set_ts_templates_cmd') then
+    create trigger set_ts_templates_cmd
+    before update on public.templates_commandes
+    for each row execute procedure public.trg_set_timestamp();
+  end if;
+end $$;
+
+-- 7. RLS & Policies
+alter table public.mamas enable row level security;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='mamas' and policyname='mamas_all') then
+    create policy mamas_all on public.mamas
+      for all using (id = current_user_mama_id())
+      with check (id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='fournisseurs' and policyname='fournisseurs_all') then
+    create policy fournisseurs_all on public.fournisseurs
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='produits' and policyname='produits_all') then
+    create policy produits_all on public.produits
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='roles' and policyname='roles_self_mama') then
+    create policy roles_self_mama on public.roles
+      for select using (mama_id = current_user_mama_id());
+  end if;
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='roles' and policyname='roles_insert_mama') then
+    create policy roles_insert_mama on public.roles
+      for insert with check (mama_id = current_user_mama_id());
+  end if;
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='roles' and policyname='roles_update_mama') then
+    create policy roles_update_mama on public.roles
+      for update using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='utilisateurs' and policyname='utilisateurs_self_mama') then
+    create policy utilisateurs_self_mama on public.utilisateurs
+      for select using (mama_id = current_user_mama_id());
+  end if;
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='utilisateurs' and policyname='utilisateurs_insert_mama') then
+    create policy utilisateurs_insert_mama on public.utilisateurs
+      for insert with check (mama_id = current_user_mama_id());
+  end if;
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='utilisateurs' and policyname='utilisateurs_update_mama') then
+    create policy utilisateurs_update_mama on public.utilisateurs
+      for update using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='commandes' and policyname='commandes_all') then
+    create policy commandes_all on public.commandes
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='commande_lignes' and policyname='commande_lignes_all') then
+    create policy commande_lignes_all on public.commande_lignes
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='templates_commandes' and policyname='templates_commandes_select') then
+    create policy templates_commandes_select on public.templates_commandes
+      for select using (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='templates_commandes' and policyname='templates_commandes_crud_admin') then
+    create policy templates_commandes_crud_admin on public.templates_commandes
+      for all using (mama_id = current_user_mama_id() and current_user_is_admin_or_manager())
+      with check (mama_id = current_user_mama_id() and current_user_is_admin_or_manager());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='emails_envoyes' and policyname='emails_envoyes_all') then
+    create policy emails_envoyes_all on public.emails_envoyes
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='permissions' and policyname='permissions_self_mama') then
+    create policy permissions_self_mama on public.permissions
+      for select using (mama_id = current_user_mama_id());
+  end if;
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='permissions' and policyname='permissions_insert_mama') then
+    create policy permissions_insert_mama on public.permissions
+      for insert with check (mama_id = current_user_mama_id());
+  end if;
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='permissions' and policyname='permissions_update_mama') then
+    create policy permissions_update_mama on public.permissions
+      for update using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='consentements_utilisateur' and policyname='consentements_utilisateur_all') then
+    create policy consentements_utilisateur_all on public.consentements_utilisateur
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+-- 9. Sécurité (GRANT)
+grant select, insert, update, delete on public.mamas to authenticated;
+
+-- 10. Données initiales (insert)
+-- (aucune donnée initiale)
+
+-- ===================================================================
+-- Generated placeholders for previously missing schema elements
+
+-- 2.b Additional Tables
+create table if not exists public.achats (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid not null,
+  produit_id uuid not null,
+  fournisseur_id uuid not null,
+  quantite numeric not null,
+  prix numeric not null,
+  date_achat date not null,
+  actif boolean default true,
+  created_at timestamptz default now()
+);
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='achats' and policyname='achats_all') then
+    create policy achats_all on public.achats
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='alertes' and policyname='alertes_all') then
+    create policy alertes_all on public.alertes
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='api_keys' and policyname='api_keys_all') then
+    create policy api_keys_all on public.api_keys
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='auth_double_facteur' and policyname='auth_double_facteur_all') then
+    create policy auth_double_facteur_all on public.auth_double_facteur
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='bons_livraison' and policyname='bons_livraison_all') then
+    create policy bons_livraison_all on public.bons_livraison
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='catalogue_updates' and policyname='catalogue_updates_all') then
+    create policy catalogue_updates_all on public.catalogue_updates
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='centres_de_cout' and policyname='centres_de_cout_all') then
+    create policy centres_de_cout_all on public.centres_de_cout
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='compta_mapping' and policyname='compta_mapping_all') then
+    create policy compta_mapping_all on public.compta_mapping
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='documentation' and policyname='documentation_all') then
+    create policy documentation_all on public.documentation
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='documents' and policyname='documents_all') then
+    create policy documents_all on public.documents
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='etapes_onboarding' and policyname='etapes_onboarding_all') then
+    create policy etapes_onboarding_all on public.etapes_onboarding
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='facture_lignes' and policyname='facture_lignes_all') then
+    create policy facture_lignes_all on public.facture_lignes
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='factures' and policyname='factures_all') then
+    create policy factures_all on public.factures
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='familles' and policyname='familles_all') then
+    create policy familles_all on public.familles
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='feedback' and policyname='feedback_all') then
+    create policy feedback_all on public.feedback
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='fiche_cout_history' and policyname='fiche_cout_history_all') then
+    create policy fiche_cout_history_all on public.fiche_cout_history
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='fiche_lignes' and policyname='fiche_lignes_all') then
+    create policy fiche_lignes_all on public.fiche_lignes
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='fiches' and policyname='fiches_all') then
+    create policy fiches_all on public.fiches
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='fiches_techniques' and policyname='fiches_techniques_all') then
+    create policy fiches_techniques_all on public.fiches_techniques
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='fournisseur_contacts' and policyname='fournisseur_contacts_all') then
+    create policy fournisseur_contacts_all on public.fournisseur_contacts
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='fournisseur_notes' and policyname='fournisseur_notes_all') then
+    create policy fournisseur_notes_all on public.fournisseur_notes
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='fournisseur_produits' and policyname='fournisseur_produits_all') then
+    create policy fournisseur_produits_all on public.fournisseur_produits
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='fournisseurs_api_config' and policyname='fournisseurs_api_config_all') then
+    create policy fournisseurs_api_config_all on public.fournisseurs_api_config
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='gadgets' and policyname='gadgets_all') then
+    create policy gadgets_all on public.gadgets
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='groupes' and policyname='groupes_all') then
+    create policy groupes_all on public.groupes
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='guides_seen' and policyname='guides_seen_all') then
+    create policy guides_seen_all on public.guides_seen
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='help_articles' and policyname='help_articles_all') then
+    create policy help_articles_all on public.help_articles
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='inventaire_zones' and policyname='inventaire_zones_all') then
+    create policy inventaire_zones_all on public.inventaire_zones
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='inventaires' and policyname='inventaires_select') then
+    create policy inventaires_select on public.inventaires
+      for select using (mama_id = current_user_mama_id());
+  end if;
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='inventaires' and policyname='inventaires_update') then
+    create policy inventaires_update on public.inventaires
+      for update using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='inventaires' and policyname='inventaires_delete') then
+    create policy inventaires_delete on public.inventaires
+      for delete using (mama_id = current_user_mama_id());
+  end if;
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='inventaires' and policyname='inventaire_insert') then
+    create policy inventaire_insert on public.inventaires
+      for insert with check (
+        mama_id = current_user_mama_id()
+        and exists (select 1 from periodes_comptables p where p.id = periode_id and p.cloturee = false)
+      );
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='produits_inventaire' and policyname='produits_inventaire_rls') then
+    create policy produits_inventaire_rls on public.produits_inventaire
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='journaux_utilisateur' and policyname='journaux_utilisateur_all') then
+    create policy journaux_utilisateur_all on public.journaux_utilisateur
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='lignes_bl' and policyname='lignes_bl_all') then
+    create policy lignes_bl_all on public.lignes_bl
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='logs_securite' and policyname='logs_securite_all') then
+    create policy logs_securite_all on public.logs_securite
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='menu_fiches' and policyname='menu_fiches_all') then
+    create policy menu_fiches_all on public.menu_fiches
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='menus' and policyname='menus_all') then
+    create policy menus_all on public.menus
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='menus_groupes' and policyname='menus_groupes_all') then
+    create policy menus_groupes_all on public.menus_groupes
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='menus_groupes_fiches' and policyname='menus_groupes_fiches_all') then
+    create policy menus_groupes_fiches_all on public.menus_groupes_fiches
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='menus_jour' and policyname='menus_jour_all') then
+    create policy menus_jour_all on public.menus_jour
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='menus_jour_fiches' and policyname='menus_jour_fiches_all') then
+    create policy menus_jour_fiches_all on public.menus_jour_fiches
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='notification_preferences' and policyname='notification_preferences_all') then
+    create policy notification_preferences_all on public.notification_preferences
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='notifications' and policyname='notifications_all') then
+    create policy notifications_all on public.notifications
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='parametres_commandes' and policyname='parametres_commandes_all') then
+    create policy parametres_commandes_all on public.parametres_commandes
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='periodes_comptables' and policyname='periodes_comptables_rls') then
+    create policy periodes_comptables_rls on public.periodes_comptables
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='pertes' and policyname='pertes_all') then
+    create policy pertes_all on public.pertes
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='planning_lignes' and policyname='planning_lignes_all') then
+    create policy planning_lignes_all on public.planning_lignes
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='planning_previsionnel' and policyname='planning_previsionnel_all') then
+    create policy planning_previsionnel_all on public.planning_previsionnel
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='promotions' and policyname='promotions_all') then
+    create policy promotions_all on public.promotions
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='regles_alertes' and policyname='regles_alertes_all') then
+    create policy regles_alertes_all on public.regles_alertes
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+drop policy if exists requisitions_insert on public.requisitions;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='signalements' and policyname='signalements_all') then
+    create policy signalements_all on public.signalements
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='sous_familles' and policyname='sous_familles_all') then
+    create policy sous_familles_all on public.sous_familles
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='stocks' and policyname='stocks_all') then
+    create policy stocks_all on public.stocks
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='tableaux_de_bord' and policyname='tableaux_de_bord_all') then
+    create policy tableaux_de_bord_all on public.tableaux_de_bord
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='taches' and policyname='taches_all') then
+    create policy taches_all on public.taches
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='tooltips' and policyname='tooltips_all') then
+    create policy tooltips_all on public.tooltips
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='transfert_lignes' and policyname='transfert_lignes_all') then
+    create policy transfert_lignes_all on public.transfert_lignes
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='transferts' and policyname='transferts_all') then
+    create policy transferts_all on public.transferts
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='unites' and policyname='unites_all') then
+    create policy unites_all on public.unites
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='usage_stats' and policyname='usage_stats_all') then
+    create policy usage_stats_all on public.usage_stats
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='utilisateurs_taches' and policyname='utilisateurs_taches_all') then
+    create policy utilisateurs_taches_all on public.utilisateurs_taches
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='validation_requests' and policyname='validation_requests_all') then
+    create policy validation_requests_all on public.validation_requests
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='ventes_boissons' and policyname='ventes_boissons_all') then
+    create policy ventes_boissons_all on public.ventes_boissons
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='ventes_fiches_carte' and policyname='ventes_fiches_carte_all') then
+    create policy ventes_fiches_carte_all on public.ventes_fiches_carte
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+-- Zones de stock
+create table if not exists public.zones_stock (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid not null references public.mamas(id) on delete cascade,
+  nom text not null,
+  code text,
+  type text not null check (type in ('cave','shop','cuisine','bar','entrepot','autre')),
+  parent_id uuid references public.zones_stock(id) on delete set null,
+  actif boolean default true,
+  position int default 0,
+  adresse text,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now(),
+  unique (mama_id, nom)
+);
+
+-- Droits par utilisateur
+create table if not exists public.zones_droits (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid not null references public.mamas(id) on delete cascade,
+  zone_id uuid not null references public.zones_stock(id) on delete cascade,
+  user_id uuid not null,
+  lecture boolean default true,
+  ecriture boolean default false,
+  transfert boolean default false,
+  requisition boolean default false,
+  created_at timestamptz default now(),
+  unique (mama_id, zone_id, user_id)
+);
+
+-- Row Level Security
+alter table public.zones_stock enable row level security;
+
+drop policy if exists zones_stock_all on public.zones_stock;
+
+do $$ begin
+  if not exists (select 1 from pg_trigger where tgname = 'set_ts_zones') then
+    create trigger set_ts_zones before update on public.zones_stock
+    for each row execute procedure public.trg_set_timestamp();
+  end if;
+end $$;
+
+-- RPC Functions
+create or replace function public.can_access_zone(p_zone uuid, p_mode text default 'lecture')
+returns boolean
+language sql stable security definer
+as $$
+  select case
+    when p_mode = 'lecture' then exists(select 1 from public.zones_droits where zone_id=p_zone and user_id=auth.uid() and lecture=true)
+    when p_mode = 'ecriture' then exists(select 1 from public.zones_droits where zone_id=p_zone and user_id=auth.uid() and ecriture=true)
+    when p_mode = 'transfert' then exists(select 1 from public.zones_droits where zone_id=p_zone and user_id=auth.uid() and transfert=true)
+    when p_mode = 'requisition' then exists(select 1 from public.zones_droits where zone_id=p_zone and user_id=auth.uid() and requisition=true)
+    else false end;
+$$;
+
+-- 8. Views
+create or replace view public.utilisateurs_complets (
+  id, nom, email, auth_id, role_id, mama_id, access_rights, actif, created_at, updated_at,
+  role_nom, role_description
+) as
+select
+  u.id, u.nom, u.email, u.auth_id, u.role_id, u.mama_id, u.access_rights, u.actif, u.created_at, u.updated_at,
+  r.nom as role_nom, r.description as role_description
+from public.utilisateurs u
+left join public.roles r on r.id = u.role_id;
+
+-- Additional Views
+create or replace view public.v_achats_mensuels as
+select
+  mama_id,
+  date_trunc('month', date_achat)::date as mois,
+  sum(quantite * prix) as achats,
+  sum(quantite * prix) as montant,
+  sum(quantite * prix) as montant_total
+from public.achats
+where actif = true
+group by mama_id, date_trunc('month', date_achat)::date;
+
+-- 6.b Placeholder Functions
+create or replace function public.advanced_stats()
+returns void
+language plpgsql as $$
+begin
+  raise notice 'TODO';
+  return;
+end;
+$$;
+
+-- Menu groupe tables and views
+create table if not exists public.menu_groupes (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid not null references public.mamas(id) on delete cascade,
+  nom text not null,
+  prix_vente_personne numeric,
+  statut text not null default 'brouillon' check (statut in ('brouillon','valide')),
+  actif boolean default true,
+  archive boolean default false,
+  archive_at timestamptz,
+  note text,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now(),
+  unique (mama_id, nom)
+);
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='menu_groupes' and policyname='menu_groupes_all') then
+    create policy menu_groupes_all on public.menu_groupes
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='menu_groupe_lignes' and policyname='menu_groupe_lignes_all') then
+    create policy menu_groupe_lignes_all on public.menu_groupe_lignes
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='menu_groupe_modeles' and policyname='menu_groupe_modeles_all') then
+    create policy menu_groupe_modeles_all on public.menu_groupe_modeles
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_policies where schemaname='public' and tablename='menu_groupe_modele_lignes' and policyname='menu_groupe_modele_lignes_all') then
+    create policy menu_groupe_modele_lignes_all on public.menu_groupe_modele_lignes
+      for all using (mama_id = current_user_mama_id())
+      with check (mama_id = current_user_mama_id());
+  end if;
+end $$;
+
+-- View: v_costing_carte
+create or replace view public.v_costing_carte as
+select
+  f.mama_id,
+  f.id as fiche_id,
+  f.nom,
+  f.type,
+  f.famille,
+  f.actif,
+  cf.cout,
+  cf.portions,
+  case
+    when cf.portions is null or cf.portions = 0 then null
+    else cf.cout / cf.portions
+  end as cout_par_portion,
+  f.prix_vente,
+  (coalesce(f.prix_vente,0) - coalesce(cf.cout / nullif(cf.portions,0),0)) as marge_euro,
+  case
+    when f.prix_vente is null or f.prix_vente = 0 then null
+    else round(((coalesce(f.prix_vente,0) - coalesce(cf.cout / nullif(cf.portions,0),0)) / f.prix_vente) * 100, 2)
+  end as marge_pct,
+  case
+    when f.prix_vente is null or f.prix_vente = 0 then null
+    else round((coalesce(cf.cout / nullif(cf.portions,0),0) / f.prix_vente) * 100, 2)
+  end as food_cost_pct
+from public.fiches_techniques f
+left join public.v_couts_fiches cf
+  on cf.fiche_id = f.id and cf.mama_id = f.mama_id;
+
+-- Added missing tables
+create table if not exists public.alertes_rupture (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid not null,
+  produit_id uuid,
+  type text,
+  stock_actuel numeric,
+  stock_min numeric,
+  stock_projete numeric,
+  cree_le timestamptz default now(),
+  traite boolean default false
+);
+
+-- Functions
+create or replace function public.log_action(
+  p_mama_id uuid,
+  p_type text,
+  p_module text,
+  p_description text,
+  p_donnees jsonb default '{}'::jsonb,
+  p_critique boolean default false
+) returns void
+language plpgsql
+security definer
+as $$
+begin
+  insert into public.logs_activite(mama_id, user_id, type, module, description, donnees, critique)
+  values (p_mama_id, auth.uid(), p_type, p_module, p_description, p_donnees, p_critique);
+end;
+$$;
+
+-- Views
+create or replace view public.v_menu_du_jour_lignes_cout as
+select
+  l.id,
+  l.menu_id,
+  l.mama_id,
+  l.categorie,
+  l.fiche_id,
+  l.portions,
+  cf.cout as cout_total_fiche,
+  cf.portions as portions_fiche,
+  (cf.cout / nullif(cf.portions,0)) as cout_par_portion,
+  ((cf.cout / nullif(cf.portions,0)) * l.portions) as cout_ligne_total
+from public.menus_jour_lignes l
+join public.v_couts_fiches cf on cf.fiche_id = l.fiche_id and cf.mama_id = l.mama_id;
+
+-- produits_zones pivot table
+create table if not exists public.produits_zones (
+  id uuid primary key default gen_random_uuid(),
+  mama_id uuid not null references public.mamas(id) on delete cascade,
+  produit_id uuid not null references public.produits(id) on delete cascade,
+  zone_id uuid not null references public.zones_stock(id) on delete cascade,
+  stock_reel numeric default 0,
+  stock_min numeric default 0,
+  actif boolean default true,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now(),
+  unique (mama_id, produit_id, zone_id)
+);
+
+do $$ begin
+  if not exists (select 1 from pg_trigger where tgname = 'trg_pz_ts') then
+    create trigger trg_pz_ts before update on public.produits_zones
+    for each row execute procedure public.trg_set_timestamp();
+  end if;
+end $$;
+
+insert into public.produits_zones(mama_id, produit_id, zone_id, actif, stock_reel, stock_min)
+select distinct p.mama_id, p.id, p.zone_id, true, p.stock_reel, p.stock_min
+from public.produits p
+where p.zone_id is not null
+  and not exists (
+    select 1 from public.produits_zones px
+    where px.mama_id = p.mama_id and px.produit_id = p.id and px.zone_id = p.zone_id
+  );
+
+do $$ begin
+  if not exists (select 1 from pg_trigger where tgname = 'trg_prod_sync_zone') then
+    create trigger trg_prod_sync_zone
+    after insert or update of zone_id on public.produits
+    for each row execute procedure public.sync_pivot_from_produits();
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_trigger where tgname = 'trg_pz_sync_prod') then
+    create trigger trg_pz_sync_prod
+    after insert or update of actif on public.produits_zones
+    for each row execute procedure public.sync_produits_from_pivot();
+  end if;
+end $$;
+
+-- CLEANUP BEGIN
+-- drop view if exists public.v_boissons cascade;
+-- drop view if exists public.suggestions_commandes cascade;
+-- drop view if exists public.v_couts_fiches cascade;
+-- drop function if exists public.current_user_mama_id cascade;
+-- drop function if exists public.current_user_is_admin_or_manager cascade;
+-- drop function if exists public.current_user_is_admin cascade;
+-- drop function if exists public.calcul_ecarts_inventaire cascade;
+-- drop function if exists public.can_transfer cascade;
+-- drop function if exists public.zone_is_cave_or_shop cascade;
+-- drop function if exists public.compare_fiche cascade;
+-- drop function if exists public.stats_multi_mamas cascade;
+-- drop function if exists public.sync_pivot_from_produits cascade;
+-- drop function if exists public.sync_produits_from_pivot cascade;
+-- drop function if exists public.safe_delete_zone cascade;
+-- drop table if exists public.emails_envoyes cascade;
+-- drop table if exists public.alertes cascade;
+-- drop table if exists public.documentation cascade;
+-- drop table if exists public.fiches cascade;
+-- drop table if exists public.groupes cascade;
+-- drop table if exists public.guides_seen cascade;
+-- drop table if exists public.menus_groupes cascade;
+-- drop table if exists public.menus_groupes_fiches cascade;
+-- drop table if exists public.parametres_commandes cascade;
+-- drop table if exists public.stocks cascade;
+-- drop table if exists public.tooltips cascade;
+-- drop table if exists public.ventes_boissons cascade;
+-- drop table if exists public.ventes_fiches_carte cascade;
+-- CLEANUP END

--- a/scripts/buildSupabaseSQL.js
+++ b/scripts/buildSupabaseSQL.js
@@ -1,0 +1,308 @@
+import fs from 'fs';
+import path from 'path';
+
+// Determine input SQL file
+const candidates = [
+  'db/full_setup_final.sql',
+  'db/full_setup_fixed.sql',
+  'full_setup_final.sql',
+  'full_setup.sql'
+];
+const inputFile = candidates.find(f => fs.existsSync(f));
+if (!inputFile) {
+  console.error('No SQL source file found');
+  process.exit(1);
+}
+
+// Read inputs
+const sqlSource = fs.readFileSync(inputFile, 'utf8');
+const report = JSON.parse(fs.readFileSync('REPORTS/FRONT_BACK_ALIGN.json', 'utf8'));
+
+// Tokenizer respecting $$ blocks
+function tokenize(sql) {
+  const tokens = [];
+  let current = '';
+  let inSingle = false;
+  let inDouble = false;
+  let inDollar = false;
+  let inLineComment = false;
+  let inBlockComment = false;
+  for (let i = 0; i < sql.length; i++) {
+    const ch = sql[i];
+    const next = sql[i + 1];
+
+    if (inLineComment) {
+      current += ch;
+      if (ch === '\n') inLineComment = false;
+      continue;
+    }
+    if (inBlockComment) {
+      current += ch;
+      if (ch === '*' && next === '/') {
+        current += '/';
+        i++;
+        inBlockComment = false;
+      }
+      continue;
+    }
+
+    if (!inSingle && !inDouble && !inDollar) {
+      if (ch === '-' && next === '-') {
+        inLineComment = true;
+        current += ch + next;
+        i++;
+        continue;
+      }
+      if (ch === '/' && next === '*') {
+        inBlockComment = true;
+        current += ch + next;
+        i++;
+        continue;
+      }
+    }
+
+    if (!inSingle && !inDouble) {
+      if (!inDollar && ch === '$' && next === '$') {
+        inDollar = true;
+        current += '$$';
+        i++;
+        continue;
+      }
+      if (inDollar && ch === '$' && next === '$') {
+        inDollar = false;
+        current += '$$';
+        i++;
+        continue;
+      }
+    }
+
+    if (!inDouble && !inDollar && ch === "'") {
+      inSingle = !inSingle;
+      current += ch;
+      continue;
+    }
+    if (!inSingle && !inDollar && ch === '"') {
+      inDouble = !inDouble;
+      current += ch;
+      continue;
+    }
+
+    if (ch === ';' && !inSingle && !inDouble && !inDollar) {
+      current += ch;
+      if (current.trim()) tokens.push(current.trim());
+      current = '';
+      continue;
+    }
+
+    current += ch;
+  }
+  if (current.trim()) tokens.push(current.trim());
+  return tokens;
+}
+
+const statements = tokenize(sqlSource);
+
+// Buckets
+const buckets = {
+  EXTENSIONS: [],
+  FUNCTIONS: [],
+  TABLES: [],
+  ADDCOLUMNS: [],
+  INDEXES: [],
+  TRIGGERS: [],
+  RLS_ENABLE: [],
+  POLICIES: [],
+  GRANTS: [],
+  VIEWS: [],
+  OTHER: []
+};
+
+const summary = {
+  columnsAdded: [],
+  policiesWrapped: [],
+  constraintsWrapped: [],
+  viewsTouched: [],
+  functionAliases: [],
+  cleanup: {
+    tables: [],
+    views: [],
+    functions: []
+  }
+};
+
+// Helper to categorize
+function categorize(stmt) {
+  const s = stmt.trim().toLowerCase();
+  if (s.startsWith('create extension')) return 'EXTENSIONS';
+  if (s.startsWith('create or replace function') || s.startsWith('create function')) return 'FUNCTIONS';
+  if (s.startsWith('create table')) return 'TABLES';
+  if (s.startsWith('alter table') && s.includes(' add column')) return 'ADDCOLUMNS';
+  if (s.startsWith('create index') || s.startsWith('create unique index')) return 'INDEXES';
+  if (s.startsWith('create trigger')) return 'TRIGGERS';
+  if (s.startsWith('alter table') && s.includes(' enable row level security')) return 'RLS_ENABLE';
+  if (s.startsWith('create policy')) return 'POLICIES';
+  if (s.startsWith('grant')) return 'GRANTS';
+  if (s.startsWith('create view') || s.startsWith('create or replace view')) return 'VIEWS';
+  return 'OTHER';
+}
+
+// Track defined functions
+const definedFunctions = new Set();
+
+// Process statements
+for (let stmt of statements) {
+  let cat = categorize(stmt);
+
+  // Normalize view creation
+  if (cat === 'VIEWS') {
+    stmt = stmt.replace(/^create\s+view/i, 'create or replace view');
+    const m = stmt.match(/create or replace view\s+([^\s]+)\s+/i);
+    if (m) summary.viewsTouched.push(m[1]);
+  }
+
+  // Wrap policies
+  if (cat === 'POLICIES') {
+    const m = stmt.match(/create\s+policy\s+([^\s]+)\s+on\s+([^\s]+)\s+(.*)/is);
+    if (m) {
+      const [_, pol, table, rest] = m;
+      summary.policiesWrapped.push(`${pol} on ${table}`);
+      stmt = `do $$\nbegin\n  if not exists (\n    select 1 from pg_policies\n    where schemaname='${table.includes('.') ? table.split('.')[0] : 'public'}'\n      and tablename='${table.includes('.') ? table.split('.')[1] : table}'\n      and policyname='${pol}'\n  ) then\n    create policy ${pol} on ${table} ${rest.trim()}\n;\n  end if;\nend$$;`;
+    }
+  }
+
+  // Capture functions defined
+  if (cat === 'FUNCTIONS') {
+    const fm = stmt.match(/create\s+(?:or\s+replace\s+)?function\s+([^\s(]+)/i);
+    if (fm) definedFunctions.add(fm[1].replace(/"/g, ''));
+  }
+
+  // Handle FK constraints
+  if (cat === 'ADDCOLUMNS' || (cat === 'OTHER' && /foreign key/i.test(stmt))) {
+    const fk = stmt.match(/alter\s+table\s+([^\s]+)\s+add\s+constraint\s+([^\s]+)\s+foreign\s+key\s*\(([^)]+)\)\s+references\s+([^\s(]+)\s*\(([^)]+)\)/i);
+    if (fk) {
+      const [, table, cname, col, refTable, refCol] = fk;
+      const schema = table.includes('.') ? table.split('.')[0] : 'public';
+      const tbl = table.includes('.') ? table.split('.')[1] : table;
+      const column = col.trim();
+      const refTbl = refTable;
+      const refColumn = refCol.trim();
+      // Determine type
+      let type = 'uuid';
+      if ((refTbl === 'public.utilisateurs' || refTbl === 'auth.users' || refTbl === 'public.mamas') && refColumn === 'id') {
+        type = 'uuid';
+      }
+      const addCol = `do $$\nbegin\n  if not exists (\n    select 1 from information_schema.columns\n    where table_schema='${schema}' and table_name='${tbl}' and column_name='${column}'\n  ) then\n    alter table ${schema}.${tbl} add column ${column} ${type};\n  end if;\nend$$;`;
+      const addFk = `do $$\nbegin\n  if not exists (\n    select 1 from pg_constraint where conname='${cname}'\n  ) then\n    alter table ${schema}.${tbl} add constraint ${cname} foreign key (${column}) references ${refTable}(${refColumn});\n  end if;\nend$$;`;
+      summary.columnsAdded.push(`${schema}.${tbl}.${column} -> ${refTable}(${refColumn})`);
+      summary.constraintsWrapped.push(cname);
+      buckets.ADDCOLUMNS.push(addCol);
+      buckets.ADDCOLUMNS.push(addFk);
+      continue;
+    }
+  }
+
+  buckets[cat].push(stmt);
+}
+
+// Functions used in policies
+const policyFuncs = new Set();
+for (const pol of summary.policiesWrapped) {
+  const original = statements.find(s => s.includes(pol.split(' on ')[0]));
+  if (original) {
+    const matches = original.match(/public\.(\w+)\s*\(/g);
+    if (matches) {
+      matches.forEach(m => policyFuncs.add('public.' + m.match(/public\.(\w+)\s*\(/)[1]));
+    }
+  }
+}
+
+for (const fn of policyFuncs) {
+  if (!definedFunctions.has(fn)) {
+    if (fn.endsWith('current_user_is_admin') && definedFunctions.has('public.current_user_is_admin_or_manager')) {
+      const alias = `create or replace function ${fn}()\nreturns boolean\nlanguage sql stable\nas $$\n  select public.current_user_is_admin_or_manager()\n$$;`;
+      buckets.FUNCTIONS.push(alias);
+      summary.functionAliases.push(`${fn} alias current_user_is_admin_or_manager`);
+      definedFunctions.add(fn);
+    } else {
+      const stub = `create or replace function ${fn}()\nreturns boolean\nlanguage sql stable\nas $$\n  select true\n$$;`;
+      buckets.FUNCTIONS.push(stub);
+      summary.functionAliases.push(`${fn} stubbed`);
+      definedFunctions.add(fn);
+    }
+  }
+}
+
+// RLS enable and grants
+const usedTables = Object.keys(report.sqlIndex?.tables || {});
+const usedFunctions = (report.sqlIndex?.functions || []).map(f => f.name);
+
+usedTables.forEach(t => {
+  buckets.RLS_ENABLE.push(`alter table if exists public.${t} enable row level security;`);
+  buckets.GRANTS.push(`grant select, insert, update, delete on table public.${t} to authenticated;`);
+});
+
+usedFunctions.filter(f => !report.unused?.functions?.includes(f)).forEach(f => {
+  const fn = report.sqlIndex.functions.find(x => x.name === f);
+  if (fn && fn.args === 0) {
+    buckets.GRANTS.push(`grant execute on function public.${f}() to authenticated;`);
+  }
+});
+
+// Cleanup block
+const withCleanup = process.argv.includes('--with-cleanup');
+if (withCleanup) {
+  summary.cleanup.views = report.unused?.views || [];
+  summary.cleanup.functions = report.unused?.functions || [];
+  summary.cleanup.tables = report.unused?.tables || [];
+}
+
+function buildCleanup() {
+  let out = '-- CLEANUP BEGIN\n';
+  summary.cleanup.views.forEach(v => {
+    out += `-- drop view if exists public.${v} cascade;\n`;
+  });
+  summary.cleanup.functions.forEach(f => {
+    out += `-- drop function if exists public.${f} cascade;\n`;
+  });
+  summary.cleanup.tables.forEach(t => {
+    out += `-- drop table if exists public.${t} cascade;\n`;
+  });
+  out += '-- CLEANUP END';
+  return out;
+}
+
+// Build final SQL
+const order = ['EXTENSIONS','FUNCTIONS','TABLES','ADDCOLUMNS','INDEXES','TRIGGERS','RLS_ENABLE','POLICIES','GRANTS','VIEWS','OTHER'];
+let finalSQL = order.map(k => buckets[k].join('\n\n')).filter(Boolean).join('\n\n');
+if (withCleanup && (summary.cleanup.views.length || summary.cleanup.functions.length || summary.cleanup.tables.length)) {
+  finalSQL += '\n\n' + buildCleanup() + '\n';
+}
+
+fs.writeFileSync('db/full_setup_ONE.sql', finalSQL.trim() + '\n');
+
+// Summary report
+function writeSummary() {
+  let md = '# SQL Build Summary\n\n';
+  md += '## Columns added for FKs\n';
+  if (summary.columnsAdded.length) summary.columnsAdded.forEach(c => md += `- ${c}\n`); else md += 'None\n';
+  md += '\n## Policies wrapped\n';
+  if (summary.policiesWrapped.length) summary.policiesWrapped.forEach(p => md += `- ${p}\n`); else md += 'None\n';
+  md += '\n## Constraints wrapped\n';
+  if (summary.constraintsWrapped.length) summary.constraintsWrapped.forEach(c => md += `- ${c}\n`); else md += 'None\n';
+  md += '\n## Views touched\n';
+  if (summary.viewsTouched.length) summary.viewsTouched.forEach(v => md += `- ${v}\n`); else md += 'None\n';
+  md += '\n## Functions aliased/stubbed\n';
+  if (summary.functionAliases.length) summary.functionAliases.forEach(f => md += `- ${f}\n`); else md += 'None\n';
+  md += '\n## Execution order\n';
+  md += order.join(' -> ') + '\n';
+  if (withCleanup) {
+    md += '\n## Cleanup suggestions\n';
+    if (summary.cleanup.views.length) md += '- Views: ' + summary.cleanup.views.join(', ') + '\n';
+    if (summary.cleanup.functions.length) md += '- Functions: ' + summary.cleanup.functions.join(', ') + '\n';
+    if (summary.cleanup.tables.length) md += '- Tables: ' + summary.cleanup.tables.join(', ') + '\n';
+    if (!summary.cleanup.views.length && !summary.cleanup.functions.length && !summary.cleanup.tables.length) md += 'None\n';
+  }
+  fs.writeFileSync('REPORTS/SQL_BUILD_SUMMARY.md', md);
+}
+
+writeSummary();


### PR DESCRIPTION
## Summary
- add script to assemble idempotent SQL schema from existing scripts and alignment report
- generate single `db/full_setup_ONE.sql` and build summary report with optional cleanup

## Testing
- `node scripts/buildSupabaseSQL.js --with-cleanup`
- `npm test` *(fails: useNotifications is not a function; missing default export in usePeriodes mock)*


------
https://chatgpt.com/codex/tasks/task_e_6899c20cef88832da21f8abaffea36ac