### PR TITLE
feat: expose AuthProvider as named export

### DIFF
--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -49,3 +49,5 @@ export default function AuthProvider({ children }) {
     </AuthCtx.Provider>
   )
 }
+
+export { AuthProvider }


### PR DESCRIPTION
## Summary
- export AuthProvider as both default and named
- ensure main entry imports AuthProvider via named export

## Testing
- `npm test` *(fails: No "default" export is defined on the "@/hooks/usePeriodes" mock)*

------
https://chatgpt.com/codex/tasks/task_e_689f2325f540832db5beb9ba3b66568e