### PR TITLE
feat: add utility classes and Firefox transition fix

### DIFF
--- a/src/globals.css
+++ b/src/globals.css
@@ -243,3 +243,15 @@ html.dark body {
 }
 .animate-touch-fade { animation: touch-fade 0.6s ease-out forwards; }
 }
+
+/* Corrections transition (Firefox est strict) */
+[data-state="open"].animate-in { transition: opacity 150ms ease, transform 150ms ease; }
+[data-state="closed"].animate-out { transition: opacity 120ms ease, transform 120ms ease; }
+
+/* Couleurs utilitaires si manquantes (adaptation shadcn/tailwind) */
+.bg-muted { background-color: rgba(0,0,0,0.04); }
+.text-muted-foreground { color: rgba(0,0,0,0.55); }
+
+/* Tailwind-like (si vous n’avez pas Tailwind complet) */
+.rounded-2xl { border-radius: 1rem; }
+.backdrop-blur { backdrop-filter: blur(6px); }


### PR DESCRIPTION
## Summary
- ensure animation transitions work in Firefox with explicit opacity/transform rules
- add utility classes for muted colors and basic rounded/backdrop styles

## Testing
- `npm test` *(fails: fetch failed)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1d9b33eb4832d8d5d5f44ad01cd29