### PR TITLE
fix: make SQL scripts idempotent

### DIFF
--- a/db/01_app_safe.sql
+++ b/db/01_app_safe.sql
@@ -12,272 +12,36 @@ begin
   end loop;
 end $$;
 
-do $$ begin
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='achats' and column_name='mama_id') then
-    alter table public.achats add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='alertes' and column_name='mama_id') then
-    alter table public.alertes add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='alertes_rupture' and column_name='mama_id') then
-    alter table public.alertes_rupture add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='api_keys' and column_name='mama_id') then
-    alter table public.api_keys add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='auth_double_facteur' and column_name='mama_id') then
-    alter table public.auth_double_facteur add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='bons_livraison' and column_name='mama_id') then
-    alter table public.bons_livraison add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='catalogue_updates' and column_name='mama_id') then
-    alter table public.catalogue_updates add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='centres_de_cout' and column_name='mama_id') then
-    alter table public.centres_de_cout add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='commande_lignes' and column_name='mama_id') then
-    alter table public.commande_lignes add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='commandes' and column_name='mama_id') then
-    alter table public.commandes add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='compta_mapping' and column_name='mama_id') then
-    alter table public.compta_mapping add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='consentements_utilisateur' and column_name='mama_id') then
-    alter table public.consentements_utilisateur add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='documentation' and column_name='mama_id') then
-    alter table public.documentation add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='documents' and column_name='mama_id') then
-    alter table public.documents add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='emails_envoyes' and column_name='mama_id') then
-    alter table public.emails_envoyes add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='etapes_onboarding' and column_name='mama_id') then
-    alter table public.etapes_onboarding add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='facture_lignes' and column_name='mama_id') then
-    alter table public.facture_lignes add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='factures' and column_name='mama_id') then
-    alter table public.factures add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='familles' and column_name='mama_id') then
-    alter table public.familles add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='feedback' and column_name='mama_id') then
-    alter table public.feedback add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='fiche_cout_history' and column_name='mama_id') then
-    alter table public.fiche_cout_history add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='fiche_lignes' and column_name='mama_id') then
-    alter table public.fiche_lignes add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='fiches' and column_name='mama_id') then
-    alter table public.fiches add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='fiches_techniques' and column_name='mama_id') then
-    alter table public.fiches_techniques add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='fournisseur_contacts' and column_name='mama_id') then
-    alter table public.fournisseur_contacts add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='fournisseur_notes' and column_name='mama_id') then
-    alter table public.fournisseur_notes add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='fournisseur_produits' and column_name='mama_id') then
-    alter table public.fournisseur_produits add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='fournisseurs' and column_name='mama_id') then
-    alter table public.fournisseurs add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='fournisseurs_api_config' and column_name='mama_id') then
-    alter table public.fournisseurs_api_config add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='gadgets' and column_name='mama_id') then
-    alter table public.gadgets add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='groupes' and column_name='mama_id') then
-    alter table public.groupes add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='guides_seen' and column_name='mama_id') then
-    alter table public.guides_seen add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='help_articles' and column_name='mama_id') then
-    alter table public.help_articles add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='inventaire_zones' and column_name='mama_id') then
-    alter table public.inventaire_zones add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='inventaires' and column_name='mama_id') then
-    alter table public.inventaires add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='journaux_utilisateur' and column_name='mama_id') then
-    alter table public.journaux_utilisateur add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='lignes_bl' and column_name='mama_id') then
-    alter table public.lignes_bl add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='lignes_transfert' and column_name='mama_id') then
-    alter table public.lignes_transfert add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='logs_activite' and column_name='mama_id') then
-    alter table public.logs_activite add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='logs_securite' and column_name='mama_id') then
-    alter table public.logs_securite add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='mamas' and column_name='mama_id') then
-    alter table public.mamas add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='menu_fiches' and column_name='mama_id') then
-    alter table public.menu_fiches add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='menu_groupe_lignes' and column_name='mama_id') then
-    alter table public.menu_groupe_lignes add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='menu_groupe_modele_lignes' and column_name='mama_id') then
-    alter table public.menu_groupe_modele_lignes add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='menu_groupe_modeles' and column_name='mama_id') then
-    alter table public.menu_groupe_modeles add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='menu_groupes' and column_name='mama_id') then
-    alter table public.menu_groupes add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='menus' and column_name='mama_id') then
-    alter table public.menus add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='menus_groupes' and column_name='mama_id') then
-    alter table public.menus_groupes add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='menus_groupes_fiches' and column_name='mama_id') then
-    alter table public.menus_groupes_fiches add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='menus_jour' and column_name='mama_id') then
-    alter table public.menus_jour add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='menus_jour_fiches' and column_name='mama_id') then
-    alter table public.menus_jour_fiches add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='menus_jour_lignes' and column_name='mama_id') then
-    alter table public.menus_jour_lignes add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='notification_preferences' and column_name='mama_id') then
-    alter table public.notification_preferences add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='notifications' and column_name='mama_id') then
-    alter table public.notifications add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='parametres_commandes' and column_name='mama_id') then
-    alter table public.parametres_commandes add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='periodes_comptables' and column_name='mama_id') then
-    alter table public.periodes_comptables add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='permissions' and column_name='mama_id') then
-    alter table public.permissions add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='pertes' and column_name='mama_id') then
-    alter table public.pertes add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='planning_lignes' and column_name='mama_id') then
-    alter table public.planning_lignes add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='planning_previsionnel' and column_name='mama_id') then
-    alter table public.planning_previsionnel add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='produits' and column_name='mama_id') then
-    alter table public.produits add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='produits_inventaire' and column_name='mama_id') then
-    alter table public.produits_inventaire add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='promotions' and column_name='mama_id') then
-    alter table public.promotions add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='rapports_generes' and column_name='mama_id') then
-    alter table public.rapports_generes add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='regles_alertes' and column_name='mama_id') then
-    alter table public.regles_alertes add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='requisition_lignes' and column_name='mama_id') then
-    alter table public.requisition_lignes add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='requisitions' and column_name='mama_id') then
-    alter table public.requisitions add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='roles' and column_name='mama_id') then
-    alter table public.roles add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='settings' and column_name='mama_id') then
-    alter table public.settings add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='signalements' and column_name='mama_id') then
-    alter table public.signalements add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='sous_familles' and column_name='mama_id') then
-    alter table public.sous_familles add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='stocks' and column_name='mama_id') then
-    alter table public.stocks add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='tableaux_de_bord' and column_name='mama_id') then
-    alter table public.tableaux_de_bord add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='taches' and column_name='mama_id') then
-    alter table public.taches add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='templates_commandes' and column_name='mama_id') then
-    alter table public.templates_commandes add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='tooltips' and column_name='mama_id') then
-    alter table public.tooltips add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='transferts' and column_name='mama_id') then
-    alter table public.transferts add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='unites' and column_name='mama_id') then
-    alter table public.unites add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='usage_stats' and column_name='mama_id') then
-    alter table public.usage_stats add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='utilisateurs' and column_name='mama_id') then
-    alter table public.utilisateurs add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='utilisateurs_taches' and column_name='mama_id') then
-    alter table public.utilisateurs_taches add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='validation_requests' and column_name='mama_id') then
-    alter table public.validation_requests add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='ventes_boissons' and column_name='mama_id') then
-    alter table public.ventes_boissons add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='ventes_fiches' and column_name='mama_id') then
-    alter table public.ventes_fiches add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='ventes_fiches_carte' and column_name='mama_id') then
-    alter table public.ventes_fiches_carte add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='ventes_import_staging' and column_name='mama_id') then
-    alter table public.ventes_import_staging add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='zones_droits' and column_name='mama_id') then
-    alter table public.zones_droits add column mama_id uuid;
-  end if;
-  if not exists (select 1 from information_schema.columns where table_schema='public' and table_name='zones_stock' and column_name='mama_id') then
-    alter table public.zones_stock add column mama_id uuid;
-  end if;
+do $$
+declare tbl text;
+begin
+  foreach tbl in array[
+    'achats','alertes','alertes_rupture','api_keys','auth_double_facteur',
+    'bons_livraison','catalogue_updates','centres_de_cout','commande_lignes',
+    'commandes','compta_mapping','consentements_utilisateur','documentation',
+    'documents','emails_envoyes','etapes_onboarding','facture_lignes',
+    'factures','familles','feedback','fiche_cout_history','fiche_lignes',
+    'fiches','fiches_techniques','fournisseur_contacts','fournisseur_notes',
+    'fournisseur_produits','fournisseurs','fournisseurs_api_config','gadgets',
+    'groupes','guides_seen','help_articles','inventaire_zones','inventaires',
+    'journaux_utilisateur','lignes_bl','lignes_transfert','logs_activite',
+    'logs_securite','mamas','menu_fiches','menu_groupe_lignes',
+    'menu_groupe_modele_lignes','menu_groupe_modeles','menu_groupes','menus',
+    'menus_groupes','menus_groupes_fiches','menus_jour','menus_jour_fiches',
+    'menus_jour_lignes','notification_preferences','notifications',
+    'parametres_commandes','periodes_comptables','permissions','pertes',
+    'planning_lignes','planning_previsionnel','produits','produits_inventaire',
+    'promotions','rapports_generes','regles_alertes','requisition_lignes',
+    'requisitions','roles','settings','signalements','sous_familles','stocks',
+    'tableaux_de_bord','taches','templates_commandes','tooltips','transferts',
+    'unites','usage_stats','utilisateurs','utilisateurs_taches',
+    'validation_requests','ventes_boissons','ventes_fiches',
+    'ventes_fiches_carte','ventes_import_staging','zones_droits','zones_stock'
+  ] loop
+    execute format('alter table if exists public.%I add column if not exists mama_id uuid;', tbl);
+  end loop;
 end $$;
+
 -- SAFE
 set search_path = public, pg_catalog;
 set check_function_bodies = off;
@@ -365,20 +129,8 @@ create table if not exists public.commandes (
 );
 
 -- FK safety for commandes
-do $$ begin
-  if not exists (
-    select 1 from information_schema.columns
-    where table_schema='public' and table_name='commandes' and column_name='created_by'
-  ) then
-    alter table public.commandes add column created_by uuid;
-  end if;
-  if not exists (
-    select 1 from information_schema.columns
-    where table_schema='public' and table_name='commandes' and column_name='validated_by'
-  ) then
-    alter table public.commandes add column validated_by uuid;
-  end if;
-end $$;
+alter table if exists public.commandes add column if not exists created_by uuid;
+alter table if exists public.commandes add column if not exists validated_by uuid;
 
 create table if not exists public.commande_lignes (
   id uuid primary key default gen_random_uuid(),
@@ -443,140 +195,140 @@ create table if not exists public.consentements_utilisateur (
 -- 3. Foreign keys
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_fournisseurs_mama_id') then
-    alter table public.fournisseurs
+    alter table if exists public.fournisseurs
       add constraint fk_fournisseurs_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
 
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_produits_mama_id') then
-    alter table public.produits
+    alter table if exists public.produits
       add constraint fk_produits_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
 
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_roles_mama_id') then
-    alter table public.roles
+    alter table if exists public.roles
       add constraint fk_roles_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
 
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_utilisateurs_mama_id') then
-    alter table public.utilisateurs
+    alter table if exists public.utilisateurs
       add constraint fk_utilisateurs_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
 
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_utilisateurs_role_id') then
-    alter table public.utilisateurs
+    alter table if exists public.utilisateurs
       add constraint fk_utilisateurs_role_id foreign key (role_id) references public.roles(id) on delete restrict;
   end if;
 end $$;
 
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_commandes_mama_id') then
-    alter table public.commandes
+    alter table if exists public.commandes
       add constraint fk_commandes_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
 
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_commandes_fournisseur_id') then
-    alter table public.commandes
+    alter table if exists public.commandes
       add constraint fk_commandes_fournisseur_id foreign key (fournisseur_id) references public.fournisseurs(id) on delete set null;
   end if;
 end $$;
 
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_commandes_created_by') then
-    alter table public.commandes
+    alter table if exists public.commandes
       add constraint fk_commandes_created_by foreign key (created_by) references public.utilisateurs(id) on delete set null;
   end if;
 end $$;
 
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_commandes_validated_by') then
-    alter table public.commandes
+    alter table if exists public.commandes
       add constraint fk_commandes_validated_by foreign key (validated_by) references public.utilisateurs(id) on delete set null;
   end if;
 end $$;
 
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_commande_lignes_commande_id') then
-    alter table public.commande_lignes
+    alter table if exists public.commande_lignes
       add constraint fk_commande_lignes_commande_id foreign key (commande_id) references public.commandes(id) on delete cascade;
   end if;
 end $$;
 
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_commande_lignes_produit_id') then
-    alter table public.commande_lignes
+    alter table if exists public.commande_lignes
       add constraint fk_commande_lignes_produit_id foreign key (produit_id) references public.produits(id) on delete cascade;
   end if;
 end $$;
 
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_commande_lignes_mama_id') then
-    alter table public.commande_lignes
+    alter table if exists public.commande_lignes
       add constraint fk_commande_lignes_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
 
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_templates_commandes_mama_id') then
-    alter table public.templates_commandes
+    alter table if exists public.templates_commandes
       add constraint fk_templates_commandes_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
 
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_templates_commandes_fournisseur_id') then
-    alter table public.templates_commandes
+    alter table if exists public.templates_commandes
       add constraint fk_templates_commandes_fournisseur_id foreign key (fournisseur_id) references public.fournisseurs(id) on delete set null;
   end if;
 end $$;
 
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_emails_envoyes_commande_id') then
-    alter table public.emails_envoyes
+    alter table if exists public.emails_envoyes
       add constraint fk_emails_envoyes_commande_id foreign key (commande_id) references public.commandes(id) on delete cascade;
   end if;
 end $$;
 
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_emails_envoyes_mama_id') then
-    alter table public.emails_envoyes
+    alter table if exists public.emails_envoyes
       add constraint fk_emails_envoyes_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
 
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_permissions_role_id') then
-    alter table public.permissions
+    alter table if exists public.permissions
       add constraint fk_permissions_role_id foreign key (role_id) references public.roles(id) on delete cascade;
   end if;
 end $$;
 
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_permissions_mama_id') then
-    alter table public.permissions
+    alter table if exists public.permissions
       add constraint fk_permissions_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
 
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_consentements_utilisateur_utilisateur_id') then
-    alter table public.consentements_utilisateur
+    alter table if exists public.consentements_utilisateur
       add constraint fk_consentements_utilisateur_utilisateur_id foreign key (utilisateur_id) references public.utilisateurs(id) on delete cascade;
   end if;
 end $$;
 
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_consentements_utilisateur_mama_id') then
-    alter table public.consentements_utilisateur
+    alter table if exists public.consentements_utilisateur
       add constraint fk_consentements_utilisateur_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
@@ -672,7 +424,7 @@ begin
   end loop;
 end$$;
 -- 7. RLS & Policies
-alter table public.mamas enable row level security;
+alter table if exists public.mamas enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='mamas' and policyname='mamas_all') then
     create policy mamas_all on public.mamas
@@ -681,7 +433,7 @@ do $$ begin
   end if;
 end $$;
 
-alter table public.fournisseurs enable row level security;
+alter table if exists public.fournisseurs enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='fournisseurs' and policyname='fournisseurs_all') then
     create policy fournisseurs_all on public.fournisseurs
@@ -690,7 +442,7 @@ do $$ begin
   end if;
 end $$;
 
-alter table public.produits enable row level security;
+alter table if exists public.produits enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='produits' and policyname='produits_all') then
     create policy produits_all on public.produits
@@ -699,7 +451,7 @@ do $$ begin
   end if;
 end $$;
 
-alter table public.roles enable row level security;
+alter table if exists public.roles enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='roles' and policyname='roles_self_mama') then
     create policy roles_self_mama on public.roles
@@ -716,7 +468,7 @@ do $$ begin
   end if;
 end $$;
 
-alter table public.utilisateurs enable row level security;
+alter table if exists public.utilisateurs enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='utilisateurs' and policyname='utilisateurs_self_mama') then
     create policy utilisateurs_self_mama on public.utilisateurs
@@ -733,7 +485,7 @@ do $$ begin
   end if;
 end $$;
 
-alter table public.commandes enable row level security;
+alter table if exists public.commandes enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='commandes' and policyname='commandes_all') then
     create policy commandes_all on public.commandes
@@ -742,7 +494,7 @@ do $$ begin
   end if;
 end $$;
 
-alter table public.commande_lignes enable row level security;
+alter table if exists public.commande_lignes enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='commande_lignes' and policyname='commande_lignes_all') then
     create policy commande_lignes_all on public.commande_lignes
@@ -751,7 +503,7 @@ do $$ begin
   end if;
 end $$;
 
-alter table public.templates_commandes enable row level security;
+alter table if exists public.templates_commandes enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='templates_commandes' and policyname='templates_commandes_select') then
     create policy templates_commandes_select on public.templates_commandes
@@ -766,7 +518,7 @@ do $$ begin
   end if;
 end $$;
 
-alter table public.emails_envoyes enable row level security;
+alter table if exists public.emails_envoyes enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='emails_envoyes' and policyname='emails_envoyes_all') then
     create policy emails_envoyes_all on public.emails_envoyes
@@ -775,7 +527,7 @@ do $$ begin
   end if;
 end $$;
 
-alter table public.permissions enable row level security;
+alter table if exists public.permissions enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='permissions' and policyname='permissions_self_mama') then
     create policy permissions_self_mama on public.permissions
@@ -792,7 +544,7 @@ do $$ begin
   end if;
 end $$;
 
-alter table public.consentements_utilisateur enable row level security;
+alter table if exists public.consentements_utilisateur enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='consentements_utilisateur' and policyname='consentements_utilisateur_all') then
     create policy consentements_utilisateur_all on public.consentements_utilisateur
@@ -840,23 +592,23 @@ create index if not exists idx_achats_fournisseur_id on public.achats(fournisseu
 create index if not exists idx_achats_date on public.achats(date_achat);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_achats_mama_id') then
-    alter table public.achats
+    alter table if exists public.achats
       add constraint fk_achats_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_achats_produit_id') then
-    alter table public.achats
+    alter table if exists public.achats
       add constraint fk_achats_produit_id foreign key (produit_id) references public.produits(id) on delete restrict;
   end if;
 end $$;
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_achats_fournisseur_id') then
-    alter table public.achats
+    alter table if exists public.achats
       add constraint fk_achats_fournisseur_id foreign key (fournisseur_id) references public.fournisseurs(id) on delete restrict;
   end if;
 end $$;
-alter table public.achats enable row level security;
+alter table if exists public.achats enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='achats' and policyname='achats_all') then
     create policy achats_all on public.achats
@@ -873,11 +625,11 @@ create table if not exists public.alertes (
 create index if not exists idx_alertes_mama_id on public.alertes(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_alertes_mama_id') then
-    alter table public.alertes
+    alter table if exists public.alertes
       add constraint fk_alertes_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.alertes enable row level security;
+alter table if exists public.alertes enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='alertes' and policyname='alertes_all') then
     create policy alertes_all on public.alertes
@@ -894,11 +646,11 @@ create table if not exists public.api_keys (
 create index if not exists idx_api_keys_mama_id on public.api_keys(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_api_keys_mama_id') then
-    alter table public.api_keys
+    alter table if exists public.api_keys
       add constraint fk_api_keys_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.api_keys enable row level security;
+alter table if exists public.api_keys enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='api_keys' and policyname='api_keys_all') then
     create policy api_keys_all on public.api_keys
@@ -915,11 +667,11 @@ create table if not exists public.auth_double_facteur (
 create index if not exists idx_auth_double_facteur_mama_id on public.auth_double_facteur(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_auth_double_facteur_mama_id') then
-    alter table public.auth_double_facteur
+    alter table if exists public.auth_double_facteur
       add constraint fk_auth_double_facteur_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.auth_double_facteur enable row level security;
+alter table if exists public.auth_double_facteur enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='auth_double_facteur' and policyname='auth_double_facteur_all') then
     create policy auth_double_facteur_all on public.auth_double_facteur
@@ -936,11 +688,11 @@ create table if not exists public.bons_livraison (
 create index if not exists idx_bons_livraison_mama_id on public.bons_livraison(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_bons_livraison_mama_id') then
-    alter table public.bons_livraison
+    alter table if exists public.bons_livraison
       add constraint fk_bons_livraison_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.bons_livraison enable row level security;
+alter table if exists public.bons_livraison enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='bons_livraison' and policyname='bons_livraison_all') then
     create policy bons_livraison_all on public.bons_livraison
@@ -957,11 +709,11 @@ create table if not exists public.catalogue_updates (
 create index if not exists idx_catalogue_updates_mama_id on public.catalogue_updates(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_catalogue_updates_mama_id') then
-    alter table public.catalogue_updates
+    alter table if exists public.catalogue_updates
       add constraint fk_catalogue_updates_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.catalogue_updates enable row level security;
+alter table if exists public.catalogue_updates enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='catalogue_updates' and policyname='catalogue_updates_all') then
     create policy catalogue_updates_all on public.catalogue_updates
@@ -978,11 +730,11 @@ create table if not exists public.centres_de_cout (
 create index if not exists idx_centres_de_cout_mama_id on public.centres_de_cout(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_centres_de_cout_mama_id') then
-    alter table public.centres_de_cout
+    alter table if exists public.centres_de_cout
       add constraint fk_centres_de_cout_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.centres_de_cout enable row level security;
+alter table if exists public.centres_de_cout enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='centres_de_cout' and policyname='centres_de_cout_all') then
     create policy centres_de_cout_all on public.centres_de_cout
@@ -999,11 +751,11 @@ create table if not exists public.compta_mapping (
 create index if not exists idx_compta_mapping_mama_id on public.compta_mapping(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_compta_mapping_mama_id') then
-    alter table public.compta_mapping
+    alter table if exists public.compta_mapping
       add constraint fk_compta_mapping_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.compta_mapping enable row level security;
+alter table if exists public.compta_mapping enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='compta_mapping' and policyname='compta_mapping_all') then
     create policy compta_mapping_all on public.compta_mapping
@@ -1020,11 +772,11 @@ create table if not exists public.documentation (
 create index if not exists idx_documentation_mama_id on public.documentation(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_documentation_mama_id') then
-    alter table public.documentation
+    alter table if exists public.documentation
       add constraint fk_documentation_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.documentation enable row level security;
+alter table if exists public.documentation enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='documentation' and policyname='documentation_all') then
     create policy documentation_all on public.documentation
@@ -1041,11 +793,11 @@ create table if not exists public.documents (
 create index if not exists idx_documents_mama_id on public.documents(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_documents_mama_id') then
-    alter table public.documents
+    alter table if exists public.documents
       add constraint fk_documents_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.documents enable row level security;
+alter table if exists public.documents enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='documents' and policyname='documents_all') then
     create policy documents_all on public.documents
@@ -1062,11 +814,11 @@ create table if not exists public.etapes_onboarding (
 create index if not exists idx_etapes_onboarding_mama_id on public.etapes_onboarding(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_etapes_onboarding_mama_id') then
-    alter table public.etapes_onboarding
+    alter table if exists public.etapes_onboarding
       add constraint fk_etapes_onboarding_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.etapes_onboarding enable row level security;
+alter table if exists public.etapes_onboarding enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='etapes_onboarding' and policyname='etapes_onboarding_all') then
     create policy etapes_onboarding_all on public.etapes_onboarding
@@ -1083,11 +835,11 @@ create table if not exists public.facture_lignes (
 create index if not exists idx_facture_lignes_mama_id on public.facture_lignes(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_facture_lignes_mama_id') then
-    alter table public.facture_lignes
+    alter table if exists public.facture_lignes
       add constraint fk_facture_lignes_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.facture_lignes enable row level security;
+alter table if exists public.facture_lignes enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='facture_lignes' and policyname='facture_lignes_all') then
     create policy facture_lignes_all on public.facture_lignes
@@ -1104,11 +856,11 @@ create table if not exists public.factures (
 create index if not exists idx_factures_mama_id on public.factures(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_factures_mama_id') then
-    alter table public.factures
+    alter table if exists public.factures
       add constraint fk_factures_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.factures enable row level security;
+alter table if exists public.factures enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='factures' and policyname='factures_all') then
     create policy factures_all on public.factures
@@ -1127,11 +879,11 @@ create table if not exists public.familles (
 create index if not exists idx_familles_mama_id on public.familles(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_familles_mama_id') then
-    alter table public.familles
+    alter table if exists public.familles
       add constraint fk_familles_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.familles enable row level security;
+alter table if exists public.familles enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='familles' and policyname='familles_all') then
     create policy familles_all on public.familles
@@ -1148,11 +900,11 @@ create table if not exists public.feedback (
 create index if not exists idx_feedback_mama_id on public.feedback(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_feedback_mama_id') then
-    alter table public.feedback
+    alter table if exists public.feedback
       add constraint fk_feedback_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.feedback enable row level security;
+alter table if exists public.feedback enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='feedback' and policyname='feedback_all') then
     create policy feedback_all on public.feedback
@@ -1169,11 +921,11 @@ create table if not exists public.fiche_cout_history (
 create index if not exists idx_fiche_cout_history_mama_id on public.fiche_cout_history(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_fiche_cout_history_mama_id') then
-    alter table public.fiche_cout_history
+    alter table if exists public.fiche_cout_history
       add constraint fk_fiche_cout_history_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.fiche_cout_history enable row level security;
+alter table if exists public.fiche_cout_history enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='fiche_cout_history' and policyname='fiche_cout_history_all') then
     create policy fiche_cout_history_all on public.fiche_cout_history
@@ -1195,11 +947,11 @@ create table if not exists public.fiches_techniques (
 create index if not exists idx_fiches_techniques_mama_id on public.fiches_techniques(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_fiches_techniques_mama_id') then
-    alter table public.fiches_techniques
+    alter table if exists public.fiches_techniques
       add constraint fk_fiches_techniques_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.fiches_techniques enable row level security;
+alter table if exists public.fiches_techniques enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='fiches_techniques' and policyname='fiches_techniques_all') then
     create policy fiches_techniques_all on public.fiches_techniques
@@ -1221,23 +973,23 @@ create index if not exists idx_fiche_lignes_fiche_id on public.fiche_lignes(fich
 create index if not exists idx_fiche_lignes_produit_id on public.fiche_lignes(produit_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_fiche_lignes_mama_id') then
-    alter table public.fiche_lignes
+    alter table if exists public.fiche_lignes
       add constraint fk_fiche_lignes_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_fiche_lignes_fiche_id') then
-    alter table public.fiche_lignes
+    alter table if exists public.fiche_lignes
       add constraint fk_fiche_lignes_fiche_id foreign key (fiche_id) references public.fiches_techniques(id) on delete cascade;
   end if;
 end $$;
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_fiche_lignes_produit_id') then
-    alter table public.fiche_lignes
+    alter table if exists public.fiche_lignes
       add constraint fk_fiche_lignes_produit_id foreign key (produit_id) references public.produits(id);
   end if;
 end $$;
-alter table public.fiche_lignes enable row level security;
+alter table if exists public.fiche_lignes enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='fiche_lignes' and policyname='fiche_lignes_all') then
     create policy fiche_lignes_all on public.fiche_lignes
@@ -1254,11 +1006,11 @@ create table if not exists public.fiches (
 create index if not exists idx_fiches_mama_id on public.fiches(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_fiches_mama_id') then
-    alter table public.fiches
+    alter table if exists public.fiches
       add constraint fk_fiches_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.fiches enable row level security;
+alter table if exists public.fiches enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='fiches' and policyname='fiches_all') then
     create policy fiches_all on public.fiches
@@ -1275,11 +1027,11 @@ create table if not exists public.fournisseur_contacts (
 create index if not exists idx_fournisseur_contacts_mama_id on public.fournisseur_contacts(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_fournisseur_contacts_mama_id') then
-    alter table public.fournisseur_contacts
+    alter table if exists public.fournisseur_contacts
       add constraint fk_fournisseur_contacts_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.fournisseur_contacts enable row level security;
+alter table if exists public.fournisseur_contacts enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='fournisseur_contacts' and policyname='fournisseur_contacts_all') then
     create policy fournisseur_contacts_all on public.fournisseur_contacts
@@ -1296,11 +1048,11 @@ create table if not exists public.fournisseur_notes (
 create index if not exists idx_fournisseur_notes_mama_id on public.fournisseur_notes(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_fournisseur_notes_mama_id') then
-    alter table public.fournisseur_notes
+    alter table if exists public.fournisseur_notes
       add constraint fk_fournisseur_notes_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.fournisseur_notes enable row level security;
+alter table if exists public.fournisseur_notes enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='fournisseur_notes' and policyname='fournisseur_notes_all') then
     create policy fournisseur_notes_all on public.fournisseur_notes
@@ -1323,23 +1075,23 @@ create index if not exists idx_fournisseur_produits_produit_id on public.fournis
 create index if not exists idx_fournisseur_produits_fournisseur_id on public.fournisseur_produits(fournisseur_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_fournisseur_produits_mama_id') then
-    alter table public.fournisseur_produits
+    alter table if exists public.fournisseur_produits
       add constraint fk_fournisseur_produits_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_fournisseur_produits_produit_id') then
-    alter table public.fournisseur_produits
+    alter table if exists public.fournisseur_produits
       add constraint fk_fournisseur_produits_produit_id foreign key (produit_id) references public.produits(id) on delete cascade;
   end if;
 end $$;
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_fournisseur_produits_fournisseur_id') then
-    alter table public.fournisseur_produits
+    alter table if exists public.fournisseur_produits
       add constraint fk_fournisseur_produits_fournisseur_id foreign key (fournisseur_id) references public.fournisseurs(id) on delete cascade;
   end if;
 end $$;
-alter table public.fournisseur_produits enable row level security;
+alter table if exists public.fournisseur_produits enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='fournisseur_produits' and policyname='fournisseur_produits_all') then
     create policy fournisseur_produits_all on public.fournisseur_produits
@@ -1356,11 +1108,11 @@ create table if not exists public.fournisseurs_api_config (
 create index if not exists idx_fournisseurs_api_config_mama_id on public.fournisseurs_api_config(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_fournisseurs_api_config_mama_id') then
-    alter table public.fournisseurs_api_config
+    alter table if exists public.fournisseurs_api_config
       add constraint fk_fournisseurs_api_config_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.fournisseurs_api_config enable row level security;
+alter table if exists public.fournisseurs_api_config enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='fournisseurs_api_config' and policyname='fournisseurs_api_config_all') then
     create policy fournisseurs_api_config_all on public.fournisseurs_api_config
@@ -1377,11 +1129,11 @@ create table if not exists public.gadgets (
 create index if not exists idx_gadgets_mama_id on public.gadgets(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_gadgets_mama_id') then
-    alter table public.gadgets
+    alter table if exists public.gadgets
       add constraint fk_gadgets_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.gadgets enable row level security;
+alter table if exists public.gadgets enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='gadgets' and policyname='gadgets_all') then
     create policy gadgets_all on public.gadgets
@@ -1398,11 +1150,11 @@ create table if not exists public.groupes (
 create index if not exists idx_groupes_mama_id on public.groupes(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_groupes_mama_id') then
-    alter table public.groupes
+    alter table if exists public.groupes
       add constraint fk_groupes_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.groupes enable row level security;
+alter table if exists public.groupes enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='groupes' and policyname='groupes_all') then
     create policy groupes_all on public.groupes
@@ -1419,11 +1171,11 @@ create table if not exists public.guides_seen (
 create index if not exists idx_guides_seen_mama_id on public.guides_seen(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_guides_seen_mama_id') then
-    alter table public.guides_seen
+    alter table if exists public.guides_seen
       add constraint fk_guides_seen_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.guides_seen enable row level security;
+alter table if exists public.guides_seen enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='guides_seen' and policyname='guides_seen_all') then
     create policy guides_seen_all on public.guides_seen
@@ -1440,11 +1192,11 @@ create table if not exists public.help_articles (
 create index if not exists idx_help_articles_mama_id on public.help_articles(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_help_articles_mama_id') then
-    alter table public.help_articles
+    alter table if exists public.help_articles
       add constraint fk_help_articles_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.help_articles enable row level security;
+alter table if exists public.help_articles enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='help_articles' and policyname='help_articles_all') then
     create policy help_articles_all on public.help_articles
@@ -1461,11 +1213,11 @@ create table if not exists public.inventaire_zones (
 create index if not exists idx_inventaire_zones_mama_id on public.inventaire_zones(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_inventaire_zones_mama_id') then
-    alter table public.inventaire_zones
+    alter table if exists public.inventaire_zones
       add constraint fk_inventaire_zones_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.inventaire_zones enable row level security;
+alter table if exists public.inventaire_zones enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='inventaire_zones' and policyname='inventaire_zones_all') then
     create policy inventaire_zones_all on public.inventaire_zones
@@ -1485,7 +1237,7 @@ create table if not exists public.periodes_comptables (
   created_at timestamptz default now()
 );
 create index if not exists idx_periodes_comptables_mama_id on public.periodes_comptables(mama_id);
-alter table public.periodes_comptables enable row level security;
+alter table if exists public.periodes_comptables enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='periodes_comptables' and policyname='periodes_comptables_rls') then
     create policy periodes_comptables_rls on public.periodes_comptables
@@ -1507,7 +1259,7 @@ create table if not exists public.inventaires (
 );
 create index if not exists idx_inventaires_mama_id on public.inventaires(mama_id);
 create index if not exists idx_inventaires_periode_id on public.inventaires(periode_id);
-alter table public.inventaires enable row level security;
+alter table if exists public.inventaires enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='inventaires' and policyname='inventaires_select') then
     create policy inventaires_select on public.inventaires
@@ -1544,7 +1296,7 @@ create table if not exists public.produits_inventaire (
 );
 create index if not exists idx_produits_inventaire_mama_id on public.produits_inventaire(mama_id);
 create index if not exists idx_produits_inventaire_inventaire_id on public.produits_inventaire(inventaire_id);
-alter table public.produits_inventaire enable row level security;
+alter table if exists public.produits_inventaire enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='produits_inventaire' and policyname='produits_inventaire_rls') then
     create policy produits_inventaire_rls on public.produits_inventaire
@@ -1561,11 +1313,11 @@ create table if not exists public.journaux_utilisateur (
 create index if not exists idx_journaux_utilisateur_mama_id on public.journaux_utilisateur(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_journaux_utilisateur_mama_id') then
-    alter table public.journaux_utilisateur
+    alter table if exists public.journaux_utilisateur
       add constraint fk_journaux_utilisateur_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.journaux_utilisateur enable row level security;
+alter table if exists public.journaux_utilisateur enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='journaux_utilisateur' and policyname='journaux_utilisateur_all') then
     create policy journaux_utilisateur_all on public.journaux_utilisateur
@@ -1582,11 +1334,11 @@ create table if not exists public.lignes_bl (
 create index if not exists idx_lignes_bl_mama_id on public.lignes_bl(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_lignes_bl_mama_id') then
-    alter table public.lignes_bl
+    alter table if exists public.lignes_bl
       add constraint fk_lignes_bl_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.lignes_bl enable row level security;
+alter table if exists public.lignes_bl enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='lignes_bl' and policyname='lignes_bl_all') then
     create policy lignes_bl_all on public.lignes_bl
@@ -1603,11 +1355,11 @@ create table if not exists public.logs_securite (
 create index if not exists idx_logs_securite_mama_id on public.logs_securite(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_logs_securite_mama_id') then
-    alter table public.logs_securite
+    alter table if exists public.logs_securite
       add constraint fk_logs_securite_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.logs_securite enable row level security;
+alter table if exists public.logs_securite enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='logs_securite' and policyname='logs_securite_all') then
     create policy logs_securite_all on public.logs_securite
@@ -1624,11 +1376,11 @@ create table if not exists public.menu_fiches (
 create index if not exists idx_menu_fiches_mama_id on public.menu_fiches(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_menu_fiches_mama_id') then
-    alter table public.menu_fiches
+    alter table if exists public.menu_fiches
       add constraint fk_menu_fiches_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.menu_fiches enable row level security;
+alter table if exists public.menu_fiches enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='menu_fiches' and policyname='menu_fiches_all') then
     create policy menu_fiches_all on public.menu_fiches
@@ -1645,11 +1397,11 @@ create table if not exists public.menus (
 create index if not exists idx_menus_mama_id on public.menus(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_menus_mama_id') then
-    alter table public.menus
+    alter table if exists public.menus
       add constraint fk_menus_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.menus enable row level security;
+alter table if exists public.menus enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='menus' and policyname='menus_all') then
     create policy menus_all on public.menus
@@ -1666,11 +1418,11 @@ create table if not exists public.menus_groupes (
 create index if not exists idx_menus_groupes_mama_id on public.menus_groupes(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_menus_groupes_mama_id') then
-    alter table public.menus_groupes
+    alter table if exists public.menus_groupes
       add constraint fk_menus_groupes_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.menus_groupes enable row level security;
+alter table if exists public.menus_groupes enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='menus_groupes' and policyname='menus_groupes_all') then
     create policy menus_groupes_all on public.menus_groupes
@@ -1687,11 +1439,11 @@ create table if not exists public.menus_groupes_fiches (
 create index if not exists idx_menus_groupes_fiches_mama_id on public.menus_groupes_fiches(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_menus_groupes_fiches_mama_id') then
-    alter table public.menus_groupes_fiches
+    alter table if exists public.menus_groupes_fiches
       add constraint fk_menus_groupes_fiches_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.menus_groupes_fiches enable row level security;
+alter table if exists public.menus_groupes_fiches enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='menus_groupes_fiches' and policyname='menus_groupes_fiches_all') then
     create policy menus_groupes_fiches_all on public.menus_groupes_fiches
@@ -1719,7 +1471,7 @@ create table if not exists public.menus_jour_fiches (
 );
 create index if not exists idx_menus_jour_mama on public.menus_jour(mama_id, date_menu);
 create index if not exists idx_menus_jour_fiches_menu on public.menus_jour_fiches(menu_jour_id);
-alter table public.menus_jour enable row level security;
+alter table if exists public.menus_jour enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='menus_jour' and policyname='menus_jour_all') then
     create policy menus_jour_all on public.menus_jour
@@ -1728,7 +1480,7 @@ do $$ begin
   end if;
 end $$;
 grant select, insert, update, delete on public.menus_jour to authenticated;
-alter table public.menus_jour_fiches enable row level security;
+alter table if exists public.menus_jour_fiches enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='menus_jour_fiches' and policyname='menus_jour_fiches_all') then
     create policy menus_jour_fiches_all on public.menus_jour_fiches
@@ -1745,11 +1497,11 @@ create table if not exists public.notification_preferences (
 create index if not exists idx_notification_preferences_mama_id on public.notification_preferences(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_notification_preferences_mama_id') then
-    alter table public.notification_preferences
+    alter table if exists public.notification_preferences
       add constraint fk_notification_preferences_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.notification_preferences enable row level security;
+alter table if exists public.notification_preferences enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='notification_preferences' and policyname='notification_preferences_all') then
     create policy notification_preferences_all on public.notification_preferences
@@ -1766,11 +1518,11 @@ create table if not exists public.notifications (
 create index if not exists idx_notifications_mama_id on public.notifications(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_notifications_mama_id') then
-    alter table public.notifications
+    alter table if exists public.notifications
       add constraint fk_notifications_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.notifications enable row level security;
+alter table if exists public.notifications enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='notifications' and policyname='notifications_all') then
     create policy notifications_all on public.notifications
@@ -1787,11 +1539,11 @@ create table if not exists public.parametres_commandes (
 create index if not exists idx_parametres_commandes_mama_id on public.parametres_commandes(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_parametres_commandes_mama_id') then
-    alter table public.parametres_commandes
+    alter table if exists public.parametres_commandes
       add constraint fk_parametres_commandes_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.parametres_commandes enable row level security;
+alter table if exists public.parametres_commandes enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='parametres_commandes' and policyname='parametres_commandes_all') then
     create policy parametres_commandes_all on public.parametres_commandes
@@ -1808,11 +1560,11 @@ create table if not exists public.pertes (
 create index if not exists idx_pertes_mama_id on public.pertes(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_pertes_mama_id') then
-    alter table public.pertes
+    alter table if exists public.pertes
       add constraint fk_pertes_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.pertes enable row level security;
+alter table if exists public.pertes enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='pertes' and policyname='pertes_all') then
     create policy pertes_all on public.pertes
@@ -1829,11 +1581,11 @@ create table if not exists public.planning_lignes (
 create index if not exists idx_planning_lignes_mama_id on public.planning_lignes(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_planning_lignes_mama_id') then
-    alter table public.planning_lignes
+    alter table if exists public.planning_lignes
       add constraint fk_planning_lignes_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.planning_lignes enable row level security;
+alter table if exists public.planning_lignes enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='planning_lignes' and policyname='planning_lignes_all') then
     create policy planning_lignes_all on public.planning_lignes
@@ -1850,11 +1602,11 @@ create table if not exists public.planning_previsionnel (
 create index if not exists idx_planning_previsionnel_mama_id on public.planning_previsionnel(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_planning_previsionnel_mama_id') then
-    alter table public.planning_previsionnel
+    alter table if exists public.planning_previsionnel
       add constraint fk_planning_previsionnel_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.planning_previsionnel enable row level security;
+alter table if exists public.planning_previsionnel enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='planning_previsionnel' and policyname='planning_previsionnel_all') then
     create policy planning_previsionnel_all on public.planning_previsionnel
@@ -1871,11 +1623,11 @@ create table if not exists public.promotions (
 create index if not exists idx_promotions_mama_id on public.promotions(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_promotions_mama_id') then
-    alter table public.promotions
+    alter table if exists public.promotions
       add constraint fk_promotions_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.promotions enable row level security;
+alter table if exists public.promotions enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='promotions' and policyname='promotions_all') then
     create policy promotions_all on public.promotions
@@ -1892,11 +1644,11 @@ create table if not exists public.regles_alertes (
 create index if not exists idx_regles_alertes_mama_id on public.regles_alertes(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_regles_alertes_mama_id') then
-    alter table public.regles_alertes
+    alter table if exists public.regles_alertes
       add constraint fk_regles_alertes_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.regles_alertes enable row level security;
+alter table if exists public.regles_alertes enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='regles_alertes' and policyname='regles_alertes_all') then
     create policy regles_alertes_all on public.regles_alertes
@@ -1941,20 +1693,32 @@ create index if not exists idx_zones_droits_zone on public.zones_droits(zone_id)
 create index if not exists idx_zones_droits_user on public.zones_droits(user_id);
 
 -- Row Level Security
-alter table public.zones_stock enable row level security;
-alter table public.zones_droits enable row level security;
+  alter table if exists public.zones_stock enable row level security;
+  alter table if exists public.zones_droits enable row level security;
 
-drop policy if exists zones_stock_admin_iud on public.zones_stock;
-create policy zones_stock_admin_iud on public.zones_stock
-  for all using (mama_id = current_user_mama_id() and current_user_is_admin_or_manager())
-  with check (mama_id = current_user_mama_id() and current_user_is_admin_or_manager());
+  do $$ begin
+    if not exists (
+      select 1 from pg_policies
+      where schemaname='public' and tablename='zones_stock' and policyname='zones_stock_admin_iud'
+    ) then
+      create policy zones_stock_admin_iud on public.zones_stock
+        for all using (mama_id = current_user_mama_id() and current_user_is_admin_or_manager())
+        with check (mama_id = current_user_mama_id() and current_user_is_admin_or_manager());
+    end if;
+  end $$;
 
-drop policy if exists zones_droits_admin_all on public.zones_droits;
-create policy zones_droits_admin_all on public.zones_droits
-  for all using (mama_id = current_user_mama_id() and current_user_is_admin())
-  with check (mama_id = current_user_mama_id() and current_user_is_admin());
+  do $$ begin
+    if not exists (
+      select 1 from pg_policies
+      where schemaname='public' and tablename='zones_droits' and policyname='zones_droits_admin_all'
+    ) then
+      create policy zones_droits_admin_all on public.zones_droits
+        for all using (mama_id = current_user_mama_id() and current_user_is_admin())
+        with check (mama_id = current_user_mama_id() and current_user_is_admin());
+    end if;
+  end $$;
 
-grant select, insert, update, delete on public.zones_stock, public.zones_droits to authenticated;
+  grant select, insert, update, delete on public.zones_stock, public.zones_droits to authenticated;
 
 
 -- RPC Functions
@@ -1994,22 +1758,36 @@ create table if not exists public.requisitions (
 );
 create index if not exists idx_requisitions_mama_id on public.requisitions(mama_id);
 create index if not exists idx_requisitions_zone on public.requisitions(zone_id);
-alter table public.requisitions enable row level security;
-drop policy if exists requisitions_select on public.requisitions;
-create policy requisitions_select on public.requisitions for select using (mama_id = current_user_mama_id());
-drop policy if exists requisitions_insert on public.requisitions;
-create policy requisitions_insert on public.requisitions
-for insert with check (
-  mama_id = current_user_mama_id()
-  and exists (
-    select 1 from public.zones_stock z
-    where z.id = zone_id and z.mama_id = mama_id and z.type in ('cave','shop')
-  )
-);
-drop policy if exists requisitions_update on public.requisitions;
-create policy requisitions_update on public.requisitions for update using (mama_id = current_user_mama_id());
-drop policy if exists requisitions_delete on public.requisitions;
-create policy requisitions_delete on public.requisitions for delete using (mama_id = current_user_mama_id());
+alter table if exists public.requisitions enable row level security;
+do $$ begin
+  if not exists (
+    select 1 from pg_policies where schemaname='public' and tablename='requisitions' and policyname='requisitions_select'
+  ) then
+    create policy requisitions_select on public.requisitions for select using (mama_id = current_user_mama_id());
+  end if;
+  if not exists (
+    select 1 from pg_policies where schemaname='public' and tablename='requisitions' and policyname='requisitions_insert'
+  ) then
+    create policy requisitions_insert on public.requisitions
+    for insert with check (
+      mama_id = current_user_mama_id()
+      and exists (
+        select 1 from public.zones_stock z
+        where z.id = zone_id and z.mama_id = mama_id and z.type in ('cave','shop')
+      )
+    );
+  end if;
+  if not exists (
+    select 1 from pg_policies where schemaname='public' and tablename='requisitions' and policyname='requisitions_update'
+  ) then
+    create policy requisitions_update on public.requisitions for update using (mama_id = current_user_mama_id());
+  end if;
+  if not exists (
+    select 1 from pg_policies where schemaname='public' and tablename='requisitions' and policyname='requisitions_delete'
+  ) then
+    create policy requisitions_delete on public.requisitions for delete using (mama_id = current_user_mama_id());
+  end if;
+end $$;
 grant select, insert, update, delete on public.requisitions to authenticated;
 
 create table if not exists public.requisition_lignes (
@@ -2023,7 +1801,7 @@ create table if not exists public.requisition_lignes (
 );
 create index if not exists idx_requisition_lignes_requisition on public.requisition_lignes(requisition_id);
 create index if not exists idx_requisition_lignes_mama_id on public.requisition_lignes(mama_id);
-alter table public.requisition_lignes enable row level security;
+alter table if exists public.requisition_lignes enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='requisition_lignes' and policyname='requisition_lignes_select') then
     create policy requisition_lignes_select on public.requisition_lignes for select using (mama_id = current_user_mama_id());
@@ -2053,11 +1831,11 @@ create table if not exists public.signalements (
 create index if not exists idx_signalements_mama_id on public.signalements(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_signalements_mama_id') then
-    alter table public.signalements
+    alter table if exists public.signalements
       add constraint fk_signalements_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.signalements enable row level security;
+alter table if exists public.signalements enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='signalements' and policyname='signalements_all') then
     create policy signalements_all on public.signalements
@@ -2077,17 +1855,17 @@ create table if not exists public.sous_familles (
 create index if not exists idx_sous_familles_mama_id on public.sous_familles(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_sous_familles_mama_id') then
-    alter table public.sous_familles
+    alter table if exists public.sous_familles
       add constraint fk_sous_familles_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_sous_familles_famille_id') then
-    alter table public.sous_familles
+    alter table if exists public.sous_familles
       add constraint fk_sous_familles_famille_id foreign key (famille_id) references public.familles(id) on delete cascade;
   end if;
 end $$;
-alter table public.sous_familles enable row level security;
+alter table if exists public.sous_familles enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='sous_familles' and policyname='sous_familles_all') then
     create policy sous_familles_all on public.sous_familles
@@ -2104,11 +1882,11 @@ create table if not exists public.stocks (
 create index if not exists idx_stocks_mama_id on public.stocks(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_stocks_mama_id') then
-    alter table public.stocks
+    alter table if exists public.stocks
       add constraint fk_stocks_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.stocks enable row level security;
+alter table if exists public.stocks enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='stocks' and policyname='stocks_all') then
     create policy stocks_all on public.stocks
@@ -2125,11 +1903,11 @@ create table if not exists public.tableaux_de_bord (
 create index if not exists idx_tableaux_de_bord_mama_id on public.tableaux_de_bord(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_tableaux_de_bord_mama_id') then
-    alter table public.tableaux_de_bord
+    alter table if exists public.tableaux_de_bord
       add constraint fk_tableaux_de_bord_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.tableaux_de_bord enable row level security;
+alter table if exists public.tableaux_de_bord enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='tableaux_de_bord' and policyname='tableaux_de_bord_all') then
     create policy tableaux_de_bord_all on public.tableaux_de_bord
@@ -2146,11 +1924,11 @@ create table if not exists public.taches (
 create index if not exists idx_taches_mama_id on public.taches(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_taches_mama_id') then
-    alter table public.taches
+    alter table if exists public.taches
       add constraint fk_taches_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.taches enable row level security;
+alter table if exists public.taches enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='taches' and policyname='taches_all') then
     create policy taches_all on public.taches
@@ -2167,11 +1945,11 @@ create table if not exists public.tooltips (
 create index if not exists idx_tooltips_mama_id on public.tooltips(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_tooltips_mama_id') then
-    alter table public.tooltips
+    alter table if exists public.tooltips
       add constraint fk_tooltips_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.tooltips enable row level security;
+alter table if exists public.tooltips enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='tooltips' and policyname='tooltips_all') then
     create policy tooltips_all on public.tooltips
@@ -2191,11 +1969,11 @@ create table if not exists public.unites (
 create index if not exists idx_unites_mama_id on public.unites(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_unites_mama_id') then
-    alter table public.unites
+    alter table if exists public.unites
       add constraint fk_unites_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.unites enable row level security;
+alter table if exists public.unites enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='unites' and policyname='unites_all') then
     create policy unites_all on public.unites
@@ -2232,7 +2010,7 @@ create index if not exists idx_transferts_date on public.transferts(mama_id, dat
 create index if not exists idx_lignes_transfert_mama on public.lignes_transfert(mama_id);
 create index if not exists idx_lignes_transfert_transfert on public.lignes_transfert(transfert_id);
 create index if not exists idx_lignes_transfert_produit on public.lignes_transfert(produit_id);
-alter table public.transferts enable row level security;
+alter table if exists public.transferts enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='transferts' and policyname='transferts_all') then
     create policy transferts_all on public.transferts
@@ -2241,7 +2019,7 @@ do $$ begin
   end if;
 end $$;
 grant select, insert, update, delete on public.transferts to authenticated;
-alter table public.lignes_transfert enable row level security;
+alter table if exists public.lignes_transfert enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='lignes_transfert' and policyname='lignes_transfert_all') then
     create policy lignes_transfert_all on public.lignes_transfert
@@ -2258,11 +2036,11 @@ create table if not exists public.usage_stats (
 create index if not exists idx_usage_stats_mama_id on public.usage_stats(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_usage_stats_mama_id') then
-    alter table public.usage_stats
+    alter table if exists public.usage_stats
       add constraint fk_usage_stats_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.usage_stats enable row level security;
+alter table if exists public.usage_stats enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='usage_stats' and policyname='usage_stats_all') then
     create policy usage_stats_all on public.usage_stats
@@ -2279,11 +2057,11 @@ create table if not exists public.utilisateurs_taches (
 create index if not exists idx_utilisateurs_taches_mama_id on public.utilisateurs_taches(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_utilisateurs_taches_mama_id') then
-    alter table public.utilisateurs_taches
+    alter table if exists public.utilisateurs_taches
       add constraint fk_utilisateurs_taches_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.utilisateurs_taches enable row level security;
+alter table if exists public.utilisateurs_taches enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='utilisateurs_taches' and policyname='utilisateurs_taches_all') then
     create policy utilisateurs_taches_all on public.utilisateurs_taches
@@ -2300,11 +2078,11 @@ create table if not exists public.validation_requests (
 create index if not exists idx_validation_requests_mama_id on public.validation_requests(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_validation_requests_mama_id') then
-    alter table public.validation_requests
+    alter table if exists public.validation_requests
       add constraint fk_validation_requests_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.validation_requests enable row level security;
+alter table if exists public.validation_requests enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='validation_requests' and policyname='validation_requests_all') then
     create policy validation_requests_all on public.validation_requests
@@ -2321,11 +2099,11 @@ create table if not exists public.ventes_boissons (
 create index if not exists idx_ventes_boissons_mama_id on public.ventes_boissons(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_ventes_boissons_mama_id') then
-    alter table public.ventes_boissons
+    alter table if exists public.ventes_boissons
       add constraint fk_ventes_boissons_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.ventes_boissons enable row level security;
+alter table if exists public.ventes_boissons enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='ventes_boissons' and policyname='ventes_boissons_all') then
     create policy ventes_boissons_all on public.ventes_boissons
@@ -2342,11 +2120,11 @@ create table if not exists public.ventes_fiches_carte (
 create index if not exists idx_ventes_fiches_carte_mama_id on public.ventes_fiches_carte(mama_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_ventes_fiches_carte_mama_id') then
-    alter table public.ventes_fiches_carte
+    alter table if exists public.ventes_fiches_carte
       add constraint fk_ventes_fiches_carte_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
   end if;
 end $$;
-alter table public.ventes_fiches_carte enable row level security;
+alter table if exists public.ventes_fiches_carte enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='ventes_fiches_carte' and policyname='ventes_fiches_carte_all') then
     create policy ventes_fiches_carte_all on public.ventes_fiches_carte
@@ -2362,13 +2140,13 @@ do $$ begin
     select 1 from information_schema.columns
     where table_schema='public' and table_name='produits' and column_name='sous_famille_id'
   ) then
-    alter table public.produits add column sous_famille_id uuid;
+    alter table if exists public.produits add column sous_famille_id uuid;
   end if;
   if not exists (
     select 1 from information_schema.columns
     where table_schema='public' and table_name='produits' and column_name='zone_id'
   ) then
-    alter table public.produits add column zone_id uuid;
+    alter table if exists public.produits add column zone_id uuid;
   end if;
 end $$;
 
@@ -2377,7 +2155,7 @@ do $$ begin
   if not exists (
     select 1 from pg_constraint where conname = 'fk_produits_zone_id'
   ) then
-    alter table public.produits
+    alter table if exists public.produits
       add constraint fk_produits_zone_id
       foreign key (zone_id) references public.zones_stock(id) on delete set null;
   end if;
@@ -2385,28 +2163,28 @@ end $$;
 
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_produits_fournisseur_id') then
-    alter table public.produits
+    alter table if exists public.produits
       add constraint fk_produits_fournisseur_id foreign key (fournisseur_id) references public.fournisseurs(id) on delete set null;
   end if;
 end $$;
 
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_produits_unite_id') then
-    alter table public.produits
+    alter table if exists public.produits
       add constraint fk_produits_unite_id foreign key (unite_id) references public.unites(id) on delete set null;
   end if;
 end $$;
 
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_produits_famille_id') then
-    alter table public.produits
+    alter table if exists public.produits
       add constraint fk_produits_famille_id foreign key (famille_id) references public.familles(id) on delete set null;
   end if;
 end $$;
 
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_produits_sous_famille_id') then
-    alter table public.produits
+    alter table if exists public.produits
       add constraint fk_produits_sous_famille_id foreign key (sous_famille_id) references public.sous_familles(id) on delete set null;
   end if;
 end $$;
@@ -2928,7 +2706,7 @@ create table if not exists public.menu_groupes (
   unique (mama_id, nom)
 );
 create index if not exists idx_menu_groupes_mama on public.menu_groupes(mama_id);
-alter table public.menu_groupes enable row level security;
+alter table if exists public.menu_groupes enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='menu_groupes' and policyname='menu_groupes_all') then
     create policy menu_groupes_all on public.menu_groupes
@@ -2950,7 +2728,7 @@ create table if not exists public.menu_groupe_lignes (
 );
 create index if not exists idx_menu_groupe_lignes_menu on public.menu_groupe_lignes(menu_groupe_id);
 create index if not exists idx_menu_groupe_lignes_fiche on public.menu_groupe_lignes(fiche_id);
-alter table public.menu_groupe_lignes enable row level security;
+alter table if exists public.menu_groupe_lignes enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='menu_groupe_lignes' and policyname='menu_groupe_lignes_all') then
     create policy menu_groupe_lignes_all on public.menu_groupe_lignes
@@ -2968,7 +2746,7 @@ create table if not exists public.menu_groupe_modeles (
   created_at timestamptz default now()
 );
 create index if not exists idx_menu_groupe_modeles_mama on public.menu_groupe_modeles(mama_id);
-alter table public.menu_groupe_modeles enable row level security;
+alter table if exists public.menu_groupe_modeles enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='menu_groupe_modeles' and policyname='menu_groupe_modeles_all') then
     create policy menu_groupe_modeles_all on public.menu_groupe_modeles
@@ -2989,7 +2767,7 @@ create table if not exists public.menu_groupe_modele_lignes (
   created_at timestamptz default now()
 );
 create index if not exists idx_menu_groupe_modele_lignes_modele on public.menu_groupe_modele_lignes(modele_id);
-alter table public.menu_groupe_modele_lignes enable row level security;
+alter table if exists public.menu_groupe_modele_lignes enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='menu_groupe_modele_lignes' and policyname='menu_groupe_modele_lignes_all') then
     create policy menu_groupe_modele_lignes_all on public.menu_groupe_modele_lignes
@@ -3076,7 +2854,7 @@ create table if not exists public.alertes_rupture (
   traite boolean default false
 );
 create index if not exists idx_alertes_rupture_mama on public.alertes_rupture(mama_id);
-alter table public.alertes_rupture enable row level security;
+alter table if exists public.alertes_rupture enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='alertes_rupture' and policyname='alertes_rupture_all') then
     create policy alertes_rupture_all on public.alertes_rupture for all using (mama_id = current_user_mama_id()) with check (mama_id = current_user_mama_id());
@@ -3098,7 +2876,7 @@ create table if not exists public.logs_activite (
   date_log timestamptz default now()
 );
 create index if not exists idx_logs_activite_mama on public.logs_activite(mama_id, date_log desc);
-alter table public.logs_activite enable row level security;
+alter table if exists public.logs_activite enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='logs_activite' and policyname='logs_activite_all') then
     create policy logs_activite_all on public.logs_activite for all using (mama_id = current_user_mama_id()) with check (mama_id = current_user_mama_id());
@@ -3118,7 +2896,7 @@ create table if not exists public.menus_jour_lignes (
 );
 create index if not exists idx_menus_jour_lignes_menu on public.menus_jour_lignes(menu_id);
 create index if not exists idx_menus_jour_lignes_fiche on public.menus_jour_lignes(fiche_id);
-alter table public.menus_jour_lignes enable row level security;
+alter table if exists public.menus_jour_lignes enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='menus_jour_lignes' and policyname='menus_jour_lignes_all') then
     create policy menus_jour_lignes_all on public.menus_jour_lignes for all using (mama_id = current_user_mama_id()) with check (mama_id = current_user_mama_id());
@@ -3138,7 +2916,7 @@ create table if not exists public.rapports_generes (
   created_by uuid
 );
 create index if not exists idx_rapports_generes_mama on public.rapports_generes(mama_id);
-alter table public.rapports_generes enable row level security;
+alter table if exists public.rapports_generes enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='rapports_generes' and policyname='rapports_generes_all') then
     create policy rapports_generes_all on public.rapports_generes for all using (mama_id = current_user_mama_id()) with check (mama_id = current_user_mama_id());
@@ -3158,7 +2936,7 @@ create table if not exists public.settings (
   created_at timestamptz default now()
 );
 create index if not exists idx_settings_mama on public.settings(mama_id);
-alter table public.settings enable row level security;
+alter table if exists public.settings enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='settings' and policyname='settings_all') then
     create policy settings_all on public.settings for all using (mama_id = current_user_mama_id()) with check (mama_id = current_user_mama_id());
@@ -3174,7 +2952,7 @@ create table if not exists public.user_mama_access (
   created_at timestamptz default now(),
   unique (user_id, mama_id)
 );
-alter table public.user_mama_access enable row level security;
+alter table if exists public.user_mama_access enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='user_mama_access' and policyname='user_mama_access_modify') then
     create policy user_mama_access_modify on public.user_mama_access for all using (current_user_is_admin()) with check (current_user_is_admin());
@@ -3193,7 +2971,7 @@ create table if not exists public.ventes_fiches (
   unique (mama_id, fiche_id, date_vente)
 );
 create index if not exists idx_ventes_fiches_mama on public.ventes_fiches(mama_id);
-alter table public.ventes_fiches enable row level security;
+alter table if exists public.ventes_fiches enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='ventes_fiches' and policyname='ventes_fiches_all') then
     create policy ventes_fiches_all on public.ventes_fiches for all using (mama_id = current_user_mama_id()) with check (mama_id = current_user_mama_id());
@@ -3212,7 +2990,7 @@ create table if not exists public.ventes_import_staging (
   created_at timestamptz default now()
 );
 create index if not exists idx_vis_mama on public.ventes_import_staging(mama_id);
-alter table public.ventes_import_staging enable row level security;
+alter table if exists public.ventes_import_staging enable row level security;
 do $$ begin
   if not exists (select 1 from pg_policies where schemaname='public' and tablename='ventes_import_staging' and policyname='ventes_import_staging_all') then
     create policy ventes_import_staging_all on public.ventes_import_staging for all using (mama_id = current_user_mama_id()) with check (mama_id = current_user_mama_id());


### PR DESCRIPTION
## Summary
- ensure mama_id columns are added conditionally across all tables
- create RLS policies only when missing and guard against absent dependencies
- wrap admin grants with checks for existing functions

## Testing
- `npm test` *(fails: useNotifications is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_689d9139653c832d8e7dfdb9203193ba