### PR TITLE
refactor: forward refs for shadcn primitives

### DIFF
--- a/src/components/ui/button.jsx
+++ b/src/components/ui/button.jsx
@@ -1,27 +1,32 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { forwardRef } from 'react';
+import * as React from 'react';
 
-export const Button = forwardRef(function Button(
-  { children, variant = 'secondary', icon: Icon, className = '', ...props },
-  ref
-) {
-  const base =
-    'inline-flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-semibold transition-colors';
-  const styles = {
-    primary: 'bg-primary text-white hover:bg-primary-90',
-    secondary: 'bg-white/10 text-white hover:bg-white/20',
-    ghost: 'bg-transparent text-white hover:bg-white/10',
-  };
-  return (
-    <button
-      ref={ref}
-      className={`${base} ${styles[variant] || styles.secondary} ${className}`}
-      {...props}
-    >
-      {Icon && <Icon className="w-4 h-4" />}
-      {children}
-    </button>
-  );
-});
+const Button = React.forwardRef(
+  (
+    { children, variant = 'secondary', icon: Icon, className = '', ...props },
+    ref
+  ) => {
+    const base =
+      'inline-flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-semibold transition-colors';
+    const styles = {
+      primary: 'bg-primary text-white hover:bg-primary-90',
+      secondary: 'bg-white/10 text-white hover:bg-white/20',
+      ghost: 'bg-transparent text-white hover:bg-white/10',
+    };
+    return (
+      <button
+        ref={ref}
+        className={`${base} ${styles[variant] || styles.secondary} ${className}`}
+        {...props}
+      >
+        {Icon && <Icon className="w-4 h-4" />}
+        {children}
+      </button>
+    );
+  }
+);
 
+Button.displayName = 'Button';
+
+export { Button };
 export default Button;

--- a/src/components/ui/input.jsx
+++ b/src/components/ui/input.jsx
@@ -1,35 +1,43 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 // src/components/ui/input.jsx
 
-import { forwardRef } from 'react';
+import * as React from 'react';
 
-export const Input = forwardRef(function Input(
-  {
-    type = "text",
-    value,
-    onChange,
-    placeholder,
-    className = "",
-    disabled = false,
-    ariaLabel,
-    ...props
-  },
-  ref
-) {
-  return (
-    <input
-      ref={ref}
-      type={type}
-      value={value}
-      onChange={onChange}
-      placeholder={placeholder}
-      disabled={disabled}
-      aria-label={ariaLabel || placeholder || "Champ de saisie"}
-      className={`w-full px-4 py-2 font-semibold text-white placeholder-white/50 bg-white/10 backdrop-blur rounded-md shadow-lg border border-white/20 ring-1 ring-white/20 focus:outline-none hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed ${className}`}
-      {...props}
-      id="fld-field-a16p"
-    />
-  );
-});
+const Input = React.forwardRef(
+  (
+    {
+      type = 'text',
+      value,
+      onChange,
+      placeholder,
+      className = '',
+      disabled = false,
+      ariaLabel,
+      ...props
+    },
+    ref
+  ) => {
+    return (
+      <input
+        ref={ref}
+        type={type}
+        value={value}
+        onChange={onChange}
+        placeholder={placeholder}
+        disabled={disabled}
+        aria-label={ariaLabel || placeholder || 'Champ de saisie'}
+        className={`w-full px-4 py-2 font-semibold text-white placeholder-white/50 bg-white/10 backdrop-blur rounded-md shadow-lg
+border border-white/20 ring-1 ring-white/20 focus:outline-none hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed
+ ${className}`}
+        {...props}
+        id="fld-field-a16p"
+      />
+    );
+  }
+);
 
+Input.displayName = 'Input';
+
+export { Input };
 export default Input;
+


### PR DESCRIPTION
## Summary
- forward refs for Button component to support Radix asChild
- forward refs for Input component to support Radix asChild

## Testing
- `npm test` *(fails: fetch failed from supabase; multiple GoTrueClient instances)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0e4f6c830832d9d1e49e43a1e3911