### PR TITLE
refactor: unify supabase client and auth handling

### DIFF
--- a/src/components/parametrage/UtilisateurRow.jsx
+++ b/src/components/parametrage/UtilisateurRow.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import toast from "react-hot-toast";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 
 export default function UtilisateurRow({
   utilisateur,

--- a/src/components/produits/ModalImportProduits.jsx
+++ b/src/components/produits/ModalImportProduits.jsx
@@ -9,7 +9,7 @@ import {
 import { useAuth } from '@/hooks/useAuth';
 import { Button } from "@/components/ui/button";
 import { toast } from "react-hot-toast";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 
 export default function ModalImportProduits({ open, onClose, onSuccess }) {
   const { mama_id } = useAuth();

--- a/src/context/HelpProvider.jsx
+++ b/src/context/HelpProvider.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 /* eslint-disable react-hooks/exhaustive-deps */
 import { createContext, useContext, useEffect, useState } from 'react';
-import { supabase } from '@/lib/supabase';
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 const HelpContext = createContext();

--- a/src/context/MultiMamaContext.jsx
+++ b/src/context/MultiMamaContext.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 /* eslint-disable react-hooks/exhaustive-deps */
 import { createContext, useContext, useEffect, useState } from 'react';
-import { supabase } from '@/lib/supabase';
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import toast from 'react-hot-toast';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useRef, useState } from 'react'
+import { useEffect, useState, useRef, createContext, useContext } from 'react'
 import supabase from '@/lib/supabaseClient'
 
 const AuthCtx = createContext(null)
@@ -7,50 +7,61 @@ export const useAuth = () => useContext(AuthCtx)
 function AuthProvider({ children }) {
   const [session, setSession] = useState(null)
   const [userData, setUserData] = useState(null)
-  const [loading, setLoading] = useState(true)
+  const [loading, setLoading] = useState(false)
   const initRef = useRef(false)
   const lastLoadedUserRef = useRef(null)
+  const pollTimerRef = useRef(null)
 
   async function loadProfile(sess) {
-    try {
-      if (!sess) { setUserData(null); return }
-      const displayName = sess.user?.user_metadata?.full_name || sess.user?.email || null
-      await supabase.rpc('bootstrap_my_profile', { p_nom: displayName })
-      const { data, error } = await supabase.rpc('get_my_profile') // jsonb objet
-      if (error) { console.error('[get_my_profile] error', error); setUserData(null) }
-      else { setUserData(data) }
-    } catch (e) { console.error('[auth] loadProfile failed', e); setUserData(null) }
+    if (!sess) { setUserData(null); return }
+    const displayName = sess.user?.user_metadata?.full_name || sess.user?.email || null
+    await supabase.rpc('bootstrap_my_profile', { p_nom: displayName })
+    const { data, error } = await supabase.rpc('get_my_profile')
+    if (error) { console.error(error); setUserData(null) }
+    else { setUserData(data) }
   }
 
   useEffect(() => {
     if (initRef.current) return
     initRef.current = true
     console.info('[auth] init once')
-    let mounted = true
     const init = async () => {
       const { data: { session } } = await supabase.auth.getSession()
-      if (!mounted) return
       setSession(session ?? null)
-      if (session) {
-        lastLoadedUserRef.current = session?.user?.id || null
-        setLoading(true)
-        await loadProfile(session)
-        setLoading(false)
-      } else {
-        setLoading(false)
-      }
+      if (session) { setLoading(true); await loadProfile(session) }
+      setLoading(false)
     }
     init()
     const { data: sub } = supabase.auth.onAuthStateChange(async (_evt, sess) => {
-      setSession(sess ?? null)
-      if (sess?.user?.id && lastLoadedUserRef.current === sess.user.id && userData) return
       console.info('[auth] onAuthStateChange -> loadProfile for', sess?.user?.id)
-      lastLoadedUserRef.current = sess?.user?.id || null
+      setSession(sess ?? null)
       setLoading(true)
+      if (sess?.user?.id && lastLoadedUserRef.current === sess.user.id && userData) {
+        setLoading(false)
+        return
+      }
+      lastLoadedUserRef.current = sess?.user?.id || null
       await loadProfile(sess)
       setLoading(false)
     })
-    return () => { mounted = false; sub?.subscription?.unsubscribe?.() }
+    let tries = 0
+    const tick = async () => {
+      tries++
+      const { data: { session } } = await supabase.auth.getSession()
+      if (session && !userData) {
+        setSession(session)
+        setLoading(true)
+        await loadProfile(session)
+        setLoading(false)
+        window.clearInterval(pollTimerRef.current)
+        pollTimerRef.current = null
+      } else if (tries >= 10) {
+        window.clearInterval(pollTimerRef.current)
+        pollTimerRef.current = null
+      }
+    }
+    pollTimerRef.current = window.setInterval(tick, 500)
+    return () => { sub?.subscription?.unsubscribe?.(); if (pollTimerRef.current) window.clearInterval(pollTimerRef.current) }
   }, [])
 
   return <AuthCtx.Provider value={{ session, userData, loading }}>{children}</AuthCtx.Provider>
@@ -58,4 +69,3 @@ function AuthProvider({ children }) {
 
 export default AuthProvider
 export { AuthProvider }
-

--- a/src/hooks/gadgets/useAchatsMensuels.js
+++ b/src/hooks/gadgets/useAchatsMensuels.js
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { supabase } from '@/lib/supabase';
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export default function useAchatsMensuels() {

--- a/src/hooks/gadgets/useEvolutionAchats.js
+++ b/src/hooks/gadgets/useEvolutionAchats.js
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { supabase } from '@/lib/supabase';
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export default function useEvolutionAchats() {

--- a/src/hooks/gadgets/useTopFournisseurs.js
+++ b/src/hooks/gadgets/useTopFournisseurs.js
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { supabase } from '@/lib/supabase';
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export default function useTopFournisseurs() {

--- a/src/hooks/useAchats.js
+++ b/src/hooks/useAchats.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useAchats() {

--- a/src/hooks/useAdvancedStats.js
+++ b/src/hooks/useAdvancedStats.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 
 export function useAdvancedStats() {
   const [data, setData] = useState([]);

--- a/src/hooks/useAide.js
+++ b/src/hooks/useAide.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback } from 'react';
-import { supabase } from '@/lib/supabase';
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useAide() {

--- a/src/hooks/useAlerts.js
+++ b/src/hooks/useAlerts.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useAlerts() {

--- a/src/hooks/useAnalyse.js
+++ b/src/hooks/useAnalyse.js
@@ -1,5 +1,5 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useAnalyse() {

--- a/src/hooks/useAnalytique.js
+++ b/src/hooks/useAnalytique.js
@@ -1,5 +1,5 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useAnalytique() {

--- a/src/hooks/useApiKeys.js
+++ b/src/hooks/useApiKeys.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback } from 'react';
-import { supabase } from '@/lib/supabase';
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useApiKeys() {

--- a/src/hooks/useAuditLog.js
+++ b/src/hooks/useAuditLog.js
@@ -1,5 +1,5 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useAuditLog() {

--- a/src/hooks/useBonsLivraison.js
+++ b/src/hooks/useBonsLivraison.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useBonsLivraison() {

--- a/src/hooks/useCarte.js
+++ b/src/hooks/useCarte.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useCarte() {

--- a/src/hooks/useCommandes.js
+++ b/src/hooks/useCommandes.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useCommandes() {

--- a/src/hooks/useComparatif.js
+++ b/src/hooks/useComparatif.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useEffect, useCallback } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 /**

--- a/src/hooks/useConsolidatedStats.js
+++ b/src/hooks/useConsolidatedStats.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 
 export function useConsolidatedStats() {
   const [stats, setStats] = useState([]);

--- a/src/hooks/useConsolidation.js
+++ b/src/hooks/useConsolidation.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import * as XLSX from "xlsx";
 import jsPDF from "jspdf";
 import "jspdf-autotable";

--- a/src/hooks/useCostCenterMonthlyStats.js
+++ b/src/hooks/useCostCenterMonthlyStats.js
@@ -1,5 +1,5 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useCostCenterMonthlyStats() {

--- a/src/hooks/useCostCenterStats.js
+++ b/src/hooks/useCostCenterStats.js
@@ -1,5 +1,5 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useCostCenterStats() {

--- a/src/hooks/useCostCenterSuggestions.js
+++ b/src/hooks/useCostCenterSuggestions.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useCostCenterSuggestions() {

--- a/src/hooks/useCostCenters.js
+++ b/src/hooks/useCostCenters.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import { useAuditLog } from "@/hooks/useAuditLog";
 import * as XLSX from "xlsx";

--- a/src/hooks/useCostingCarte.js
+++ b/src/hooks/useCostingCarte.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback } from 'react'
-import { supabase } from '@/lib/supabase'
+import supabase from '@/lib/supabaseClient'
 import { useAuth } from '@/hooks/useAuth'
 import * as XLSX from 'xlsx'
 import jsPDF from 'jspdf'

--- a/src/hooks/useDashboard.js
+++ b/src/hooks/useDashboard.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import * as XLSX from "xlsx";
 import { saveAs } from "file-saver";

--- a/src/hooks/useDashboardStats.js
+++ b/src/hooks/useDashboardStats.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useRef, useEffect, useCallback } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 /**

--- a/src/hooks/useDashboards.js
+++ b/src/hooks/useDashboards.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useDashboards() {

--- a/src/hooks/useDocuments.js
+++ b/src/hooks/useDocuments.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import { uploadFile, deleteFile, pathFromUrl } from "@/hooks/useStorage";
 

--- a/src/hooks/useEcartsInventaire.js
+++ b/src/hooks/useEcartsInventaire.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useEcartsInventaire() {

--- a/src/hooks/useEnrichedProducts.js
+++ b/src/hooks/useEnrichedProducts.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useEnrichedProducts() {

--- a/src/hooks/useExport.js
+++ b/src/hooks/useExport.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from 'react';
-import { supabase } from '@/lib/supabase';
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import {
   exportToPDF,

--- a/src/hooks/useExportCompta.js
+++ b/src/hooks/useExportCompta.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from 'react';
-import { supabase } from '@/lib/supabase';
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import { exportToCSV } from '@/lib/export/exportHelpers';
 import toast from 'react-hot-toast';

--- a/src/hooks/useFactures.js
+++ b/src/hooks/useFactures.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import usePeriodes from "@/hooks/usePeriodes";
 

--- a/src/hooks/useFacturesAutocomplete.js
+++ b/src/hooks/useFacturesAutocomplete.js
@@ -1,5 +1,5 @@
 import { useState, useCallback } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useFacturesAutocomplete() {

--- a/src/hooks/useFeedback.js
+++ b/src/hooks/useFeedback.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useFeedback() {

--- a/src/hooks/useFicheCoutHistory.js
+++ b/src/hooks/useFicheCoutHistory.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useFicheCoutHistory() {

--- a/src/hooks/useFiches.js
+++ b/src/hooks/useFiches.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import * as XLSX from "xlsx";
 import { saveAs } from "file-saver";

--- a/src/hooks/useFichesAutocomplete.js
+++ b/src/hooks/useFichesAutocomplete.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useFichesAutocomplete() {

--- a/src/hooks/useFichesTechniques.js
+++ b/src/hooks/useFichesTechniques.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useFichesTechniques() {

--- a/src/hooks/useFournisseurAPI.js
+++ b/src/hooks/useFournisseurAPI.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import toast from "react-hot-toast";
 

--- a/src/hooks/useFournisseurApiConfig.js
+++ b/src/hooks/useFournisseurApiConfig.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from 'react';
-import { supabase } from '@/lib/supabase';
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import toast from 'react-hot-toast';
 

--- a/src/hooks/useFournisseurNotes.js
+++ b/src/hooks/useFournisseurNotes.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useFournisseurNotes() {

--- a/src/hooks/useFournisseurStats.js
+++ b/src/hooks/useFournisseurStats.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 // src/hooks/useFournisseurStats.js
 
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 // Stats d’évolution d’achats (tous fournisseurs ou par fournisseur)

--- a/src/hooks/useFournisseurs.js
+++ b/src/hooks/useFournisseurs.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 // src/hooks/useFournisseurs.js
 import { useState, useCallback } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import * as XLSX from "xlsx";
 import { safeImportXLSX } from "@/lib/xlsx/safeImportXLSX";

--- a/src/hooks/useFournisseursAutocomplete.js
+++ b/src/hooks/useFournisseursAutocomplete.js
@@ -1,5 +1,5 @@
 import { useState, useCallback } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useFournisseursAutocomplete() {

--- a/src/hooks/useFournisseursInactifs.js
+++ b/src/hooks/useFournisseursInactifs.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useFournisseursInactifs() {

--- a/src/hooks/useGadgets.js
+++ b/src/hooks/useGadgets.js
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react';
-import { supabase } from '@/lib/supabase';
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useGadgets() {

--- a/src/hooks/useGlobalSearch.js
+++ b/src/hooks/useGlobalSearch.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback } from 'react';
-import { supabase } from '@/lib/supabase';
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useGlobalSearch() {

--- a/src/hooks/useGraphiquesMultiZone.js
+++ b/src/hooks/useGraphiquesMultiZone.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useGraphiquesMultiZone() {

--- a/src/hooks/useHelpArticles.js
+++ b/src/hooks/useHelpArticles.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 
 export function useHelpArticles() {
   const [items, setItems] = useState([]);

--- a/src/hooks/useInventaireLignes.js
+++ b/src/hooks/useInventaireLignes.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useInventaireLignes() {

--- a/src/hooks/useInventaireZones.js
+++ b/src/hooks/useInventaireZones.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import { toast } from "react-hot-toast";
 

--- a/src/hooks/useInventaires.js
+++ b/src/hooks/useInventaires.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useEffect } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import usePeriodes from "@/hooks/usePeriodes";
 

--- a/src/hooks/useInvoiceImport.js
+++ b/src/hooks/useInvoiceImport.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 
 export function useInvoiceImport() {
   const [loading, setLoading] = useState(false);

--- a/src/hooks/useInvoiceItems.js
+++ b/src/hooks/useInvoiceItems.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 // Hook managing invoice line items (facture_lignes)

--- a/src/hooks/useInvoices.js
+++ b/src/hooks/useInvoices.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import * as XLSX from "xlsx";
 import { safeImportXLSX } from "@/lib/xlsx/safeImportXLSX";

--- a/src/hooks/useLogs.js
+++ b/src/hooks/useLogs.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import { saveAs } from "file-saver";
 import * as XLSX from "xlsx";

--- a/src/hooks/useMama.js
+++ b/src/hooks/useMama.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useMama() {

--- a/src/hooks/useMamaSettings.js
+++ b/src/hooks/useMamaSettings.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 const defaults = {

--- a/src/hooks/useMamas.js
+++ b/src/hooks/useMamas.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import * as XLSX from "xlsx";
 import { safeImportXLSX } from "@/lib/xlsx/safeImportXLSX";

--- a/src/hooks/useMenuDuJour.js
+++ b/src/hooks/useMenuDuJour.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import { useAuditLog } from "@/hooks/useAuditLog";
 import * as XLSX from "xlsx";

--- a/src/hooks/useMenuEngineering.js
+++ b/src/hooks/useMenuEngineering.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback } from 'react';
-import { supabase } from '@/lib/supabase';
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useMenuEngineering() {

--- a/src/hooks/useMenuGroupe.js
+++ b/src/hooks/useMenuGroupe.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from 'react';
-import { supabase } from '@/lib/supabase';
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export default function useMenuGroupe() {

--- a/src/hooks/useMenus.js
+++ b/src/hooks/useMenus.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import { useAuditLog } from "@/hooks/useAuditLog";
 import * as XLSX from "xlsx";

--- a/src/hooks/useMouvementCostCenters.js
+++ b/src/hooks/useMouvementCostCenters.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import { useAuditLog } from "@/hooks/useAuditLog";
 

--- a/src/hooks/useNotifications.js
+++ b/src/hooks/useNotifications.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback } from "react";
 import toast from "react-hot-toast";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth as useAuthContext } from '@/hooks/useAuth';
 
 export default function useNotifications() {

--- a/src/hooks/useOnboarding.js
+++ b/src/hooks/useOnboarding.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useEffect, useCallback } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useOnboarding() {

--- a/src/hooks/usePerformanceFiches.js
+++ b/src/hooks/usePerformanceFiches.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from 'react';
-import { supabase } from '@/lib/supabase';
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export default function usePerformanceFiches() {

--- a/src/hooks/usePeriodes.js
+++ b/src/hooks/usePeriodes.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from 'react';
-import { supabase } from '@/lib/supabase';
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export default function usePeriodes() {

--- a/src/hooks/usePermissions.js
+++ b/src/hooks/usePermissions.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import * as XLSX from "xlsx";
 import { safeImportXLSX } from "@/lib/xlsx/safeImportXLSX";

--- a/src/hooks/usePertes.js
+++ b/src/hooks/usePertes.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import { useAuditLog } from "@/hooks/useAuditLog";
 

--- a/src/hooks/usePlanning.js
+++ b/src/hooks/usePlanning.js
@@ -1,5 +1,5 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function usePlanning() {

--- a/src/hooks/usePriceTrends.js
+++ b/src/hooks/usePriceTrends.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from 'react';
-import { supabase } from '@/lib/supabase';
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function usePriceTrends(productIdInitial) {

--- a/src/hooks/useProducts.js
+++ b/src/hooks/useProducts.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 // src/hooks/useProducts.js
 import { useState, useCallback, useEffect } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import * as XLSX from "xlsx";
 import { safeImportXLSX } from "@/lib/xlsx/safeImportXLSX";

--- a/src/hooks/useProduitsAutocomplete.js
+++ b/src/hooks/useProduitsAutocomplete.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useProduitsAutocomplete() {

--- a/src/hooks/useProduitsFournisseur.js
+++ b/src/hooks/useProduitsFournisseur.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 export function useProduitsFournisseur() {
   const { mama_id } = useAuth();

--- a/src/hooks/useProduitsInventaire.js
+++ b/src/hooks/useProduitsInventaire.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback } from 'react';
-import { supabase } from '@/lib/supabase';
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useProduitsInventaire() {

--- a/src/hooks/usePromotions.js
+++ b/src/hooks/usePromotions.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function usePromotions() {

--- a/src/hooks/useRGPD.js
+++ b/src/hooks/useRGPD.js
@@ -1,5 +1,5 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useRGPD() {

--- a/src/hooks/useRecommendations.js
+++ b/src/hooks/useRecommendations.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useEffect, useCallback } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export async function getRecommendations(user_id, mama_id) {

--- a/src/hooks/useReporting.js
+++ b/src/hooks/useReporting.js
@@ -1,5 +1,5 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useReporting() {

--- a/src/hooks/useRequisitions.js
+++ b/src/hooks/useRequisitions.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 // src/hooks/useRequisitions.js
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useRequisitions() {

--- a/src/hooks/useRoles.js
+++ b/src/hooks/useRoles.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 
 export function useRoles() {
   const [roles, setRoles] = useState([]);

--- a/src/hooks/useRuptureAlerts.js
+++ b/src/hooks/useRuptureAlerts.js
@@ -1,5 +1,5 @@
 // Hook for stock rupture alerts
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useRuptureAlerts() {

--- a/src/hooks/useSignalements.js
+++ b/src/hooks/useSignalements.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState, useCallback } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useSignalements() {

--- a/src/hooks/useSimulation.js
+++ b/src/hooks/useSimulation.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 // src/hooks/useSimulation.js
 import { useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export const useSimulation = () => {

--- a/src/hooks/useSousFamilles.js
+++ b/src/hooks/useSousFamilles.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useCallback, useState } from 'react';
 import { toast } from 'react-hot-toast';
-import { supabase } from '@/lib/supabase';
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useSousFamilles() {

--- a/src/hooks/useStats.js
+++ b/src/hooks/useStats.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 // src/hooks/useStats.js
 import { useState, useEffect, useCallback } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useStats() {

--- a/src/hooks/useStock.js
+++ b/src/hooks/useStock.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useStock() {

--- a/src/hooks/useStockRequisitionne.js
+++ b/src/hooks/useStockRequisitionne.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useEffect, useCallback } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useStockRequisitionne() {

--- a/src/hooks/useStorage.js
+++ b/src/hooks/useStorage.js
@@ -1,5 +1,5 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 
 export function pathFromUrl(url) {
   const match = url?.match(/\/object\/public\/[^/]+\/(.*)$/);

--- a/src/hooks/useSupabaseClient.js
+++ b/src/hooks/useSupabaseClient.js
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { supabase } from '@/lib/supabase';
+import supabase from '@/lib/supabaseClient';
 
 export default function useSupabaseClient() {
   return useMemo(() => supabase, []);

--- a/src/hooks/useTacheAssignation.js
+++ b/src/hooks/useTacheAssignation.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 
 export function useTacheAssignation() {
   const [loading, setLoading] = useState(false);

--- a/src/hooks/useTaches.js
+++ b/src/hooks/useTaches.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useTaches() {

--- a/src/hooks/useTasks.js
+++ b/src/hooks/useTasks.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useTasks() {

--- a/src/hooks/useTemplatesCommandes.js
+++ b/src/hooks/useTemplatesCommandes.js
@@ -1,5 +1,5 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export async function getTemplatesCommandesActifs() {

--- a/src/hooks/useTopProducts.js
+++ b/src/hooks/useTopProducts.js
@@ -1,5 +1,5 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { supabase } from '@/lib/supabase';
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useTopProducts() {

--- a/src/hooks/useTransferts.js
+++ b/src/hooks/useTransferts.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import usePeriodes from "@/hooks/usePeriodes";
 

--- a/src/hooks/useTwoFactorAuth.js
+++ b/src/hooks/useTwoFactorAuth.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { authenticator } from "otplib";
 
 export function useTwoFactorAuth() {

--- a/src/hooks/useUnites.js
+++ b/src/hooks/useUnites.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import * as XLSX from "xlsx";
 import { safeImportXLSX } from "@/lib/xlsx/safeImportXLSX";

--- a/src/hooks/useUsageStats.js
+++ b/src/hooks/useUsageStats.js
@@ -1,5 +1,5 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useUsageStats() {

--- a/src/hooks/useUtilisateurs.js
+++ b/src/hooks/useUtilisateurs.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import * as XLSX from "xlsx";
 import { safeImportXLSX } from "@/lib/xlsx/safeImportXLSX";

--- a/src/hooks/useValidations.js
+++ b/src/hooks/useValidations.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useValidations() {

--- a/src/hooks/useZoneProducts.js
+++ b/src/hooks/useZoneProducts.js
@@ -1,5 +1,5 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { supabase } from '@/lib/supabase';
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import { toast } from 'react-hot-toast';
 

--- a/src/hooks/useZoneRights.js
+++ b/src/hooks/useZoneRights.js
@@ -1,5 +1,5 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { supabase } from '@/lib/supabase';
+import supabase from '@/lib/supabaseClient';
 import { toast } from 'react-hot-toast';
 import { useAuth } from '@/hooks/useAuth';
 

--- a/src/hooks/useZones.js
+++ b/src/hooks/useZones.js
@@ -1,5 +1,5 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { supabase } from '@/lib/supabase';
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import { toast } from 'react-hot-toast';
 import { useState } from 'react';

--- a/src/hooks/useZonesStock.js
+++ b/src/hooks/useZonesStock.js
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from "@/hooks/useAuth";
 
 export async function fetchZonesForValidation(mama_id) {

--- a/src/lib/loginUser.js
+++ b/src/lib/loginUser.js
@@ -1,5 +1,5 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { supabase } from "./supabase";
+import supabase from '@/lib/supabaseClient';
 
 // Simple wrapper used by the AuthContext and auth pages
 export async function login(email, password) {

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,7 +1,10 @@
 import { createClient } from '@supabase/supabase-js'
+
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string
 const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string
+
 export const supabase = createClient(supabaseUrl, supabaseKey, {
-  auth: { persistSession: true, storageKey: 'mamastock-auth' },
+  auth: { persistSession: true, storageKey: 'mamastock-auth', autoRefreshToken: true, detectSessionInUrl: true },
 })
+
 export default supabase

--- a/src/pages/BarManager.jsx
+++ b/src/pages/BarManager.jsx
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useEffect } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import toast, { Toaster } from "react-hot-toast";
 import * as XLSX from "xlsx";

--- a/src/pages/CartePlats.jsx
+++ b/src/pages/CartePlats.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useEffect } from "react";
 import { useAuth } from '@/hooks/useAuth';
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { Toaster } from "react-hot-toast";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 import TableContainer from "@/components/ui/TableContainer";

--- a/src/pages/Transferts.jsx
+++ b/src/pages/Transferts.jsx
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useEffect } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import toast, { Toaster } from "react-hot-toast";
 import * as XLSX from "xlsx";

--- a/src/pages/auth/CreateMama.jsx
+++ b/src/pages/auth/CreateMama.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import PageWrapper from "@/components/ui/PageWrapper";
 import GlassCard from "@/components/ui/GlassCard";

--- a/src/pages/auth/ResetPassword.jsx
+++ b/src/pages/auth/ResetPassword.jsx
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import logo from "@/assets/logo-mamastock.png";
 import toast, { Toaster } from "react-hot-toast";
 import GlassCard from "@/components/ui/GlassCard";

--- a/src/pages/auth/UpdatePassword.jsx
+++ b/src/pages/auth/UpdatePassword.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import logo from "@/assets/logo-mamastock.png";
 import toast, { Toaster } from "react-hot-toast";
 import GlassCard from "@/components/ui/GlassCard";

--- a/src/pages/catalogue/CatalogueSyncViewer.jsx
+++ b/src/pages/catalogue/CatalogueSyncViewer.jsx
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import { Button } from "@/components/ui/button";
 import TableContainer from "@/components/ui/TableContainer";

--- a/src/pages/commandes/CommandeDetail.jsx
+++ b/src/pages/commandes/CommandeDetail.jsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { PDFDownloadLink, pdf } from "@react-pdf/renderer";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useCommandes } from "@/hooks/useCommandes";
 import { useTemplatesCommandes } from "@/hooks/useTemplatesCommandes";
 import CommandePDF from "@/components/pdf/CommandePDF";

--- a/src/pages/commandes/CommandesEnvoyees.jsx
+++ b/src/pages/commandes/CommandesEnvoyees.jsx
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import { Button } from "@/components/ui/button";
 import { useFournisseurAPI } from "@/hooks/useFournisseurAPI";

--- a/src/pages/consolidation/AccessMultiSites.jsx
+++ b/src/pages/consolidation/AccessMultiSites.jsx
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import TableContainer from "@/components/ui/TableContainer";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 

--- a/src/pages/costboisson/CostBoisson.jsx
+++ b/src/pages/costboisson/CostBoisson.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useEffect } from "react";
 import { useAuth } from '@/hooks/useAuth';
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { Button } from "@/components/ui/button";
 import toast, { Toaster } from "react-hot-toast";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";

--- a/src/pages/emails/EmailsEnvoyes.jsx
+++ b/src/pages/emails/EmailsEnvoyes.jsx
@@ -16,7 +16,7 @@ import * as XLSX from 'xlsx';
 import { saveAs } from 'file-saver';
 import { pdf } from '@react-pdf/renderer';
 import CommandePDF from '@/components/pdf/CommandePDF';
-import { supabase } from '@/lib/supabase';
+import supabase from '@/lib/supabaseClient';
 import toast from 'react-hot-toast';
 
 export default function EmailsEnvoyes() {

--- a/src/pages/factures/FactureForm.jsx
+++ b/src/pages/factures/FactureForm.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 /* eslint-disable react-hooks/exhaustive-deps */
 import { useState, useEffect, useRef } from 'react';
-import { supabase } from '@/lib/supabase';
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import { useFactures } from '@/hooks/useFactures';
 import { useProduitsAutocomplete } from '@/hooks/useProduitsAutocomplete';

--- a/src/pages/fournisseurs/FournisseurDetail.jsx
+++ b/src/pages/fournisseurs/FournisseurDetail.jsx
@@ -6,7 +6,7 @@ import { useFournisseurStats } from '@/hooks/useFournisseurStats';
 import { useProduitsFournisseur } from '@/hooks/useProduitsFournisseur';
 import { useInvoices } from '@/hooks/useInvoices';
 import { useFournisseurs } from '@/hooks/useFournisseurs';
-import { supabase } from '@/lib/supabase';
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import {

--- a/src/pages/fournisseurs/comparatif/ComparatifPrix.jsx
+++ b/src/pages/fournisseurs/comparatif/ComparatifPrix.jsx
@@ -2,7 +2,7 @@
 // src/pages/fournisseurs/comparatif/ComparatifPrix.jsx
 import { useEffect, useState } from "react";
 import PrixFournisseurs from "./PrixFournisseurs";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 import { Select } from "@/components/ui/select";

--- a/src/pages/inventaire/EcartInventaire.jsx
+++ b/src/pages/inventaire/EcartInventaire.jsx
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useEffect, useCallback } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import { useInventaireZones } from "@/hooks/useInventaireZones";
 import TableContainer from "@/components/ui/TableContainer";

--- a/src/pages/legal/Confidentialite.jsx
+++ b/src/pages/legal/Confidentialite.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import LegalLayout from "@/layout/LegalLayout";
 
 export default function Confidentialite() {

--- a/src/pages/legal/MentionsLegales.jsx
+++ b/src/pages/legal/MentionsLegales.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import LegalLayout from "@/layout/LegalLayout";
 
 export default function MentionsLegales() {

--- a/src/pages/menus/MenuPDF.jsx
+++ b/src/pages/menus/MenuPDF.jsx
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
 export default function MenuPDF({ id }) {

--- a/src/pages/mobile/MobileInventaire.jsx
+++ b/src/pages/mobile/MobileInventaire.jsx
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import { useInventaires } from "@/hooks/useInventaires";
 import { LiquidBackground, TouchLight } from "@/components/LiquidBackground";

--- a/src/pages/mobile/MobileRequisition.jsx
+++ b/src/pages/mobile/MobileRequisition.jsx
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { toast } from "react-toastify";
 import { useAuth } from '@/hooks/useAuth';
 import { LiquidBackground, TouchLight } from "@/components/LiquidBackground";

--- a/src/pages/parametrage/CentreCoutForm.jsx
+++ b/src/pages/parametrage/CentreCoutForm.jsx
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import PrimaryButton from "@/components/ui/PrimaryButton";
 import SecondaryButton from "@/components/ui/SecondaryButton";

--- a/src/pages/parametrage/InvitationsEnAttente.jsx
+++ b/src/pages/parametrage/InvitationsEnAttente.jsx
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useEffect } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { Button } from "@/components/ui/button";
 import { useAuth } from '@/hooks/useAuth';
 import toast, { Toaster } from "react-hot-toast";

--- a/src/pages/parametrage/InviteUser.jsx
+++ b/src/pages/parametrage/InviteUser.jsx
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useEffect } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import PrimaryButton from "@/components/ui/PrimaryButton";
 import SecondaryButton from "@/components/ui/SecondaryButton";

--- a/src/pages/parametrage/MamaForm.jsx
+++ b/src/pages/parametrage/MamaForm.jsx
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 import PrimaryButton from "@/components/ui/PrimaryButton";

--- a/src/pages/parametrage/Mamas.jsx
+++ b/src/pages/parametrage/Mamas.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 /* eslint-disable react-hooks/exhaustive-deps */
 import { useState, useEffect } from 'react';
-import { supabase } from '@/lib/supabase';
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import { Button } from '@/components/ui/button';
 import TableContainer from '@/components/ui/TableContainer';

--- a/src/pages/parametrage/ParametresCommandes.jsx
+++ b/src/pages/parametrage/ParametresCommandes.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useEffect } from "react";
 import { useAuth } from '@/hooks/useAuth';
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { toast } from "react-hot-toast";
 
 export default function ParametresCommandes() {

--- a/src/pages/parametrage/Permissions.jsx
+++ b/src/pages/parametrage/Permissions.jsx
@@ -2,7 +2,7 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import { useState, useEffect } from 'react';
 import { useAuth } from '@/hooks/useAuth';
-import { supabase } from '@/lib/supabase';
+import supabase from '@/lib/supabaseClient';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,

--- a/src/pages/parametrage/PermissionsAdmin.jsx
+++ b/src/pages/parametrage/PermissionsAdmin.jsx
@@ -2,7 +2,7 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import { useState, useEffect } from 'react';
 import { useAuth } from '@/hooks/useAuth';
-import { supabase } from '@/lib/supabase';
+import supabase from '@/lib/supabaseClient';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,

--- a/src/pages/parametrage/PermissionsForm.jsx
+++ b/src/pages/parametrage/PermissionsForm.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 /* eslint-disable react-hooks/exhaustive-deps */
 import { useState, useEffect } from 'react';
-import { supabase } from '@/lib/supabase';
+import supabase from '@/lib/supabaseClient';
 import { Button } from '@/components/ui/button';
 import GlassCard from '@/components/ui/GlassCard';
 import toast, { Toaster } from 'react-hot-toast';

--- a/src/pages/parametrage/RGPDConsentForm.jsx
+++ b/src/pages/parametrage/RGPDConsentForm.jsx
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import PrimaryButton from "@/components/ui/PrimaryButton";
 import toast, { Toaster } from "react-hot-toast";

--- a/src/pages/parametrage/SousFamilles.jsx
+++ b/src/pages/parametrage/SousFamilles.jsx
@@ -2,7 +2,7 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import { useEffect, useState } from 'react';
 import { Toaster, toast } from 'react-hot-toast';
-import { supabase } from '@/lib/supabase';
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import ListingContainer from '@/components/ui/ListingContainer';
 import PaginationFooter from '@/components/ui/PaginationFooter';

--- a/src/pages/parametrage/TemplateCommandeForm.jsx
+++ b/src/pages/parametrage/TemplateCommandeForm.jsx
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useTemplatesCommandes } from "@/hooks/useTemplatesCommandes";
 import { Button } from "@/components/ui/button";
 

--- a/src/pages/parametrage/Unites.jsx
+++ b/src/pages/parametrage/Unites.jsx
@@ -11,7 +11,7 @@ import UniteForm from '@/forms/UniteForm';
 import { useAuth } from '@/hooks/useAuth';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import Unauthorized from '@/pages/auth/Unauthorized';
-import { supabase } from '@/lib/supabase';
+import supabase from '@/lib/supabaseClient';
 
 export default function Unites() {
   const { unites, total, fetchUnites, addUnite, updateUnite } = useUnites();

--- a/src/pages/parametrage/Zones.jsx
+++ b/src/pages/parametrage/Zones.jsx
@@ -8,7 +8,7 @@ import { useNavigate } from 'react-router-dom';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import { useAuth } from '@/hooks/useAuth';
 import Unauthorized from '@/pages/auth/Unauthorized';
-import { supabase } from '@/lib/supabase';
+import supabase from '@/lib/supabaseClient';
 
 export default function Zones() {
   const { fetchZones, updateZone } = useZones();

--- a/src/pages/simulation/SimulationForm.jsx
+++ b/src/pages/simulation/SimulationForm.jsx
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import toast from "react-hot-toast";
 import GlassCard from "@/components/ui/GlassCard";

--- a/src/pages/stats/StatsFiches.jsx
+++ b/src/pages/stats/StatsFiches.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useEffect } from "react";
 import { useAuth } from '@/hooks/useAuth';
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import toast, { Toaster } from "react-hot-toast";
 import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Legend, LineChart, Line } from "recharts";
 import { Button } from "@/components/ui/button";

--- a/src/pages/supervision/ComparateurFiches.jsx
+++ b/src/pages/supervision/ComparateurFiches.jsx
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useMultiMama } from "@/context/MultiMamaContext";
 import TableContainer from "@/components/ui/TableContainer";
 import { Button } from "@/components/ui/button";

--- a/src/pages/supervision/GroupeParamForm.jsx
+++ b/src/pages/supervision/GroupeParamForm.jsx
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState, useCallback } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import { Button } from "@/components/ui/button";
 import GlassCard from "@/components/ui/GlassCard";

--- a/src/pages/supervision/Rapports.jsx
+++ b/src/pages/supervision/Rapports.jsx
@@ -2,7 +2,7 @@
 import { useEffect, useState, useCallback } from "react";
 import { useAuth } from '@/hooks/useAuth';
 import { useLogs } from "@/hooks/useLogs";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import GlassCard from "@/components/ui/GlassCard";
 import TableContainer from "@/components/ui/TableContainer";
 import { Input } from "@/components/ui/input";

--- a/src/pages/supervision/SupervisionGroupe.jsx
+++ b/src/pages/supervision/SupervisionGroupe.jsx
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState, useCallback } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useMultiMama } from "@/context/MultiMamaContext";
 import TableContainer from "@/components/ui/TableContainer";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";

--- a/src/pages/taches/Alertes.jsx
+++ b/src/pages/taches/Alertes.jsx
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState } from "react";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 import TableContainer from "@/components/ui/TableContainer";

--- a/src/utils/exportExcelProduits.js
+++ b/src/utils/exportExcelProduits.js
@@ -1,6 +1,6 @@
 import * as XLSX from "xlsx";
 import { saveAs } from "file-saver";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 
 // Colonnes exportées avec libellés lisibles
 const EXPORT_HEADERS = [

--- a/src/utils/importExcelProduits.js
+++ b/src/utils/importExcelProduits.js
@@ -1,6 +1,6 @@
 import * as XLSX from "xlsx";
 import { v4 as uuidv4 } from "uuid";
-import { supabase } from "@/lib/supabase";
+import supabase from '@/lib/supabaseClient';
 import { fetchFamillesForValidation } from "@/hooks/useFamilles";
 import { fetchUnitesForValidation } from "@/hooks/useUnites";
 import { fetchZonesForValidation } from "@/hooks/useZonesStock";


### PR DESCRIPTION
## Summary
- centralize Supabase client configuration with persistent auth and auto refresh
- enhance AuthContext with logging, deduplication and fallback polling
- ensure login flow logs submissions and redirects after profile load
- add PrivateOutlet guard and standardize Supabase imports

## Testing
- `npm test` *(fails: TypeError fetch failed, ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_689f9012b898832d9c4067fbcf2a72ee