### PR TITLE
fix: expose Supabase client via default hook

### DIFF
--- a/src/hooks/useSupabaseClient.js
+++ b/src/hooks/useSupabaseClient.js
@@ -1,6 +1,6 @@
-import { useMemo } from 'react';
+// Retourne le client Supabase initialisé
 import supabase from '@/lib/supabaseClient';
 
 export default function useSupabaseClient() {
-  return useMemo(() => supabase, []);
+  return supabase;
 }


### PR DESCRIPTION
## Summary
- adjust `useSupabaseClient` to be a default export returning the initialized Supabase client

## Testing
- `npm run lint`
- `npm test` *(fails: fetch failed / ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68a1d1c70a2c832daaa9eed8fd273004