### PR TITLE
Prefill invoice line fields on product selection

### DIFF
--- a/src/components/FactureLigne.jsx
+++ b/src/components/FactureLigne.jsx
@@ -19,14 +19,16 @@ export default function FactureLigne({ value, onChange, onRemove, mamaId, lignes
 
   const update = (patch) => onChange({ ...value, ...patch });
   const onPick = (p) => {
-    update({
+    const ligne = {
+      ...value,
       produit_id: p.id,
       produit_nom: p.nom,
       unite: p.unite ?? "",
       pmp: Number(p.pmp ?? 0),
-      tva: typeof p.tva === "number" ? p.tva : (value?.tva ?? 0),
-      zone_id: p.default_zone_id ?? value?.zone_id ?? "",
-    });
+      tva: typeof p.tva === "number" ? p.tva : 0,
+      zone_id: p.zone_id ?? null,
+    };
+    onChange(ligne);
   };
 
   return (

--- a/src/components/forms/ProductPickerModal.jsx
+++ b/src/components/forms/ProductPickerModal.jsx
@@ -28,11 +28,11 @@ export default function ProductPickerModal({ open, onOpenChange, mamaId, onPick,
   async function search(term) {
     if (!mamaId || !term) { setRows([]); return; }
 
-    // 1/ Essaye la vue enrichie si disponible (unite, tva, default_zone_id)
+    // 1/ Essaye la vue enrichie si disponible (unite, tva, zone_id)
     let data = [];
     let { data: vData, error: vErr } = await supabase
       .from("v_produits_actifs")
-      .select("id, nom, unite, tva, default_zone_id, stock_reel, pmp")
+      .select("id, nom, unite, tva, zone_id, stock_reel, pmp")
       .eq("mama_id", mamaId)
       .ilike("nom", `%${term}%`)
       .order("nom", { ascending: true })
@@ -55,7 +55,7 @@ export default function ProductPickerModal({ open, onOpenChange, mamaId, onPick,
           ...p,
           unite: null,
           tva: null,
-          default_zone_id: null,
+          zone_id: null,
         }));
       }
     }

--- a/src/pages/factures/FactureForm.jsx
+++ b/src/pages/factures/FactureForm.jsx
@@ -34,7 +34,7 @@ export default function FactureForm() {
   });
   const fournisseurs = Array.isArray(fournisseursData) ? fournisseursData : [];
 
-  // Zones (liste globale, préremplie ligne par ligne si default_zone_id arrive du produit)
+  // Zones (liste globale, préremplie ligne par ligne si zone_id arrive du produit)
   const { data: zonesData } = useQuery({
     queryKey: ["zones_stock", mamaId],
     enabled: !!mamaId,


### PR DESCRIPTION
## Summary
- Pre-fill unit, PMP, VAT and zone in invoice lines when a product is picked
- Include zone information in product picker queries

## Testing
- `npm test` *(fails: fetch failed / ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68a59cb04fcc832d9b3e6dd4ce987227