### PR TITLE
feat: add fast product search hook

### DIFF
--- a/src/hooks/useProductSearch.js
+++ b/src/hooks/useProductSearch.js
@@ -1,35 +1,50 @@
-import { useState } from 'react'
-import { useQuery } from '@tanstack/react-query'
-import useSupabaseClient from '@/hooks/useSupabaseClient'
-import useDebounce from './useDebounce'
-import { useMultiMama } from '@/context/MultiMamaContext'
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import useSupabaseClient from '@/hooks/useSupabaseClient';
+import useDebounce from './useDebounce';
+import { useMultiMama } from '@/context/MultiMamaContext';
 
 export default function useProductSearch(initialQuery = '') {
-  const [query, setQuery] = useState(initialQuery)
-  const supabase = useSupabaseClient()
-  const { mamaActif: currentMamaId } = useMultiMama()
+  const [query, setQuery] = useState(initialQuery);
+  const supabase = useSupabaseClient();
+  const { mamaActif: currentMamaId } = useMultiMama();
 
-  const debounced = useDebounce(query.trim(), 300)
+  const debounced = useDebounce(query.trim(), 250);
 
   const fetchProducts = async () => {
-    const { data, error } = await supabase
-      .from('produits')
-      .select('id, nom, stock_reel, pmp, v_produits_dernier_prix (prix)')
-      .ilike('nom', `%${debounced}%`)
-      .eq('mama_id', currentMamaId)
-      .limit(20)
-      .order('nom', { ascending: true })
+    try {
+      const { data, error } = await supabase
+        .from('produits')
+        .select('id, nom, pmp')
+        .ilike('nom', `%${debounced}%`)
+        .eq('mama_id', currentMamaId)
+        .limit(50)
+        .order('nom', { ascending: true });
 
-    if (error) throw error
-    return data ?? []
-  }
+      if (error) {
+        console.error('[useProductSearch] error', error);
+        throw error;
+      }
 
-  const { data: results = [], isLoading, error } = useQuery({
+      return data ?? [];
+    } catch (err) {
+      console.error('[useProductSearch] failed to fetch products', err);
+      throw err;
+    }
+  };
+
+  const {
+    data: results = [],
+    isLoading,
+    error,
+  } = useQuery({
     queryKey: ['product-search', currentMamaId, debounced],
     queryFn: fetchProducts,
     enabled: !!currentMamaId && debounced.length > 0,
-  })
+    staleTime: 0,
+    gcTime: 0,
+  });
 
-  return { query, setQuery, results, isLoading, error }
+  return { query, setQuery, results, isLoading, error };
 }
 


### PR DESCRIPTION
## Summary
- implement debounced product search hook using React Query
- fetch only id, name and pmp with a 50 result limit

## Testing
- `npm test` (fails: supabaseUrl is required)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4d11b5a18832d8c38065687f4acde