### PR TITLE
Refactor auth context with single Supabase client

### DIFF
--- a/src/layout/Layout.jsx
+++ b/src/layout/Layout.jsx
@@ -1,8 +1,9 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { Outlet, useLocation, Link } from "react-router-dom";
+import { Outlet, Link } from "react-router-dom";
 import { useState, useEffect } from "react";
 import Sidebar from "@/components/Sidebar";
-import { useAuth } from "@/hooks/useAuth";
+import { useAuth } from "@/contexts/AuthContext";
+import supabase from "@/lib/supabaseClient";
 import useNotifications from "@/hooks/useNotifications";
 import { Badge } from "@/components/ui/badge";
 import { Bell } from "lucide-react";
@@ -18,8 +19,7 @@ import {
 } from "@/components/LiquidBackground";
 
 export default function Layout() {
-  const { pathname } = useLocation();
-  const { session, userData, loading, logout } = useAuth();
+  const { session, userData, loading } = useAuth();
   const { fetchUnreadCount, subscribeToNotifications } = useNotifications();
   const [unread, setUnread] = useState(0);
 
@@ -30,24 +30,10 @@ export default function Layout() {
     });
     return unsub;
   }, [fetchUnreadCount, subscribeToNotifications]);
-  if (pathname === "/login" || pathname === "/unauthorized") return <Outlet />;
   if (loading) {
     return <PageSkeleton />;
   }
-
-  if (session && !userData) {
-    return (
-      <div className="flex items-center justify-center h-screen text-white">
-        Profil incomplet
-      </div>
-    );
-  }
-
-  if (!session) {
-    return <Outlet />;
-  }
-
-  const user = session.user;
+  const user = session?.user;
 
   return (
     <div className="relative flex h-screen overflow-auto text-shadow">
@@ -78,7 +64,7 @@ export default function Layout() {
               )}
               <button
                 onClick={() => {
-                  logout();
+                  supabase.auth.signOut();
                   toast.success("Déconnecté");
                 }}
                 className="text-red-400 hover:underline"

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -4,9 +4,7 @@ const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string
 const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string
 
 export const supabase = createClient(supabaseUrl, supabaseKey, {
-  auth: {
-    persistSession: true,
-    storageKey: 'mamastock-auth'
-  }
+  auth: { persistSession: true, storageKey: 'mamastock-auth' },
 })
+
 export default supabase

--- a/src/pages/auth/Login.jsx
+++ b/src/pages/auth/Login.jsx
@@ -2,7 +2,8 @@
 import { useState, useEffect, useMemo } from "react";
 import { useNavigate, useLocation, Link } from "react-router-dom";
 import toast from "react-hot-toast";
-import { useAuth } from "@/hooks/useAuth";
+import supabase from "@/lib/supabaseClient";
+import { useAuth } from "@/contexts/AuthContext";
 import useFormErrors from "@/hooks/useFormErrors";
 import MamaLogo from "@/components/ui/MamaLogo";
 import GlassCard from "@/components/ui/GlassCard";
@@ -20,16 +21,15 @@ export default function Login() {
   const { errors, setError, clearErrors } = useFormErrors();
   const navigate = useNavigate();
   const location = useLocation();
-  const { session, userData, loading, signInWithPassword } = useAuth();
+  const { session, userData, loading } = useAuth();
   const emailId = useMemo(() => makeId("fld"), []);
   const passwordId = useMemo(() => makeId("fld"), []);
 
   useEffect(() => {
-    if (!loading && session && userData) {
-      const redirectTo = location.state?.from || "/dashboard";
-      navigate(redirectTo, { replace: true });
+    if (!loading && session && userData && userData.id) {
+      navigate("/dashboard", { replace: true });
     }
-  }, [loading, session, userData, navigate, location]);
+  }, [loading, session, userData, navigate]);
 
   if (loading) {
     return <LoadingSpinner message="Chargement..." />;
@@ -44,7 +44,7 @@ export default function Login() {
     if (!email || !password) return;
 
     setFormLoading(true);
-    const { error } = await signInWithPassword({
+    const { error } = await supabase.auth.signInWithPassword({
       email: email.trim(),
       password,
     });
@@ -125,4 +125,3 @@ export default function Login() {
     </PageWrapper>
   );
 }
-

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -7,8 +7,8 @@ import { useLocation } from 'react-router-dom';
 import ErrorBoundary from "@/components/ErrorBoundary";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 import PageSkeleton from "@/components/ui/PageSkeleton";
-import { Routes, Route, Navigate } from "react-router-dom";
-import { useAuth } from '@/hooks/useAuth';
+import { Routes, Route, Navigate, Outlet } from "react-router-dom";
+import { useAuth } from '@/contexts/AuthContext';
 import Layout from "@/layout/Layout";
 import Login from "@/pages/auth/Login";
 import Unauthorized from "@/pages/auth/Unauthorized";
@@ -18,6 +18,13 @@ import OnboardingUtilisateur from "@/pages/onboarding/OnboardingUtilisateur";
 import AuthDebug from "@/pages/debug/AuthDebug";
 import AccessExample from "@/pages/debug/AccessExample";
 import ProtectedRoute from "@/components/ProtectedRoute";
+
+function PrivateOutlet() {
+  const { session, userData, loading } = useAuth()
+  if (loading) return <LoadingSpinner message="Chargement..." />
+  if (!session || !userData || !userData.id) return <Navigate to="/unauthorized" replace />
+  return <Outlet />
+}
 
 const Dashboard = lazyWithPreload(() => import("@/pages/Dashboard.jsx"));
 const Fournisseurs = lazyWithPreload(() => import("@/pages/fournisseurs/Fournisseurs.jsx"));
@@ -248,7 +255,8 @@ export default function Router() {
         {/* Routes internes protégées par les droits utilisateurs.
             Chaque sous-route est enveloppée dans <ProtectedRoute accessKey="...">.
             La clé correspond au module autorisé dans access_rights. */}
-        <Route path="/" element={<Layout />}>
+        <Route element={<PrivateOutlet />}>
+          <Route path="/" element={<Layout />}>
           <Route
             path="dashboard"
             element={
@@ -622,6 +630,7 @@ export default function Router() {
             path="/debug/access"
             element={<ProtectedRoute accessKey="dashboard"><AccessExample /></ProtectedRoute>}
           />
+        </Route>
         </Route>
       </Routes>
       </Suspense>


### PR DESCRIPTION
## Summary
- Centralize Supabase initialization with a shared client and persistent session storage
- Bootstrap and load user profile in AuthContext and expose loading state
- Defer login redirect until profile is ready and guard private routes with `PrivateOutlet`
- Update layout to use context session and sign out via shared Supabase client

## Testing
- `npm test -s` *(fails: numerous unit tests)*
- `npm run lint -s`


------
https://chatgpt.com/codex/tasks/task_e_689f1efeed88832dbc3fa812f7bad896