### PR TITLE
refactor: centralize supabase client

### DIFF
--- a/src/lib/supabaseClient.js
+++ b/src/lib/supabaseClient.js
@@ -1,23 +1,14 @@
-import { createClient as createSupabaseClient } from "@supabase/supabase-js";
+import { createClient } from '@supabase/supabase-js';
 
-// TODO ⚠️ Veillez à vérifier que la table/fonction appelée existe bien dans full_setup_final.sql
-// TODO ✅ Ajouter mama_id dans tous les appels Supabase concernés
-
-let supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-let supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
-
-let supabase = null;
-try {
-  if (!supabaseUrl || !supabaseKey) {
-    throw new Error("Missing Supabase credentials");
+export const supabase = createClient(
+  import.meta.env.VITE_SUPABASE_URL,
+  import.meta.env.VITE_SUPABASE_ANON_KEY,
+  {
+    auth: {
+      storageKey: 'mamastock.supabase.auth',
+      persistSession: true,
+      autoRefreshToken: true,
+      detectSessionInUrl: true,
+    },
   }
-  supabase = createSupabaseClient(supabaseUrl, supabaseKey);
-} catch (e) {
-  console.error(e.message || e);
-  supabase = null;
-}
-
-export { supabase };
-export function createClient() {
-  return supabase;
-}
+);


### PR DESCRIPTION
## Summary
- centralize Supabase initialization into a singleton with custom auth options

## Testing
- `npm test` *(fails: Missing Supabase credentials, useNotifications is not a function, etc.)*
- `npm run lint` *(fails: Could not find plugin @typescript-eslint/eslint-plugin)*
- `grep -R "createClient(" src | grep -v "src/lib/supabaseClient.js"`


------
https://chatgpt.com/codex/tasks/task_e_689dbe3e29c8832d87b1400f826b6b39