### PR TITLE
feat(factures): add stable invoice list hook

### DIFF
--- a/src/hooks/useFacturesList.js
+++ b/src/hooks/useFacturesList.js
@@ -1,0 +1,48 @@
+import { useQuery } from '@tanstack/react-query';
+import { useAuth } from '@/hooks/useAuth';
+import supabase from '@/lib/supabaseClient';
+
+export function useFacturesList(params = {}) {
+  const { userData } = useAuth();
+  const mamaId = userData?.mama_id;
+  const {
+    search = '',
+    fournisseur = '',
+    statut = '',
+    actif = true,
+    page = 1,
+    pageSize = 20,
+  } = params;
+
+  return useQuery({
+    queryKey: ['factures-list', mamaId, search, fournisseur, statut, actif, page, pageSize],
+    enabled: !!mamaId,
+    staleTime: Infinity,
+    gcTime: Infinity,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    refetchOnMount: false,
+    keepPreviousData: true,
+    queryFn: async () => {
+      let query = supabase
+        .from('factures')
+        .select('*, fournisseur:fournisseur_id(id, nom)', { count: 'exact' })
+        .eq('mama_id', mamaId)
+        .order('date_facture', { ascending: false })
+        .range((page - 1) * pageSize, page * pageSize - 1);
+
+      if (search) {
+        query = query.or(`numero.ilike.%${search}%,fournisseurs.nom.ilike.%${search}%`);
+      }
+      if (fournisseur) query = query.eq('fournisseur_id', fournisseur);
+      if (statut) query = query.eq('statut', statut);
+      if (actif !== null) query = query.eq('actif', actif);
+
+      const { data, error, count } = await query;
+      if (error) throw error;
+      return { factures: data || [], total: count || 0 };
+    },
+  });
+}
+
+export default useFacturesList;


### PR DESCRIPTION
## Summary
- add `useFacturesList` hook with stable query key and passive refresh
- refactor invoice list page to use react-query and drop manual refresh loop

## Testing
- `npm test` *(fails: ENETUNREACH and other test errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c2f0d0c8832dbf6b9d0c75f5630a