### PR TITLE
feat: restore parametrage sidebar links

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -25,6 +25,10 @@ export default function Sidebar() {
   };
   const canAnalyse = has("analyse");
   const isAdmin = userData?.role === "admin";
+  const canConfigure =
+    rights?.enabledModules?.includes?.("parametrage") ||
+    userData?.can_configurer ||
+    has("parametrage");
 
   if (authLoading || settingsLoading) return null;
 
@@ -121,9 +125,7 @@ export default function Sidebar() {
         {has("notifications") && <Link to="/notifications">Notifications</Link>}
 
         {(isAdmin ||
-          has("familles") ||
-          has("sous_familles") ||
-          has("unites") ||
+          canConfigure ||
           has("parametrage") ||
           has("utilisateurs") ||
           has("roles") ||
@@ -136,13 +138,13 @@ export default function Sidebar() {
               {has("parametrage") && (
                 <Link to="/parametrage/settings">Paramètres</Link>
               )}
-              {has("familles") && (
+              {canConfigure && (
                 <Link to="/parametrage/familles">Familles</Link>
               )}
-              {has("sous_familles") && (
+              {canConfigure && (
                 <Link to="/parametrage/sous-familles">Sous-familles</Link>
               )}
-              {has("unites") && <Link to="/parametrage/unites">Unités</Link>}
+              {canConfigure && <Link to="/parametrage/unites">Unités</Link>}
               {has("utilisateurs") && (
                 <Link to="/parametrage/utilisateurs">Utilisateurs</Link>
               )}

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -7,12 +7,17 @@ import { useAuth } from '@/hooks/useAuth';
 import logo from "@/assets/logo-mamastock.png";
 
 export default function Sidebar() {
-  const { loading, hasAccess } = useAuth();
+  const { loading, hasAccess, userData } = useAuth();
   const { pathname } = useLocation();
 
   if (loading) return null;
+  const rights = userData?.access_rights || {};
   const has = (key) => hasAccess(key);
   const canAnalyse = has("analyse");
+  const canConfigure =
+    rights?.enabledModules?.includes?.("parametrage") ||
+    userData?.can_configurer ||
+    has("parametrage");
 
   return (
     <aside className="w-64 bg-white/10 border border-white/10 backdrop-blur-xl text-white p-4 h-screen shadow-md text-shadow">
@@ -82,10 +87,13 @@ export default function Sidebar() {
 
         {has("notifications") && <Link to="/notifications">Notifications</Link>}
 
-        {(has("parametrage") || has("utilisateurs") || has("roles") || has("mamas") || has("permissions") || has("access")) && (
-          <details open={pathname.startsWith("/parametrage")}> 
+        {(canConfigure || has("utilisateurs") || has("roles") || has("mamas") || has("permissions") || has("access")) && (
+          <details open={pathname.startsWith("/parametrage")}>
             <summary className="cursor-pointer">Paramétrage</summary>
             <div className="ml-4 flex flex-col gap-1 mt-1">
+              {canConfigure && <Link to="/parametrage/familles">Familles</Link>}
+              {canConfigure && <Link to="/parametrage/sous-familles">Sous-familles</Link>}
+              {canConfigure && <Link to="/parametrage/unites">Unités</Link>}
               {has("utilisateurs") && <Link to="/parametrage/utilisateurs">Utilisateurs</Link>}
               {has("roles") && <Link to="/parametrage/roles">Rôles</Link>}
               {has("mamas") && <Link to="/parametrage/mamas">Mamas</Link>}

--- a/test/Sidebar.parametrage.test.jsx
+++ b/test/Sidebar.parametrage.test.jsx
@@ -1,0 +1,58 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { vi } from 'vitest';
+
+const authMock = vi.fn();
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: (...args) => authMock(...args),
+}));
+
+vi.mock('@/hooks/useMamaSettings', () => ({
+  default: () => ({ loading: false, enabledModules: {} }),
+}));
+
+import Sidebar from '@/components/Sidebar.jsx';
+
+describe('Sidebar paramétrage links', () => {
+  beforeEach(() => {
+    authMock.mockReset();
+  });
+
+  function setup({ userData }) {
+    authMock.mockReturnValue({
+      loading: false,
+      userData,
+      hasAccess: (key) => !!userData.access_rights[key],
+    });
+    return render(
+      <MemoryRouter initialEntries={['/']}>
+        <Sidebar />
+        <Routes>
+          <Route path="/" element={<div />} />
+          <Route path="/parametrage/familles" element={<div>Familles Page</div>} />
+          <Route path="/parametrage/sous-familles" element={<div>SousFamilles Page</div>} />
+          <Route path="/parametrage/unites" element={<div>Unites Page</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+  }
+
+  it('affiche les liens quand le module parametrage est activé', async () => {
+    setup({
+      userData: { access_rights: { enabledModules: ['parametrage'], parametrage: true } },
+    });
+    expect(screen.getByText('Familles')).toBeInTheDocument();
+    expect(screen.getByText('Sous-familles')).toBeInTheDocument();
+    expect(screen.getByText('Unités')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Familles'));
+    expect(screen.getByText('Familles Page')).toBeInTheDocument();
+  });
+
+  it('masque les liens quand le module parametrage est absent', () => {
+    setup({ userData: { access_rights: {} } });
+    expect(screen.queryByText('Familles')).toBeNull();
+    expect(screen.queryByText('Sous-familles')).toBeNull();
+    expect(screen.queryByText('Unités')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- ensure configurator rights reveal Familles, Sous-familles and Unités links
- support paramétrage links in admin sidebar
- test sidebar parametrage visibility and navigation

## Testing
- `npm test test/Sidebar.parametrage.test.jsx`

------
https://chatgpt.com/codex/tasks/task_e_68a4af14a980832d91f9e826d904a9bf