### PR TITLE
Stabilize help-related fetch effects

### DIFF
--- a/src/components/help/DocumentationPanel.jsx
+++ b/src/components/help/DocumentationPanel.jsx
@@ -1,5 +1,4 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-/* eslint-disable react-hooks/exhaustive-deps */
 import { useEffect, useState } from 'react';
 import {
   Dialog,
@@ -16,7 +15,7 @@ export default function DocumentationPanel({ open, onOpenChange }) {
 
   useEffect(() => {
     if (open) fetchDocs({ search });
-  }, [open, search]);
+  }, [open, search, fetchDocs]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/src/components/help/TooltipHelper.jsx
+++ b/src/components/help/TooltipHelper.jsx
@@ -1,5 +1,4 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-/* eslint-disable react-hooks/exhaustive-deps */
 import { useEffect, useState } from 'react';
 import { useHelp } from '@/context/HelpProvider';
 
@@ -13,7 +12,7 @@ export default function TooltipHelper({ field }) {
     } else if (Object.keys(tooltips).length === 0) {
       fetchTooltips();
     }
-  }, [tooltips, field]);
+  }, [tooltips, field, fetchTooltips]);
 
   if (!text) return null;
 

--- a/src/context/HelpProvider.jsx
+++ b/src/context/HelpProvider.jsx
@@ -1,6 +1,5 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-/* eslint-disable react-hooks/exhaustive-deps */
-import { createContext, useContext, useEffect, useState } from 'react';
+import { createContext, useContext, useEffect, useState, useCallback } from 'react';
 import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
 
@@ -12,14 +11,7 @@ export function HelpProvider({ children }) {
   const [docs, setDocs] = useState([]);
   const [loading, setLoading] = useState(false);
 
-  useEffect(() => {
-    if (mama_id) {
-      fetchTooltips();
-      fetchDocs();
-    }
-  }, [mama_id]);
-
-  async function fetchTooltips() {
+  const fetchTooltips = useCallback(async () => {
     if (!mama_id) return {};
     setLoading(true);
     const { data } = await supabase
@@ -33,9 +25,9 @@ export function HelpProvider({ children }) {
     });
     setTooltips(map);
     return map;
-  }
+  }, [mama_id]);
 
-  async function fetchDocs({ search = '' } = {}) {
+  const fetchDocs = useCallback(async ({ search = '' } = {}) => {
     if (!mama_id) return [];
     setLoading(true);
     let query = supabase
@@ -47,7 +39,14 @@ export function HelpProvider({ children }) {
     setLoading(false);
     setDocs(Array.isArray(data) ? data : []);
     return data || [];
-  }
+  }, [mama_id]);
+
+  useEffect(() => {
+    if (mama_id) {
+      fetchTooltips();
+      fetchDocs();
+    }
+  }, [mama_id, fetchTooltips, fetchDocs]);
 
   async function markGuideSeen(module) {
     if (!user_id || !mama_id) return;


### PR DESCRIPTION
## Summary
- wrap help center fetchers in `useCallback`
- include fetch dependencies to avoid re-triggering effects

## Testing
- `npm run lint`
- `npm test` *(fails: ENETUNREACH, TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a9caa3fc832da4b676e5e9c20d06