### PR TITLE
feat: log supabase errors in hooks

### DIFF
--- a/src/hooks/gadgets/useAlerteStockFaible.js
+++ b/src/hooks/gadgets/useAlerteStockFaible.js
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import useSupabaseClient from '@/hooks/useSupabaseClient';
 import { useAuth } from '@/hooks/useAuth';
+import { logSupaError } from '@/lib/supa/logError';
 
 export default function useAlerteStockFaible() {
   const supabase = useSupabaseClient();
@@ -30,7 +31,10 @@ export default function useAlerteStockFaible() {
         .is('traite', false)
         .order('cree_le', { ascending: false });
 
-      if (error) throw error;
+      if (error) {
+        logSupaError('alertes_rupture', error);
+        throw error;
+      }
 
       const list = (data || [])
         .filter(

--- a/src/hooks/useProductSearch.js
+++ b/src/hooks/useProductSearch.js
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import useSupabaseClient from '@/hooks/useSupabaseClient'
 import useDebounce from './useDebounce'
 import { useMultiMama } from '@/context/MultiMamaContext'
+import { logSupaError } from '@/lib/supa/logError'
 
 export default function useProductSearch(initialQuery = '') {
   const supabase = useSupabaseClient()
@@ -30,7 +31,10 @@ export default function useProductSearch(initialQuery = '') {
         if (q) req = req.ilike('nom', `%${q}%`)
 
         const { data, error } = await req
-        if (error) throw error
+        if (error) {
+          logSupaError('produits', error)
+          throw error
+        }
         if (!cancel) setResults(data ?? [])
       } catch (e) {
         if (!cancel) setError(e)

--- a/src/lib/supa/logError.js
+++ b/src/lib/supa/logError.js
@@ -1,0 +1,9 @@
+export const logSupaError = (label, error) => {
+  if (!error) return;
+  console.error(`[supa] ${label}`, {
+    message: error.message,
+    details: error.details,
+    hint: error.hint,
+    code: error.code,
+  });
+};


### PR DESCRIPTION
## Summary
- add `logSupaError` helper for consistent Supabase error logging
- use `logSupaError` in `useAlerteStockFaible` and `useProductSearch`

## Testing
- `npm test` *(fails: supabaseUrl is required, Invalid Chai property, hasAccess is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68a36bb69a00832d863ed05958d1073a