### PR TITLE
fix(a11y): ensure htmlFor/id pairing across inputs; add scan utility

### DIFF
--- a/scripts/a11y-scan.js
+++ b/scripts/a11y-scan.js
@@ -1,0 +1,16 @@
+import fs from 'fs';
+import path from 'path';
+const exts = new Set(['.jsx','.tsx']);
+function* walk(d){ for(const e of fs.readdirSync(d,{withFileTypes:true})) {
+  const p = path.join(d,e.name);
+  if(e.isDirectory()) yield* walk(p);
+  else if(exts.has(path.extname(e.name))) yield p;
+}}
+const root = path.join(path.dirname(new URL(import.meta.url).pathname),'..','src');
+let issues = [];
+for (const f of walk(root)) {
+  const s = fs.readFileSync(f,'utf8');
+  if (/<label(?![^>]*htmlFor)/.test(s) || /<input(?![^>]*id=)/.test(s))
+    issues.push(f);
+}
+console.log(JSON.stringify(issues,null,2));

--- a/src/components/Reporting/GraphMultiZone.jsx
+++ b/src/components/Reporting/GraphMultiZone.jsx
@@ -10,8 +10,9 @@ import {
   Legend,
   ResponsiveContainer,
 } from "recharts";
-import { useRef, useState } from "react";
+import { useRef, useState, useMemo } from "react";
 import html2canvas from "html2canvas";
+import { makeId } from "@/utils/formIds";
 
 const allZones = [
   { key: "cost_cuisine", label: "Cuisine", color: "#bfa14d" },
@@ -23,6 +24,7 @@ const allZones = [
 export default function GraphMultiZone({ data }) {
   const chartRef = useRef(null);
   const [selectedZones, setSelectedZones] = useState(allZones.map(z => z.key));
+  const checkboxIds = useMemo(() => Object.fromEntries(allZones.map(z => [z.key, makeId('fld')])), []);
 
   const toggleZone = (key) => {
     setSelectedZones((prev) =>
@@ -53,16 +55,20 @@ export default function GraphMultiZone({ data }) {
       </div>
 
       <div className="flex gap-4 mb-4 flex-wrap text-white">
-        {allZones.map((zone) => (
-          <label key={zone.key} className="flex items-center gap-2 text-sm">
-            <input
-              type="checkbox"
-              checked={selectedZones.includes(zone.key)}
-              onChange={() => toggleZone(zone.key)}
-            />
-            {zone.label}
-          </label>
-        ))}
+        {allZones.map((zone) => {
+          const id = checkboxIds[zone.key];
+          return (
+            <label key={zone.key} htmlFor={id} className="flex items-center gap-2 text-sm">
+              <input
+                id={id}
+                type="checkbox"
+                checked={selectedZones.includes(zone.key)}
+                onChange={() => toggleZone(zone.key)}
+              />
+              {zone.label}
+            </label>
+          );
+        })}
       </div>
 
       <div ref={chartRef}>

--- a/src/components/Utilisateurs/UtilisateurForm.jsx
+++ b/src/components/Utilisateurs/UtilisateurForm.jsx
@@ -1,5 +1,5 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useUtilisateurs } from "@/hooks/useUtilisateurs";
 import { useRoles } from "@/hooks/useRoles";
 import { useAuth } from '@/hooks/useAuth';
@@ -9,6 +9,7 @@ import { Select } from "@/components/ui/select";
 import PrimaryButton from "@/components/ui/PrimaryButton";
 import SecondaryButton from "@/components/ui/SecondaryButton";
 import toast from "react-hot-toast";
+import { makeId } from "@/utils/formIds";
 
 export default function UtilisateurForm({ utilisateur, onClose }) {
   const { createUtilisateur, updateUtilisateur } = useUtilisateurs();
@@ -19,6 +20,7 @@ export default function UtilisateurForm({ utilisateur, onClose }) {
   const [roleId, setRoleId] = useState(utilisateur?.role_id || "");
   const [actif, setActif] = useState(utilisateur?.actif ?? true);
   const [loading, setLoading] = useState(false);
+  const actifId = useMemo(() => makeId('fld'), []);
 
   useEffect(() => {
     fetchRoles();
@@ -75,8 +77,13 @@ export default function UtilisateurForm({ utilisateur, onClose }) {
             <option key={r.id} value={r.id}>{r.nom}</option>
           ))}
         </Select>
-        <label className="flex items-center gap-2 mb-2">
-          <input type="checkbox" checked={actif} onChange={e => setActif(e.target.checked)} />
+        <label htmlFor={actifId} className="flex items-center gap-2 mb-2">
+          <input
+            id={actifId}
+            type="checkbox"
+            checked={actif}
+            onChange={e => setActif(e.target.checked)}
+          />
           Actif
         </label>
         <div className="flex gap-2 mt-4">

--- a/src/components/utilisateurs/UtilisateurForm.jsx
+++ b/src/components/utilisateurs/UtilisateurForm.jsx
@@ -1,5 +1,5 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useUtilisateurs } from "@/hooks/useUtilisateurs";
 import { useRoles } from "@/hooks/useRoles";
 import { useAuth } from '@/hooks/useAuth';
@@ -9,6 +9,7 @@ import { Select } from "@/components/ui/select";
 import PrimaryButton from "@/components/ui/PrimaryButton";
 import SecondaryButton from "@/components/ui/SecondaryButton";
 import toast from "react-hot-toast";
+import { makeId } from "@/utils/formIds";
 
 export default function UtilisateurForm({ utilisateur, onClose }) {
   const { createUtilisateur, updateUtilisateur } = useUtilisateurs();
@@ -19,6 +20,7 @@ export default function UtilisateurForm({ utilisateur, onClose }) {
   const [roleId, setRoleId] = useState(utilisateur?.role_id || "");
   const [actif, setActif] = useState(utilisateur?.actif ?? true);
   const [loading, setLoading] = useState(false);
+  const actifId = useMemo(() => makeId('fld'), []);
 
   useEffect(() => {
     fetchRoles();
@@ -75,8 +77,13 @@ export default function UtilisateurForm({ utilisateur, onClose }) {
             <option key={r.id} value={r.id}>{r.nom}</option>
           ))}
         </Select>
-        <label className="flex items-center gap-2 mb-2">
-          <input type="checkbox" checked={actif} onChange={e => setActif(e.target.checked)} />
+        <label htmlFor={actifId} className="flex items-center gap-2 mb-2">
+          <input
+            id={actifId}
+            type="checkbox"
+            checked={actif}
+            onChange={e => setActif(e.target.checked)}
+          />
           Actif
         </label>
         <div className="flex gap-2 mt-4">

--- a/src/pages/auth/Login.jsx
+++ b/src/pages/auth/Login.jsx
@@ -1,5 +1,5 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
 import { useNavigate, useLocation, Link } from "react-router-dom";
 import MamaLogo from "@/components/ui/MamaLogo";
 import ResetAuthButton from "@/components/ResetAuthButton";
@@ -12,6 +12,7 @@ import PreviewBanner from "@/components/ui/PreviewBanner";
 import PrimaryButton from "@/components/ui/PrimaryButton";
 import { Input } from "@/components/ui/input";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import { makeId } from "@/utils/formIds";
 
 export default function Login() {
   const [email, setEmail] = useState("");
@@ -59,6 +60,9 @@ export default function Login() {
   if (authLoading || (session && !userData)) {
     return <LoadingSpinner message="Chargement..." />;
   }
+
+  const emailId = useMemo(() => makeId('fld'), []);
+  const passwordId = useMemo(() => makeId('fld'), []);
 
   const handleLogin = async (e) => {
     e.preventDefault();
@@ -112,8 +116,9 @@ export default function Login() {
         <p className="text-xs text-white/70 text-center mb-6">Plateforme F&B<br />by MamaStock</p>
         <form onSubmit={handleLogin} className="w-full flex flex-col gap-4">
             <div>
-              <label className="block text-xs font-semibold text-white/90 mb-1">Email</label>
+              <label htmlFor={emailId} className="block text-xs font-semibold text-white/90 mb-1">Email</label>
               <Input
+                id={emailId}
                 type="email"
                 value={email}
                 onChange={e => setEmail(e.target.value)}
@@ -127,8 +132,9 @@ export default function Login() {
               )}
             </div>
             <div>
-              <label className="block text-xs font-semibold text-white/90 mb-1">Mot de passe</label>
+              <label htmlFor={passwordId} className="block text-xs font-semibold text-white/90 mb-1">Mot de passe</label>
               <Input
+                id={passwordId}
                 type="password"
                 value={password}
                 onChange={e => setPassword(e.target.value)}

--- a/src/utils/formIds.js
+++ b/src/utils/formIds.js
@@ -1,6 +1,2 @@
-export function idFromLabel(label, prefix = "fld") {
-  if (!label) return `${prefix}-${Math.random().toString(36).slice(2,8)}`;
-  return `${prefix}-${label.toLowerCase().trim()
-    .replace(/[^\p{L}\p{N}]+/gu,"-")
-    .replace(/(^-|-$)/g,"")}-${Math.random().toString(36).slice(2,5)}`;
-}
+export const makeId = (prefix='fld') =>
+  `${prefix}-${Math.random().toString(36).slice(2,6)}`;


### PR DESCRIPTION
## Summary
- add `makeId` helper for stable form field IDs
- include `a11y-scan` script to detect missing htmlFor/id pairs
- wire up memoized IDs for labels/inputs in login, user form, and multi-zone graph components

## Testing
- `node scripts/a11y-scan.js`
- `npm test` *(fails: useNotifications is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6899e4c1d4ac832d9b528b73e2032b4d