### PR TITLE
feat(sidebar): restore parametrage links with rights

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -32,13 +32,23 @@ export default function Sidebar() {
     if (typeof r === "object") return Object.values(r).some(Boolean);
     return false;
   };
+  const paramKeys = ["familles", "sous_familles", "unites"];
+  const modulesFiltered = paramKeys.some((k) =>
+    Object.prototype.hasOwnProperty.call(modules, normalizeAccessKey(k))
+  );
+  const canParam = (key) =>
+    modulesFiltered ? has(key) && hasParamRight(key) : true;
+  const canFamilles = canParam("familles");
+  const canSousFamilles = canParam("sous_familles");
+  const canUnites = canParam("unites");
   const showParametrage =
-    rights?.menus?.parametrage === true ||
-    hasParamRight("familles") ||
-    hasParamRight("sous_familles") ||
-    hasParamRight("unites") ||
     isAdmin ||
-    import.meta.env.DEV;
+    import.meta.env.DEV ||
+    rights?.menus?.parametrage === true ||
+    !modulesFiltered ||
+    canFamilles ||
+    canSousFamilles ||
+    canUnites;
 
   if (authLoading || settingsLoading) return null;
 
@@ -135,27 +145,39 @@ export default function Sidebar() {
         {has("notifications") && <Link to="/notifications">Notifications</Link>}
 
         {showParametrage && (
-          <details open={pathname.startsWith("/parametrage")}> 
+          <details open={pathname.startsWith("/parametrage")}>
             <summary className="cursor-pointer">Paramétrage</summary>
             <div className="ml-4 flex flex-col gap-1 mt-1">
-              <NavLink
-                to="/parametrage/familles"
-                className={({ isActive }) => (isActive ? "text-mamastockGold" : "")}
-              >
-                Familles
-              </NavLink>
-              <NavLink
-                to="/parametrage/sous-familles"
-                className={({ isActive }) => (isActive ? "text-mamastockGold" : "")}
-              >
-                Sous-familles
-              </NavLink>
-              <NavLink
-                to="/parametrage/unites"
-                className={({ isActive }) => (isActive ? "text-mamastockGold" : "")}
-              >
-                Unités
-              </NavLink>
+              {canFamilles && (
+                <NavLink
+                  to="/parametrage/familles"
+                  className={({ isActive }) =>
+                    isActive ? "text-mamastockGold" : ""
+                  }
+                >
+                  Familles
+                </NavLink>
+              )}
+              {canSousFamilles && (
+                <NavLink
+                  to="/parametrage/sous-familles"
+                  className={({ isActive }) =>
+                    isActive ? "text-mamastockGold" : ""
+                  }
+                >
+                  Sous-familles
+                </NavLink>
+              )}
+              {canUnites && (
+                <NavLink
+                  to="/parametrage/unites"
+                  className={({ isActive }) =>
+                    isActive ? "text-mamastockGold" : ""
+                  }
+                >
+                  Unités
+                </NavLink>
+              )}
             </div>
           </details>
         )}

--- a/test/Sidebar.parametrage.test.jsx
+++ b/test/Sidebar.parametrage.test.jsx
@@ -68,15 +68,32 @@ describe('Sidebar paramétrage links', () => {
     expect(screen.getByText('Unités')).toBeInTheDocument();
   });
 
-  it('masque la section quand aucun droit', () => {
+  it("affiche la section quand aucun droit parametrage n'est défini", () => {
     import.meta.env.DEV = false;
     setup({ userData: { role: 'user', access_rights: {} } });
+    expect(screen.getByText('Paramétrage')).toBeInTheDocument();
+    expect(screen.getByText('Familles')).toBeInTheDocument();
+  });
+
+  it('masque la section quand tous les modules paramétrage sont refusés', () => {
+    import.meta.env.DEV = false;
+    setup({
+      userData: {
+        role: 'user',
+        access_rights: { familles: false, sous_familles: false, unites: false },
+      },
+    });
     expect(screen.queryByText('Paramétrage')).toBeNull();
   });
 
-  it('affiche la section en mode dev sans droits', () => {
+  it('affiche la section en mode dev même si modules refusés', () => {
     import.meta.env.DEV = true;
-    setup({ userData: { role: 'user', access_rights: {} } });
+    setup({
+      userData: {
+        role: 'user',
+        access_rights: { familles: false, sous_familles: false, unites: false },
+      },
+    });
     expect(screen.getByText('Paramétrage')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- restore Paramétrage menu entries (familles, sous-familles, unités) with rights checks and fallback
- test sidebar behavior for parametrage links

## Testing
- `npx vitest run test/Sidebar.parametrage.test.jsx`
- `npx eslint src/components/Sidebar.jsx test/Sidebar.parametrage.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68a593d7d7e4832da6026cb24953798c