### PR TITLE
feat: improve product picker accessibility

### DIFF
--- a/src/components/forms/ProductPickerModal.jsx
+++ b/src/components/forms/ProductPickerModal.jsx
@@ -1,10 +1,5 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogTitle,
-} from '@/components/ui/dialog';
+import { useEffect, useRef, useState } from 'react';
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/SmartDialog';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { useProductSearch } from '@/hooks/useProductSearch';
@@ -13,22 +8,15 @@ export default function ProductPickerModal({ open, onOpenChange, mamaId, onPick 
   const [term, setTerm] = useState('');
   const inputRef = useRef(null);
 
-  // recherche branchée UNIQUEMENT sur table "produits" / colonne "nom"
-  const {
-    data: produits = [],
-    isFetching,
-    isError,
-    error,
-  } = useProductSearch({ mamaId, term, open, limit: 50 });
+  const { data: produits = [], isFetching, isError, error } =
+    useProductSearch({ mamaId, term, open, limit: 50 });
 
-  // focus auto quand on ouvre
   useEffect(() => {
     if (open) setTimeout(() => inputRef.current?.focus(), 0);
     else setTerm('');
   }, [open]);
 
-  // clavier: Enter sélectionne le premier résultat pour accélérer la saisie longue
-  const first = useMemo(() => produits[0], [produits]);
+  const first = produits[0];
   const onKeyDown = (e) => {
     if (e.key === 'Enter' && first) {
       e.preventDefault();
@@ -42,7 +30,7 @@ export default function ProductPickerModal({ open, onOpenChange, mamaId, onPick 
       <DialogContent aria-describedby="product-picker-desc">
         <DialogTitle>Sélecteur de produits</DialogTitle>
         <DialogDescription id="product-picker-desc" className="sr-only">
-          Recherchez un produit par nom. Tapez et validez avec Entrée pour choisir le premier résultat.
+          Recherchez un produit par nom. Tapez et appuyez sur Entrée pour sélectionner le premier résultat.
         </DialogDescription>
 
         <div className="space-y-3">
@@ -54,19 +42,11 @@ export default function ProductPickerModal({ open, onOpenChange, mamaId, onPick 
             placeholder="Nom du produit…"
           />
 
-          {isError && (
-            <div className="text-sm text-red-600">
-              Erreur de recherche : {error?.message ?? 'Inconnue'}
-            </div>
-          )}
-
-          {isFetching && (
-            <div className="text-sm text-muted-foreground">Recherche…</div>
-          )}
-
+          {isError && <div className="text-sm text-red-600">Erreur : {error?.message}</div>}
+          {isFetching && <div className="text-sm text-muted-foreground">Recherche…</div>}
           {!isFetching && produits.length === 0 && (
             <div className="text-sm text-muted-foreground">
-              {term ? <>Aucun résultat pour « {term} ».</> : <>Aucun produit à afficher.</>}
+              {term ? <>Aucun résultat pour « {term} ».</> : <>Aucun produit.</>}
             </div>
           )}
 
@@ -80,13 +60,7 @@ export default function ProductPickerModal({ open, onOpenChange, mamaId, onPick 
                       {p.code ?? '—'} · {p.unite_achat ?? p.unite_vente ?? 'u.'}
                     </div>
                   </div>
-                  <Button
-                    size="sm"
-                    onClick={() => {
-                      onPick?.(p);
-                      onOpenChange?.(false);
-                    }}
-                  >
+                  <Button size="sm" onClick={() => (onPick?.(p), onOpenChange?.(false))}>
                     Sélectionner
                   </Button>
                 </li>
@@ -98,4 +72,3 @@ export default function ProductPickerModal({ open, onOpenChange, mamaId, onPick 
     </Dialog>
   );
 }
-


### PR DESCRIPTION
## Summary
- refactor product picker modal with SmartDialog
- autofocus search and pick first result via Enter key
- show search states and errors

## Testing
- `npm test` *(fails: fetch failed)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1c97edc2c832da12f03e744339b73