### PR TITLE
feat: add cached fournisseurs hook

### DIFF
--- a/src/components/produits/ProduitForm.jsx
+++ b/src/components/produits/ProduitForm.jsx
@@ -5,7 +5,7 @@ import { useProducts } from "@/hooks/useProducts";
 import { useFamilles } from "@/hooks/useFamilles";
 import { useSousFamilles } from "@/hooks/useSousFamilles";
 import { useUnites } from "@/hooks/useUnites";
-import { useFournisseurs } from "@/hooks/useFournisseurs";
+import useFournisseurs from "@/hooks/data/useFournisseurs";
 import useZonesStock from "@/hooks/useZonesStock";
 import { toast } from "react-hot-toast";
 import GlassCard from "@/components/ui/GlassCard";
@@ -20,7 +20,7 @@ export default function ProduitForm({
   onClose,
 }) {
   const editing = !!produit;
-  const { fournisseurs, fetchFournisseurs } = useFournisseurs();
+  const { data: fournisseurs = [] } = useFournisseurs({ actif: true });
   const {
     familles,
     fetchFamilles,
@@ -61,8 +61,7 @@ export default function ProduitForm({
   useEffect(() => {
     fetchFamilles();
     fetchUnites();
-    fetchFournisseurs();
-  }, [fetchFamilles, fetchUnites, fetchFournisseurs]);
+  }, [fetchFamilles, fetchUnites]);
 
   const [familleHasSous, setFamilleHasSous] = useState(false);
 

--- a/src/hooks/data/useFournisseurs.js
+++ b/src/hooks/data/useFournisseurs.js
@@ -1,0 +1,35 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { useQuery } from '@tanstack/react-query';
+import { useAuth } from '@/hooks/useAuth';
+import supabase from '@/lib/supabaseClient';
+
+export function useFournisseurs(params = {}) {
+  const { mama_id } = useAuth();
+  const { search = '', actif = true } = params;
+
+  return useQuery({
+    queryKey: ['fournisseurs', mama_id, search, actif],
+    enabled: !!mama_id,
+    staleTime: Infinity,
+    gcTime: Infinity,
+    queryFn: async () => {
+      let query = supabase
+        .from('fournisseurs')
+        .select('id, nom, actif, contact:fournisseur_contacts(nom,email,tel)')
+        .eq('mama_id', mama_id)
+        .order('nom', { ascending: true });
+
+      if (search) query = query.ilike('nom', `%${search}%`);
+      if (actif !== null && actif !== undefined) query = query.eq('actif', actif);
+
+      const { data, error } = await query;
+      if (error) throw error;
+      return (data || []).map(f => ({
+        ...f,
+        contact: Array.isArray(f.contact) ? f.contact[0] : f.contact,
+      }));
+    },
+  });
+}
+
+export default useFournisseurs;

--- a/src/pages/achats/Achats.jsx
+++ b/src/pages/achats/Achats.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState, useCallback } from "react";
 import { useAchats } from "@/hooks/useAchats";
-import { useFournisseurs } from "@/hooks/useFournisseurs";
+import useFournisseurs from "@/hooks/data/useFournisseurs";
 import { useProduitsAutocomplete } from "@/hooks/useProduitsAutocomplete";
 import AchatForm from "./AchatForm.jsx";
 import AchatDetail from "./AchatDetail.jsx";
@@ -14,7 +14,7 @@ import { useAuth } from '@/hooks/useAuth';
 
 export default function Achats() {
   const { achats, total, getAchats, deleteAchat } = useAchats();
-  const { fournisseurs } = useFournisseurs();
+  const { data: fournisseurs = [] } = useFournisseurs({ actif: true });
   const { results: produitOptions, searchProduits } = useProduitsAutocomplete();
   const [produit, setProduit] = useState("");
   const [fournisseur, setFournisseur] = useState("");

--- a/src/pages/bons_livraison/BLCreate.jsx
+++ b/src/pages/bons_livraison/BLCreate.jsx
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useNavigate } from "react-router-dom";
-import { useFournisseurs } from "@/hooks/useFournisseurs";
+import useFournisseurs from "@/hooks/data/useFournisseurs";
 import BLForm from "./BLForm.jsx";
 import GlassCard from "@/components/ui/GlassCard";
 import { LiquidBackground } from "@/components/LiquidBackground";
@@ -10,7 +10,7 @@ import Unauthorized from "@/pages/auth/Unauthorized";
 
 export default function BLCreate() {
   const navigate = useNavigate();
-  const { fournisseurs } = useFournisseurs();
+  const { data: fournisseurs = [] } = useFournisseurs({ actif: true });
   const { hasAccess, loading: authLoading } = useAuth();
   const canEdit = hasAccess("bons_livraison", "peut_modifier");
 

--- a/src/pages/bons_livraison/BonsLivraison.jsx
+++ b/src/pages/bons_livraison/BonsLivraison.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState, useCallback } from "react";
 import { useBonsLivraison } from "@/hooks/useBonsLivraison";
-import { useFournisseurs } from "@/hooks/useFournisseurs";
+import useFournisseurs from "@/hooks/data/useFournisseurs";
 import BLForm from "./BLForm.jsx";
 import BLDetail from "./BLDetail.jsx";
 import { Button } from "@/components/ui/button";
@@ -13,7 +13,7 @@ import { useAuth } from '@/hooks/useAuth';
 
 export default function BonsLivraison() {
   const { bons, total, getBonsLivraison, toggleBonActif } = useBonsLivraison();
-  const { fournisseurs, getFournisseurs } = useFournisseurs();
+  const { data: fournisseurs = [] } = useFournisseurs({ actif: true });
   const { hasAccess } = useAuth();
   const canEdit = hasAccess("bons_livraison", "peut_modifier");
   const [showForm, setShowForm] = useState(false);
@@ -25,7 +25,6 @@ export default function BonsLivraison() {
   const [page, setPage] = useState(1);
   const PAGE_SIZE = 50;
 
-  useEffect(() => { getFournisseurs(); }, [getFournisseurs]);
 
   const refreshList = useCallback(() => {
     const debut = monthFilter ? `${monthFilter}-01` : "";

--- a/src/pages/commandes/CommandeForm.jsx
+++ b/src/pages/commandes/CommandeForm.jsx
@@ -2,7 +2,7 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { useCommandes } from "@/hooks/useCommandes";
-import { useFournisseurs } from "@/hooks/useFournisseurs";
+import useFournisseurs from "@/hooks/data/useFournisseurs";
 import { useProduitsFournisseur } from "@/hooks/useProduitsFournisseur";
 import { useAuth } from '@/hooks/useAuth';
 import { toast } from "react-hot-toast";
@@ -12,7 +12,7 @@ export default function CommandeForm() {
   const navigate = useNavigate();
   const { role } = useAuth();
   const { createCommande } = useCommandes();
-  const { fournisseurs, fetchFournisseurs } = useFournisseurs();
+  const { data: fournisseurs = [] } = useFournisseurs({ actif: true });
   const { useProduitsDuFournisseur } = useProduitsFournisseur();
   const [fournisseurId, setFournisseurId] = useState("");
   const { products, fetch } = useProduitsDuFournisseur(fournisseurId);
@@ -27,7 +27,6 @@ export default function CommandeForm() {
     champs_visibles: {},
   });
 
-  useEffect(() => { fetchFournisseurs({ limit: 1000 }); }, [fetchFournisseurs]);
   useEffect(() => { if (fournisseurId) fetch(); }, [fournisseurId, fetch]);
   useEffect(() => {
     getTemplatesCommandesActifs().then(({ data }) => {

--- a/src/pages/commandes/Commandes.jsx
+++ b/src/pages/commandes/Commandes.jsx
@@ -3,15 +3,14 @@ import { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
 import { useAuth } from '@/hooks/useAuth';
 import { useCommandes } from "@/hooks/useCommandes";
-import { useFournisseurs } from "@/hooks/useFournisseurs";
+import useFournisseurs from "@/hooks/data/useFournisseurs";
 
 export default function Commandes() {
   const { mama_id, role } = useAuth();
   const { data: commandes, fetchCommandes, validateCommande, loading } = useCommandes();
-  const { fournisseurs, fetchFournisseurs } = useFournisseurs();
+  const { data: fournisseurs = [] } = useFournisseurs({ actif: true });
   const [filters, setFilters] = useState({ fournisseur: "", statut: "", debut: "", fin: "" });
 
-  useEffect(() => { fetchFournisseurs({ limit: 1000 }); }, [fetchFournisseurs]);
   useEffect(() => {
     if (!mama_id) return;
     fetchCommandes({ ...filters });

--- a/src/pages/factures/FactureDetail.jsx
+++ b/src/pages/factures/FactureDetail.jsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import supabase from '@/lib/supabaseClient';
 import FactureForm, { mapDbLineToUI } from './FactureForm.jsx';
-import { useFournisseurs } from '@/hooks/useFournisseurs';
+import useFournisseurs from '@/hooks/data/useFournisseurs';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import toast from 'react-hot-toast';
 
@@ -38,13 +38,10 @@ async function tableExists(name) {
 export default function FactureDetail() {
   const { id } = useParams();
   const navigate = useNavigate();
-  const { fournisseurs, getFournisseurs } = useFournisseurs();
+  const { data: fournisseurs = [] } = useFournisseurs({ actif: true });
   const [loading, setLoading] = useState(true);
   const [formState, setFormState] = useState({ header: null, lignes: [] });
 
-  useEffect(() => {
-    getFournisseurs();
-  }, [getFournisseurs]);
 
   useEffect(() => {
     let isMounted = true;

--- a/src/pages/factures/Factures.jsx
+++ b/src/pages/factures/Factures.jsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from "react";
 import { useFactures } from "@/hooks/useFactures";
 import { useFacturesList } from "@/hooks/useFacturesList";
-import { useFournisseurs } from "@/hooks/useFournisseurs";
+import useFournisseurs from "@/hooks/data/useFournisseurs";
 import { useFournisseursAutocomplete } from "@/hooks/useFournisseursAutocomplete";
 import { useAuth } from '@/hooks/useAuth';
 import { useFacturesAutocomplete } from "@/hooks/useFacturesAutocomplete";
@@ -25,7 +25,7 @@ import { FACTURE_STATUTS } from "@/constants/factures";
 
 export default function Factures() {
   const { deleteFacture, toggleFactureActive } = useFactures();
-  const { fournisseurs, getFournisseurs } = useFournisseurs();
+  const { data: fournisseurs = [] } = useFournisseurs({ actif: true });
   const { results: fournisseurOptions, searchFournisseurs } = useFournisseursAutocomplete();
   const { loading: authLoading, hasAccess } = useAuth();
   const { results: factureOptions, searchFactures } = useFacturesAutocomplete();
@@ -60,7 +60,6 @@ export default function Factures() {
 
   const canEdit = hasAccess("factures", "peut_modifier");
 
-  useEffect(() => { getFournisseurs(); }, [getFournisseurs]);
   useEffect(() => { searchFactures(search); }, [search, searchFactures]);
   useEffect(() => { searchFournisseurs(fournisseurInput); }, [fournisseurInput, searchFournisseurs]);
 

--- a/src/pages/parametrage/TemplatesCommandes.jsx
+++ b/src/pages/parametrage/TemplatesCommandes.jsx
@@ -1,22 +1,19 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState, useCallback } from "react";
 import { useTemplatesCommandes } from "@/hooks/useTemplatesCommandes";
-import { useFournisseurs } from "@/hooks/useFournisseurs";
+import useFournisseurs from "@/hooks/data/useFournisseurs";
 import TemplateCommandeForm from "./TemplateCommandeForm";
 import { Button } from "@/components/ui/button";
 
 export default function TemplatesCommandes() {
   const { fetchTemplates, deleteTemplate } = useTemplatesCommandes();
-  const { fournisseurs, fetchFournisseurs } = useFournisseurs();
+  const { data: fournisseurs = [] } = useFournisseurs({ actif: true });
   const [templates, setTemplates] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [selected, setSelected] = useState(null);
   const [fournisseurId, setFournisseurId] = useState("");
 
-  useEffect(() => {
-    fetchFournisseurs({ limit: 1000 });
-  }, [fetchFournisseurs]);
 
   const load = useCallback(async () => {
     setLoading(true);

--- a/test/CommandeForm.test.jsx
+++ b/test/CommandeForm.test.jsx
@@ -5,7 +5,7 @@ import { vi } from 'vitest';
 vi.mock('@/hooks/useCommandes', () => ({
   useCommandes: () => ({ data: [], commandes: [], loading: false, createCommande: vi.fn() }),
 }));
-vi.mock('@/hooks/useFournisseurs', () => ({ useFournisseurs: () => ({ fournisseurs: [], fetchFournisseurs: vi.fn() }) }));
+vi.mock('@/hooks/data/useFournisseurs', () => ({ default: () => ({ data: [], isLoading: false }) }));
 vi.mock('@/hooks/useProduitsFournisseur', () => ({ useProduitsFournisseur: () => ({ useProduitsDuFournisseur: () => ({ products: [], fetch: vi.fn() }) }) }));
 vi.mock('@/hooks/useAuth', () => ({ useAuth: () => ({ role: 'admin' }) }));
 

--- a/test/Commandes.test.jsx
+++ b/test/Commandes.test.jsx
@@ -11,7 +11,7 @@ vi.mock('@/hooks/useCommandes', () => ({
     validateCommande: vi.fn(),
   }),
 }));
-vi.mock('@/hooks/useFournisseurs', () => ({ useFournisseurs: () => ({ fournisseurs: [], fetchFournisseurs: vi.fn() }) }));
+vi.mock('@/hooks/data/useFournisseurs', () => ({ default: () => ({ data: [], isLoading: false }) }));
 vi.mock('@/hooks/useAuth', () => ({ useAuth: () => ({ mama_id: 'm1', role: 'admin' }) }));
 
 import Commandes from '@/pages/commandes/Commandes.jsx';

--- a/test/MenuEngineering.test.jsx
+++ b/test/MenuEngineering.test.jsx
@@ -25,9 +25,9 @@ vi.mock('@/hooks/useMenuEngineering', () => ({
   }),
 }))
 vi.mock('@/hooks/useAuth', () => ({ useAuth: () => ({ mama_id: 'm1', roles: ['admin'], loading: false }) }))
-vi.mock('@/components/engineering/EngineeringFilters', () => ({ useAuth: () => <div /> }))
-vi.mock('@/components/engineering/EngineeringChart', () => ({ useAuth: () => <div /> }))
-vi.mock('@/components/engineering/ImportVentesExcel', () => ({ useAuth: () => <div /> }))
+vi.mock('@/components/engineering/EngineeringFilters', () => ({ default: () => <div /> }))
+vi.mock('@/components/engineering/EngineeringChart', () => ({ default: () => <div /> }))
+vi.mock('@/components/engineering/ImportVentesExcel', () => ({ default: () => <div /> }))
 vi.mock('html2canvas', () => ({ useAuth: vi.fn() }))
 vi.mock('jspdf', () => ({ useAuth: vi.fn(() => ({ addImage: vi.fn(), save: vi.fn() })) }))
 vi.mock('xlsx', () => ({ utils: { json_to_sheet: vi.fn(), book_new: vi.fn(() => ({})), book_append_sheet: vi.fn() }, writeFile: vi.fn() }))

--- a/test/ProduitForm.subfam.test.jsx
+++ b/test/ProduitForm.subfam.test.jsx
@@ -37,8 +37,8 @@ vi.mock('@/hooks/useSousFamilles', () => {
 vi.mock('@/hooks/useUnites', () => ({
   useUnites: () => ({ unites: [{ id: 'u1', nom: 'kg' }], fetchUnites: vi.fn() }),
 }));
-vi.mock('@/hooks/useFournisseurs', () => ({
-  useFournisseurs: () => ({ fournisseurs: [], fetchFournisseurs: vi.fn() }),
+vi.mock('@/hooks/data/useFournisseurs', () => ({
+  default: () => ({ data: [], isLoading: false }),
 }));
 vi.mock('@/hooks/useZonesStock', () => ({ default: () => ({ zones: [] }) }));
 vi.mock('react-hot-toast', () => ({ toast: { error: vi.fn(), success: vi.fn(), loading: vi.fn() } }));

--- a/test/ProduitForm.test.jsx
+++ b/test/ProduitForm.test.jsx
@@ -20,8 +20,8 @@ vi.mock('@/hooks/useSousFamilles', () => ({
 vi.mock('@/hooks/useUnites', () => ({
   useUnites: () => ({ unites: [], fetchUnites: vi.fn(), addUnite: vi.fn() })
 }));
-vi.mock('@/hooks/useFournisseurs', () => ({
-  useFournisseurs: () => ({ fournisseurs: [], fetchFournisseurs: vi.fn() })
+vi.mock('@/hooks/data/useFournisseurs', () => ({
+  default: () => ({ data: [], isLoading: false })
 }));
 vi.mock('@/hooks/useZonesStock', () => ({
   default: () => ({ zones: [], loading: false })

--- a/test/Produits.test.jsx
+++ b/test/Produits.test.jsx
@@ -21,8 +21,8 @@ vi.mock('@/hooks/useFamilles', () => ({
 vi.mock('@/hooks/useUnites', () => ({
   useUnites: () => ({ unites: [], fetchUnites: vi.fn(), addUnite: vi.fn() })
 }));
-vi.mock('@/hooks/useFournisseurs', () => ({
-  useFournisseurs: () => ({ fournisseurs: [], fetchFournisseurs: vi.fn() })
+vi.mock('@/hooks/data/useFournisseurs', () => ({
+  default: () => ({ data: [], isLoading: false })
 }));
 vi.mock('@/hooks/useSousFamilles', () => ({
   useSousFamilles: () => ({


### PR DESCRIPTION
## Summary
- add React Query-based `useFournisseurs` hook
- consume cached fournisseurs data across UI
- adjust related tests and mocks

## Testing
- `npm run lint`
- `npm test` *(fails: No "default" export is defined on the "@/components/engineering/EngineeringFilters" mock, TypeError: hasAccess is not a function, Cannot destructure property 'basename' of 'React10.useContext(...)' as it is null)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a17c27a4832d988e6122e37cecd5