### PR TITLE
feat: add debounced product search hook

### DIFF
--- a/src/hooks/useProductSearch.js
+++ b/src/hooks/useProductSearch.js
@@ -1,3 +1,5 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+// src/hooks/useProductSearch.js
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import useSupabaseClient from '@/hooks/useSupabaseClient';
@@ -12,6 +14,7 @@ export default function useProductSearch(initialQuery = '') {
   const debounced = useDebounce(query.trim(), 250);
 
   const fetchProducts = async () => {
+    if (!debounced) return [];
     try {
       const { data, error } = await supabase
         .from('produits')


### PR DESCRIPTION
## Summary
- add debounced product search hook that queries Supabase for id, name, and pmp

## Testing
- `npm test` *(fails: TypeError: fetch failed, ENETUNREACH)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4d3080484832daa5628b01d8ed4c4