### PR TITLE
feat: add get_facture_complete RPC

### DIFF
--- a/supabase/migrations/20240731000000_get_facture_complete.sql
+++ b/supabase/migrations/20240731000000_get_facture_complete.sql
@@ -1,0 +1,34 @@
+-- RPC get_facture_complete: returns invoice header and lines with product details
+create or replace function public.get_facture_complete(p_id uuid)
+returns jsonb
+language plpgsql
+stable
+security definer
+as $$
+declare
+  v_header jsonb;
+  v_lignes jsonb;
+begin
+  select to_jsonb(f.*)
+    into v_header
+  from public.factures f
+  where f.id = p_id
+    and f.mama_id = current_user_mama_id()
+  limit 1;
+
+  select coalesce(
+      jsonb_agg(to_jsonb(l.*) || jsonb_build_object('produit', to_jsonb(p.*))),
+      '[]'::jsonb
+    )
+    into v_lignes
+  from public.facture_lignes l
+  left join public.produits p on p.id = l.produit_id
+  where l.facture_id = p_id
+    and l.mama_id = current_user_mama_id()
+  order by l.position asc;
+
+  return jsonb_build_object('header', v_header, 'lignes', v_lignes);
+end;
+$$;
+
+grant execute on function public.get_facture_complete(uuid) to authenticated;


### PR DESCRIPTION
## Summary
- add get_facture_complete RPC to fetch invoice header with lines and product details

## Testing
- `npm test` *(fails: fetch failed ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68a05ed450a4832d9fbcdabde7ce9a3a