### PR TITLE
refactor auth flow with profile bootstrap

### DIFF
--- a/db/overlay_auth_access.SQL_EDITOR_READY.sql
+++ b/db/overlay_auth_access.SQL_EDITOR_READY.sql
@@ -1,0 +1,105 @@
+-- =========================================================
+-- OVERLAY AUTH & ACCESS (app-safe, idempotent) — à coller dans le SQL Editor
+-- NE CRÉE PAS de tables; ne fait que fonctions/GRANTs/policies sûres
+-- =========================================================
+set search_path = public;
+set check_function_bodies = off;
+
+-- 1) Helpers JWT
+create or replace function public.jwt_claim(claim text)
+returns text language sql stable as $$
+  select coalesce(
+    nullif(current_setting('request.jwt.claims', true), '')::jsonb ->> claim,
+    nullif(current_setting('jwt.claims',     true), '')::jsonb ->> claim
+  );
+$$;
+
+-- 2) current_user_mama_id avec fallback table (SECURITY DEFINER)
+create or replace function public.current_user_mama_id()
+returns uuid
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+declare v uuid;
+begin
+  v := nullif(public.jwt_claim('mama_id'), '')::uuid;
+  if v is not null then return v; end if;
+
+  select u.mama_id into v
+  from public.utilisateurs u
+  where u.auth_id = auth.uid()
+  limit 1;
+
+  return v;
+end;
+$$;
+grant execute on function public.current_user_mama_id() to authenticated;
+
+-- 3) get_my_profile => JSON objet (jamais vide); drop conditionnel si autre signature
+do $$
+declare rt text;
+begin
+  select pg_get_function_result(p.oid)
+    into rt
+  from pg_proc p join pg_namespace n on n.oid = p.pronamespace
+  where n.nspname='public' and p.proname='get_my_profile' and p.pronargs=0
+  limit 1;
+
+  if rt is not null and rt !~* '\\bjsonb\\b' then
+    execute 'drop function public.get_my_profile()';
+  end if;
+end
+$$ language plpgsql;
+
+create or replace function public.get_my_profile()
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+declare result jsonb;
+begin
+  select jsonb_build_object(
+    'id', u.id,
+    'nom', u.nom,
+    'access_rights', coalesce(u.access_rights, '{}'::jsonb),
+    'mama_id', u.mama_id,
+    'role_id', u.role_id
+  )
+  into result
+  from public.utilisateurs u
+  where u.auth_id = auth.uid()
+  limit 1;
+
+  if result is null then
+    result := jsonb_build_object(
+      'id', null, 'nom', null, 'access_rights', '{}'::jsonb, 'mama_id', null, 'role_id', null
+    );
+  end if;
+  return result;
+end;
+$$;
+grant execute on function public.get_my_profile() to authenticated;
+
+-- 4) bootstrap_my_profile (idempotent)
+create or replace function public.bootstrap_my_profile(p_nom text)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  insert into public.utilisateurs (auth_id, nom)
+  values (auth.uid(), p_nom)
+  on conflict (auth_id) do update
+    set nom = coalesce(excluded.nom, public.utilisateurs.nom);
+end;
+$$;
+grant execute on function public.bootstrap_my_profile(text) to authenticated;
+
+-- =========================================================
+-- FIN DU SCRIPT
+-- =========================================================

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -14,7 +14,7 @@ function AuthProvider({ children }) {
       if (!sess) { setUserData(null); return }
       const displayName = sess.user?.user_metadata?.full_name || sess.user?.email || null
       await supabase.rpc('bootstrap_my_profile', { p_nom: displayName })
-      const { data, error } = await supabase.rpc('get_my_profile') // RPC renvoie un OBJET JSON
+      const { data, error } = await supabase.rpc('get_my_profile')
       if (error) {
         console.error('[get_my_profile] error', error)
         setUserData(null)

--- a/src/router/PrivateOutlet.jsx
+++ b/src/router/PrivateOutlet.jsx
@@ -3,7 +3,7 @@ import { useAuth } from '@/contexts/AuthContext'
 
 export default function PrivateOutlet() {
   const { session, userData, loading } = useAuth()
-  if (loading || (session && !userData)) return null // pas de faux unauthorized pendant chargement
+  if (loading || (session && !userData)) return null
   if (!session) return <Navigate to="/login" replace />
   if (!userData) return <Navigate to="/unauthorized" replace />
   return <Outlet />


### PR DESCRIPTION
## Summary
- refresh auth context to bootstrap and load profile
- add guard-based private outlet
- provide SQL overlay for auth/access functions

## Testing
- `npm test` *(fails: No "default" export is defined on the "@/hooks/usePeriodes" mock; useExport is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_689f3eb0bee4832da973ba27eaff1c21