### PR TITLE
chore: sanitize source files

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ npm test
 npm run test:e2e
 npm run build
 npm run preview
+npm run sanitize:src
 ```
+
+Run `npm run sanitize:src` to strip BOM, NBSP, and Unicode line separators from source files.
 
 If linting or tests fail because required packages are missing, simply run
 `npm install` again. This ensures `tesseract.js`, `vitest`, `@eslint/js` and

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "schema:repair:apply": "SCHEMA_APPLY=1 node scripts/repairSchema.js",
     "fix:fe": "node scripts/fixFrontend.js",
     "fix:fe:write": "node scripts/fixFrontend.js --write",
-    "schema:analyze": "node scripts/analyzeFrontBackend.js"
+    "schema:analyze": "node scripts/analyzeFrontBackend.js",
+    "sanitize:src": "node scripts/sanitize-source.js"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.14",

--- a/scripts/sanitize-source.js
+++ b/scripts/sanitize-source.js
@@ -1,0 +1,26 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+const exts = new Set(['.js','.jsx','.ts','.tsx']);
+
+function* walk(dir){
+  for (const e of fs.readdirSync(dir,{withFileTypes:true})) {
+    const p = path.join(dir,e.name);
+    if (e.isDirectory()) yield* walk(p);
+    else if (exts.has(path.extname(e.name))) yield p;
+  }
+}
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const srcDir = path.join(__dirname,'..','src');
+let changed = 0;
+
+for (const file of walk(srcDir)) {
+  const raw = fs.readFileSync(file,'utf8');
+  const clean = raw
+    .replace(/\uFEFF/g,'')        // BOM
+    .replace(/\u00A0/g,' ')       // NBSP
+    .replace(/\u2028|\u2029/g,'\n'); // line sep
+  if (clean !== raw) { fs.writeFileSync(file, clean, 'utf8'); changed++; }
+}
+console.log(changed ? `Sanitized ${changed} files` : 'No sanitation needed');
+process.exitCode = 0;


### PR DESCRIPTION
## Summary
- add script to strip BOM, NBSP, and Unicode line separators from source files
- expose sanitizer as `npm run sanitize:src` and document its usage

## Testing
- `npm run sanitize:src`
- `npm test` *(fails: useNotifications is not a function; [vitest] No "default" export is defined on the "@/hooks/usePeriodes" mock)*

------
https://chatgpt.com/codex/tasks/task_e_6899c7dece78832d9652165d8be7cacb