### PR TITLE
feat: restore basic parametrage pages

### DIFF
--- a/src/layout/Sidebar.jsx
+++ b/src/layout/Sidebar.jsx
@@ -162,6 +162,7 @@ export default function Sidebar() {
         { module: "settings", to: "/parametrage/settings", label: "Autres", icon: <Settings size={16} /> },
         { module: "zones_stock", to: "/parametrage/zones", label: "Zones de stock", icon: <Boxes size={16} /> },
         { module: "parametrage", to: "/parametrage/familles", label: "Familles", icon: <Boxes size={16} /> },
+        { module: "parametrage", to: "/parametrage/sous-familles", label: "Sous-familles", icon: <Boxes size={16} /> },
         { module: "parametrage", to: "/parametrage/unites", label: "Unités", icon: <Boxes size={16} /> },
         { module: "parametrage", to: "/consentements", label: "Consentements", icon: <CheckSquare size={16} /> },
       ],

--- a/src/pages/parametrage/Familles.jsx
+++ b/src/pages/parametrage/Familles.jsx
@@ -2,29 +2,29 @@
 import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import { useAuth } from '@/hooks/useAuth';
-import { useUnites } from '@/hooks/useUnites';
+import { useFamilles } from '@/hooks/useFamilles';
 import ListingContainer from '@/components/ui/ListingContainer';
 import TableHeader from '@/components/ui/TableHeader';
 import { Button } from '@/components/ui/button';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import Unauthorized from '@/pages/auth/Unauthorized';
 
-export default function Unites() {
+export default function Familles() {
   const { hasAccess, loading: authLoading } = useAuth();
   const canEdit = hasAccess('parametrage', 'peut_modifier');
-  const { unites, fetchUnites, addUnite, updateUnite, deleteUnite, loading } = useUnites();
+  const { familles, fetchFamilles, addFamille, updateFamille, deleteFamille, loading } = useFamilles();
   const [edit, setEdit] = useState(null);
 
   useEffect(() => {
-    fetchUnites();
-  }, [fetchUnites]);
+    fetchFamilles();
+  }, [fetchFamilles]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      if (edit?.id) await updateUnite(edit.id, { code: edit.code, nom: edit.nom });
-      else await addUnite({ code: edit?.code || '', nom: edit?.nom || '' });
-      toast.success('Unité enregistrée');
+      if (edit?.id) await updateFamille(edit.id, { code: edit.code, nom: edit.nom });
+      else await addFamille({ code: edit?.code || '', nom: edit?.nom || '' });
+      toast.success('Famille enregistrée');
       setEdit(null);
     } catch (err) {
       console.error(err);
@@ -35,8 +35,8 @@ export default function Unites() {
   const handleDelete = async (id) => {
     if (confirm('Supprimer cet élément ?')) {
       try {
-        await deleteUnite(id);
-        toast.success('Unité supprimée');
+        await deleteFamille(id);
+        toast.success('Famille supprimée');
       } catch (err) {
         console.error(err);
         toast.error('Suppression échouée');
@@ -49,9 +49,9 @@ export default function Unites() {
 
   return (
     <div className="p-6 max-w-2xl mx-auto">
-      <h1 className="text-2xl font-bold mb-4">Unités</h1>
+      <h1 className="text-2xl font-bold mb-4">Familles</h1>
       <TableHeader className="gap-2">
-        <Button onClick={() => setEdit({ code: '', nom: '' })}>+ Nouvelle unité</Button>
+        <Button onClick={() => setEdit({ code: '', nom: '' })}>+ Nouvelle famille</Button>
       </TableHeader>
       <ListingContainer className="w-full overflow-x-auto">
         <table className="text-sm w-full">
@@ -63,24 +63,28 @@ export default function Unites() {
             </tr>
           </thead>
           <tbody>
-            {unites.map((u) => (
-              <tr key={u.id}>
-                <td className="px-2 py-1">{u.code}</td>
-                <td className="px-2 py-1">{u.nom}</td>
+            {familles.map((f) => (
+              <tr key={f.id}>
+                <td className="px-2 py-1">{f.code}</td>
+                <td className="px-2 py-1">{f.nom}</td>
                 <td className="px-2 py-1 flex gap-2">
-                  <Button size="sm" variant="outline" onClick={() => setEdit(u)}>
+                  <Button size="sm" variant="outline" onClick={() => setEdit(f)}>
                     Modifier
                   </Button>
-                  <Button size="sm" variant="outline" onClick={() => handleDelete(u.id)}>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => handleDelete(f.id)}
+                  >
                     Supprimer
                   </Button>
                 </td>
               </tr>
             ))}
-            {unites.length === 0 && (
+            {familles.length === 0 && (
               <tr>
                 <td colSpan="3" className="py-2">
-                  Aucune unité
+                  Aucune famille
                 </td>
               </tr>
             )}

--- a/src/pages/parametrage/SousFamilles.jsx
+++ b/src/pages/parametrage/SousFamilles.jsx
@@ -1,127 +1,136 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-/* eslint-disable react-hooks/exhaustive-deps */
 import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
-import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
+import { useSousFamilles } from '@/hooks/useSousFamilles';
+import { useFamilles } from '@/hooks/useFamilles';
 import ListingContainer from '@/components/ui/ListingContainer';
-import PaginationFooter from '@/components/ui/PaginationFooter';
 import TableHeader from '@/components/ui/TableHeader';
 import { Button } from '@/components/ui/button';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import Unauthorized from '@/pages/auth/Unauthorized';
 
-const PAGE_SIZE = 50;
-
 export default function SousFamilles() {
-  const { mama_id, hasAccess, loading: authLoading } = useAuth();
+  const { hasAccess, loading: authLoading } = useAuth();
   const canEdit = hasAccess('parametrage', 'peut_modifier');
-  const [sousFamilles, setSousFamilles] = useState([]);
-  const [search, setSearch] = useState('');
-  const [page, setPage] = useState(1);
-  const [total, setTotal] = useState(0);
-  const [loading, setLoading] = useState(false);
+  const { sousFamilles, list, create, update, remove, loading } = useSousFamilles();
+  const { familles } = useFamilles();
+  const [edit, setEdit] = useState(null);
 
   useEffect(() => {
-    if (!authLoading && mama_id) {
-      fetchSousFamilles();
-    }
-  }, [authLoading, mama_id, page, search]);
+    list();
+  }, [list]);
 
-  async function fetchSousFamilles() {
-    setLoading(true);
-    let query = supabase
-      .from('sous_familles')
-      .select('id, nom, famille_id, familles(nom)', { count: 'exact' })
-      .eq('mama_id', mama_id)
-      .range((page - 1) * PAGE_SIZE, page * PAGE_SIZE - 1)
-      .order('nom', { ascending: true });
-    if (search) query = query.ilike('nom', `%${search}%`);
-    const { data, error, count } = await query;
-    if (error) {
-      toast.error(error.message);
-      setSousFamilles([]);
-      setTotal(0);
-    } else {
-      setSousFamilles(data || []);
-      setTotal(count || 0);
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      if (edit?.id) await update(edit.id, { code: edit.code, nom: edit.nom, famille_id: edit.famille_id });
+      else await create({ code: edit?.code || '', nom: edit?.nom || '', famille_id: edit?.famille_id });
+      toast.success('Sous-famille enregistrée');
+      setEdit(null);
+    } catch (err) {
+      console.error(err);
+      toast.error("Erreur lors de l'enregistrement");
     }
-    setLoading(false);
-  }
+  };
 
-  async function handleDelete(id) {
-    setLoading(true);
-    const { error } = await supabase
-      .from('sous_familles')
-      .delete()
-      .eq('id', id);
-    if (error) {
-      console.error('Erreur suppression :', error);
-      toast.error('Suppression échouée.');
-    } else {
-      toast.success('Élément supprimé !');
+  const handleDelete = async (id) => {
+    if (confirm('Supprimer cet élément ?')) {
+      try {
+        await remove(id);
+        toast.success('Sous-famille supprimée');
+      } catch (err) {
+        console.error(err);
+        toast.error('Suppression échouée');
+      }
     }
-    await fetchSousFamilles();
-    setLoading(false);
-  }
-
-  const pages = Math.ceil(total / PAGE_SIZE) || 1;
+  };
 
   if (authLoading || loading) return <LoadingSpinner message="Chargement..." />;
   if (!canEdit) return <Unauthorized />;
 
   return (
     <div className="p-6 max-w-2xl mx-auto">
-            <h1 className="text-2xl font-bold mb-4">Sous-familles</h1>
+      <h1 className="text-2xl font-bold mb-4">Sous-familles</h1>
       <TableHeader className="gap-2">
-        <input
-          className="input flex-1"
-          placeholder="Recherche"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-        />
+        <Button onClick={() => setEdit({ code: '', nom: '', famille_id: familles[0]?.id })}>+ Nouvelle sous-famille</Button>
       </TableHeader>
       <ListingContainer className="w-full overflow-x-auto">
         <table className="text-sm w-full">
           <thead>
             <tr>
-              <th className="px-2 py-1 w-full">Nom</th>
-              <th className="px-2 py-1 w-full">Famille</th>
-              <th className="px-2 py-1 w-full">Actions</th>
+              <th className="px-2 py-1">Code</th>
+              <th className="px-2 py-1">Nom</th>
+              <th className="px-2 py-1">Famille</th>
+              <th className="px-2 py-1">Actions</th>
             </tr>
           </thead>
           <tbody>
-            {sousFamilles.length === 0 ? (
+            {sousFamilles.map((sf) => (
+              <tr key={sf.id}>
+                <td className="px-2 py-1">{sf.code}</td>
+                <td className="px-2 py-1">{sf.nom}</td>
+                <td className="px-2 py-1">{sf.familles?.nom || ''}</td>
+                <td className="px-2 py-1 flex gap-2">
+                  <Button size="sm" variant="outline" onClick={() => setEdit(sf)}>
+                    Modifier
+                  </Button>
+                  <Button size="sm" variant="outline" onClick={() => handleDelete(sf.id)}>
+                    Supprimer
+                  </Button>
+                </td>
+              </tr>
+            ))}
+            {sousFamilles.length === 0 && (
               <tr>
-                <td colSpan="3" className="py-2">
+                <td colSpan="4" className="py-2">
                   Aucune sous-famille
                 </td>
               </tr>
-            ) : (
-              sousFamilles.map((sf) => (
-                <tr key={sf.id}>
-                  <td className="px-2 py-1">{sf.nom}</td>
-                  <td className="px-2 py-1">{sf.familles?.nom || ''}</td>
-                  <td className="px-2 py-1 flex justify-center">
-                    <Button
-                      size="sm"
-                      className="bg-red-500 hover:bg-red-600 text-white"
-                      onClick={() => {
-                        if (confirm('Supprimer cet élément ?')) {
-                          handleDelete(sf.id);
-                        }
-                      }}
-                    >
-                      🗑 Supprimer
-                    </Button>
-                  </td>
-                </tr>
-              ))
             )}
           </tbody>
         </table>
       </ListingContainer>
-      <PaginationFooter page={page} pages={pages} onPageChange={setPage} />
+      {edit && (
+        <div className="fixed inset-0 flex items-center justify-center z-50">
+          <div className="absolute inset-0 bg-black/50" onClick={() => setEdit(null)} />
+          <div className="relative bg-white/10 backdrop-blur-xl border border-white/20 rounded-xl shadow-lg p-6 w-full max-w-md">
+            <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+              <input
+                className="input"
+                placeholder="Code"
+                value={edit.code || ''}
+                onChange={(e) => setEdit({ ...edit, code: e.target.value })}
+              />
+              <input
+                className="input"
+                placeholder="Nom"
+                required
+                value={edit.nom || ''}
+                onChange={(e) => setEdit({ ...edit, nom: e.target.value })}
+              />
+              <select
+                className="input"
+                value={edit.famille_id || ''}
+                onChange={(e) => setEdit({ ...edit, famille_id: e.target.value })}
+              >
+                <option value="">Sélectionner une famille</option>
+                {familles.map((f) => (
+                  <option key={f.id} value={f.id}>
+                    {f.nom}
+                  </option>
+                ))}
+              </select>
+              <div className="flex justify-end gap-2 mt-2">
+                <Button type="button" variant="outline" onClick={() => setEdit(null)}>
+                  Annuler
+                </Button>
+                <Button type="submit">Enregistrer</Button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -68,7 +68,8 @@ const MamaSettingsForm = lazyWithPreload(() => import("@/pages/parametrage/MamaS
 const Zones = lazyWithPreload(() => import("@/pages/parametrage/Zones.jsx"));
 const ZoneForm = lazyWithPreload(() => import("@/pages/parametrage/ZoneForm.jsx"));
 const ZoneAccess = lazyWithPreload(() => import("@/pages/parametrage/ZoneAccess.jsx"));
-const Familles = lazyWithPreload(() => import("@/pages/Parametres/Familles.jsx"));
+const Familles = lazyWithPreload(() => import("@/pages/parametrage/Familles.jsx"));
+const SousFamilles = lazyWithPreload(() => import("@/pages/parametrage/SousFamilles.jsx"));
 const Unites = lazyWithPreload(() => import("@/pages/parametrage/Unites.jsx"));
 const Periodes = lazyWithPreload(() => import("@/pages/parametrage/Periodes.jsx"));
 const Onboarding = lazyWithPreload(() => import("@/pages/public/Onboarding.jsx"));
@@ -181,6 +182,7 @@ export const routePreloadMap = {
   '/parametrage/zones/:id': ZoneForm.preload,
   '/parametrage/zones/:id/droits': ZoneAccess.preload,
   '/parametrage/familles': Familles.preload,
+  '/parametrage/sous-familles': SousFamilles.preload,
   '/parametrage/unites': Unites.preload,
   '/parametrage/periodes': Periodes.preload,
   '/consentements': Consentements.preload,
@@ -564,6 +566,10 @@ export default function Router() {
           <Route
             path="/parametrage/familles"
             element={<Familles />}
+          />
+          <Route
+            path="/parametrage/sous-familles"
+            element={<SousFamilles />}
           />
           <Route
             path="/parametrage/unites"


### PR DESCRIPTION
## Summary
- add simple React Query hooks for familles, sous-familles and unités
- create minimal list and form pages for familles, sous-familles and unités
- wire routes and sidebar entries for new parametrage pages

## Testing
- `npm test` *(fails: fetch failed, missing QueryClient)*

------
https://chatgpt.com/codex/tasks/task_e_68a488197bb8832d94977dda85b9138d