### PR TITLE
fix: restrict product search fields

### DIFF
--- a/src/hooks/useProductSearch.js
+++ b/src/hooks/useProductSearch.js
@@ -1,39 +1,48 @@
-import { useState } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { useState, useEffect } from 'react'
 import useSupabaseClient from '@/hooks/useSupabaseClient'
+import useDebounce from './useDebounce'
 import { useMultiMama } from '@/context/MultiMamaContext'
 
-const ESCAPE_RE = /[%_]/g
-const escapeLike = (s) => s.replace(ESCAPE_RE, '\\$&')
-
-export default function useProductSearch(initial = '') {
-  const { mamaActif: mamaId } = useMultiMama()
-  const [query, setQuery] = useState(initial)
-  const q = (query ?? '').trim()
+export default function useProductSearch(initialQuery = '') {
   const supabase = useSupabaseClient()
+  const { mamaActif: currentMamaId } = useMultiMama()
+  const [query, setQuery] = useState(initialQuery)
+  const [results, setResults] = useState([])
+  const [isLoading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
 
-  const { data = [], isFetching, error } = useQuery({
-    queryKey: ['produits:picker', mamaId, q],
-    enabled: !!mamaId,
-    staleTime: 5 * 60 * 1000,
-    refetchOnWindowFocus: false,
-    keepPreviousData: true,
-    placeholderData: [],
-    queryFn: async () => {
-      let req = supabase
-        .from('produits')
-        .select('id, nom, code, unite')
-        .eq('mama_id', mamaId)
-        .order('nom', { ascending: true })
-        .limit(100)
-      if (q) {
-        req = req.ilike('nom', `%${escapeLike(q)}%`)
+  const q = useDebounce(query.trim(), 150)
+
+  useEffect(() => {
+    let cancel = false
+    ;(async () => {
+      setLoading(true)
+      setError(null)
+      try {
+        let req = supabase
+          .from('produits')
+          .select('id, nom')
+          .eq('mama_id', currentMamaId)
+          .eq('actif', true)
+          .order('nom', { ascending: true })
+          .limit(50)
+
+        if (q) req = req.ilike('nom', `%${q}%`)
+
+        const { data, error } = await req
+        if (error) throw error
+        if (!cancel) setResults(data ?? [])
+      } catch (e) {
+        if (!cancel) setError(e)
+      } finally {
+        if (!cancel) setLoading(false)
       }
-      const { data, error } = await req
-      if (error) throw error
-      return data ?? []
+    })()
+    return () => {
+      cancel = true
     }
-  })
+  }, [supabase, currentMamaId, q])
 
-  return { query, setQuery, isLoading: isFetching, results: data, error }
+  return { query, setQuery, results, isLoading, error }
 }
+


### PR DESCRIPTION
## Summary
- refactor product search hook to fetch only `id` and `nom`
- filter by current mama and active products, ordering alphabetically

## Testing
- `npm test` *(fails: supabaseUrl is required, invalid Chai property)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a21171c2d4832d8d55ecc52335e383