### PR TITLE
feat: improve product picker modal

### DIFF
--- a/src/components/FactureLigne.jsx
+++ b/src/components/FactureLigne.jsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
@@ -6,6 +6,7 @@ import ProductPickerModal from "@/components/forms/ProductPickerModal";
 
 export default function FactureLigne({ value, onChange, onRemove, mamaId, lignes, zones }) {
   const [pickerOpen, setPickerOpen] = useState(false);
+  const produitRef = useRef(null);
 
   const excludeIds = useMemo(
     () => (Array.isArray(lignes) ? lignes.map((l) => l.produit_id).filter(Boolean) : []),
@@ -33,6 +34,7 @@ export default function FactureLigne({ value, onChange, onRemove, mamaId, lignes
       {/* Produit (picker) */}
       <div className="flex items-center gap-2">
         <Input
+          ref={produitRef}
           readOnly
           value={value?.produit_nom || ""}
           placeholder="Choisir un produit…"
@@ -102,7 +104,7 @@ export default function FactureLigne({ value, onChange, onRemove, mamaId, lignes
       {/* Modal de sélection produit */}
       <ProductPickerModal
         open={pickerOpen}
-        onOpenChange={setPickerOpen}
+        onOpenChange={(v) => { setPickerOpen(v); if (!v) produitRef.current?.focus(); }}
         mamaId={mamaId}
         onPick={onPick}
         excludeIds={excludeIds}

--- a/src/components/forms/ProductPickerModal.jsx
+++ b/src/components/forms/ProductPickerModal.jsx
@@ -4,13 +4,21 @@ import { X } from "lucide-react";
 import supabase from "@/lib/supabaseClient";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { useVirtualizer } from "@tanstack/react-virtual";
 
-export default function ProductPickerModal({ open, onOpenChange, mamaId, onPick, excludeIds = [] }) {
+export default function ProductPickerModal({ open, onOpenChange, mamaId, onPick, onSelect, excludeIds = [] }) {
+  const handlePick = onPick || onSelect;
   const [q, setQ] = useState("");
   const [rows, setRows] = useState([]);
   const [active, setActive] = useState(0);
   const inputRef = useRef(null);
   const listRef = useRef(null);
+  const rowVirtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => listRef.current,
+    estimateSize: () => 52,
+    overscan: 10,
+  });
 
   useEffect(() => {
     if (open) setTimeout(() => inputRef.current?.focus(), 10);
@@ -28,7 +36,7 @@ export default function ProductPickerModal({ open, onOpenChange, mamaId, onPick,
       .eq("mama_id", mamaId)
       .ilike("nom", `%${term}%`)
       .order("nom", { ascending: true })
-      .limit(50);
+      .limit(2000);
 
     if (!vErr && Array.isArray(vData)) data = vData;
 
@@ -41,7 +49,7 @@ export default function ProductPickerModal({ open, onOpenChange, mamaId, onPick,
         .eq("actif", true)
         .ilike("nom", `%${term}%`)
         .order("nom", { ascending: true })
-        .limit(50);
+        .limit(2000);
       if (!pErr && Array.isArray(pData)) {
         data = pData.map(p => ({
           ...p,
@@ -65,19 +73,11 @@ export default function ProductPickerModal({ open, onOpenChange, mamaId, onPick,
     const term = (q || "").trim();
     if (!open) return;
     if (!term) { setRows([]); return; }
-    let t = setTimeout(() => search(term), 120);
+    let t = setTimeout(() => search(term), 250);
     return () => clearTimeout(t);
   }, [q, open, mamaId, excludeIds]);
 
-  const scrollTo = (i) => {
-    const c = listRef.current;
-    const el = c?.querySelector(`[data-idx="${i}"]`);
-    if (!c || !el) return;
-    const top = el.offsetTop - c.offsetTop;
-    const bottom = top + el.offsetHeight;
-    if (top < c.scrollTop) c.scrollTop = top;
-    else if (bottom > c.scrollTop + c.clientHeight) c.scrollTop = bottom - c.clientHeight;
-  };
+  const scrollTo = (i) => rowVirtualizer.scrollToIndex(i, { align: "auto" });
 
   const onKey = (e) => {
     if (!rows.length) return;
@@ -85,7 +85,7 @@ export default function ProductPickerModal({ open, onOpenChange, mamaId, onPick,
     else if (e.key === "ArrowUp") { e.preventDefault(); const i = Math.max(active - 1, 0); setActive(i); scrollTo(i); }
     else if (e.key === "Enter" || e.key === "Tab") {
       e.preventDefault();
-      if (rows[active]) { onPick(rows[active]); onOpenChange(false); }
+      if (rows[active]) { handlePick(rows[active]); onOpenChange(false); }
     } else if (e.key === "Escape") onOpenChange(false);
   };
 
@@ -93,7 +93,7 @@ export default function ProductPickerModal({ open, onOpenChange, mamaId, onPick,
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
         {/* Overlay clair, dans le thème */}
-        <Dialog.Overlay className="fixed inset-0 bg-background/45 backdrop-blur-sm" />
+        <Dialog.Overlay className="fixed inset-0 bg-background/40 backdrop-blur-sm" />
         <Dialog.Content className="fixed left-1/2 top-1/2 w-[min(760px,95vw)] max-h-[85vh] -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-border bg-card shadow-2xl overflow-hidden">
           <div className="flex items-center justify-between px-4 py-3 border-b border-border bg-muted/40">
             <Dialog.Title className="text-sm font-semibold">Rechercher un produit</Dialog.Title>
@@ -108,28 +108,50 @@ export default function ProductPickerModal({ open, onOpenChange, mamaId, onPick,
               placeholder="Tapez un nom de produit…"
               onKeyDown={onKey}
               autoComplete="off"
+              autoCorrect="off"
+              autoCapitalize="none"
+              spellCheck={false}
               name="no-autofill"
+              data-lpignore="true"
+              data-form-type="other"
             />
             <div ref={listRef} className="mt-3 max-h-[55vh] overflow-auto rounded-lg border border-border">
               {rows.length === 0 ? (
                 <div className="p-6 text-sm text-muted-foreground">Aucun résultat</div>
-              ) : rows.map((p, i) => (
-                <button
-                  key={p.id}
-                  data-idx={i}
-                  onClick={() => { onPick(p); onOpenChange(false); }}
-                  onMouseEnter={() => setActive(i)}
-                  className={`w-full flex items-center justify-between gap-3 px-4 py-2 text-left ${i === active ? "bg-accent" : "bg-card"} hover:bg-accent transition`}
+              ) : (
+                <div
+                  style={{ height: `${rowVirtualizer.getTotalSize()}px`, position: "relative" }}
                 >
-                  <div className="truncate">
-                    <div className="font-medium truncate">{p.nom}</div>
-                    <div className="text-xs text-muted-foreground">
-                      {p.unite ? `Unité: ${p.unite} • ` : ""}Stock: {Number(p.stock_reel ?? 0)} • PMP: {Number(p.pmp ?? 0).toFixed(2)}{typeof p.tva === "number" ? ` • TVA par défaut: ${p.tva}%` : ""}
-                    </div>
-                  </div>
-                  <span className="text-[11px] text-muted-foreground">Entrée ↵ • Tab ↹</span>
-                </button>
-              ))}
+                  {rowVirtualizer.getVirtualItems().map((vr) => {
+                    const p = rows[vr.index];
+                    return (
+                      <button
+                        key={p.id}
+                        ref={vr.measureElement}
+                        data-idx={vr.index}
+                        onClick={() => { handlePick(p); onOpenChange(false); }}
+                        onMouseEnter={() => setActive(vr.index)}
+                        className={`w-full flex items-center justify-between gap-3 px-4 py-2 text-left ${vr.index === active ? "bg-accent" : "bg-card"} hover:bg-accent transition`}
+                        style={{
+                          position: "absolute",
+                          top: 0,
+                          left: 0,
+                          width: "100%",
+                          transform: `translateY(${vr.start}px)`,
+                        }}
+                      >
+                        <div className="truncate">
+                          <div className="font-medium truncate">{p.nom}</div>
+                          <div className="text-xs text-muted-foreground">
+                            {p.unite ? `Unité: ${p.unite} • ` : ""}Stock: {Number(p.stock_reel ?? 0)} • PMP: {Number(p.pmp ?? 0).toFixed(2)}{typeof p.tva === "number" ? ` • TVA par défaut: ${p.tva}%` : ""}
+                          </div>
+                        </div>
+                        <span className="text-[11px] text-muted-foreground">Entrée ↵ • Tab ↹</span>
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- virtualize product list to render thousands of results smoothly
- restore focus to product field when closing modal

## Testing
- `npm test` *(fails: No "default" export defined on mocked hooks, useExport not a function)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a593b2e4d8832d8990bc1d126e1648