### PR TITLE
feat: avoid duplicate products in invoice picker

### DIFF
--- a/src/components/FactureLigne.jsx
+++ b/src/components/FactureLigne.jsx
@@ -1,17 +1,12 @@
-import { useMemo, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
 import ProductPickerModal from "@/components/forms/ProductPickerModal";
 
-export default function FactureLigne({ value, onChange, onRemove, mamaId, lignes, zones }) {
+export default function FactureLigne({ value, onChange, onRemove, mamaId, zones, excludeIds = [] }) {
   const [pickerOpen, setPickerOpen] = useState(false);
   const produitRef = useRef(null);
-
-  const excludeIds = useMemo(
-    () => (Array.isArray(lignes) ? lignes.map((l) => l.produit_id).filter(Boolean) : []),
-    [lignes]
-  );
 
   const q   = Number(value?.quantite || 0);
   const lht = Number(value?.prix_total_ht || 0);

--- a/src/components/forms/ProductPickerModal.jsx
+++ b/src/components/forms/ProductPickerModal.jsx
@@ -62,8 +62,8 @@ export default function ProductPickerModal({ open, onOpenChange, mamaId, onPick,
 
     // Exclure les produits déjà présents
     if (excludeIds?.length) {
-      const set = new Set(excludeIds);
-      data = data.filter(r => !set.has(r.id));
+      const set = new Set(excludeIds.map(String));
+      data = data.filter((r) => !set.has(String(r.id)));
     }
     setRows(data);
     setActive(0);

--- a/src/pages/factures/FactureForm.jsx
+++ b/src/pages/factures/FactureForm.jsx
@@ -77,6 +77,11 @@ export default function FactureForm() {
   const { fields, append, remove, update } = useFieldArray({ control, name: "lignes" });
   const lignes = watch("lignes");
 
+  const excludeIds = useMemo(
+    () => (Array.isArray(lignes) ? lignes.map((l) => l.produit_id).filter(Boolean) : []),
+    [lignes]
+  );
+
   // Totaux facture (HT = somme des prix_total_ht ; TVA et TTC calculés par ligne)
   const totals = useMemo(() => {
     let ht = 0, tvaSum = 0;
@@ -247,8 +252,8 @@ export default function FactureForm() {
               onChange={(patch) => updateLigne(i, patch)}
               onRemove={() => remove(i)}
               mamaId={mamaId}
-              lignes={lignes}
               zones={zones}
+              excludeIds={excludeIds}
             />
           ))}
         </div>


### PR DESCRIPTION
## Summary
- prevent selecting a product more than once in a new invoice
- ensure product search modal skips excluded ids

## Testing
- `npm test` *(fails: fetch failed errors, missing environment setup)*

------
https://chatgpt.com/codex/tasks/task_e_68a59ca650bc832d8d5c4f096053fcd5