### PR TITLE
chore: centralize supabase client

### DIFF
--- a/src/lib/supabaseClient.js
+++ b/src/lib/supabaseClient.js
@@ -1,14 +1,14 @@
 import { createClient } from '@supabase/supabase-js';
 
-export const supabase = createClient(
-  import.meta.env.VITE_SUPABASE_URL,
-  import.meta.env.VITE_SUPABASE_ANON_KEY,
-  {
-    auth: {
-      storageKey: 'mamastock.supabase.auth',
-      persistSession: true,
-      autoRefreshToken: true,
-      detectSessionInUrl: true,
-    },
-  }
-);
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+  auth: {
+    storageKey: 'mamastock.supabase.auth',
+    persistSession: true,
+    autoRefreshToken: true,
+    detectSessionInUrl: true,
+  },
+});
+

--- a/src/supabaseClient.js
+++ b/src/supabaseClient.js
@@ -1,1 +1,0 @@
-export { supabase } from "@/lib/supabaseClient";


### PR DESCRIPTION
## Summary
- refactor supabase client instantiation to be a singleton
- drop unused top-level `supabaseClient` re-export

## Testing
- `npm test` *(fails: TypeError: useNotifications is not a function)*
- `npm run lint` *(fails: 'Blob' is not defined; @typescript-eslint/no-unused-vars, etc.)*
- `grep -R "createClient(" src | grep -v "src/lib/supabaseClient"`

------
https://chatgpt.com/codex/tasks/task_e_689dceb92c0c832dbf0b8ef0550052f9