### PR TITLE
fix: guard list props and support Select placeholders

### DIFF
--- a/src/components/FactureLigne.jsx
+++ b/src/components/FactureLigne.jsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
 import ProductPickerModal from "@/components/forms/ProductPickerModal";
 
-export default function FactureLigne({ value, onChange, onRemove, mamaId, lignes, zones }) {
+export default function FactureLigne({ value, onChange, onRemove, mamaId, lignes, zones = [] }) {
   const [pickerOpen, setPickerOpen] = useState(false);
   const produitRef = useRef(null);
 

--- a/src/components/fiches/FicheLigne.jsx
+++ b/src/components/fiches/FicheLigne.jsx
@@ -2,7 +2,7 @@ import { Select } from "@/components/ui/select";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 
-export default function FicheLigne({ ligne, products, ficheOptions, onChange, onRemove }) {
+export default function FicheLigne({ ligne, products = [], ficheOptions = [], onChange, onRemove }) {
   const prod = products.find((p) => p.id === ligne.produit_id);
   const sf = ficheOptions.find((f) => f.id === ligne.sous_fiche_id);
   const prixUnitaire =

--- a/src/components/mouvements/MouvementFormModal.jsx
+++ b/src/components/mouvements/MouvementFormModal.jsx
@@ -14,7 +14,7 @@ export default function MouvementFormModal({
   open,
   onOpenChange,
   onSubmit,
-  produits,
+  produits = [],
   initial = {},
   loading = false,
   editMode = false,

--- a/src/components/ui/controls/index.jsx
+++ b/src/components/ui/controls/index.jsx
@@ -11,13 +11,14 @@ export function Input(props) {
 }
 
 export function Select(props) {
-  const { id, className = "", children, ...rest } = props;
+  const { id, className = "", children, placeholder, ...rest } = props;
   return (
     <select
       id={id}
       className={`block w-full rounded-lg border border-gray-300 px-3 py-2 text-sm outline-none focus:border-gray-900 focus:ring-1 focus:ring-gray-900 ${className}`}
       {...rest}
     >
+      {placeholder !== undefined && <option value="">{placeholder}</option>}
       {children}
     </select>
   );


### PR DESCRIPTION
## Summary
- prevent `.map` errors with default empty arrays in form components
- add placeholder support to base `<Select>` control

## Testing
- `npm test` *(fails: fetch failed and missing mocks)*

------
https://chatgpt.com/codex/tasks/task_e_68a59d1aa114832d8774d085bffc8fd7