### PR TITLE
chore(db): harden preflight and admin scripts

### DIFF
--- a/db/00_admin_preflight.sql
+++ b/db/00_admin_preflight.sql
@@ -6,6 +6,11 @@ set search_path = public, pg_catalog;
 -- Vérif de contexte
 select current_user as user, session_user, current_schema;
 
+-- Nettoyage des privilèges par défaut
+revoke all on schema public from public;
+revoke all on schema public from authenticated;
+revoke all on schema public from anon;
+
 -- Ownership + droits schéma 'public'
 alter schema public owner to postgres;
 grant usage, create on schema public to postgres;


### PR DESCRIPTION
## Summary
- restrict default privileges on public schema before running admin operations
- install pgcrypto/pg_net in extensions schema and scope pgcrypto calls accordingly

## Testing
- `npm test` *(fails: useNotifications is not a function, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689dac93be10832d9549147603b5eb7a