### PR TITLE
feat: wire auth context and login

### DIFF
--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -3,16 +3,7 @@ import { createClient } from '@supabase/supabase-js'
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string
 const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string
 
-const globalForSupabase = globalThis as any
-
-export const supabase =
-  globalForSupabase.supabase ||
-  createClient(supabaseUrl, supabaseKey, {
-    auth: { persistSession: true, storageKey: 'mamastock-auth' },
-  })
-
-if (!globalForSupabase.supabase) {
-  globalForSupabase.supabase = supabase
-}
-
+export const supabase = createClient(supabaseUrl, supabaseKey, {
+  auth: { persistSession: true, storageKey: 'mamastock-auth' },
+})
 export default supabase

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -7,7 +7,7 @@ import 'nprogress/nprogress.css';
 import "@/i18n/i18n";
 import "./registerSW.js";
 import { BrowserRouter } from "react-router-dom";
-import { AuthProvider } from "@/contexts/AuthContext";
+import AuthProvider from "@/contexts/AuthContext";
 
 // Avoid noisy output in production by disabling debug logs
 if (!import.meta.env.DEV) {

--- a/src/router/PrivateOutlet.jsx
+++ b/src/router/PrivateOutlet.jsx
@@ -8,5 +8,3 @@ export default function PrivateOutlet() {
   if (!userData) return <Navigate to="/unauthorized" replace />
   return <Outlet />
 }
-
-export { PrivateOutlet }


### PR DESCRIPTION
## Summary
- centralize Supabase client
- wrap router with AuthProvider
- simplify login form submit with pending state and errors
- ensure guard waits for auth loading

## Testing
- `npm run lint`
- `npm test` *(fails: [vitest] No "default" export is defined on the "@/hooks/usePeriodes" mock. Did you forget to return it from "vi.mock"?)*

------
https://chatgpt.com/codex/tasks/task_e_689f2aad91b8832d97fc8a2e3a485e4f