### PR TITLE
fix: expose Radix dialog primitives

### DIFF
--- a/src/components/ui/SmartDialog.jsx
+++ b/src/components/ui/SmartDialog.jsx
@@ -1,27 +1,27 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useId } from "react";
-import * as Dialog from "@radix-ui/react-dialog";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { AnimatePresence, motion as Motion } from "framer-motion";
 
-export {
-  Root as Dialog,
-  Trigger as DialogTrigger,
-  Portal as DialogPortal,
-  Overlay as DialogOverlay,
-  Content as DialogContent,
-  Title as DialogTitle,
-  Description as DialogDescription,
-  Close as DialogClose,
-} from "@radix-ui/react-dialog";
+// Si tu exposes des wrappers, garde-les. Sinon, expose au minimum ceci :
+export const Dialog = DialogPrimitive.Root;
+export const DialogTrigger = DialogPrimitive.Trigger;
+export const DialogPortal = DialogPrimitive.Portal;
+export const DialogOverlay = DialogPrimitive.Overlay;
+export const DialogContent = DialogPrimitive.Content;
+export const DialogTitle = DialogPrimitive.Title;
+export const DialogClose = DialogPrimitive.Close;
+// 👇 AJOUT : règle le warning "Missing Description"
+export const DialogDescription = DialogPrimitive.Description;
 
 export default function SmartDialog({ open, onClose, title, description, children }) {
   const descriptionId = useId();
   return (
-    <Dialog.Root open={open} onOpenChange={(v) => !v && onClose?.()}>
+    <DialogPrimitive.Root open={open} onOpenChange={(v) => !v && onClose?.()}>
       <AnimatePresence>
         {open && (
-          <Dialog.Portal forceMount>
-            <Dialog.Overlay asChild>
+          <DialogPrimitive.Portal forceMount>
+            <DialogPrimitive.Overlay asChild>
               <Motion.div
                 className="fixed inset-0 bg-black/50 backdrop-blur-sm z-40"
                 initial={{ opacity: 0 }}
@@ -29,7 +29,7 @@ export default function SmartDialog({ open, onClose, title, description, childre
                 exit={{ opacity: 0 }}
                 onClick={onClose}
               />
-            </Dialog.Overlay>
+            </DialogPrimitive.Overlay>
             <Motion.div
               className="fixed inset-0 z-50 flex items-center justify-center p-4"
               initial={{ opacity: 0, scale: 0.95 }}
@@ -37,19 +37,19 @@ export default function SmartDialog({ open, onClose, title, description, childre
               exit={{ opacity: 0, scale: 0.95 }}
               transition={{ type: "spring", stiffness: 260, damping: 20 }}
             >
-              <Dialog.Content
+              <DialogPrimitive.Content
                 aria-describedby={descriptionId}
                 className="relative bg-white/10 border border-white/20 backdrop-blur-xl rounded-2xl shadow-xl p-6 w-full max-w-lg"
               >
                 {title && (
-                  <Dialog.Title className="text-lg font-semibold mb-4">
+                  <DialogPrimitive.Title className="text-lg font-semibold mb-4">
                     {title}
-                  </Dialog.Title>
+                  </DialogPrimitive.Title>
                 )}
-                <Dialog.Description id={descriptionId} className="sr-only">
+                <DialogPrimitive.Description id={descriptionId} className="sr-only">
                   {description || ""}
-                </Dialog.Description>
-                <Dialog.Close asChild onClick={onClose}>
+                </DialogPrimitive.Description>
+                <DialogPrimitive.Close asChild onClick={onClose}>
                   <button
                     className="absolute top-3 right-3 text-mamastockGold hover:text-mamastockGold/80"
                     aria-label="Fermer"
@@ -57,13 +57,13 @@ export default function SmartDialog({ open, onClose, title, description, childre
                   >
                     ×
                   </button>
-                </Dialog.Close>
+                </DialogPrimitive.Close>
                 {children}
-              </Dialog.Content>
+              </DialogPrimitive.Content>
             </Motion.div>
-          </Dialog.Portal>
+          </DialogPrimitive.Portal>
         )}
       </AnimatePresence>
-    </Dialog.Root>
+    </DialogPrimitive.Root>
   );
 }


### PR DESCRIPTION
## Summary
- switch SmartDialog to export Radix primitives directly
- include DialogDescription to avoid missing description warnings

## Testing
- `npm test` *(fails: fetch failed / ENETUNREACH)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1d187c2f0832d8e6db4ab26b36f87