### PR TITLE
feat: add parent ref to familles table

### DIFF
--- a/db/01_app_safe.sql
+++ b/db/01_app_safe.sql
@@ -1132,15 +1132,25 @@ create table if not exists public.familles (
   id uuid primary key default gen_random_uuid(),
   mama_id uuid not null,
   nom text not null,
+  parent_id uuid references public.familles(id) on delete set null,
   actif boolean default true,
   created_at timestamptz default now()
 );
 create index if not exists idx_familles_mama_id on public.familles(mama_id);
+create index if not exists idx_familles_parent_id on public.familles(parent_id);
 do $do$
 begin
   if not exists (select 1 from pg_constraint where conname = 'fk_familles_mama_id') then
     alter table if exists public.familles
       add constraint fk_familles_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
+  end if;
+end;
+$do$ language plpgsql;
+do $do$
+begin
+  if not exists (select 1 from pg_constraint where conname = 'fk_familles_parent_id') then
+    alter table if exists public.familles
+      add constraint fk_familles_parent_id foreign key (parent_id) references public.familles(id) on delete set null;
   end if;
 end;
 $do$ language plpgsql;

--- a/db/full_setup initial.sql
+++ b/db/full_setup initial.sql
@@ -883,14 +883,22 @@ create table if not exists public.familles (
   id uuid primary key default gen_random_uuid(),
   mama_id uuid not null,
   nom text not null,
+  parent_id uuid references public.familles(id) on delete set null,
   actif boolean default true,
   created_at timestamptz default now()
 );
 create index if not exists idx_familles_mama_id on public.familles(mama_id);
+create index if not exists idx_familles_parent_id on public.familles(parent_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_familles_mama_id') then
     alter table public.familles
       add constraint fk_familles_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
+  end if;
+end $$;
+do $$ begin
+  if not exists (select 1 from pg_constraint where conname = 'fk_familles_parent_id') then
+    alter table public.familles
+      add constraint fk_familles_parent_id foreign key (parent_id) references public.familles(id) on delete set null;
   end if;
 end $$;
 alter table public.familles enable row level security;

--- a/db/full_setup.sql
+++ b/db/full_setup.sql
@@ -897,14 +897,22 @@ create table if not exists public.familles (
   id uuid primary key default gen_random_uuid(),
   mama_id uuid not null,
   nom text not null,
+  parent_id uuid references public.familles(id) on delete set null,
   actif boolean default true,
   created_at timestamptz default now()
 );
 create index if not exists idx_familles_mama_id on public.familles(mama_id);
+create index if not exists idx_familles_parent_id on public.familles(parent_id);
 do $$ begin
   if not exists (select 1 from pg_constraint where conname = 'fk_familles_mama_id') then
     alter table public.familles
       add constraint fk_familles_mama_id foreign key (mama_id) references public.mamas(id) on delete cascade;
+  end if;
+end $$;
+do $$ begin
+  if not exists (select 1 from pg_constraint where conname = 'fk_familles_parent_id') then
+    alter table public.familles
+      add constraint fk_familles_parent_id foreign key (parent_id) references public.familles(id) on delete set null;
   end if;
 end $$;
 alter table public.familles enable row level security;

--- a/supabase/migrations/20240715000000_parametrage_familles_sous_familles.sql
+++ b/supabase/migrations/20240715000000_parametrage_familles_sous_familles.sql
@@ -22,6 +22,7 @@ create table if not exists familles (
   id uuid primary key default gen_random_uuid(),
   mama_id uuid not null references mamas(id) on delete cascade,
   nom text not null,
+  parent_id uuid references familles(id) on delete set null,
   position int default 0,
   actif boolean default true,
   created_at timestamptz default now(),
@@ -44,7 +45,12 @@ create table if not exists sous_familles (
 -- Ensure new columns exist on pre-existing tables
 alter table if exists familles
   add column if not exists position int default 0,
-  add column if not exists updated_at timestamptz default now();
+  add column if not exists updated_at timestamptz default now(),
+  add column if not exists parent_id uuid;
+
+alter table if exists familles
+  add constraint if not exists fk_familles_parent_id
+    foreign key (parent_id) references familles(id) on delete set null;
 
 alter table if exists sous_familles
   add column if not exists position int default 0,
@@ -64,6 +70,7 @@ DO $$ BEGIN
 END $$;
 
 create index if not exists idx_familles_mama_pos on familles(mama_id, position);
+create index if not exists idx_familles_parent on familles(parent_id);
 create index if not exists idx_sous_familles_famille_pos on sous_familles(famille_id, position);
 
 -- 2) RLS policies


### PR DESCRIPTION
## Summary
- add optional `parent_id` to `familles` for hierarchical grouping
- include self-referential FK and index in setup SQL scripts

## Testing
- `npm test` *(fails: numerous unit tests do not pass)*

------
https://chatgpt.com/codex/tasks/task_e_689dba4cc2a0832daef0165c13796462