### PR TITLE
feat: enhance product picker modal

### DIFF
--- a/src/components/FactureLigne.jsx
+++ b/src/components/FactureLigne.jsx
@@ -6,7 +6,14 @@ import { Button } from '@/components/ui/button'
 
 const parseNum = (v) => parseFloat(String(v).replace(',', '.')) || 0
 
-export default function FactureLigne({ ligne, index, onChange, onRemove, onProduitFocus }) {
+export default function FactureLigne({
+  ligne,
+  index,
+  onChange,
+  onRemove,
+  onProduitFocus,
+  existingProductIds = [],
+}) {
   const [pickerOpen, setPickerOpen] = useState(false)
   const quantiteRef = useRef(null)
 
@@ -55,6 +62,7 @@ export default function FactureLigne({ ligne, index, onChange, onRemove, onProdu
           open={pickerOpen}
           onOpenChange={setPickerOpen}
           onSelect={handleProduitSelection}
+          excludeIds={existingProductIds}
         />
       </div>
       <div className="basis-[15%] min-w-0">

--- a/src/pages/factures/FactureForm.jsx
+++ b/src/pages/factures/FactureForm.jsx
@@ -146,6 +146,9 @@ function FactureFormInner({ defaultValues, fournisseurs, onSaved, onClose }) {
                 index={idx}
                 onChange={(l) => update(idx, l)}
                 onRemove={() => remove(idx)}
+                existingProductIds={lignes
+                  .map((l, i) => (i !== idx ? l.produit_id : null))
+                  .filter(Boolean)}
               />
             ))}
           </div>


### PR DESCRIPTION
## Summary
- overhaul product picker modal with Radix Dialog UI and keyboard-friendly search
- prevent selecting products already on invoice
- clear search input on open and disable browser autofill

## Testing
- `npm test` *(fails: fetch failed, ENETUNREACH)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4dc93dd20832db32e5b0ab9908d0e