### PR TITLE
feat: audit and fix scripts for mama_id policies

### DIFF
--- a/db/audit_mama_id.sql
+++ b/db/audit_mama_id.sql
@@ -1,0 +1,34 @@
+-- Audit des vues/fonctions et policies utilisant current_user_mama_id
+
+-- Vues et fonctions contenant current_user_mama_id
+select obj_type,
+       obj_schema,
+       obj_name
+from (
+    select 'view' as obj_type,
+           schemaname as obj_schema,
+           viewname as obj_name,
+           definition
+    from pg_views
+    where definition ilike '%current_user_mama_id%'
+    union all
+    select 'function' as obj_type,
+           n.nspname as obj_schema,
+           p.proname as obj_name,
+           pg_get_functiondef(p.oid) as definition
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where pg_get_functiondef(p.oid) ilike '%current_user_mama_id%'
+      and n.nspname not in ('pg_catalog', 'information_schema')
+) s
+order by obj_type, obj_schema, obj_name;
+
+-- Policies contenant des sous-requêtes vers utilisateurs
+select schemaname,
+       tablename,
+       policyname,
+       policydef
+from pg_policies
+where policydef ilike '%select%'
+  and policydef ilike '%utilisateurs%'
+order by schemaname, tablename, policyname;

--- a/db/fix_mama_id.sql
+++ b/db/fix_mama_id.sql
@@ -1,0 +1,49 @@
+-- Correction des policies et vues/fonctions utilisant current_user_mama_id
+set search_path = public, pg_catalog;
+
+do $$
+declare r record;
+begin
+  -- Réécriture des policies avec sous-requêtes vers utilisateurs
+  for r in (
+      select schemaname, tablename, policyname
+      from pg_policies
+      where policydef ilike '%select%'
+        and policydef ilike '%utilisateurs%'
+  ) loop
+      execute format('alter table %I.%I drop policy if exists %I;',
+                     r.schemaname, r.tablename, r.policyname);
+      execute format(
+          'create policy %I on %I.%I for all using (mama_id = current_user_mama_id());',
+          r.policyname, r.schemaname, r.tablename
+      );
+  end loop;
+
+  -- Reconstruction des vues utilisant current_user_mama_id
+  for r in (
+      select schemaname as obj_schema,
+             viewname as obj_name,
+             definition
+      from pg_views
+      where definition ilike '%current_user_mama_id%'
+  ) loop
+      execute format('drop view if exists %I.%I cascade;', r.obj_schema, r.obj_name);
+      execute format('create or replace view %I.%I as %s;', r.obj_schema, r.obj_name, r.definition);
+  end loop;
+
+  -- Reconstruction des fonctions utilisant current_user_mama_id
+  for r in (
+      select n.nspname as obj_schema,
+             p.proname as obj_name,
+             pg_get_functiondef(p.oid) as definition,
+             pg_get_function_identity_arguments(p.oid) as args
+      from pg_proc p
+      join pg_namespace n on n.oid = p.pronamespace
+      where pg_get_functiondef(p.oid) ilike '%current_user_mama_id%'
+        and n.nspname not in ('pg_catalog', 'information_schema')
+  ) loop
+      execute format('drop function if exists %I.%I(%s);', r.obj_schema, r.obj_name, r.args);
+      execute r.definition;
+  end loop;
+end;
+$$ language plpgsql;


### PR DESCRIPTION
## Summary
- add audit script to list views/functions using `current_user_mama_id` and policies with `utilisateurs` subqueries
- add correction script rewriting faulty policies and refreshing dependent views/functions

## Testing
- `npm run lint`
- `npm test` *(fails: useNotifications is not a function, useExport is not a function, missing default export in vi.mock)*

------
https://chatgpt.com/codex/tasks/task_e_689ddd6e5098832d83571abf3754acda