### PR TITLE
fix: improve authentication flow

### DIFF
--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useRef, createContext, useContext, useMemo } from 'react'
+import { useNavigate } from 'react-router-dom'
 import supabase from '@/lib/supabaseClient'
 import { normalizeAccessKey } from '@/lib/access'
 
@@ -7,12 +8,14 @@ export const useAuth = () => useContext(AuthCtx)
 
 function AuthProvider({ children }) {
   const [session, setSession] = useState(null)
+  const [user, setUser] = useState(null)
   const [userData, setUserData] = useState(null)
   const [loading, setLoading] = useState(false)
   const rights = useMemo(() => userData?.access_rights ?? {}, [userData?.access_rights])
   const initRef = useRef(false)
   const lastLoadedUserRef = useRef(null)
   const pollTimerRef = useRef(null)
+  const navigate = useNavigate()
 
   async function loadProfile(sess) {
     if (!sess) { setUserData(null); return }
@@ -26,25 +29,34 @@ function AuthProvider({ children }) {
   useEffect(() => {
     if (initRef.current) return
     initRef.current = true
-    console.info('[auth] init once')
+    if (import.meta.env.DEV) console.debug('[auth] init')
     const init = async () => {
       const { data: { session } } = await supabase.auth.getSession()
       setSession(session ?? null)
-      if (session) { setLoading(true); await loadProfile(session) }
-      setLoading(false)
+      setUser(session?.user ?? null)
+      if (session) {
+        setLoading(true)
+        if (import.meta.env.DEV) console.time('[auth] loadProfile')
+        await loadProfile(session)
+        if (import.meta.env.DEV) console.timeEnd('[auth] loadProfile')
+        setLoading(false)
+        navigate('/dashboard')
+      }
     }
     init()
     const { data: sub } = supabase.auth.onAuthStateChange(async (_evt, sess) => {
-      console.info('[auth] onAuthStateChange -> loadProfile for', sess?.user?.id)
       setSession(sess ?? null)
-      setLoading(true)
-      if (sess?.user?.id && lastLoadedUserRef.current === sess.user.id && userData) {
+      setUser(sess?.user ?? null)
+      if (sess) {
+        setLoading(true)
+        if (import.meta.env.DEV) console.time('[auth] loadProfile')
+        await loadProfile(sess)
+        if (import.meta.env.DEV) console.timeEnd('[auth] loadProfile')
         setLoading(false)
-        return
+        navigate('/dashboard')
+      } else {
+        setUserData(null)
       }
-      lastLoadedUserRef.current = sess?.user?.id || null
-      await loadProfile(sess)
-      setLoading(false)
     })
     let tries = 0
     const tick = async () => {
@@ -52,8 +64,11 @@ function AuthProvider({ children }) {
       const { data: { session } } = await supabase.auth.getSession()
       if (session && !userData) {
         setSession(session)
+        setUser(session.user)
         setLoading(true)
+        if (import.meta.env.DEV) console.time('[auth] loadProfile')
         await loadProfile(session)
+        if (import.meta.env.DEV) console.timeEnd('[auth] loadProfile')
         setLoading(false)
         window.clearInterval(pollTimerRef.current)
         pollTimerRef.current = null
@@ -64,7 +79,7 @@ function AuthProvider({ children }) {
     }
     pollTimerRef.current = window.setInterval(tick, 500)
     return () => { sub?.subscription?.unsubscribe?.(); if (pollTimerRef.current) window.clearInterval(pollTimerRef.current) }
-  }, [])
+  }, [navigate, userData])
   const hasAccess = useMemo(() => {
     return (key) => {
       const k = normalizeAccessKey(key)
@@ -74,8 +89,8 @@ function AuthProvider({ children }) {
   }, [rights])
 
   const value = useMemo(
-    () => ({ session, userData, loading, hasAccess, ...(userData || {}) }),
-    [session, userData, loading, hasAccess]
+    () => ({ session, user, userData, loading, hasAccess, ...(userData || {}) }),
+    [session, user, userData, loading, hasAccess]
   )
   return <AuthCtx.Provider value={value}>{children}</AuthCtx.Provider>
 }

--- a/src/pages/auth/Login.jsx
+++ b/src/pages/auth/Login.jsx
@@ -1,7 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
-import { useAuth } from '@/contexts/AuthContext'
 import supabase from '@/lib/supabaseClient'
 import PageWrapper from '@/components/ui/PageWrapper'
 import GlassCard from '@/components/ui/GlassCard'
@@ -10,16 +9,16 @@ import PreviewBanner from '@/components/ui/PreviewBanner'
 
 export default function Login() {
   const navigate = useNavigate()
-  const { session, userData, loading } = useAuth()
   const [pending, setPending] = useState(false)
   const [errorMsg, setErrorMsg] = useState('')
 
   async function handleLogin(e) {
     e.preventDefault()
+    if (pending) return
     const form = e.currentTarget
     const email = form.email?.value?.trim()
     const password = form.password?.value ?? ''
-    console.log('[login] submit', { emailPresent: !!email, passwordPresent: !!password })
+    if (import.meta.env.DEV) console.debug('[login] submit', { emailPresent: !!email, passwordPresent: !!password })
     setErrorMsg('')
     setPending(true)
     if (!email || !password) {
@@ -27,26 +26,29 @@ export default function Login() {
       setPending(false)
       return
     }
-    console.time('[login] signIn')
+    if (import.meta.env.DEV) console.time('[login] signIn')
     const { error } = await supabase.auth.signInWithPassword({ email, password })
-    console.timeEnd('[login] signIn')
+    if (import.meta.env.DEV) console.timeEnd('[login] signIn')
     if (error) {
       console.error('[login] error', error)
       setErrorMsg(error.message || 'Connexion impossible')
       setPending(false)
       return
     }
+    let tries = 0
+    let sess = null
+    while (!sess && tries < 10) {
+      const { data: { session } } = await supabase.auth.getSession()
+      sess = session
+      if (!sess) await new Promise((r) => setTimeout(r, 200))
+      tries++
+    }
     setPending(false)
-    // Ne pas navigate ici: on attend AuthContext (bootstrap + get_my_profile)
-    // L’AuthContext passera loading=false et remplira userData.
-  }
-
-  useEffect(() => {
-    if (!loading && session && userData) {
-      console.info('[login] redirect to /dashboard')
+    if (sess) {
+      if (import.meta.env.DEV) console.debug('[login] navigate to /dashboard')
       navigate('/dashboard', { replace: true })
     }
-  }, [loading, session, userData, navigate])
+  }
 
   return (
     <PageWrapper>

--- a/src/router/PrivateOutlet.jsx
+++ b/src/router/PrivateOutlet.jsx
@@ -1,9 +1,8 @@
 import { Navigate, Outlet } from 'react-router-dom'
 import { useAuth } from '@/contexts/AuthContext'
+
 export default function PrivateOutlet() {
-  const { session, userData, loading } = useAuth()
-  if (loading || (session && !userData)) return null
-  if (!session) return <Navigate to="/login" replace />
-  if (!userData) return <Navigate to="/unauthorized" replace />
+  const { user } = useAuth()
+  if (!user) return <Navigate to="/login" replace />
   return <Outlet />
 }


### PR DESCRIPTION
## Summary
- redirect to dashboard when session active
- await session after login and disable resubmission
- simplify PrivateOutlet user check

## Testing
- `npm test` *(fails: fetch failed / network issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a4af0adc88832d86f6070d45c7f43d