### PR TITLE
refactor: centralize Supabase client

### DIFF
--- a/src/api/shared/supabaseClient.js
+++ b/src/api/shared/supabaseClient.js
@@ -1,26 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 /* eslint-env node */
-import { createClient } from '@supabase/supabase-js';
-import { getSupabaseEnv } from './supabaseEnv.js';
+import { supabase } from "@/lib/supabaseClient";
 
-const cache = new Map();
-
-export function getSupabaseClient(url = null, key = null) {
-  let envUrl, envKey;
-  try {
-    ({ supabaseUrl: envUrl, supabaseKey: envKey } = getSupabaseEnv());
-  } catch {
-    envUrl = undefined;
-    envKey = undefined;
-  }
-  const supabaseUrl = url || envUrl;
-  const supabaseKey = key || envKey;
-  if (!supabaseUrl || !supabaseKey) {
-    throw new Error('Missing Supabase credentials');
-  }
-  const cacheKey = `${supabaseUrl}:${supabaseKey}`;
-  if (!cache.has(cacheKey)) {
-    cache.set(cacheKey, createClient(supabaseUrl, supabaseKey));
-  }
-  return cache.get(cacheKey);
+export function getSupabaseClient() {
+  return supabase;
 }

--- a/src/hooks/useConsentements.js
+++ b/src/hooks/useConsentements.js
@@ -1,11 +1,10 @@
 import { useEffect, useState, useCallback } from "react";
-import { createClient } from "@/lib/supabaseClient";
+import { supabase } from "@/lib/supabaseClient";
 import { useAuth } from '@/hooks/useAuth';
 
 export default function useConsentements() {
   const { user_id, mama_id } = useAuth();
   const [consentements, setConsentements] = useState([]);
-  const supabase = createClient();
 
   const fetchConsentements = useCallback(
     async (utilisateurId = user_id) => {

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -1,18 +1,2 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-/* eslint-env node */
-import { createClient } from "@supabase/supabase-js";
-
-const supabaseUrl =
-  import.meta.env?.VITE_SUPABASE_URL ||
-  process.env.VITE_SUPABASE_URL ||
-  process.env.SUPABASE_URL;
-const supabaseKey =
-  import.meta.env?.VITE_SUPABASE_ANON_KEY ||
-  process.env.VITE_SUPABASE_ANON_KEY ||
-  process.env.SUPABASE_ANON_KEY;
-
-if (!supabaseUrl || !supabaseKey) {
-  throw new Error('Missing Supabase credentials');
-}
-
-export const supabase = createClient(supabaseUrl, supabaseKey);
+export { supabase } from "./supabaseClient";

--- a/src/lib/supabaseClient.js
+++ b/src/lib/supabaseClient.js
@@ -1,23 +1,16 @@
-import { createClient as createSupabaseClient } from "@supabase/supabase-js";
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { createClient } from "@supabase/supabase-js";
 
-// TODO ⚠️ Veillez à vérifier que la table/fonction appelée existe bien dans full_setup_final.sql
-// TODO ✅ Ajouter mama_id dans tous les appels Supabase concernés
-
-let supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-let supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
-
-let supabase = null;
-try {
-  if (!supabaseUrl || !supabaseKey) {
-    throw new Error("Missing Supabase credentials");
+export const supabase = createClient(
+  import.meta.env.VITE_SUPABASE_URL,
+  import.meta.env.VITE_SUPABASE_ANON_KEY,
+  {
+    auth: {
+      storageKey: "mamastock.supabase.auth",
+      persistSession: true,
+      autoRefreshToken: true,
+      detectSessionInUrl: true,
+    },
   }
-  supabase = createSupabaseClient(supabaseUrl, supabaseKey);
-} catch (e) {
-  console.error(e.message || e);
-  supabase = null;
-}
+);
 
-export { supabase };
-export function createClient() {
-  return supabase;
-}

--- a/test/supabase_client.test.js
+++ b/test/supabase_client.test.js
@@ -1,65 +1,20 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
-let createClientMock = vi.fn();
 vi.mock('@supabase/supabase-js', () => ({
-  createClient: (...args) => createClientMock(...args),
+  createClient: vi.fn(() => ({})),
 }));
 
 beforeEach(() => {
-  createClientMock.mockClear();
-  delete process.env.VITE_SUPABASE_URL;
-  delete process.env.VITE_SUPABASE_ANON_KEY;
-  delete process.env.SUPABASE_URL;
-  delete process.env.SUPABASE_ANON_KEY;
-  delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+  process.env.VITE_SUPABASE_URL = 'https://env.supabase.co';
+  process.env.VITE_SUPABASE_ANON_KEY = 'env';
   vi.resetModules();
 });
 
 describe('getSupabaseClient', () => {
-  it('uses explicit credentials when provided and caches the client', async () => {
-    const mod = await import('../src/api/shared/supabaseClient.js');
-    const a = mod.getSupabaseClient('https://cli.supabase.co', 'cli');
-    const b = mod.getSupabaseClient('https://cli.supabase.co', 'cli');
-    expect(a).toBe(b);
-    expect(createClientMock).toHaveBeenCalledTimes(1);
-    expect(createClientMock).toHaveBeenCalledWith('https://cli.supabase.co', 'cli');
-  });
-
-  it('falls back to env variables', async () => {
-    process.env.SUPABASE_URL = 'https://env.supabase.co';
-    process.env.SUPABASE_ANON_KEY = 'env';
-    const mod = await import('../src/api/shared/supabaseClient.js');
-    mod.getSupabaseClient();
-    expect(createClientMock).toHaveBeenCalledWith('https://env.supabase.co', 'env');
-  });
-
-  it('mixes cli and env credentials', async () => {
-    process.env.SUPABASE_URL = 'https://env.supabase.co';
-    process.env.SUPABASE_ANON_KEY = 'env';
-    let mod = await import('../src/api/shared/supabaseClient.js');
-    mod.getSupabaseClient(null, 'cli');
-    expect(createClientMock).toHaveBeenCalledWith('https://env.supabase.co', 'cli');
-    const firstCalls = createClientMock.mock.calls.length;
-    mod.getSupabaseClient(null, 'cli');
-    expect(createClientMock).toHaveBeenCalledTimes(firstCalls); // cached
-    vi.resetModules();
-    createClientMock.mockClear();
-    mod = await import('../src/api/shared/supabaseClient.js');
-    mod.getSupabaseClient('https://cli.supabase.co');
-    expect(createClientMock).toHaveBeenCalledWith('https://cli.supabase.co', 'env');
-  });
-
-  it('uses service role key when available', async () => {
-    process.env.SUPABASE_URL = 'https://env.supabase.co';
-    process.env.SUPABASE_SERVICE_ROLE_KEY = 'service';
-    const mod = await import('../src/api/shared/supabaseClient.js');
-    mod.getSupabaseClient();
-    expect(createClientMock).toHaveBeenCalledWith('https://env.supabase.co', 'service');
-  });
-
-  it('throws when credentials missing', async () => {
-    const mod = await import('../src/api/shared/supabaseClient.js');
-    expect(() => mod.getSupabaseClient()).toThrow('Missing Supabase credentials');
+  it('returns the singleton supabase client', async () => {
+    const { getSupabaseClient } = await import('../src/api/shared/supabaseClient.js');
+    const { supabase } = await import('../src/lib/supabaseClient.js');
+    expect(getSupabaseClient()).toBe(supabase);
   });
 });

--- a/vitest.setup.js
+++ b/vitest.setup.js
@@ -6,6 +6,11 @@ import { vi } from 'vitest';
 // Ensure test environment uses the dedicated .env.test file
 dotenv.config({ path: '.env.test' });
 
+process.env.VITE_SUPABASE_URL =
+  process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL;
+process.env.VITE_SUPABASE_ANON_KEY =
+  process.env.VITE_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY;
+
 vi.mock('@/contexts/AuthContext', () => {
   const fake = {
     user: { id: 'u-test', email: 'test@ex.com' },


### PR DESCRIPTION
## Summary
- create singleton Supabase client with persistent auth configuration
- remove local Supabase instantiations in favor of shared client
- align tests and setup with new Supabase client

## Testing
- `grep -R "createClient(" src | grep -v "src/lib/supabaseClient.js"`
- `npm test` *(fails: useNotifications is not a function; missing default export on @/hooks/usePeriodes mock)*

------
https://chatgpt.com/codex/tasks/task_e_689db9cdd254832da03a7a45f4215d27