### PR TITLE
feat: stabilize auth flow

### DIFF
--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -43,9 +43,9 @@ function AuthProvider({ children }) {
     init()
     const { data: sub } = supabase.auth.onAuthStateChange(async (_evt, sess) => {
       setSession(sess ?? null)
-      if (sess?.user?.id === lastLoadedUserRef.current && userData) return
-      lastLoadedUserRef.current = sess?.user?.id || null
+      if (sess?.user?.id && lastLoadedUserRef.current === sess.user.id && userData) return
       console.info('[auth] onAuthStateChange -> loadProfile for', sess?.user?.id)
+      lastLoadedUserRef.current = sess?.user?.id || null
       setLoading(true)
       await loadProfile(sess)
       setLoading(false)

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -3,9 +3,8 @@ import { createClient } from '@supabase/supabase-js'
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string
 const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string
 
-const supabase = createClient(supabaseUrl, supabaseKey, {
+export const supabase = createClient(supabaseUrl, supabaseKey, {
   auth: { persistSession: true, storageKey: 'mamastock-auth' },
 })
 
 export default supabase
-export { supabase }

--- a/src/pages/auth/Login.jsx
+++ b/src/pages/auth/Login.jsx
@@ -14,30 +14,32 @@ export default function Login() {
   const [pending, setPending] = useState(false)
   const [errorMsg, setErrorMsg] = useState('')
 
-  async function handleLogin(e) {
-    e.preventDefault()
-    setErrorMsg('')
-    setPending(true)
-    const form = e.currentTarget
-    const email = form.email?.value?.trim()
-    const password = form.password?.value ?? ''
-    if (!email || !password) {
-      setErrorMsg('Veuillez saisir email et mot de passe.')
+    async function handleLogin(e) {
+      e.preventDefault()
+      const form = e.currentTarget
+      const email = form.email?.value?.trim()
+      const password = form.password?.value ?? ''
+      console.log('[login] submit', { emailPresent: !!email, passwordPresent: !!password })
+      setErrorMsg('')
+      setPending(true)
+      if (!email || !password) {
+        setErrorMsg('Veuillez saisir email et mot de passe.')
+        setPending(false)
+        return
+      }
+      console.time('[login] signIn')
+      const { data, error } = await supabase.auth.signInWithPassword({ email, password })
+      console.timeEnd('[login] signIn')
+      if (error) {
+        console.error('[login] error', error)
+        setErrorMsg(error.message || 'Connexion impossible')
+        setPending(false)
+        return
+      }
       setPending(false)
-      return
+      // Ne pas navigate ici: on attend AuthContext (bootstrap + get_my_profile)
+      // L’AuthContext passera loading=false et remplira userData.
     }
-    const { error } = await supabase.auth.signInWithPassword({ email, password })
-    console.log('[login] submit', { emailPresent: !!email })
-    if (error) {
-      console.error('[signInWithPassword] error', error)
-      setErrorMsg(error.message || 'Connexion impossible')
-      setPending(false)
-      return
-    }
-    setPending(false)
-    // Ne pas navigate ici: on attend AuthContext (bootstrap + get_my_profile)
-    // L’AuthContext passera loading=false et remplira userData.
-  }
 
   useEffect(() => {
     if (!loading && session && userData) {


### PR DESCRIPTION
## Summary
- ensure Supabase client uses a single persisted instance
- avoid duplicate profile loading in AuthContext with refs and logging
- wire login form to `signInWithPassword` with submit logging and timing
- unify auth guards via `PrivateOutlet`
- add SQL overlay for profile bootstrap and lookup

## Testing
- `npm run lint`
- `npm test` *(fails: 58 failed, 77 passed, 1 error)*

------
https://chatgpt.com/codex/tasks/task_e_689f88db01e0832dbd1a256cdeb27a28