### PR TITLE
feat: add reusable debounce hook for search inputs

### DIFF
--- a/src/components/forms/AutocompleteProduit.jsx
+++ b/src/components/forms/AutocompleteProduit.jsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect, useId, forwardRef, useImperativeHandle } f
 import { Input } from '@/components/ui/input';
 import { useAuth } from '@/hooks/useAuth';
 import { useProduitsSearch } from '@/hooks/useProduitsSearch';
+import useDebounce from '@/hooks/useDebounce';
 import ProductPickerModal from './ProductPickerModal';
 
 function AutocompleteProduit(
@@ -48,20 +49,19 @@ function AutocompleteProduit(
     setActive(-1);
   }, [lineKey, value?.id, value?.nom]);
 
-  // debounce search
+  const debouncedInput = useDebounce(inputValue, 250);
+
   useEffect(() => {
     if (composing.current) return;
-    const val = inputValue.trim();
+    const val = debouncedInput.trim();
     if (val.length < 2) {
-      const t = setTimeout(() => setSearch(''), 250);
-      return () => clearTimeout(t);
+      setSearch('');
+      setOpen(false);
+      return;
     }
-    const t = setTimeout(() => {
-      setSearch(val);
-      setOpen(true);
-    }, 250);
-    return () => clearTimeout(t);
-  }, [inputValue]);
+    setSearch(val);
+    setOpen(true);
+  }, [debouncedInput]);
 
   useEffect(() => {
     setActive(-1);

--- a/src/components/forms/ProductPickerModal.jsx
+++ b/src/components/forms/ProductPickerModal.jsx
@@ -5,6 +5,7 @@ import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Select } from '@/components/ui/select';
 import { useProductSearch } from '@/hooks/useProductSearch';
+import useDebounce from '@/hooks/useDebounce';
 import * as Dialog from '@radix-ui/react-dialog';
 
 function highlight(str, q) {
@@ -25,8 +26,9 @@ export default function ProductPickerModal({ open, onClose, onSelect }) {
   const [page, setPage] = useState(1);
   const [limit, setLimit] = useState(20);
   const [recents, setRecents] = useState([]);
-  const searchEnabled = open && query.trim().length >= 2;
-  const { data: searchResults = [] } = useProductSearch(query, {
+  const debouncedQuery = useDebounce(query, 300);
+  const searchEnabled = open && debouncedQuery.trim().length >= 2;
+  const { data: searchResults = [] } = useProductSearch(debouncedQuery, {
     enabled: searchEnabled,
   });
   const results = searchEnabled ? searchResults : recents;

--- a/src/hooks/useDebounce.js
+++ b/src/hooks/useDebounce.js
@@ -1,0 +1,12 @@
+import { useState, useEffect } from 'react';
+
+export default function useDebounce(value, delay = 300) {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(t);
+  }, [value, delay]);
+
+  return debounced;
+}

--- a/src/hooks/useProduitsSearch.js
+++ b/src/hooks/useProduitsSearch.js
@@ -1,18 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { useState, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import useDebounce from '@/hooks/useDebounce';
 import supabase from '@/lib/supabaseClient';
-
-function useDebounced(value, delay = 300) {
-  const [debounced, setDebounced] = useState(value);
-
-  useEffect(() => {
-    const t = setTimeout(() => setDebounced(value), delay);
-    return () => clearTimeout(t);
-  }, [value, delay]);
-
-  return debounced;
-}
 
 function normalize(list = []) {
   return list.map((p) => ({
@@ -26,7 +15,7 @@ function normalize(list = []) {
 }
 
 export function useProduitsSearch(term = '', mamaId, { enabled = true, debounce = 300 } = {}) {
-  const debounced = useDebounced(term, debounce);
+  const debounced = useDebounce(term, debounce);
 
   return useQuery({
     queryKey: ['produits-search', mamaId, debounced],


### PR DESCRIPTION
## Summary
- add generic `useDebounce` hook
- use debounced values for product searches and autocomplete

## Testing
- `npm test` *(fails: No "default" export is defined on the "@/hooks/usePeriodes" mock)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1a7ea1234832d80454363593b584d