### PR TITLE
refactor: update select component

### DIFF
--- a/src/components/ui/select.jsx
+++ b/src/components/ui/select.jsx
@@ -1,23 +1,68 @@
-// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 // src/components/ui/select.jsx
+import * as React from "react";
+import * as SelectPrimitive from "@radix-ui/react-select";
+const cn = (...c) => c.filter(Boolean).join(" ");
 
-export function Select({
-  value,
-  onChange,
-  children,
-  className = "",
-  ariaLabel,
-  ...props
-}) {
-  return (
-    <select
-      value={value}
-      onChange={onChange}
-      aria-label={ariaLabel || "Sélection"}
-      className={`form-select ${className}`}
+export const Select = SelectPrimitive.Root;
+
+export const SelectGroup = SelectPrimitive.Group;
+export const SelectValue = SelectPrimitive.Value; // <= manquait
+export const SelectLabel = SelectPrimitive.Label;
+export const SelectIcon = SelectPrimitive.Icon;
+export const SelectSeparator = SelectPrimitive.Separator;
+
+export const SelectTrigger = React.forwardRef(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "inline-flex w-full items-center justify-between rounded-md border border-border bg-background px-3 py-2 text-sm",
+      "focus:outline-none focus:ring-2 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon className="ml-2 opacity-60">▾</SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+));
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
+
+export const SelectContent = React.forwardRef(({ className, children, position = "popper", ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        "z-50 min-w-[8rem] overflow-hidden rounded-md border border-border bg-popover text-popover-foreground shadow-md",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out",
+        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+        "data-[side=bottom]:slide-in-from-top-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      position={position}
       {...props}
     >
-      {children}
-    </select>
-  );
-}
+      <SelectPrimitive.Viewport className="p-1">
+        {children}
+      </SelectPrimitive.Viewport>
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+));
+SelectContent.displayName = SelectPrimitive.Content.displayName;
+
+export const SelectItem = React.forwardRef(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none",
+      "focus:bg-accent focus:text-accent-foreground",
+      "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute left-2">✓</span>
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+));
+SelectItem.displayName = SelectPrimitive.Item.displayName;


### PR DESCRIPTION
## Summary
- refactor Select component using Radix UI primitives
- add missing SelectValue export
- provide local cn utility when global helper absent

## Testing
- `npm test` *(fails: No "default" export defined on mocked module, useExport is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68a58a43e744832dbcc29d013f1d2c5c