### PR TITLE
feat: add utility colors and firefox-safe transitions

### DIFF
--- a/src/globals.css
+++ b/src/globals.css
@@ -244,14 +244,27 @@ html.dark body {
 .animate-touch-fade { animation: touch-fade 0.6s ease-out forwards; }
 }
 
-/* Transitions explicites (Firefox strict) */
-[data-state="open"].animate-in { transition: opacity 150ms ease, transform 150ms ease; }
-[data-state="closed"].animate-out { transition: opacity 120ms ease, transform 120ms ease; }
 
 /* Couleurs utilitaires si manquantes */
 .bg-muted { background: rgba(0,0,0,0.04); }
-.text-muted-foreground { color: rgba(0,0,0,0.55); }
 
 /* Tailwind-like (si vous n’avez pas Tailwind complet) */
 .rounded-2xl { border-radius: 1rem; }
 .backdrop-blur { backdrop-filter: blur(6px); }
+/* Contrastes et couleurs utilitaires */
+.text-muted-foreground { color: rgb(107 114 128); }           /* slate-500 approx */
+.dark .text-muted-foreground { color: rgb(148 163 184); }     /* slate-400 approx */
+
+:root {
+  --primary: 59 130 246; /* bleu clair */
+}
+.focus-visible\:outline-primary:focus-visible {
+  outline: 2px solid rgb(var(--primary));
+  outline-offset: 2px;
+}
+
+/* Transitions compatibles Firefox (évite "Déclaration abandonnée") */
+[data-state="open"].animate-in,
+[data-state="closed"].animate-out {
+  transition: opacity .15s ease, transform .15s ease;
+}


### PR DESCRIPTION
## Summary
- tweak CSS to add muted foreground colors and primary outline utilities
- unify open/closed state transitions for Firefox

## Testing
- `npm test` *(fails: TypeError: fetch failed)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1e29a2120832d9d3962386b1867a9