### PR TITLE
Handle missing mama settings and normalize order syntax

### DIFF
--- a/src/api/public/produits.js
+++ b/src/api/public/produits.js
@@ -34,8 +34,18 @@ router.get('/', async (req, res) => {
     if (famille) query = query.ilike('famille', `%${famille}%`);
     if (search) query = query.ilike('nom', `%${search}%`);
     if (actif !== undefined) query = query.eq('actif', actif === 'true');
+    let sortField = sortBy;
+    let ascending = order !== 'desc';
+    if (sortField.includes('.')) {
+      const parts = sortField.split('.');
+      const dir = parts.pop();
+      if (dir === 'asc' || dir === 'desc') {
+        ascending = dir === 'asc';
+        sortField = parts.join('.');
+      }
+    }
     query = query
-      .order(sortBy, { ascending: order !== 'desc' })
+      .order(sortField, { ascending })
       .order('nom', { ascending: true });
     const p = Math.max(parseInt(page, 10), 1);
     const l = Math.max(parseInt(limit, 10), 1);

--- a/src/api/public/promotions.js
+++ b/src/api/public/promotions.js
@@ -29,7 +29,17 @@ router.get('/', async (req, res) => {
     let query = supabase.from('promotions').select('*').eq('mama_id', mama_id);
     if (search) query = query.ilike('nom', `%${search}%`);
     if (actif !== undefined) query = query.eq('actif', actif === 'true');
-    query = query.order(sortBy, { ascending: order !== 'desc' }).order('nom', { ascending: true });
+    let sortField = sortBy;
+    let ascending = order !== 'desc';
+    if (sortField.includes('.')) {
+      const parts = sortField.split('.');
+      const dir = parts.pop();
+      if (dir === 'asc' || dir === 'desc') {
+        ascending = dir === 'asc';
+        sortField = parts.join('.');
+      }
+    }
+    query = query.order(sortField, { ascending }).order('nom', { ascending: true });
     const p = Math.max(parseInt(page, 10), 1);
     const l = Math.max(parseInt(limit, 10), 1);
     const start = (p - 1) * l;

--- a/src/api/public/stock.js
+++ b/src/api/public/stock.js
@@ -33,7 +33,17 @@ router.get('/', async (req, res) => {
       .eq('requisitions.statut', 'réalisée');
     if (since) query = query.gte('requisitions.date_requisition', since);
     if (type) void type; // les lignes de réquisition sont des sorties
-    query = query.order('requisitions.' + sortBy, { ascending: order !== 'desc' });
+    let column = sortBy;
+    let ascending = order !== 'desc';
+    if (column.includes('.')) {
+      const parts = column.split('.');
+      const dir = parts.pop();
+      if (dir === 'asc' || dir === 'desc') {
+        ascending = dir === 'asc';
+        column = parts.join('.');
+      }
+    }
+    query = query.order('requisitions.' + column, { ascending });
     const p = Math.max(parseInt(page, 10), 1);
     const l = Math.max(parseInt(limit, 10), 1);
     const start = (p - 1) * l;

--- a/src/hooks/useMamaSettings.js
+++ b/src/hooks/useMamaSettings.js
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback, useEffect } from "react";
 import supabase from '@/lib/supabaseClient';
-import { useAuth } from '@/hooks/useAuth';
+import { useAuth } from '@/contexts/AuthContext';
 
 const defaults = {
   logo_url: "",
@@ -18,7 +18,8 @@ const defaults = {
 };
 
 export default function useMamaSettings() {
-  const { mama_id } = useAuth();
+  const { userData } = useAuth();
+  const mamaId = userData?.mama_id;
   const [settings, setSettings] = useState(defaults);
   const [loading, setLoading] = useState(false);
   const [enabledModules, setEnabledModules] = useState(null);
@@ -26,7 +27,7 @@ export default function useMamaSettings() {
   const [ok, setOk] = useState(true);
 
   const fetchMamaSettings = useCallback(async () => {
-    if (!mama_id) {
+    if (!mamaId) {
       setLoading(false);
       return null;
     }
@@ -36,8 +37,31 @@ export default function useMamaSettings() {
       .select(
         "logo_url, primary_color, secondary_color, email_envoi, email_alertes, dark_mode, langue, monnaie, timezone, rgpd_text, mentions_legales, enabled_modules, feature_flags"
       )
-      .eq("id", mama_id)
+      .eq("id", mamaId)
       .single();
+    if (error?.code === '42703') {
+      const { data: fallback, error: fbError } = await supabase
+        .from('mamas')
+        .select(
+          "logo_url, primary_color, secondary_color, email_envoi, email_alertes, dark_mode, langue, monnaie, timezone, rgpd_text, mentions_legales"
+        )
+        .eq('id', mamaId)
+        .single();
+      setLoading(false);
+      if (fbError) {
+        console.warn('[useMamaSettings] fallback fetch failed', fbError);
+        setSettings(defaults);
+        setEnabledModules(null);
+        setFeatureFlags(null);
+        setOk(true);
+        return null;
+      }
+      setSettings({ ...defaults, ...fallback });
+      setEnabledModules(null);
+      setFeatureFlags(null);
+      setOk(true);
+      return fallback;
+    }
     setLoading(false);
     if (error) {
       console.warn("[useMamaSettings] fetch failed", error);
@@ -52,23 +76,23 @@ export default function useMamaSettings() {
     setFeatureFlags(data.feature_flags || null);
     setOk(true);
     return data;
-  }, [mama_id]);
+  }, [mamaId]);
 
   const updateMamaSettings = useCallback(
     async (fields) => {
-      if (!mama_id) return { error: "missing mama_id" };
+      if (!mamaId) return { error: "missing mama_id" };
       setLoading(true);
       const { data, error } = await supabase
         .from("mamas")
         .update(fields)
-        .eq("id", mama_id)
+        .eq("id", mamaId)
         .select()
         .single();
       setLoading(false);
       if (!error && data) setSettings((s) => ({ ...s, ...data }));
       return { data, error };
     },
-    [mama_id]
+    [mamaId]
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Safely read mama settings using auth context and Supabase client
- Gracefully fall back when `enabled_modules` column is missing (42703)
- Normalize dynamic PostgREST ordering strings

## Testing
- `npm test` *(fails: fetch failed / mock issues)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0457c3a98832d92a655ea380168cf