### PR TITLE
feat: improve product picker modal

### DIFF
--- a/src/hooks/useProduitsSearch.js
+++ b/src/hooks/useProduitsSearch.js
@@ -29,9 +29,9 @@ function normalize(list = []) {
   }));
 }
 
-export function useProduitsSearch(term = '', { enabled = true } = {}) {
+export function useProduitsSearch(term = '', { enabled = true, debounce = 300 } = {}) {
   const { mama_id } = useAuth();
-  const debounced = useDebounced(term, 300);
+  const debounced = useDebounced(term, debounce);
 
   return useQuery({
     queryKey: ['produits-search', mama_id, debounced],


### PR DESCRIPTION
## Summary
- debounce product search with 250ms and only when modal is open
- load and store recent product selections
- expose debounce option for useProduitsSearch hook

## Testing
- `npm test test/useProduitsAutocomplete.test.js` *(fails: expected "spy" to be called)*
- `npm test test/useGlobalSearch.test.js` *(fails: expected "spy" to be called)*

------
https://chatgpt.com/codex/tasks/task_e_68a1912d43b4832d850b7a2bf4e5d4b1