### PR TITLE
Handle auth loading state and protect sidebar menu

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,0 +1,114 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { Link, useLocation } from "react-router-dom";
+import { useAuth } from "@/hooks/useAuth";
+import logo from "@/assets/logo-mamastock.png";
+
+export default function Sidebar() {
+  const { loading, userData } = useAuth();
+  const { pathname } = useLocation();
+
+  if (loading || !userData) return null;
+
+  const access_rights = userData.access_rights || {};
+  const has = (key) => access_rights[key]?.peut_voir === true;
+  const canAnalyse = has("analyse");
+
+  return (
+    <aside className="w-64 bg-white/10 border border-white/10 backdrop-blur-xl text-white p-4 h-screen shadow-md text-shadow">
+      <img src={logo} alt="MamaStock" className="h-20 mx-auto mt-4 mb-6" />
+      <nav className="flex flex-col gap-2 text-sm">
+        {has("dashboard") && <Link to="/dashboard">Dashboard</Link>}
+
+        {(has("fournisseurs") || has("factures")) && (
+          <details open={pathname.startsWith("/fournisseurs") || pathname.startsWith("/factures")}>
+            <summary className="cursor-pointer">Achats</summary>
+            <div className="ml-4 flex flex-col gap-1 mt-1">
+              {has("fournisseurs") && <Link to="/fournisseurs">Fournisseurs</Link>}
+              {has("factures") && <Link to="/factures">Factures</Link>}
+            </div>
+          </details>
+        )}
+
+        {(has("fiches_techniques") || has("menus")) && (
+          <details open={pathname.startsWith("/fiches") || pathname.startsWith("/menus")}>
+            <summary className="cursor-pointer">Cuisine</summary>
+            <div className="ml-4 flex flex-col gap-1 mt-1">
+              {has("fiches_techniques") && <Link to="/fiches">Fiches</Link>}
+              {has("menus") && <Link to="/menus">Menus</Link>}
+              {has("menu_du_jour") && <Link to="/menu">Menu du jour</Link>}
+            </div>
+          </details>
+        )}
+
+        {(has("produits") || has("inventaires")) && (
+          <details open={pathname.startsWith("/produits") || pathname.startsWith("/inventaire")}>
+            <summary className="cursor-pointer">Stock</summary>
+            <div className="ml-4 flex flex-col gap-1 mt-1">
+              {has("produits") && <Link to="/produits">Produits</Link>}
+              {has("inventaires") && <Link to="/inventaire">Inventaire</Link>}
+            </div>
+          </details>
+        )}
+
+        {(has("alertes") || has("promotions")) && (
+          <details open={pathname.startsWith("/alertes") || pathname.startsWith("/promotions")}>
+            <summary className="cursor-pointer">Alertes / Promotions</summary>
+            <div className="ml-4 flex flex-col gap-1 mt-1">
+              {has("alertes") && <Link to="/alertes">Alertes</Link>}
+              {has("promotions") && <Link to="/promotions">Promotions</Link>}
+            </div>
+          </details>
+        )}
+
+        {(has("documents") || canAnalyse || has("menu_engineering")) && (
+          <details
+            open=
+              {pathname.startsWith("/documents") ||
+                pathname.startsWith("/analyse") ||
+                pathname.startsWith("/engineering") ||
+                pathname.startsWith("/menu-engineering")}
+          >
+            <summary className="cursor-pointer">Documents / Analyse</summary>
+            <div className="ml-4 flex flex-col gap-1 mt-1">
+              {has("documents") && <Link to="/documents">Documents</Link>}
+              {canAnalyse && <Link to="/analyse">Analyse</Link>}
+              {has("menu_engineering") && (
+                <Link to="/menu-engineering">Menu Engineering</Link>
+              )}
+              {canAnalyse && <Link to="/engineering">Engineering</Link>}
+              {has("costing_carte") && <Link to="/costing/carte">Costing Carte</Link>}
+            </div>
+          </details>
+        )}
+
+        {has("notifications") && <Link to="/notifications">Notifications</Link>}
+
+        {(has("parametrage") ||
+          has("utilisateurs") ||
+          has("roles") ||
+          has("mamas") ||
+          has("permissions") ||
+          has("access")) && (
+          <details open={pathname.startsWith("/parametrage")}>
+            <summary className="cursor-pointer">Paramétrage</summary>
+            <div className="ml-4 flex flex-col gap-1 mt-1">
+              {has("utilisateurs") && (
+                <Link to="/parametrage/utilisateurs">Utilisateurs</Link>
+              )}
+              {has("roles") && <Link to="/parametrage/roles">Rôles</Link>}
+              {has("mamas") && <Link to="/parametrage/mamas">Mamas</Link>}
+              {has("permissions") && (
+                <Link to="/parametrage/permissions">Permissions</Link>
+              )}
+              {has("access") && <Link to="/parametrage/access">Accès</Link>}
+            </div>
+          </details>
+        )}
+
+        <Link to="/onboarding">Onboarding</Link>
+        <Link to="/aide">Aide</Link>
+        {has("feedback") && <Link to="/feedback">Feedback</Link>}
+      </nav>
+    </aside>
+  );
+}

--- a/src/layout/Layout.jsx
+++ b/src/layout/Layout.jsx
@@ -1,14 +1,14 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { Outlet, useLocation, Link } from "react-router-dom";
 import { useState, useEffect } from "react";
-import Sidebar from "@/layout/Sidebar";
-import { useAuth } from '@/hooks/useAuth';
+import Sidebar from "@/components/Sidebar";
+import { useAuth } from "@/hooks/useAuth";
 import useNotifications from "@/hooks/useNotifications";
 import { Badge } from "@/components/ui/badge";
 import { Bell } from "lucide-react";
 import toast from "react-hot-toast";
 import Footer from "@/components/Footer";
-import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import PageSkeleton from "@/components/ui/PageSkeleton";
 import AlertBadge from "@/components/stock/AlertBadge";
 import {
   LiquidBackground,
@@ -19,15 +19,7 @@ import {
 
 export default function Layout() {
   const { pathname } = useLocation();
-  const {
-    session,
-    userData,
-    mama_id,
-    access_rights,
-    loading,
-    pending,
-    logout,
-  } = useAuth();
+  const { session, userData, loading, logout } = useAuth();
   const { fetchUnreadCount, subscribeToNotifications } = useNotifications();
   const [unread, setUnread] = useState(0);
 
@@ -38,22 +30,22 @@ export default function Layout() {
     });
     return unsub;
   }, [fetchUnreadCount, subscribeToNotifications]);
-  if (import.meta.env.DEV) {
-    console.debug("Layout", {
-      session,
-      userData,
-      mama_id,
-      access_rights,
-    });
-    console.log("\uD83E\uDDE0 moduleKey access_rights", userData?.access_rights);
+  if (pathname === "/login" || pathname === "/unauthorized") return <Outlet />;
+  if (loading) {
+    return <PageSkeleton />;
   }
 
-  if (pathname === "/login" || pathname === "/unauthorized") return <Outlet />;
+  if (session && !userData) {
+    return (
+      <div className="flex items-center justify-center h-screen text-white">
+        Profil incomplet
+      </div>
+    );
+  }
 
-  if (loading || pending) return <LoadingSpinner message="Chargement..." />;
-  if (!session || !userData)
-    return <LoadingSpinner message="Chargement utilisateur..." />;
-
+  if (!session) {
+    return <Outlet />;
+  }
 
   const user = session.user;
 


### PR DESCRIPTION
## Summary
- add access-aware Sidebar that waits for auth data and auto-expands active sections
- show skeleton while auth loading and handle missing profile in Layout

## Testing
- `npm run lint` *(fails: 'Blob is not defined', many others)*
- `npm test` *(fails: multiple module mock errors and 93 test failures)*

------
https://chatgpt.com/codex/tasks/task_e_689dd16f77f8832d86f1e3087257711c