### PR TITLE
feat(ui): export DialogDescription from SmartDialog

### DIFF
--- a/src/components/ui/SmartDialog.jsx
+++ b/src/components/ui/SmartDialog.jsx
@@ -3,6 +3,17 @@ import { useId } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 import { AnimatePresence, motion as Motion } from "framer-motion";
 
+export {
+  Root as Dialog,
+  Trigger as DialogTrigger,
+  Portal as DialogPortal,
+  Overlay as DialogOverlay,
+  Content as DialogContent,
+  Title as DialogTitle,
+  Description as DialogDescription,
+  Close as DialogClose,
+} from "@radix-ui/react-dialog";
+
 export default function SmartDialog({ open, onClose, title, description, children }) {
   const descriptionId = useId();
   return (


### PR DESCRIPTION
## Summary
- re-export Radix dialog primitives including Description in SmartDialog

## Testing
- `npm test` (fails: result.current.duplicateProduct is not a function)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1cd6d9adc832dbd9bc8b232ce731b