### PR TITLE
feat: expose debug auth info

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -108,6 +108,11 @@ export default function Sidebar() {
         <Link to="/onboarding">Onboarding</Link>
         <Link to="/aide">Aide</Link>
         {has("feedback") && <Link to="/feedback">Feedback</Link>}
+        {import.meta.env.DEV && (
+          <Link to="/debug/auth" className="text-xs opacity-50 mt-4">
+            Debug Auth
+          </Link>
+        )}
       </nav>
     </aside>
   );

--- a/src/pages/debug/DebugAuth.jsx
+++ b/src/pages/debug/DebugAuth.jsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { useAuth } from '@/contexts/AuthContext'
+
+export default function DebugAuth() {
+  const { session, userData, loading } = useAuth()
+  return (
+    <pre style={{padding:16, background:'#111', color:'#0f0', overflow:'auto'}}>
+{JSON.stringify({
+  loading,
+  session: session ? {
+    user: {
+      id: session.user?.id,
+      email: session.user?.email,
+      role: session.user?.role
+    }
+  } : null,
+  userData
+}, null, 2)}
+    </pre>
+  )
+}

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -15,7 +15,7 @@ import Unauthorized from "@/pages/auth/Unauthorized";
 import Pending from "@/pages/auth/Pending";
 import Blocked from "@/pages/auth/Blocked";
 import OnboardingUtilisateur from "@/pages/onboarding/OnboardingUtilisateur";
-import AuthDebug from "@/pages/debug/AuthDebug";
+import DebugAuth from "@/pages/debug/DebugAuth";
 import AccessExample from "@/pages/debug/AccessExample";
 import ProtectedRoute from "@/components/ProtectedRoute";
 import PrivateOutlet from "@/router/PrivateOutlet";
@@ -246,6 +246,7 @@ export default function Router() {
         <Route path="/cgv" element={<Cgv />} />
         <Route path="/contact" element={<Contact />} />
         <Route path="/licence" element={<Licence />} />
+        <Route path="/debug/auth" element={<DebugAuth />} />
         {/* Routes internes protégées par les droits utilisateurs.
             Chaque sous-route est enveloppée dans <ProtectedRoute accessKey="...">.
             La clé correspond au module autorisé dans access_rights. */}
@@ -615,10 +616,6 @@ export default function Router() {
           <Route
             path="/supervision/rapports"
             element={<ProtectedRoute accessKey="reporting"><SupervisionRapports /></ProtectedRoute>}
-          />
-          <Route
-            path="/debug/auth"
-            element={<ProtectedRoute accessKey="dashboard"><AuthDebug /></ProtectedRoute>}
           />
           <Route
             path="/debug/access"


### PR DESCRIPTION
## Summary
- add DebugAuth page to inspect auth session and user data
- expose public `/debug/auth` route
- show dev-only debug auth link in sidebar

## Testing
- `npm test` *(fails: [57 failed, 78 passed](#b90e35-L16-L18))*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f37e5846c832d856df81ec2cf414e