### PR TITLE
feat: add product picker input

### DIFF
--- a/src/components/FactureLigne.jsx
+++ b/src/components/FactureLigne.jsx
@@ -47,17 +47,28 @@ export default function FactureLigne({
   return (
     <div className="flex min-w-0 items-center gap-2 overflow-x-hidden">
       <div className="basis-[30%] min-w-0">
-        <Button
-          type="button"
-          variant="outline"
-          onClick={() => {
-            setPickerOpen(true)
-            onProduitFocus?.(index)
-          }}
-          className="h-10 w-full min-w-0 justify-start truncate"
-        >
-          {ligne.produit?.nom || 'Choisir...'}
-        </Button>
+        <div className="flex items-center gap-2">
+          <Input
+            readOnly
+            value={ligne.produit?.nom || ''}
+            placeholder="Choisir un produit…"
+            onClick={() => {
+              setPickerOpen(true)
+              onProduitFocus?.(index)
+            }}
+            className="cursor-pointer"
+          />
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => {
+              setPickerOpen(true)
+              onProduitFocus?.(index)
+            }}
+          >
+            Rechercher
+          </Button>
+        </div>
         <ProductPickerModal
           open={pickerOpen}
           onOpenChange={setPickerOpen}


### PR DESCRIPTION
## Summary
- replace product cell button with input and search button that open product picker
- keep line layout from clipping by using overflow hidden

## Testing
- `npm test` *(fails: TypeError: fetch failed: ENETUNREACH)*
- `npm run lint` *(fails: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e1ccdb44832da6e6401b01eba677