### PR TITLE
feat(auth): expose access helper

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -3,48 +3,21 @@ import { Link, useLocation } from "react-router-dom";
 import { useAuth } from "@/hooks/useAuth";
 import useMamaSettings from "@/hooks/useMamaSettings";
 import logo from "@/assets/logo-mamastock.png";
+import { normalizeAccessKey } from '@/lib/access'
 
 export default function Sidebar() {
-  const { loading: authLoading, userData } = useAuth();
+  const { loading: authLoading, hasAccess, userData } = useAuth();
   const { pathname } = useLocation();
   const { loading: settingsLoading, enabledModules } = useMamaSettings();
   const rights = userData?.access_rights ?? {};
   console.debug('[sidebar] rights keys', Object.keys(rights || {}));
   console.debug('[sidebar] enabledModules keys', enabledModules ? Object.keys(enabledModules) : null);
 
-  const KEY_MAP = {
-    dashboard: 'dashboard',
-    fournisseurs: 'fournisseurs',
-    factures: 'factures',
-    fiches: 'fiches_techniques',
-    fiches_techniques: 'fiches_techniques',
-    menus: 'menus',
-    menu_du_jour: 'menu_du_jour',
-    produits: 'produits',
-    inventaires: 'inventaires',
-    alertes: 'alertes',
-    promotions: 'promotions',
-    documents: 'documents',
-    analyse: 'analyse',
-    engineering: 'analyse',
-    menu_engineering: 'menu_engineering',
-    costing_carte: 'costing_carte',
-    notifications: 'notifications',
-    utilisateurs: 'utilisateurs',
-    roles: 'roles',
-    mamas: 'mamas',
-    permissions: 'permissions',
-    access: 'access',
-  };
-
-  const normalizeKey = (k) => KEY_MAP[k] || k;
-  function canShow(key) {
-    const nk = normalizeKey(key);
-    const hasRight = !nk || rights[nk] === true;
-    const passesSettings = enabledModules && nk ? enabledModules[nk] !== false : true;
-    return hasRight && passesSettings;
+  const has = (key) => {
+    const k = normalizeAccessKey(key)
+    const isEnabled = enabledModules ? enabledModules[k] !== false : true
+    return hasAccess(k) && isEnabled
   }
-  const has = canShow;
   const canAnalyse = has('analyse');
 
   return (

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -7,11 +7,11 @@ import { useAuth } from '@/hooks/useAuth';
 import logo from "@/assets/logo-mamastock.png";
 
 export default function Sidebar() {
-  const { access_rights, isSuperadmin, loading, pending, hasAccess } = useAuth();
+  const { loading, hasAccess } = useAuth();
   const { pathname } = useLocation();
 
-  if (loading || pending || access_rights === null) return null;
-  const has = (key) => isSuperadmin || hasAccess(key, "peut_voir");
+  if (loading) return null;
+  const has = (key) => hasAccess(key);
   const canAnalyse = has("analyse");
 
   return (

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,5 +1,17 @@
-import { useAuth as useAuthContext } from '@/contexts/AuthContext';
+import { useAuth as useAuthContext } from '@/contexts/AuthContext'
+import { normalizeAccessKey } from '@/lib/access'
 
 export function useAuth() {
-  return useAuthContext();
+  return useAuthContext()
+}
+
+/** Hook pratique: renvoie une fonction hasAccess(key) */
+export function useHasAccess() {
+  const { userData } = useAuthContext()
+  const rights = userData?.access_rights ?? {}
+  return (key?: string | null) => {
+    const k = normalizeAccessKey(key)
+    if (!k) return true
+    return !!rights[k]
+  }
 }

--- a/src/layout/Layout.jsx
+++ b/src/layout/Layout.jsx
@@ -2,7 +2,7 @@
 import { Outlet, Link } from "react-router-dom";
 import { useState, useEffect } from "react";
 import Sidebar from "@/components/Sidebar";
-import { useAuth } from "@/contexts/AuthContext";
+import { useAuth } from "@/hooks/useAuth";
 import supabase from "@/lib/supabaseClient";
 import useNotifications from "@/hooks/useNotifications";
 import { Badge } from "@/components/ui/badge";

--- a/src/layout/Sidebar.jsx
+++ b/src/layout/Sidebar.jsx
@@ -31,14 +31,10 @@ import {
 } from "lucide-react";
 
 export default function Sidebar() {
-  const {
-    access_rights,
-    loading,
-    user,
-    userData,
-    mama_id,
-    hasAccess,
-  } = useAuth();
+  const { session, userData, loading, hasAccess } = useAuth();
+  const access_rights = userData?.access_rights;
+  const user = session?.user;
+  const mama_id = userData?.mama_id;
   const { pathname } = useLocation();
   if (import.meta.env.DEV) {
     console.debug("Sidebar", { user, mama_id, access_rights });
@@ -49,7 +45,7 @@ export default function Sidebar() {
   }
 
   const peutVoir = (module) => {
-    const ok = hasAccess(module, "peut_voir");
+    const ok = hasAccess(module);
     if (!ok && access_rights && !access_rights[module]) {
       console.info(`info: module '${module}' absent des access_rights`);
     }

--- a/src/lib/access.ts
+++ b/src/lib/access.ts
@@ -1,0 +1,13 @@
+export function normalizeAccessKey(k?: string | null) {
+  if (!k) return null
+  const map: Record<string, string> = {
+    // alias -> clé réelle dans access_rights
+    fiches: 'fiches_techniques',
+    engineering: 'analyse',
+    menuEngineering: 'menu_engineering',
+    menu_engineering: 'menu_engineering',
+    costing: 'costing_carte',
+  }
+  const key = String(k).trim()
+  return map[key] ?? key
+}


### PR DESCRIPTION
## Summary
- add normalizeAccessKey helper mapping alias to real rights
- expose stable hasAccess via AuthContext and provide useHasAccess hook
- clean up Sidebar and Layout to use centralized access checks

## Testing
- `npm test` *(fails: ENETUNREACH & mock errors)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f98f90630832d8edb9af794d4c01a