### PR TITLE
fix: ensure menus_jour date column

### DIFF
--- a/db/01_app_safe.sql
+++ b/db/01_app_safe.sql
@@ -1800,6 +1800,8 @@ create table if not exists public.menus_jour (
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now()
 );
+-- Column safety for menus_jour.date_menu
+alter table if exists public.menus_jour add column if not exists date_menu date;
 create table if not exists public.menus_jour_fiches (
   id uuid primary key default gen_random_uuid(),
   mama_id uuid not null references public.mamas(id) on delete cascade,


### PR DESCRIPTION
## Summary
- add defensive ALTER TABLE to ensure menus_jour has date_menu column before indexing

## Testing
- `npm test` *(fails: No "default" export is defined on the "@/components/engineering/EngineeringFilters" mock. Did you forget to return it from "vi.mock"?)*

------
https://chatgpt.com/codex/tasks/task_e_689da53078a8832d80d2213a33047d9c