### PR TITLE
Remove security definer from get_template_commande

### DIFF
--- a/db/01_app_safe.sql
+++ b/db/01_app_safe.sql
@@ -335,7 +335,7 @@ grant execute on function public.trg_set_timestamp() to authenticated;
 
 create or replace function public.get_template_commande(p_mama uuid, p_fournisseur uuid)
 returns setof public.templates_commandes
-language sql security definer as $$
+language sql as $$
   select *
   from public.templates_commandes
   where mama_id = p_mama


### PR DESCRIPTION
## Summary
- make get_template_commande run with default security context

## Testing
- `npm test` *(fails: Invalid Chai property: toBeInTheDocument)*

------
https://chatgpt.com/codex/tasks/task_e_689c818ed0a0832d9820b21a5f50e52a