### PR TITLE
chore: add runtime access rights seeding script

### DIFF
--- a/db/runtime_seed_access_rights.sql
+++ b/db/runtime_seed_access_rights.sql
@@ -1,0 +1,31 @@
+-- Lister vos utilisateurs (copiez l'id voulu)
+select id, email, created_at from auth.users order by created_at desc;
+
+-- Appliquer des droits de base à l'utilisateur ciblé (REMPLACEZ :user_id)
+update public.utilisateurs
+set access_rights = jsonb_strip_nulls('{
+  "dashboard": true,
+  "fournisseurs": true,
+  "factures": true,
+  "fiches_techniques": true,
+  "menus": true,
+  "menu_du_jour": true,
+  "produits": true,
+  "inventaires": true,
+  "alertes": true,
+  "promotions": true,
+  "documents": true,
+  "analyse": true,
+  "menu_engineering": true,
+  "costing_carte": true,
+  "notifications": true,
+  "utilisateurs": true,
+  "roles": true,
+  "mamas": true,
+  "permissions": true,
+  "access": true
+}'::jsonb)
+where auth_id = ':user_id';
+
+-- Option: vérifier
+select id, nom, access_rights from public.utilisateurs where auth_id=':user_id';


### PR DESCRIPTION
## Summary
- add SQL script to list users and assign default access rights

## Testing
- `npm test` *(fails: [vitest] No "default" export is defined on the "@/hooks/usePeriodes" mock)*

------
https://chatgpt.com/codex/tasks/task_e_689f37ceecd0832d9c961846df35d716