### PR TITLE
refactor: centralize product picker modal

### DIFF
--- a/src/components/FactureLigne.jsx
+++ b/src/components/FactureLigne.jsx
@@ -1,49 +1,24 @@
-import { useMemo, useRef, useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
-import ProductPickerModal from "@/components/forms/ProductPickerModal";
 
-export default function FactureLigne({ value, onChange, onRemove, mamaId, lignes, zones }) {
-  const [pickerOpen, setPickerOpen] = useState(false);
-  const produitRef = useRef(null);
-
-  const excludeIds = useMemo(
-    () => (Array.isArray(lignes) ? lignes.map((l) => l.produit_id).filter(Boolean) : []),
-    [lignes]
-  );
-
+export default function FactureLigne({ value, onChange, onRemove, zones, openPicker }) {
   const q   = Number(value?.quantite || 0);
   const lht = Number(value?.prix_total_ht || 0);
   const pu  = q > 0 ? lht / q : 0;
 
   const update = (patch) => onChange({ ...value, ...patch });
-  const onPick = (p) => {
-    update({
-      produit_id: p.id,
-      produit_nom: p.nom,
-      unite: p.unite ?? "",
-      pmp: Number(p.pmp ?? 0),
-      tva: typeof p.tva === "number" ? p.tva : (value?.tva ?? 0),
-      zone_id: p.default_zone_id ?? value?.zone_id ?? "",
-    });
-  };
 
   return (
     <div className="grid grid-cols-[minmax(240px,1.4fr)_minmax(90px,0.6fr)_minmax(120px,0.8fr)_minmax(140px,0.9fr)_minmax(140px,0.9fr)_minmax(120px,0.8fr)_minmax(160px,1fr)_minmax(120px,0.9fr)] gap-3 items-center overflow-x-hidden">
       {/* Produit (picker) */}
       <div className="flex items-center gap-2">
         <Input
-          ref={produitRef}
           readOnly
           value={value?.produit_nom || ""}
-          placeholder="Choisir un produit…"
-          onClick={() => setPickerOpen(true)}
-          autoComplete="off"
-          name="no-autofill"
-          className="cursor-pointer"
+          placeholder="Aucun produit"
         />
-        <Button type="button" variant="outline" onClick={() => setPickerOpen(true)}>Rechercher</Button>
+        <Button type="button" variant="outline" onClick={openPicker}>Choisir un produit</Button>
       </div>
 
       {/* Quantité (editable) */}
@@ -115,15 +90,6 @@ export default function FactureLigne({ value, onChange, onRemove, mamaId, lignes
         </div>
         <Button type="button" variant="ghost" className="text-destructive" onClick={onRemove}>Supprimer</Button>
       </div>
-
-      {/* Modal de sélection produit */}
-      <ProductPickerModal
-        open={pickerOpen}
-        onOpenChange={(v) => { setPickerOpen(v); if (!v) produitRef.current?.focus(); }}
-        mamaId={mamaId}
-        onPick={onPick}
-        excludeIds={excludeIds}
-      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- mount `ProductPickerModal` once at the root of `FactureForm`
- manage modal open state from `FactureForm` and trigger via `openPicker`
- update `FactureLigne` to invoke central modal

## Testing
- `npm test` *(fails: fetch failed / No QueryClient set)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a59cc67158832d914f4a29b4e7a92d