### PR TITLE
feat: refresh auth profile on login

### DIFF
--- a/db/overlay_auth_access.SQL_EDITOR_READY.sql
+++ b/db/overlay_auth_access.SQL_EDITOR_READY.sql
@@ -1,11 +1,7 @@
--- =========================================================
--- OVERLAY AUTH & ACCESS (app-safe, idempotent) — à coller dans le SQL Editor
--- NE CRÉE PAS de tables; ne fait que fonctions/GRANTs/policies sûres
--- =========================================================
 set search_path = public;
 set check_function_bodies = off;
 
--- 1) Helpers JWT
+-- Helpers
 create or replace function public.jwt_claim(claim text)
 returns text language sql stable as $$
   select coalesce(
@@ -14,40 +10,31 @@ returns text language sql stable as $$
   );
 $$;
 
--- 2) current_user_mama_id avec fallback table (SECURITY DEFINER)
+-- current_user_mama_id (fallback table, SECURITY DEFINER)
 create or replace function public.current_user_mama_id()
 returns uuid
-language plpgsql
-stable
-security definer
+language plpgsql stable security definer
 set search_path = public
 as $$
 declare v uuid;
 begin
   v := nullif(public.jwt_claim('mama_id'), '')::uuid;
   if v is not null then return v; end if;
-
-  select u.mama_id into v
-  from public.utilisateurs u
-  where u.auth_id = auth.uid()
-  limit 1;
-
+  select u.mama_id into v from public.utilisateurs u where u.auth_id = auth.uid() limit 1;
   return v;
 end;
 $$;
 grant execute on function public.current_user_mama_id() to authenticated;
 
--- 3) get_my_profile => JSON objet (jamais vide); drop conditionnel si autre signature
+-- get_my_profile => jsonb objet (drop conditionnel si autre signature)
 do $$
 declare rt text;
 begin
-  select pg_get_function_result(p.oid)
-    into rt
-  from pg_proc p join pg_namespace n on n.oid = p.pronamespace
+  select pg_get_function_result(p.oid) into rt
+  from pg_proc p join pg_namespace n on n.oid=p.pronamespace
   where n.nspname='public' and p.proname='get_my_profile' and p.pronargs=0
   limit 1;
-
-  if rt is not null and rt !~* '\\bjsonb\\b' then
+  if rt is not null and rt !~* '\bjsonb\b' then
     execute 'drop function public.get_my_profile()';
   end if;
 end
@@ -55,51 +42,72 @@ $$ language plpgsql;
 
 create or replace function public.get_my_profile()
 returns jsonb
-language plpgsql
-stable
-security definer
+language plpgsql stable security definer
 set search_path = public
 as $$
 declare result jsonb;
 begin
   select jsonb_build_object(
-    'id', u.id,
-    'nom', u.nom,
-    'access_rights', coalesce(u.access_rights, '{}'::jsonb),
-    'mama_id', u.mama_id,
-    'role_id', u.role_id
-  )
-  into result
+    'id', u.id, 'nom', u.nom,
+    'access_rights', coalesce(u.access_rights,'{}'::jsonb),
+    'mama_id', u.mama_id, 'role_id', u.role_id
+  ) into result
   from public.utilisateurs u
   where u.auth_id = auth.uid()
   limit 1;
-
   if result is null then
-    result := jsonb_build_object(
-      'id', null, 'nom', null, 'access_rights', '{}'::jsonb, 'mama_id', null, 'role_id', null
-    );
+    result := jsonb_build_object('id',null,'nom',null,'access_rights','{}'::jsonb,'mama_id',null,'role_id',null);
   end if;
   return result;
 end;
 $$;
 grant execute on function public.get_my_profile() to authenticated;
 
--- 4) bootstrap_my_profile (idempotent)
-create or replace function public.bootstrap_my_profile(p_nom text)
-returns void
-language plpgsql
-security definer
+-- bootstrap_my_profile => jsonb (drop signature incompatible si présent)
+do $$
+begin
+  if to_regprocedure('public.bootstrap_my_profile(text)') is not null then
+    -- ok, on laissera le CREATE OR REPLACE ajuster le corps
+    null;
+  elsif to_regprocedure('public.bootstrap_my_profile()') is not null then
+    execute 'drop function public.bootstrap_my_profile()';
+  end if;
+end
+$$ language plpgsql;
+
+create or replace function public.bootstrap_my_profile(p_nom text default null)
+returns jsonb
+language plpgsql security definer
 set search_path = public
 as $$
+declare v_auth uuid := auth.uid(); v_mama uuid; v_row public.utilisateurs%rowtype;
 begin
-  insert into public.utilisateurs (auth_id, nom)
-  values (auth.uid(), p_nom)
-  on conflict (auth_id) do update
-    set nom = coalesce(excluded.nom, public.utilisateurs.nom);
+  if v_auth is null then raise exception 'No session'; end if;
+  select * into v_row from public.utilisateurs where auth_id=v_auth limit 1;
+  if not found then
+    v_mama := nullif(public.jwt_claim('mama_id'), '')::uuid;
+    if v_mama is null then select id into v_mama from public.mamas order by id limit 1; end if;
+    if v_mama is null then raise exception 'Aucun mama_id disponible'; end if;
+    insert into public.utilisateurs (auth_id, nom, access_rights, mama_id, role_id)
+    values (v_auth, coalesce(p_nom,''), '{}'::jsonb, v_mama, null)
+    returning * into v_row;
+  end if;
+  return jsonb_build_object(
+    'id', v_row.id, 'nom', v_row.nom, 'access_rights', coalesce(v_row.access_rights,'{}'::jsonb),
+    'mama_id', v_row.mama_id, 'role_id', v_row.role_id
+  );
 end;
 $$;
 grant execute on function public.bootstrap_my_profile(text) to authenticated;
 
--- =========================================================
--- FIN DU SCRIPT
--- =========================================================
+-- RLS rappel minimal: SELECT self sur utilisateurs (ajout si manquant, non destructif)
+do $$
+begin
+  if to_regclass('public.utilisateurs') is not null then
+    execute 'alter table public.utilisateurs enable row level security';
+    if not exists (select 1 from pg_policies where schemaname='public' and tablename='utilisateurs' and policyname='utilisateurs_select') then
+      execute $q$create policy utilisateurs_select on public.utilisateurs for select using (auth.uid()=auth_id)$q$;
+    end if;
+  end if;
+end
+$$ language plpgsql;

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -1,47 +1,32 @@
 import { createContext, useContext, useEffect, useState } from 'react'
 import supabase from '@/lib/supabaseClient'
-
 const AuthCtx = createContext(null)
 export const useAuth = () => useContext(AuthCtx)
-
 function AuthProvider({ children }) {
-  const [session, setSession]   = useState(null)
+  const [session, setSession] = useState(null)
   const [userData, setUserData] = useState(null)
-  const [loading, setLoading]   = useState(true)
-
+  const [loading, setLoading] = useState(true)
   async function loadProfile(sess) {
     try {
       if (!sess) { setUserData(null); return }
       const displayName = sess.user?.user_metadata?.full_name || sess.user?.email || null
       await supabase.rpc('bootstrap_my_profile', { p_nom: displayName })
-      const { data, error } = await supabase.rpc('get_my_profile')
-      if (error) {
-        console.error('[get_my_profile] error', error)
-        setUserData(null)
-      } else {
-        setUserData(data)
-      }
-    } catch (e) {
-      console.error('[auth] loadProfile failed', e)
-      setUserData(null)
-    }
+      const { data, error } = await supabase.rpc('get_my_profile') // jsonb objet
+      if (error) { console.error('[get_my_profile] error', error); setUserData(null) }
+      else { setUserData(data) }
+    } catch (e) { console.error('[auth] loadProfile failed', e); setUserData(null) }
   }
-
   useEffect(() => {
     let mounted = true
     const init = async () => {
       const { data: { session } } = await supabase.auth.getSession()
       if (!mounted) return
       setSession(session ?? null)
-      if (session) {
-        setLoading(true)
-        await loadProfile(session)
-      }
+      if (session) { setLoading(true); await loadProfile(session) }
       setLoading(false)
     }
     init()
-
-    const { data: sub } = supabase.auth.onAuthStateChange(async (_event, sess) => {
+    const { data: sub } = supabase.auth.onAuthStateChange(async (_evt, sess) => {
       setSession(sess ?? null)
       setLoading(true)
       await loadProfile(sess)
@@ -49,13 +34,8 @@ function AuthProvider({ children }) {
     })
     return () => { mounted = false; sub?.subscription?.unsubscribe?.() }
   }, [])
-
-  return (
-    <AuthCtx.Provider value={{ session, userData, loading }}>
-      {children}
-    </AuthCtx.Provider>
-  )
+  return <AuthCtx.Provider value={{ session, userData, loading }}>{children}</AuthCtx.Provider>
 }
-
 export default AuthProvider
 export { AuthProvider }
+

--- a/src/pages/debug/DebugRights.jsx
+++ b/src/pages/debug/DebugRights.jsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import { useAuth } from '@/contexts/AuthContext'
+export default function DebugRights() {
+  const { userData } = useAuth()
+  const rights = userData?.access_rights || {}
+  return <pre style={{padding:16, background:'#111', color:'#0f0', overflow:'auto'}}>{JSON.stringify(rights, null, 2)}</pre>
+}
+

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -17,6 +17,7 @@ import Blocked from "@/pages/auth/Blocked";
 import OnboardingUtilisateur from "@/pages/onboarding/OnboardingUtilisateur";
 import DebugAuth from "@/pages/debug/DebugAuth";
 import AccessExample from "@/pages/debug/AccessExample";
+import DebugRights from "@/pages/debug/DebugRights";
 import ProtectedRoute from "@/components/ProtectedRoute";
 import PrivateOutlet from "@/router/PrivateOutlet";
 
@@ -247,6 +248,7 @@ export default function Router() {
         <Route path="/contact" element={<Contact />} />
         <Route path="/licence" element={<Licence />} />
         <Route path="/debug/auth" element={<DebugAuth />} />
+        <Route path="/debug/rights" element={<DebugRights />} />
         {/* Routes internes protégées par les droits utilisateurs.
             Chaque sous-route est enveloppée dans <ProtectedRoute accessKey="...">.
             La clé correspond au module autorisé dans access_rights. */}


### PR DESCRIPTION
## Summary
- reload user profile on session changes via AuthContext
- add debug page to inspect access rights
- provide SQL overlay for profile helpers and RLS policy

## Testing
- `npm test` *(fails: expected 200 to be 500)*

------
https://chatgpt.com/codex/tasks/task_e_689f6d4e4a9c832dbd8b922a20bab505