### PR TITLE
Use FactureForm for invoice routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ Task management is documented in [docs/taches.md](docs/taches.md).
 - Task management available at `/taches` with creation and list pages
 - Tasks support manual or delayed due dates, priorities and recurring schedules
 - Invoice form supports OCR scanning of uploaded documents
-- Manage invoices from `/factures` with pages `/factures/nouveau` and `/factures/:id`
+- Manage invoices from `/factures` with pages `/factures/new` and `/factures/:id`
 - Index on `factures.reference` speeds up invoice search queries
 - Columns `total_ht`, `total_tva` and `total_ttc` are computed automatically via triggers
 - Index on `products.code` speeds up lookups by internal product code

--- a/router_mapping.json
+++ b/router_mapping.json
@@ -24,7 +24,7 @@
     "module": "factures"
   },
   {
-    "route": "/factures/nouveau",
+    "route": "/factures/new",
     "module": "factures"
   },
   {

--- a/src/pages/factures/FactureForm.jsx
+++ b/src/pages/factures/FactureForm.jsx
@@ -29,7 +29,9 @@ export function mapDbLineToUI(l) {
 }
 
 export default function FactureForm({ onSaved, onClose }) {
-  const { id } = useParams();
+  const { id: routeId } = useParams();
+  const id = routeId ?? 'new';
+  const isEdit = id !== 'new';
 
   const form = useForm({
     defaultValues: {
@@ -45,7 +47,7 @@ export default function FactureForm({ onSaved, onClose }) {
     isLoading,
     error,
     refetch,
-  } = useInvoice(id);
+  } = useInvoice(isEdit ? id : undefined);
 
   const mapped = useMemo(() => {
     if (!invoice) return null;
@@ -68,17 +70,17 @@ export default function FactureForm({ onSaved, onClose }) {
   }, [invoice]);
 
   useEffect(() => {
-    if (mapped && id !== 'new') {
+    if (mapped && isEdit) {
       form.reset(mapped);
     }
-  }, [mapped, id, form]);
+  }, [mapped, isEdit, form]);
 
   const handleSave = () => {
     const values = form.getValues();
     onSaved?.(values);
   };
 
-  if (id !== 'new' && isLoading) {
+  if (isEdit && isLoading) {
     return (
       <div className="p-4 flex justify-center">
         <LoadingSpinner />
@@ -86,7 +88,7 @@ export default function FactureForm({ onSaved, onClose }) {
     );
   }
 
-  if (error) {
+  if (isEdit && error) {
     return (
       <div className="p-4 text-red-500">
         <p>Erreur lors du chargement de la facture.</p>

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -27,9 +27,8 @@ const Fournisseurs = lazyWithPreload(() => import("@/pages/fournisseurs/Fourniss
 const FournisseurCreate = lazyWithPreload(() => import("@/pages/fournisseurs/FournisseurCreate.jsx"));
 const FournisseurDetailPage = lazyWithPreload(() => import("@/pages/fournisseurs/FournisseurDetailPage.jsx"));
 const Factures = lazyWithPreload(() => import("@/pages/factures/Factures.jsx"));
-const FactureDetail = lazyWithPreload(() => import("@/pages/factures/FactureDetail.jsx"));
+const FactureForm = lazyWithPreload(() => import("@/pages/factures/FactureForm.jsx"));
 const ImportFactures = lazyWithPreload(() => import("@/pages/factures/ImportFactures.jsx"));
-const FactureCreate = lazyWithPreload(() => import("@/pages/factures/FactureCreate.jsx"));
 const Achats = lazyWithPreload(() => import("@/pages/achats/Achats.jsx"));
 const Fiches = lazyWithPreload(() => import("@/pages/fiches/Fiches.jsx"));
 const FicheDetail = lazyWithPreload(() => import("@/pages/fiches/FicheDetail.jsx"));
@@ -132,6 +131,8 @@ export const routePreloadMap = {
   '/inventaire': Inventaire.preload,
   '/fournisseurs': Fournisseurs.preload,
   '/factures': Factures.preload,
+  '/factures/new': FactureForm.preload,
+  '/factures/:id': FactureForm.preload,
   '/factures/import': ImportFactures.preload,
   '/achats': Achats.preload,
   '/receptions': Receptions.preload,
@@ -284,29 +285,29 @@ export default function Router() {
             element={<Factures />}
           />
           <Route
-            path="/factures/nouveau"
-            element={<FactureCreate />}
+            path="/factures/new"
+            element={<FactureForm />}
           />
           <Route
             path="/factures/:id"
-            element={<FactureDetail />}
+            element={<FactureForm />}
           />
           <Route
             path="/factures/import"
             element={<ImportFactures />}
           />
           <Route
-          path="/receptions"
-          element={<Receptions />}
-        />
-        <Route
-          path="/achats"
-          element={<Achats />}
-        />
-        <Route
-          path="/bons-livraison"
-          element={<BonsLivraison />}
-        />
+            path="/receptions"
+            element={<Receptions />}
+          />
+          <Route
+            path="/achats"
+            element={<Achats />}
+          />
+          <Route
+            path="/bons-livraison"
+            element={<BonsLivraison />}
+          />
           <Route
             path="/bons-livraison/nouveau"
             element={<BLCreate />}


### PR DESCRIPTION
## Summary
- route invoices through a unified `FactureForm` at `/factures/new` and `/factures/:id`
- allow `FactureForm` to skip invoice fetching when creating new invoices
- document and map the new `/factures/new` path

## Testing
- `npm test` *(fails: fetch failed and other network related errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a486012dcc832d97cc699719fb32e3