### PR TITLE
feat: restore mapDbLineToUI export

### DIFF
--- a/src/pages/factures/FactureForm.jsx
+++ b/src/pages/factures/FactureForm.jsx
@@ -13,6 +13,76 @@ import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from "@
 
 const today = () => format(new Date(), "yyyy-MM-dd");
 
+/**
+ * mapDbLineToUI
+ * Objectif : convertir une ligne DB (facture_lignes + éventuels champs joints produit/zone)
+ * en forme UI attendue par la ligne du formulaire (sans rien inventer).
+ *
+ * Champs gérés côté UI (d’après tes spécifications) :
+ * - produit_id (sélectionné via popup)
+ * - quantite (éditable)
+ * - uniteLabel (affichée, non éditable)  -> best-effort si join dispo
+ * - prix_total_ht (éditable €)
+ * - prix_unitaire_ht (calcul auto = total / quantite, non éditable)
+ * - pmp (affiché, non éditable)          -> depuis produit si dispo
+ * - tva (en %, chargée du produit si dispo, éditable)
+ * - zone_id (chargée du produit si dispo, éditable)
+ *
+ * La fonction est tolérante : si la ligne ne possède pas montant/prix_unitaire,
+ * on calcule au mieux. Aucune dépendance à des colonnes non présentes.
+ */
+export function mapDbLineToUI(dbLine, produitJoin = null) {
+  const qte = Number(dbLine?.quantite ?? 0);
+
+  // valeurs possibles selon ton schéma (les colonnes montant_ht/prix_unitaire_ht
+  // peuvent exister ou non selon l’état)
+  const puDb = dbLine?.prix_unitaire_ht != null ? Number(dbLine.prix_unitaire_ht) : null;
+  const mtDb = dbLine?.montant_ht != null ? Number(dbLine.montant_ht) : null;
+
+  // si on a le montant HT côté DB, on l’utilise; sinon on dérive
+  const prix_total_ht = mtDb != null
+    ? mtDb
+    : (puDb != null && qte > 0 ? Number((puDb * qte).toFixed(4)) : 0);
+
+  // prix unitaire calculé si possible (sinon retombe sur puDb ou 0)
+  const prix_unitaire_ht = qte > 0
+    ? Number((prix_total_ht / qte).toFixed(6))
+    : Number((puDb ?? 0).toFixed(6));
+
+  // Best-effort pour les infos produit/join (on ne crée rien qui n’existe pas)
+  const produit = produitJoin ?? dbLine?.produit ?? null;
+
+  // PMP et unité sont affichés (non éditables) si fournis par le produit
+  const pmp = produit?.pmp != null ? Number(produit.pmp) : null;
+
+  // pas de colonne "unite" garantie en base : on affiche un label si présent
+  const uniteLabel =
+    produit?.unite_nom ??
+    produit?.unite ??
+    dbLine?.unite ??
+    null;
+
+  // TVA : charge depuis la ligne, ou défaut depuis le produit si dispo
+  const tva = dbLine?.tva != null
+    ? Number(dbLine.tva)
+    : (produit?.tva != null ? Number(produit.tva) : 0);
+
+  // Zone : charge depuis la ligne, sinon depuis le produit si dispo
+  const zone_id = dbLine?.zone_id ?? produit?.zone_id ?? null;
+
+  return {
+    id: dbLine?.id ?? null,
+    produit_id: dbLine?.produit_id ?? null,
+    quantite: qte,
+    uniteLabel,
+    prix_total_ht,
+    prix_unitaire_ht,
+    pmp,
+    tva,
+    zone_id,
+  };
+}
+
 export default function FactureForm() {
   const { profile } = useAuth();
   const mamaId = profile?.mama_id || null;


### PR DESCRIPTION
## Summary
- add mapDbLineToUI helper for converting DB lines to UI-ready format

## Testing
- `npm test` *(fails: TypeError: fetch failed, multiple failing tests)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a590eead40832d9d493638426adf7b