### PR TITLE
feat: add preflight and conditional admin SQL patches

### DIFF
--- a/db/00_admin_preflight.sql
+++ b/db/00_admin_preflight.sql
@@ -1,0 +1,26 @@
+-- db/00_admin_preflight.sql
+-- A exécuter en Service role (postgres) AVANT db/00_admin_only.sql
+
+set search_path = public, pg_catalog;
+
+-- Vérif de contexte
+select current_user as user, session_user, current_schema;
+
+-- Ownership + droits schéma 'public'
+alter schema public owner to postgres;
+grant usage, create on schema public to postgres;
+
+-- Lecture du schéma pour les rôles applicatifs
+grant usage on schema public to authenticated;
+grant usage on schema public to anon;
+
+-- Par défaut, exécution des fonctions pour authenticated
+alter default privileges for role postgres in schema public
+  grant execute on functions to authenticated;
+
+-- (optionnel) diagnostic
+select n.nspname as schema, pg_catalog.pg_get_userbyid(n.nspowner) as owner
+from pg_namespace n where n.nspname='public';
+
+select has_schema_privilege('public','USAGE')  as has_usage,
+       has_schema_privilege('public','CREATE') as has_create;

--- a/db/checks_after.sql
+++ b/db/checks_after.sql
@@ -1,0 +1,37 @@
+-- db/checks_after.sql
+-- Extensions admin
+select name, installed_version
+from pg_available_extensions
+where name in ('pgcrypto','pg_net');
+
+-- Fonctions admin attendues
+select n.nspname as schema, p.proname as function
+from pg_proc p join pg_namespace n on n.oid = p.pronamespace
+where n.nspname='public'
+  and p.proname in (
+    'current_user_mama_id',
+    'current_user_is_admin_or_manager',
+    'current_user_is_admin',
+    'create_utilisateur',
+    'can_access_zone',
+    'log_action'
+  )
+order by 1,2;
+
+-- Policies spécifiques
+select schemaname, tablename, policyname
+from pg_policies
+where policyname in ('zones_stock_select','user_mama_access_select')
+order by 1,2,3;
+
+-- RLS activée (adapter la liste)
+select schemaname, tablename, rowsecurity
+from pg_tables
+where schemaname='public'
+  and tablename in ('utilisateurs','fournisseurs','produits','factures','facture_lignes')
+order by 1,2;
+
+-- Aucune fausse fonction auth.uid
+select n.nspname, p.proname
+from pg_proc p join pg_namespace n on n.oid = p.pronamespace
+where n.nspname='auth' and p.proname='uid';


### PR DESCRIPTION
## Summary
- add preflight script to ensure schema ownership and default privileges
- wrap admin functions and policies in conditional DO blocks for idempotency
- provide post-deployment SQL checks

## Testing
- `npm test` *(fails: TypeError: useNotifications is not a function, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689c8af7776c832db3d3ae350294356b