### PR TITLE
refactor: use fournisseur hook in search and dashboard

### DIFF
--- a/src/components/gadgets/GadgetTopFournisseurs.jsx
+++ b/src/components/gadgets/GadgetTopFournisseurs.jsx
@@ -1,9 +1,14 @@
 import { motion as Motion } from 'framer-motion';
 import useTopFournisseurs from '@/hooks/gadgets/useTopFournisseurs';
+import useFournisseurs from '@/hooks/data/useFournisseurs';
 import LoadingSkeleton from '@/components/ui/LoadingSkeleton';
 
 export default function GadgetTopFournisseurs() {
   const { data, loading } = useTopFournisseurs();
+  const { data: fournisseurs = [] } = useFournisseurs({ actif: true });
+
+  const nameFor = (id) =>
+    fournisseurs.find((f) => f.id === id)?.nom || `Fournisseur ${id}`;
 
   if (loading) {
     return <LoadingSkeleton className="h-32 w-full rounded-2xl" />;
@@ -23,7 +28,7 @@ export default function GadgetTopFournisseurs() {
         {data.map((f) => (
           <li key={f.id} className="flex items-center justify-between">
             <div className="flex items-center gap-2">
-              <span>Fournisseur {f.id}</span>
+              <span>{nameFor(f.id)}</span>
             </div>
             <span className="font-semibold">{f.montant.toFixed(2)} €</span>
           </li>

--- a/src/hooks/useGlobalSearch.js
+++ b/src/hooks/useGlobalSearch.js
@@ -2,32 +2,31 @@
 import { useState, useCallback } from 'react';
 import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
+import useFournisseurs from '@/hooks/data/useFournisseurs';
 
 export function useGlobalSearch() {
   const { mama_id } = useAuth();
+  const { data: fournisseurs = [] } = useFournisseurs({ actif: true });
   const [results, setResults] = useState([]);
 
   const search = useCallback(async term => {
     if (!term) return setResults([]);
-    const [prod, fournisseurs] = await Promise.all([
+    const [prod] = await Promise.all([
       supabase
         .from('produits')
         .select('id, nom')
         .ilike('nom', `%${term}%`)
         .eq('mama_id', mama_id)
         .limit(5),
-      supabase
-        .from('fournisseurs')
-        .select('id, nom')
-        .ilike('nom', `%${term}%`)
-        .eq('mama_id', mama_id)
-        .limit(5),
     ]);
+    const fournisseursMatches = fournisseurs
+      .filter(f => f.nom?.toLowerCase().includes(term.toLowerCase()))
+      .slice(0, 5);
     setResults([
       ...(prod.data || []).map(p => ({ type: 'Produit', id: p.id, nom: p.nom })),
-      ...(fournisseurs.data || []).map(f => ({ type: 'Fournisseur', id: f.id, nom: f.nom })),
+      ...fournisseursMatches.map(f => ({ type: 'Fournisseur', id: f.id, nom: f.nom })),
     ]);
-  }, [mama_id]);
+  }, [mama_id, fournisseurs]);
 
   return { results, search };
 }


### PR DESCRIPTION
## Summary
- use cached fournisseur hook for global search
- show fournisseur names in top widget via shared hook
- update global search test mocks

## Testing
- `npm test` *(fails: fetch failed ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a65729f0832da54de2ab96b3cfbd