### PR TITLE
refactor: wrap app with router before auth

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -38,10 +38,10 @@ if (import.meta?.env?.DEV || process.env.NODE_ENV === 'development') {
 const root = createRoot(document.getElementById("root"));
 root.render(
   <StrictMode>
-    <AuthProvider>
-      <BrowserRouter>
+    <BrowserRouter>
+      <AuthProvider>
         <App />
-      </BrowserRouter>
-    </AuthProvider>
+      </AuthProvider>
+    </BrowserRouter>
   </StrictMode>
 );


### PR DESCRIPTION
## Summary
- move `BrowserRouter` above `AuthProvider` so navigation hooks have router context

## Testing
- `npm test` *(fails: fetch failed ENETUNREACH)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4b55a9038832dbff7d0b75092e5ea