### PR TITLE
fix: resolve UtilisateurForm import path

### DIFF
--- a/src/pages/Utilisateurs.jsx
+++ b/src/pages/Utilisateurs.jsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from "react";
 import { useUtilisateurs } from "@/hooks/useUtilisateurs";
 import { useAuth } from '@/hooks/useAuth';
-import UtilisateurForm from "@/components/utilisateurs/UtilisateurForm";
+import UtilisateurForm from "@/pages/parametrage/UtilisateurForm.jsx";
 import UtilisateurDetail from "@/components/utilisateurs/UtilisateurDetail";
 import { Button } from "@/components/ui/button";
 import ListingContainer from "@/components/ui/ListingContainer";

--- a/src/pages/parametrage/Utilisateurs.jsx
+++ b/src/pages/parametrage/Utilisateurs.jsx
@@ -3,7 +3,7 @@ import { useEffect, useState, useCallback } from "react";
 import { useUtilisateurs } from "@/hooks/useUtilisateurs";
 import { useAuth } from '@/hooks/useAuth';
 import { useRoles } from "@/hooks/useRoles";
-import UtilisateurForm from "@/components/utilisateurs/UtilisateurForm";
+import UtilisateurForm from "@/pages/parametrage/UtilisateurForm.jsx";
 import UtilisateurRow from "@/components/Utilisateurs/UtilisateurRow";
 import { Button } from "@/components/ui/button";
 import ListingContainer from "@/components/ui/ListingContainer";

--- a/test/Utilisateurs.test.jsx
+++ b/test/Utilisateurs.test.jsx
@@ -14,7 +14,7 @@ vi.mock('@/hooks/useUtilisateurs', () => ({
 vi.mock('@/hooks/useAuth', () => ({ useAuth: () => ({ mama_id: 'm1', role: 'admin', loading: false }) }));
 vi.mock('@/hooks/useRoles', () => ({ useRoles: () => ({ roles: [], fetchRoles: vi.fn() }) }));
 vi.mock('@/components/Utilisateurs/UtilisateurRow', () => ({ useAuth: () => <tr data-testid="row" /> }));
-vi.mock('@/components/utilisateurs/UtilisateurForm', () => ({ useAuth: () => <div>form</div> }));
+vi.mock('@/pages/parametrage/UtilisateurForm.jsx', () => ({ useAuth: () => <div>form</div> }));
 
 import Utilisateurs from '@/pages/parametrage/Utilisateurs.jsx';
 

--- a/test/setupTests.ts
+++ b/test/setupTests.ts
@@ -1,4 +1,5 @@
 import { expect, vi } from "vitest";
+import '@testing-library/jest-dom';
 
 // Stubs pour anciens modules supprimés
 vi.mock("@/license", () => ({ default: { validateLicense: () => true } }));


### PR DESCRIPTION
## Summary
- fix imports for `UtilisateurForm` to reference existing page component
- load `@testing-library/jest-dom` in test setup and update related mocks

## Testing
- `npm test test/Utilisateurs.test.jsx`
- `npm test` *(fails: fetch failed / network errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a487fd4358832d94bfdfade22edfd2