### PR TITLE
feat: add helper to fetch low stock alerts

### DIFF
--- a/src/hooks/useAlerteStockFaible.js
+++ b/src/hooks/useAlerteStockFaible.js
@@ -1,0 +1,17 @@
+import { useSupabase } from '@/hooks/useSupabaseClient';
+
+export async function fetchAlertesRupture(mamaId) {
+  const supabase = useSupabase();
+
+  const { data, error } = await supabase
+    .from('alertes_rupture')
+    // embed grâce à la FK alertes_rupture.produit_id -> produits.id
+    .select('id, mama_id, produit_id, traite, cree_le, produit:produits(id,nom)')
+    .eq('mama_id', mamaId)
+    .is('traite', false)
+    .order('cree_le', { ascending: false });
+
+  if (error) throw error;
+  return data;
+}
+


### PR DESCRIPTION
## Summary
- add fetchAlertesRupture helper to query unhandled stock alerts via Supabase

## Testing
- `npm test` *(fails: spy call expectations in backup_db and public_api tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a4751c3454832d91e84e5c35fb902a