### PR TITLE
Refactor auth context and login flow

### DIFF
--- a/src/api/shared/supabaseClient.js
+++ b/src/api/shared/supabaseClient.js
@@ -1,26 +1,10 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 /* eslint-env node */
-import { createClient } from '@supabase/supabase-js';
-import { getSupabaseEnv } from './supabaseEnv.js';
+import { supabase } from "../../lib/supabaseClient.js";
 
-const cache = new Map();
-
-export function getSupabaseClient(url = null, key = null) {
-  let envUrl, envKey;
-  try {
-    ({ supabaseUrl: envUrl, supabaseKey: envKey } = getSupabaseEnv());
-  } catch {
-    envUrl = undefined;
-    envKey = undefined;
-  }
-  const supabaseUrl = url || envUrl;
-  const supabaseKey = key || envKey;
-  if (!supabaseUrl || !supabaseKey) {
+export function getSupabaseClient() {
+  if (!supabase) {
     throw new Error('Missing Supabase credentials');
   }
-  const cacheKey = `${supabaseUrl}:${supabaseKey}`;
-  if (!cache.has(cacheKey)) {
-    cache.set(cacheKey, createClient(supabaseUrl, supabaseKey));
-  }
-  return cache.get(cacheKey);
+  return supabase;
 }

--- a/src/hooks/useConsentements.js
+++ b/src/hooks/useConsentements.js
@@ -1,11 +1,10 @@
 import { useEffect, useState, useCallback } from "react";
-import { createClient } from "@/lib/supabaseClient";
+import { supabase } from "@/lib/supabaseClient";
 import { useAuth } from '@/hooks/useAuth';
 
 export default function useConsentements() {
   const { user_id, mama_id } = useAuth();
   const [consentements, setConsentements] = useState([]);
-  const supabase = createClient();
 
   const fetchConsentements = useCallback(
     async (utilisateurId = user_id) => {
@@ -22,7 +21,7 @@ export default function useConsentements() {
       setConsentements(data || []);
       return data || [];
     },
-    [supabase, mama_id, user_id]
+    [mama_id, user_id]
   );
 
   useEffect(() => {

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -1,18 +1,3 @@
-// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-/* eslint-env node */
-import { createClient } from "@supabase/supabase-js";
+import { supabase } from "./supabaseClient";
 
-const supabaseUrl =
-  import.meta.env?.VITE_SUPABASE_URL ||
-  process.env.VITE_SUPABASE_URL ||
-  process.env.SUPABASE_URL;
-const supabaseKey =
-  import.meta.env?.VITE_SUPABASE_ANON_KEY ||
-  process.env.VITE_SUPABASE_ANON_KEY ||
-  process.env.SUPABASE_ANON_KEY;
-
-if (!supabaseUrl || !supabaseKey) {
-  throw new Error('Missing Supabase credentials');
-}
-
-export const supabase = createClient(supabaseUrl, supabaseKey);
+export { supabase };

--- a/src/pages/auth/Login.jsx
+++ b/src/pages/auth/Login.jsx
@@ -1,11 +1,10 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { useState, useEffect, useRef, useMemo } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useNavigate, useLocation, Link } from "react-router-dom";
-import MamaLogo from "@/components/ui/MamaLogo";
-import ResetAuthButton from "@/components/ResetAuthButton";
 import toast from "react-hot-toast";
-import { useAuth } from '@/hooks/useAuth';
+import { useAuth } from "@/hooks/useAuth";
 import useFormErrors from "@/hooks/useFormErrors";
+import MamaLogo from "@/components/ui/MamaLogo";
 import GlassCard from "@/components/ui/GlassCard";
 import PageWrapper from "@/components/ui/PageWrapper";
 import PreviewBanner from "@/components/ui/PreviewBanner";
@@ -17,157 +16,113 @@ import { makeId } from "@/utils/formIds";
 export default function Login() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-  const [loading, setLoading] = useState(false);
+  const [formLoading, setFormLoading] = useState(false);
   const { errors, setError, clearErrors } = useFormErrors();
   const navigate = useNavigate();
-  const { pathname } = useLocation();
+  const location = useLocation();
+  const { session, loading, signInWithPassword } = useAuth();
+  const emailId = useMemo(() => makeId("fld"), []);
+  const passwordId = useMemo(() => makeId("fld"), []);
 
-  const {
-    session,
-    userData,
-    loading: authLoading,
-    getAuthorizedModules,
-    login,
-    error: authError,
-    resetAuth,
-  } = useAuth();
-  const rightsLoaded =
-    userData &&
-    userData.mama_id &&
-    userData.access_rights &&
-    Object.keys(userData.access_rights).length > 0;
-
-  const redirectedRef = useRef(false);
   useEffect(() => {
-    if (redirectedRef.current) return;
-    if (!session || authLoading) return;
-    if (!userData) return;
-    if (!rightsLoaded) return;
-    redirectedRef.current = true;
-    if (userData.actif === false && pathname !== "/blocked") {
-      navigate("/blocked");
-      return;
+    if (session) {
+      const redirectTo = location.state?.from || "/dashboard";
+      navigate(redirectTo, { replace: true });
     }
-    const rights = getAuthorizedModules();
-    if (rights.length === 0 && pathname !== "/unauthorized") {
-      navigate("/unauthorized");
-      return;
-    }
-    toast.success(`Bienvenue ${session.user.email}`);
-    if (pathname !== "/dashboard") navigate("/dashboard");
-  }, [session, userData, authLoading, navigate, pathname, getAuthorizedModules, rightsLoaded]);
+  }, [session, navigate, location]);
 
-  if (authLoading || (session && !userData)) {
+  if (loading) {
     return <LoadingSpinner message="Chargement..." />;
   }
 
-  const emailId = useMemo(() => makeId('fld'), []);
-  const passwordId = useMemo(() => makeId('fld'), []);
-
   const handleLogin = async (e) => {
     e.preventDefault();
-    if (loading) return;
+    if (formLoading) return;
     clearErrors();
     if (!email) setError("email", "Email requis");
     if (!password) setError("password", "Mot de passe requis");
     if (!email || !password) return;
 
-    setLoading(true);
-    try {
-      const { data, error } = await login({ email: email.trim(), password });
-      if (error) {
-        console.error(error);
-        setError("password", error.message || error);
-        toast.error(error.message || "Échec de la connexion");
-        return;
-      }
-      if (data) {
-        toast.success("Connexion réussie");
-        // redirection handled once user data is loaded
-      }
-    } catch (err) {
-      console.error(err);
-      toast.error(err?.message || "Échec de la connexion");
-    } finally {
-      setLoading(false);
+    setFormLoading(true);
+    const { error } = await signInWithPassword({
+      email: email.trim(),
+      password,
+    });
+    if (error) {
+      console.error(error);
+      setError("password", error.message || String(error));
+      toast.error(error.message || "Échec de la connexion");
     }
+    setFormLoading(false);
   };
 
   return (
     <PageWrapper>
       <PreviewBanner />
-      {authError && (
-        <div className="text-red-500 text-center mb-2 text-sm">
-          {authError}
-          {resetAuth && (
-            <div className="mt-1">
-              <ResetAuthButton className="underline" />
-            </div>
-          )}
-        </div>
-      )}
-      {userData && !rightsLoaded && (
-        <div className="text-red-500 text-center mb-2 text-sm">Droits utilisateur incomplets. Rechargez la page ou contactez le support.</div>
-      )}
       <GlassCard title="Connexion" className="flex flex-col items-center">
         <div className="mb-6">
           <MamaLogo width={96} />
         </div>
-        <p className="text-xs text-white/70 text-center mb-6">Plateforme F&B<br />by MamaStock</p>
+        <p className="text-xs text-white/70 text-center mb-6">
+          Plateforme F&B<br />by MamaStock
+        </p>
         <form onSubmit={handleLogin} className="w-full flex flex-col gap-4">
-            <div>
-              <label htmlFor={emailId} className="block text-xs font-semibold text-white/90 mb-1">Email</label>
-              <Input
-                id={emailId}
-                type="email"
-                value={email}
-                onChange={e => setEmail(e.target.value)}
-                autoFocus
-                autoComplete="email"
-                required
-                placeholder="votre@email.com"
-              />
-              {errors.email && (
-                <p className="text-sm text-red-500 mt-1">{errors.email}</p>
-              )}
-            </div>
-            <div>
-              <label htmlFor={passwordId} className="block text-xs font-semibold text-white/90 mb-1">Mot de passe</label>
-              <Input
-                id={passwordId}
-                type="password"
-                value={password}
-                onChange={e => setPassword(e.target.value)}
-                autoComplete="current-password"
-                required
-                placeholder="••••••••"
-              />
-              {errors.password && (
-                <p className="text-sm text-red-500 mt-1">{errors.password}</p>
-              )}
-            </div>
-            <PrimaryButton
-              type="submit"
-              className="mt-3 flex items-center justify-center gap-2 disabled:opacity-50"
-              disabled={!email || !password || loading}
-            >
-              {loading ? (
-                <>
-                  <span className="loader-glass" />
-                  Connexion…
-                </>
-              ) : (
-                "Se connecter"
-              )}
-            </PrimaryButton>
-            <div className="text-right mt-2">
-              <Link to="/reset-password" className="text-xs text-gold hover:underline">
-                Mot de passe oublié ?
-              </Link>
-            </div>
-          </form>
-        </GlassCard>
-        <p className="text-xs text-center text-white/40 mt-4">© MamaStock 2025</p>
-      </PageWrapper>
+          <div>
+            <label htmlFor={emailId} className="block text-xs font-semibold text-white/90 mb-1">
+              Email
+            </label>
+            <Input
+              id={emailId}
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              autoFocus
+              autoComplete="email"
+              required
+              placeholder="votre@email.com"
+            />
+            {errors.email && <p className="text-sm text-red-500 mt-1">{errors.email}</p>}
+          </div>
+          <div>
+            <label htmlFor={passwordId} className="block text-xs font-semibold text-white/90 mb-1">
+              Mot de passe
+            </label>
+            <Input
+              id={passwordId}
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              autoComplete="current-password"
+              required
+              placeholder="••••••••"
+            />
+            {errors.password && (
+              <p className="text-sm text-red-500 mt-1">{errors.password}</p>
+            )}
+          </div>
+          <PrimaryButton
+            type="submit"
+            className="mt-3 flex items-center justify-center gap-2 disabled:opacity-50"
+            disabled={!email || !password || formLoading}
+          >
+            {formLoading ? (
+              <>
+                <span className="loader-glass" />
+                Connexion…
+              </>
+            ) : (
+              "Se connecter"
+            )}
+          </PrimaryButton>
+          <div className="text-right mt-2">
+            <Link to="/reset-password" className="text-xs text-gold hover:underline">
+              Mot de passe oublié ?
+            </Link>
+          </div>
+        </form>
+      </GlassCard>
+      <p className="text-xs text-center text-white/40 mt-4">© MamaStock 2025</p>
+    </PageWrapper>
   );
 }
+


### PR DESCRIPTION
## Summary
- rebuild AuthContext with stable hooks, session/userData state, and auth subscriptions
- update Login page to use context sign-in, redirect on session, and show loader
- remove direct Supabase client instantiations to centralize through shared client

## Testing
- `grep -R "createClient(" src | grep -v "src/lib/supabaseClient"`
- `npm test` *(fails: Missing Supabase credentials and hook mock errors)*

------
https://chatgpt.com/codex/tasks/task_e_689db9b9a038832d95c3d2ae63b2f807