### PR TITLE
Refactor invoice editing and fix UI refs

### DIFF
--- a/src/components/FactureLigne.jsx
+++ b/src/components/FactureLigne.jsx
@@ -72,7 +72,8 @@ export default function FactureLigne({
 
   useEffect(() => {
     fetchZones();
-  }, [fetchZones]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useEffect(() => {
     lastPushed.current = { tva: ligne.tva, zone_id: ligne.zone_id };

--- a/src/components/forms/AutocompleteProduit.jsx
+++ b/src/components/forms/AutocompleteProduit.jsx
@@ -1,17 +1,12 @@
-import { useState, useRef, useEffect, useId } from 'react';
+import { useState, useRef, useEffect, useId, forwardRef, useImperativeHandle } from 'react';
 import { Input } from '@/components/ui/input';
 import { useProductSearch } from '@/hooks/useProductSearch';
 import ProductPickerModal from './ProductPickerModal';
 
-export default function AutocompleteProduit({
-  value,
-  onChange,
-  required = false,
-  placeholder = '',
-  className = '',
-  lineKey = 0,
-  onFocus,
-}) {
+function AutocompleteProduit(
+  { value, onChange, required = false, placeholder = '', className = '', lineKey = 0, onFocus },
+  ref
+) {
   const [inputValue, setInputValue] = useState(value?.nom || '');
   const [selected, setSelected] = useState(value?.id ? value : null);
   const [search, setSearch] = useState('');
@@ -20,6 +15,7 @@ export default function AutocompleteProduit({
   const [modalOpen, setModalOpen] = useState(false);
   const composing = useRef(false);
   const inputRef = useRef(null);
+  useImperativeHandle(ref, () => inputRef.current);
   const listId = useId();
   const nameId = useId();
 
@@ -188,3 +184,5 @@ export default function AutocompleteProduit({
     </div>
   );
 }
+
+export default forwardRef(AutocompleteProduit);

--- a/src/components/ui/button.jsx
+++ b/src/components/ui/button.jsx
@@ -1,17 +1,27 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-export function Button({ children, variant = 'secondary', icon: Icon, className = '', ...props }) {
-  const base = 'inline-flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-semibold transition-colors';
+import { forwardRef } from 'react';
+
+export const Button = forwardRef(function Button(
+  { children, variant = 'secondary', icon: Icon, className = '', ...props },
+  ref
+) {
+  const base =
+    'inline-flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-semibold transition-colors';
   const styles = {
     primary: 'bg-primary text-white hover:bg-primary-90',
     secondary: 'bg-white/10 text-white hover:bg-white/20',
     ghost: 'bg-transparent text-white hover:bg-white/10',
   };
   return (
-    <button className={`${base} ${styles[variant] || styles.secondary} ${className}`} {...props}>
+    <button
+      ref={ref}
+      className={`${base} ${styles[variant] || styles.secondary} ${className}`}
+      {...props}
+    >
       {Icon && <Icon className="w-4 h-4" />}
       {children}
     </button>
   );
-}
+});
 
 export default Button;

--- a/src/components/ui/input.jsx
+++ b/src/components/ui/input.jsx
@@ -1,18 +1,24 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 // src/components/ui/input.jsx
 
-export function Input({
-  type = "text",
-  value,
-  onChange,
-  placeholder,
-  className = "",
-  disabled = false,
-  ariaLabel,
-  ...props
-}) {
+import { forwardRef } from 'react';
+
+export const Input = forwardRef(function Input(
+  {
+    type = "text",
+    value,
+    onChange,
+    placeholder,
+    className = "",
+    disabled = false,
+    ariaLabel,
+    ...props
+  },
+  ref
+) {
   return (
     <input
+      ref={ref}
       type={type}
       value={value}
       onChange={onChange}
@@ -21,6 +27,9 @@ export function Input({
       aria-label={ariaLabel || placeholder || "Champ de saisie"}
       className={`w-full px-4 py-2 font-semibold text-white placeholder-white/50 bg-white/10 backdrop-blur rounded-md shadow-lg border border-white/20 ring-1 ring-white/20 focus:outline-none hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed ${className}`}
       {...props}
-      id="fld-field-a16p" />
+      id="fld-field-a16p"
+    />
   );
-}
+});
+
+export default Input;

--- a/src/hooks/useInvoice.js
+++ b/src/hooks/useInvoice.js
@@ -1,0 +1,50 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { useQuery } from '@tanstack/react-query';
+import supabase from '@/lib/supabaseClient';
+import { useAuth } from '@/hooks/useAuth';
+
+async function detectExistingTable(candidates) {
+  for (const t of candidates) {
+    try {
+      const { error } = await supabase.from(t).select('id').limit(1);
+      if (!error) return t;
+    } catch {}
+  }
+  return candidates[0];
+}
+
+export function useInvoice(id, { enabled = true } = {}) {
+  const { userData } = useAuth();
+  const mamaId = userData?.mama_id;
+
+  return useQuery({
+    queryKey: ['invoice', mamaId, id],
+    enabled: enabled && !!id && !!mamaId,
+    queryFn: async () => {
+      const tableLines = await detectExistingTable(['facture_lignes', 'lignes_facture']);
+      const [headerRes, linesRes] = await Promise.all([
+        supabase
+          .from('factures')
+          .select(
+            'id, numero, date_facture, fournisseur_id, tva_mode, actif, created_at, updated_at, statut, bon_livraison, total_ht, total_tva, total_ttc, fournisseur:fournisseurs(id, nom)'
+          )
+          .eq('id', id)
+          .eq('mama_id', mamaId)
+          .single(),
+        supabase
+          .from(tableLines)
+          .select(
+            'id, facture_id, produit_id, quantite, unite, total_ht, pu, pmp, tva, zone_id, position, note, actif, produit:produits(id, nom, code, ref_fournisseur, unite_achat, unite, tva_id, zone_stock_id)'
+          )
+          .eq('facture_id', id)
+          .order('position', { ascending: true })
+      ]);
+      const { data: facture, error: e1 } = headerRes;
+      const { data: lignes, error: e2 } = linesRes;
+      if (e1 || e2) throw e1 || e2;
+      return { facture, lignes: lignes || [] };
+    },
+  });
+}
+
+export default useInvoice;

--- a/src/pages/factures/FactureDetail.jsx
+++ b/src/pages/factures/FactureDetail.jsx
@@ -59,7 +59,7 @@ export default function FactureDetail() {
           supabase
             .from('factures')
             .select(
-              'id, numero, date_facture, fournisseur_id, zone_id, tva_mode, actif, created_at, updated_at'
+              'id, numero, date_facture, fournisseur_id, tva_mode, actif, created_at, updated_at'
             )
             .eq('id', id)
             .single(),

--- a/src/pages/factures/Factures.jsx
+++ b/src/pages/factures/Factures.jsx
@@ -186,7 +186,7 @@ export default function Factures() {
       <FactureTable
         factures={factures}
         canEdit={canEdit}
-        onEdit={f => { setSelected(f); setShowForm(true); }}
+        onEdit={f => { setSelected({ id: f.id }); setShowForm(true); }}
         onDetail={f => { setSelected(f); setShowDetail(true); }}
         onToggleActive={async (id, actif) => { await toggleFactureActive(id, actif); refreshList(); }}
         onArchive={handleDelete}


### PR DESCRIPTION
## Summary
- expose refs on Button/Input/AutocompleteProduit via `forwardRef`
- load invoice header and lines through new `useInvoice` hook
- prevent infinite zone fetch and drop nonexistent `factures.zone_id`

## Testing
- `npm test` *(fails: TypeError fetch failed)*
- `npx eslint src/components/ui/button.jsx src/components/ui/input.jsx src/components/forms/AutocompleteProduit.jsx src/components/FactureLigne.jsx src/pages/factures/FactureForm.jsx src/pages/factures/Factures.jsx src/pages/factures/FactureDetail.jsx` *(fails: vitest mock errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a0bf770a18832d96bbd15ffe32dc16