### PR TITLE
refactor: search produits by name only

### DIFF
--- a/src/hooks/useProductSearch.js
+++ b/src/hooks/useProductSearch.js
@@ -5,11 +5,9 @@ import supabase from '@/lib/supabaseClient';
 
 function normalize(list = []) {
   return list.map((p) => ({
-    id: p.id,
+    id: p.id ?? p.produit_id,
     nom: p.nom,
-    code: p.code,
     unite_achat: p.unite_achat || p.unite,
-    tva: p.tva ?? p.tva_rate,
     zone_id: p.zone_id ?? p.zone_stock_id,
     pmp: p.pmp ?? p.pmp_ht,
     prix_unitaire: p.prix_unitaire ?? p.price_ht ?? p.dernier_prix ?? 0,
@@ -29,35 +27,40 @@ export function useProductSearch(query, { enabled = true } = {}) {
     queryFn: async ({ signal }) => {
       const q = (query || '').trim();
       if (!q || !mamaId) return [];
+
       try {
-        const { data, error } = await supabase.rpc(
-          'search_produits',
-          { q },
-          { signal }
-        );
-        if (!error && !signal.aborted) return normalize(data).slice(0, 50);
+        let rq = supabase
+          .from('produits')
+          .select(
+            'id, nom, unite_achat, unite, zone_id, zone_stock_id, pmp, pmp_ht, prix_unitaire, price_ht, dernier_prix'
+          )
+          .eq('mama_id', mamaId)
+          .limit(50)
+          .ilike('nom', `%${q}%`)
+          .order('nom', { ascending: true });
+        try { rq = rq.eq('actif', true); } catch {}
+        const { data, error } = await rq;
+        if (!error && !signal.aborted) return normalize(data);
       } catch (e) {
         if (e.name === 'AbortError') throw e;
       }
-      const tables = ['v_produits_actifs', 'produits'];
-      for (const t of tables) {
-        try {
-          let rq = supabase
-            .from(t)
-            .select(
-              'id, nom, code, unite_achat, unite, tva, tva_rate, zone_id, zone_stock_id, pmp, pmp_ht, prix_unitaire, price_ht, dernier_prix'
-            )
-            .eq('mama_id', mamaId)
-            .limit(50);
-          try { rq = rq.eq('actif', true); } catch {}
-          rq = rq.or(`nom.ilike.%${q}%,code.ilike.%${q}%`);
-          rq = rq.order('nom', { ascending: true });
-          const { data, error } = await rq;
-          if (!error && !signal.aborted) return normalize(data);
-        } catch (e) {
-          if (e.name === 'AbortError') throw e;
-        }
+
+      try {
+        let rq2 = supabase
+          .from('v_produits_actifs')
+          .select(
+            'id, produit_id, nom, unite_achat, unite, zone_id, zone_stock_id, pmp, pmp_ht, prix_unitaire, price_ht, dernier_prix'
+          )
+          .eq('mama_id', mamaId)
+          .limit(50)
+          .ilike('nom', `%${q}%`)
+          .order('nom', { ascending: true });
+        const { data: data2, error: error2 } = await rq2;
+        if (!error2 && !signal.aborted) return normalize(data2);
+      } catch (e) {
+        if (e.name === 'AbortError') throw e;
       }
+
       return [];
     },
   });

--- a/src/hooks/useProduitsSearch.js
+++ b/src/hooks/useProduitsSearch.js
@@ -17,12 +17,9 @@ function useDebounced(value, delay = 300) {
 
 function normalize(list = []) {
   return list.map((p) => ({
-    id: p.id ?? null,
+    id: p.id ?? p.produit_id ?? null,
     nom: p.nom ?? null,
-    code: p.code ?? null,
-    barcode: p.barcode ?? null,
     unite_id: p.unite_id ?? null,
-    tva: p.tva ?? null,
     zone_id: p.zone_id ?? null,
     pmp: p.pmp ?? null,
     dernier_prix: p.dernier_prix ?? null,
@@ -48,9 +45,9 @@ export function useProduitsSearch(term = '', { enabled = true, debounce = 300 } 
       try {
         let rq = supabase
           .from('produits')
-          .select('id, nom, code, barcode, unite_id, tva, zone_id, pmp, dernier_prix')
+          .select('id, nom, unite_id, zone_id, pmp, dernier_prix')
           .limit(50)
-          .or(`nom.ilike.%${q}%,code.ilike.%${q}%,barcode.ilike.%${q}%`)
+          .ilike('nom', `%${q}%`)
           .order('nom', { ascending: true });
         if (mama_id) rq = rq.eq('mama_id', mama_id);
 
@@ -72,9 +69,9 @@ export function useProduitsSearch(term = '', { enabled = true, debounce = 300 } 
       try {
         let rq2 = supabase
           .from('v_produits_actifs')
-          .select('id, nom, code, unite_id, tva, zone_id, pmp, dernier_prix')
+          .select('id, produit_id, nom, unite_id, zone_id, pmp, dernier_prix')
           .limit(50)
-          .or(`nom.ilike.%${q}%,code.ilike.%${q}%`)
+          .ilike('nom', `%${q}%`)
           .order('nom', { ascending: true });
         if (mama_id) rq2 = rq2.eq('mama_id', mama_id);
 


### PR DESCRIPTION
## Summary
- search only by `nom` without barcode, code or tva
- robust fallback to `v_produits_actifs` handling `id` or `produit_id`

## Testing
- `npm run lint`
- `npm test` *(fails: fetch failed ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68a19b9c40f0832d860832a60ba8777a