### PR TITLE
chore: adjust React Query defaults

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,7 +9,17 @@ import { ThemeProvider } from "@/context/ThemeProvider";
 import { Toaster } from "react-hot-toast";
 import CookieConsent from "@/components/CookieConsent";
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+      refetchOnMount: false,
+      staleTime: Infinity,
+      gcTime: Infinity,
+    },
+  },
+});
 
 export default function App() {
   useEffect(() => {


### PR DESCRIPTION
## Summary
- set non-refetching defaults for React Query

## Testing
- `npm test` *(fails: fetch failed and other test issues)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1a168d4d8832d9d78548a25716938