### PR TITLE
feat: disable readonly fields in facture line

### DIFF
--- a/src/components/FactureLigne.jsx
+++ b/src/components/FactureLigne.jsx
@@ -55,8 +55,13 @@ export default function FactureLigne({ value, onChange, onRemove, mamaId, lignes
         name="no-autofill"
       />
 
-      {/* Unité (readonly) */}
-      <Input readOnly value={value?.unite || ""} placeholder="Unité" />
+      {/* Unité (readonly, disabled for visual distinction) */}
+      <Input
+        readOnly
+        disabled
+        value={value?.unite || ""}
+        placeholder="Unité"
+      />
 
       {/* Prix total HT (€) editable */}
       <Input
@@ -70,10 +75,20 @@ export default function FactureLigne({ value, onChange, onRemove, mamaId, lignes
       />
 
       {/* Prix unitaire calculé (€) readonly */}
-      <Input readOnly value={Number.isFinite(pu) ? pu.toFixed(4) : ""} placeholder="PU HT (€)" />
+      <Input
+        readOnly
+        disabled
+        value={Number.isFinite(pu) ? pu.toFixed(4) : ""}
+        placeholder="PU HT (€)"
+      />
 
       {/* PMP (readonly) */}
-      <Input readOnly value={Number(value?.pmp ?? 0).toFixed(2)} placeholder="PMP" />
+      <Input
+        readOnly
+        disabled
+        value={Number(value?.pmp ?? 0).toFixed(2)}
+        placeholder="PMP"
+      />
 
       {/* TVA % (prefill; editable) */}
       <Input


### PR DESCRIPTION
## Summary
- visually disable non-editable fields in the invoice line component

## Testing
- `npm test` *(fails: multiple tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68a593a5d5cc832dbac69b1d5596c130