### PR TITLE
feat: add simple product search hook

### DIFF
--- a/src/components/forms/ProductPickerModal.jsx
+++ b/src/components/forms/ProductPickerModal.jsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { Dialog, DialogContent, DialogTitle, DialogDescription } from '@/components/ui/SmartDialog';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
-import { useProductSearch } from '@/hooks/useProductSearch';
+import useProductSearch from '@/hooks/useProductSearch';
 
 export default function ProductPickerModal({ open, onOpenChange, mamaId, onPick }) {
   const [term, setTerm] = useState('');

--- a/src/hooks/useProductSearch.js
+++ b/src/hooks/useProductSearch.js
@@ -1,45 +1,40 @@
 import { useQuery } from '@tanstack/react-query';
-// ⚠️ ICI : on importe le default export et on le renomme pour l'utiliser
 import useSupabaseClient from '@/hooks/useSupabaseClient';
 
-// mini debounce pour limiter le spam réseau tout en restant instantané
-const debounce = (fn, ms = 120) => {
-  let t;
-  return (...args) =>
-    new Promise((resolve) => {
-      clearTimeout(t);
-      t = setTimeout(async () => resolve(await fn(...args)), ms);
-    });
-};
+function escapeLike(value) {
+  // pour ilike : échapper % et _
+  return value.replace(/[%_]/g, '\\$&');
+}
 
-export function useProductSearch({ mamaId, term = '', open = true, limit = 50 }) {
+export default function useProductSearch({ mamaId, term = '', open = true, limit = 50 }) {
   const supabase = useSupabaseClient();
   const q = (term ?? '').trim();
 
   return useQuery({
     queryKey: ['produits:search:nom', mamaId, q, open, limit],
-    enabled: !!mamaId && !!open, // fetch seulement si la modale est ouverte
-    queryFn: debounce(async () => {
-      let query = supabase
-        .from('produits')
-        .select('id, nom, code, unite_achat, unite_vente, actif')
-        .eq('mama_id', mamaId)
-        .eq('actif', true);
-
-      if (q.length > 0) {
-        // recherche PAR NOM uniquement
-        const pattern = `%${q.replace(/[%_]/g, '\\$&')}%`;
-        query = query.ilike('nom', pattern);
-      }
-
-      const { data, error } = await query.order('nom', { ascending: true }).limit(limit);
-      if (error) throw error;
-      return data ?? [];
-    }),
+    enabled: !!mamaId && !!open,
     staleTime: 5 * 60 * 1000,
-    gcTime: 30 * 60 * 1000,
     refetchOnWindowFocus: false,
     keepPreviousData: true,
     placeholderData: [],
+    queryFn: async () => {
+      let req = supabase
+        .from('produits')
+        // 🔥 NE PAS DEMANDER 'barcode' ou 'tva' si elles n’existent pas
+        .select('id, nom, code, unite_achat, unite_vente, actif')
+        .eq('mama_id', mamaId)
+        .eq('actif', true)
+        .order('nom', { ascending: true })
+        .limit(limit);
+
+      if (q) {
+        const pattern = `%${escapeLike(q)}%`;
+        req = req.ilike('nom', pattern);
+      }
+
+      const { data, error } = await req;
+      if (error) throw error;
+      return data ?? [];
+    },
   });
 }


### PR DESCRIPTION
## Summary
- simplify product search hook to query by name for a mama
- fix ProductPickerModal to use new default export

## Testing
- `npm test` *(fails: Cannot destructure property 'session' of 'useAuth(...)' as it is null)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1d1e044f4832da16e8c7b31803c16