### PR TITLE
feat: improve product picker modal

### DIFF
--- a/src/components/FactureLigne.jsx
+++ b/src/components/FactureLigne.jsx
@@ -227,7 +227,7 @@ export default function FactureLigne({
         <ProductPickerModal
           open={pickerOpen}
           onOpenChange={setPickerOpen}
-          onPick={(p) => {
+          onSelect={(p) => {
             handleProduitSelection(p);
           }}
         />

--- a/src/components/forms/AutocompleteProduit.jsx
+++ b/src/components/forms/AutocompleteProduit.jsx
@@ -179,10 +179,9 @@ function AutocompleteProduit(
       )}
       <ProductPickerModal
         open={modalOpen}
-        onClose={() => setModalOpen(false)}
+        onOpenChange={setModalOpen}
         onSelect={(p) => {
           select(p);
-          setModalOpen(false);
         }}
       />
     </div>

--- a/src/components/forms/ProductPickerModal.jsx
+++ b/src/components/forms/ProductPickerModal.jsx
@@ -1,121 +1,109 @@
-import { useEffect, useRef, useState } from 'react';
-import { Dialog, DialogContent, DialogTitle, DialogDescription } from '@/components/ui/SmartDialog';
-import useDebounce from '@/hooks/useDebounce';
-import useProductSearch from '@/hooks/useProductSearch';
-import { useMultiMama } from '@/context/MultiMamaContext';
+import { useEffect, useRef } from 'react'
+import {
+  Dialog, DialogContent, DialogTitle, DialogDescription, DialogClose
+} from '@/components/ui/SmartDialog'
+import { X } from 'lucide-react'
+import useProductSearch from '@/hooks/useProductSearch' // ton hook qui interroge "produits" par nom
+import useDebounce from '@/hooks/useDebounce'
 
-export default function ProductPickerModal({ open, onOpenChange, onPick }) {
-  const { mamaActif: currentMamaId } = useMultiMama(); // adapte si besoin
-  const [term, setTerm] = useState('');
-  const debounced = useDebounce(term, 120);
-  const inputRef = useRef(null);
+export default function ProductPickerModal({ open, onOpenChange, onSelect, initialQuery = '' }) {
+  const inputRef = useRef(null)
+  const { query, setQuery, isLoading, results, error } = useProductSearch(initialQuery)
+  const q = useDebounce(query, 150)
 
-  const { data: produits = [], isFetching, error } = useProductSearch({
-    mamaId: currentMamaId,
-    term: debounced,
-    open,
-    limit: 50, // suffisant et rapide; on peut monter à 100 si besoin
-  });
+  // focus auto au show
+  useEffect(() => { if (open) setTimeout(() => inputRef.current?.focus(), 25) }, [open])
 
-  // focus auto à l'ouverture
-  useEffect(() => {
-    if (open) setTimeout(() => inputRef.current?.focus(), 0);
-    else setTerm('');
-  }, [open]);
+  // nb résultats
+  const count = results?.length ?? 0
 
   // navigation clavier
-  const [active, setActive] = useState(0);
-  useEffect(() => setActive(0), [debounced, open]);
+  const activeIndexRef = useRef(0)
+  useEffect(() => { activeIndexRef.current = 0 }, [q, open])
 
-  const hasResults = produits.length > 0;
+  const handleKeyDown = (e) => {
+    if (!results?.length) return
+    if ([ 'ArrowDown', 'ArrowUp', 'Enter' ].includes(e.key)) e.preventDefault()
+    const max = results.length - 1
+    if (e.key === 'ArrowDown') activeIndexRef.current = Math.min(max, activeIndexRef.current + 1)
+    if (e.key === 'ArrowUp')   activeIndexRef.current = Math.max(0,   activeIndexRef.current - 1)
+    if (e.key === 'Enter') {
+      const item = results[activeIndexRef.current]
+      if (item) { onSelect?.(item); onOpenChange(false) }
+    }
+    // force repaint en modifiant une valeur dérivée
+    // (astuce simple : pas besoin de state supplémentaire)
+    e.currentTarget.dataset.idx = String(activeIndexRef.current)
+  }
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="p-0">
-        {/* Header collant */}
-        <header className="sticky top-0 z-10 bg-white/90 backdrop-blur border-b">
-          <div className="px-4 pt-4">
+        {/* HEADER STICKY */}
+        <div className="sticky top-0 z-[1] border-b border-black/10 dark:border-white/10 bg-white/90 dark:bg-neutral-900/90 backdrop-blur px-4 py-3">
+          <div className="flex items-center gap-2">
             <DialogTitle className="text-base font-semibold">Sélecteur de produits</DialogTitle>
-            <DialogDescription className="text-xs text-muted-foreground">
-              Recherchez par <strong>nom</strong>. Utilisez ↑/↓ puis <kbd>Entrée</kbd>.
-            </DialogDescription>
+            <span className="ml-1 text-xs text-muted-foreground">({count} résultats)</span>
+            <div className="ml-auto" />
+            <DialogClose className="rounded-lg p-2 hover:bg-black/5 dark:hover:bg-white/10">
+              <X className="h-4 w-4" />
+            </DialogClose>
           </div>
-          <div className="p-4 pb-3">
+          <DialogDescription className="sr-only">Recherchez un produit par nom puis sélectionnez-le</DialogDescription>
+
+          <div className="mt-3">
             <input
               ref={inputRef}
-              type="text"
-              value={term}
-              onChange={(e) => setTerm(e.target.value)}
-              onKeyDown={(e) => {
-                if (!hasResults) return;
-                if (e.key === 'ArrowDown') {
-                  e.preventDefault();
-                  setActive((i) => Math.min(i + 1, produits.length - 1));
-                } else if (e.key === 'ArrowUp') {
-                  e.preventDefault();
-                  setActive((i) => Math.max(i - 1, 0));
-                } else if (e.key === 'Enter') {
-                  e.preventDefault();
-                  onPick?.(produits[active]);
-                  onOpenChange?.(false);
-                }
-              }}
-              placeholder="Rechercher un produit par nom…"
-              className="w-full rounded-lg border px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary/40"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="Tapez un nom de produit…"
+              className="w-full rounded-xl border border-black/10 dark:border-white/10 bg-white dark:bg-neutral-900 px-3 py-2 outline-none ring-0 focus:border-primary/40"
             />
           </div>
-        </header>
-
-        {/* Corps : scrollable */}
-        <div className="flex-1 overflow-auto">
-          {error && (
-            <div className="px-4 py-3 text-sm text-red-600">
-              Erreur de recherche : {error.message}
-            </div>
-          )}
-          {!error && !isFetching && !hasResults && (
-            <div className="px-4 py-6 text-sm opacity-70">
-              {debounced ? 'Aucun produit ne correspond.' : 'Commencez à saisir un nom de produit.'}
-            </div>
-          )}
-          {/* Liste compacte */}
-          {hasResults && (
-            <ul className="divide-y">
-              {produits.map((p, idx) => {
-                const isActive = idx === active;
-                return (
-                  <li
-                    key={p.id}
-                    onMouseEnter={() => setActive(idx)}
-                    onClick={() => {
-                      onPick?.(p);
-                      onOpenChange?.(false);
-                    }}
-                    className={[
-                      'px-4 py-2 cursor-pointer select-none',
-                      isActive ? 'bg-primary/5' : 'hover:bg-muted',
-                    ].join(' ')}
-                  >
-                    <div className="flex items-center justify-between gap-3">
-                      <span className="truncate font-medium">{p.nom}</span>
-                      {isActive && <span className="text-[10px] uppercase opacity-60">Entrée</span>}
-                    </div>
-                  </li>
-                );
-              })}
-            </ul>
-          )}
-          {isFetching && (
-            <div className="px-4 py-3 text-sm opacity-70">Recherche…</div>
-          )}
         </div>
 
-        {/* Footer collant */}
-        <footer className="sticky bottom-0 bg-white/90 backdrop-blur border-t px-4 py-2 text-[11px] text-muted-foreground">
-          {isFetching ? 'Chargement…' : `${produits.length} résultat(s)`}
-        </footer>
+        {/* LISTE SCROLLABLE */}
+        <div className="max-h-[70vh] overflow-auto px-2 py-2">
+          {error && (
+            <div className="m-2 rounded-lg border border-rose-300 bg-rose-50 p-3 text-rose-700 dark:border-rose-800 dark:bg-rose-950/40 dark:text-rose-300">
+              Erreur de recherche&nbsp;: {error.message ?? String(error)}
+            </div>
+          )}
+
+          {isLoading && <div className="px-3 py-2 text-sm text-muted-foreground">Recherche…</div>}
+
+          {!isLoading && !count && (
+            <div className="px-3 py-6 text-sm text-muted-foreground">Aucun produit</div>
+          )}
+
+          <ul className="space-y-1">
+            {results?.map((p, i) => (
+              <li key={p.id}>
+                <button
+                  type="button"
+                  onClick={() => { onSelect?.(p); onOpenChange(false) }}
+                  className="w-full rounded-xl border border-transparent px-3 py-2 text-left hover:border-black/10 dark:hover:border-white/10 hover:bg-black/5 dark:hover:bg-white/10 focus-visible:outline-primary"
+                  data-active={i === Number(inputRef.current?.dataset.idx)}
+                >
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="truncate font-medium">{p.nom}</div>
+                      <div className="truncate text-xs text-muted-foreground">
+                        {p.code ?? '—'}
+                      </div>
+                    </div>
+                    <div className="shrink-0 text-xs text-muted-foreground">
+                      {p.unite ?? ''}
+                    </div>
+                  </div>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
       </DialogContent>
     </Dialog>
-  );
+  )
 }
 


### PR DESCRIPTION
## Summary
- overhaul product picker modal with sticky header, search, and scrollable list
- add search hook with query state and expose results
- update callers to use new onSelect and onOpenChange props

## Testing
- `npm test` *(fails: fetch failed ENETUNREACH)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1e2731c80832d9d69e754d1968199