### PR TITLE
Add NotFound fallback route

### DIFF
--- a/src/router.jsx
+++ b/src/router.jsx
@@ -125,6 +125,7 @@ const Logout = lazyWithPreload(() => import("@/pages/auth/Logout.jsx"));
 const Stats = lazyWithPreload(() => import("@/pages/stats/Stats.jsx"));
 const Roles = lazyWithPreload(() => import("@/pages/parametrage/Roles.jsx"));
 const PlanningModule = lazyWithPreload(() => import("@/pages/PlanningModule.jsx"));
+const NotFound = lazyWithPreload(() => import("@/pages/NotFound.jsx"));
 
 export const routePreloadMap = {
   '/dashboard': Dashboard.preload,
@@ -629,6 +630,7 @@ export default function Router() {
           />
         </Route>
         </Route>
+        <Route path="*" element={<NotFound />} />
       </Routes>
       </Suspense>
     </ErrorBoundary>


### PR DESCRIPTION
## Summary
- handle unknown paths with a NotFound page

## Testing
- `npm run lint`
- `npm test` *(fails: fetch failed ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68a4de759544832da9671641f852e61c