### PR TITLE
chore: add product search indexes and tighten react-query defaults

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,6 +15,7 @@ const queryClient = new QueryClient({
       refetchOnWindowFocus: false,
       refetchOnReconnect: false,
       refetchOnMount: false,
+      retry: false,
       staleTime: Infinity,
       gcTime: Infinity,
     },

--- a/supabase/migrations/20240805000000_produits_search_indexes.sql
+++ b/supabase/migrations/20240805000000_produits_search_indexes.sql
@@ -1,0 +1,9 @@
+-- Enable trigram extension and indexes to speed up product searches
+create extension if not exists pg_trgm;
+
+-- Trigram index on product name (case-insensitive)
+create index if not exists produits_nom_trgm_idx
+  on public.produits using gin (lower(nom) gin_trgm_ops);
+
+-- Index on mama_id for efficient organisation filtering
+create index if not exists produits_mama_id_idx on public.produits (mama_id);


### PR DESCRIPTION
## Summary
- disable react-query retries and rely on existing cache settings
- add trigram and filtering indexes for product search performance

## Testing
- `npm run lint`
- `npm test` *(fails: fetch failed, missing mock)*

------
https://chatgpt.com/codex/tasks/task_e_68a1c4122c70832d8bb2d77ee4a5e060