### PR TITLE
fix(hooks): dedupe loading states

### DIFF
--- a/src/hooks/gadgets/useEvolutionAchats.js
+++ b/src/hooks/gadgets/useEvolutionAchats.js
@@ -3,17 +3,17 @@ import { supabase } from '@/lib/supabase';
 import { useAuth } from '@/hooks/useAuth';
 
 export default function useEvolutionAchats() {
-  const { mama_id, loading } = useAuth() || {};
+  const { mama_id, loading: authLoading } = useAuth() || {};
   const [data, setData] = useState([]);
-  const [loading, setLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
 
   useEffect(() => {
-    if (loading) return;
+    if (authLoading) return;
     if (!mama_id) return;
 
     const fetchData = async () => {
-      setLoading(true);
+      setIsLoading(true);
       setError(null);
       try {
         const start = new Date();
@@ -33,12 +33,14 @@ export default function useEvolutionAchats() {
         setError(e);
         setData([]);
       } finally {
-        setLoading(false);
+        setIsLoading(false);
       }
     };
 
     fetchData();
-  }, [loading, mama_id]);
+  }, [authLoading, mama_id]);
+
+  const loading = [authLoading, isLoading].some(Boolean);
 
   return { data, loading, error };
 }

--- a/src/hooks/useEmailsEnvoyes.js
+++ b/src/hooks/useEmailsEnvoyes.js
@@ -3,9 +3,9 @@ import { supabase } from "@/lib/supabaseClient";
 import { useAuth } from "@/hooks/useAuth";
 
 export function useEmailsEnvoyes() {
-    const { mamaId, loading } = useAuth() || {};
+  const { mamaId, loading: authLoading } = useAuth() || {};
   const [list, setList] = useState([]);
-  const [loading, setLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
   const [err, setErr] = useState(null);
 
     const baseQuery = useMemo(() => {
@@ -15,15 +15,15 @@ export function useEmailsEnvoyes() {
     }, [mamaId]);
 
   const fetchEmails = useCallback(async (filters = {}) => {
-    setLoading(true);
+    setIsLoading(true);
     setErr(null);
     let q = baseQuery;
     if (filters.commande_id) q = q.eq("commande_id", filters.commande_id);
     if (filters.statut) q = q.eq("statut", filters.statut);
     const { data, error } = await q;
-    if (error) { setErr(error); setLoading(false); return []; }
+    if (error) { setErr(error); setIsLoading(false); return []; }
     setList(data || []);
-    setLoading(false);
+    setIsLoading(false);
     return data || [];
   }, [baseQuery]);
 
@@ -37,11 +37,13 @@ export function useEmailsEnvoyes() {
     return { ok: true };
   }, [fetchEmails, mamaId]);
 
-    useEffect(() => {
-      if (loading) return;
-      if (!mamaId) return;
-      fetchEmails();
-    }, [loading, mamaId, fetchEmails]);
+  useEffect(() => {
+    if (authLoading) return;
+    if (!mamaId) return;
+    fetchEmails();
+  }, [authLoading, mamaId, fetchEmails]);
+
+  const loading = [authLoading, isLoading].some(Boolean);
 
   return { list, loading, error: err, fetchEmails, logEmail };
 }

--- a/src/hooks/useZonesStock.js
+++ b/src/hooks/useZonesStock.js
@@ -7,12 +7,12 @@ export async function fetchZonesForValidation(mama_id) {
 }
 
 export default function useZonesStock() {
-  const { mama_id, loading } = useAuth() || {};
+  const { mama_id, loading: authLoading } = useAuth() || {};
   const [zones, setZones] = useState([]);
-  const [loading, setLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    if (loading) return;
+    if (authLoading) return;
     if (!mama_id) return;
     const fetchZones = async () => {
       const { data, error } = await supabase
@@ -22,10 +22,10 @@ export default function useZonesStock() {
         .eq("actif", true)
         .order("nom", { ascending: true });
       if (!error) setZones(data);
-      setLoading(false);
+      setIsLoading(false);
     };
     fetchZones();
-  }, [loading, mama_id]);
+  }, [authLoading, mama_id]);
 
   const suggestZones = useCallback(
     async (search = "") => {
@@ -39,8 +39,10 @@ export default function useZonesStock() {
         .limit(10);
       return data || [];
     },
-      [mama_id]
-    );
+    [mama_id]
+  );
+
+  const loading = [authLoading, isLoading].some(Boolean);
 
   return { zones, loading, suggestZones };
 }


### PR DESCRIPTION
## Summary
- combine auth and fetch loading states in useEvolutionAchats
- remove loading redeclarations in useEmailsEnvoyes
- dedupe loading in useZonesStock

## Testing
- `npm test` *(fails: useLogs.test.js, useEmailsEnvoyes.test.js, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6899e233f9c4832d81bf0b729166ccae