### PR TITLE
fix: drop SelectValue usage

### DIFF
--- a/src/components/FactureLigne.jsx
+++ b/src/components/FactureLigne.jsx
@@ -4,7 +4,6 @@ import { Button } from "@/components/ui/button";
 import {
   Select,
   SelectTrigger,
-  SelectValue,
   SelectContent,
   SelectItem,
 } from "@/components/ui/select";
@@ -126,7 +125,9 @@ export default function FactureLigne({ value, onChange, onRemove, mamaId, lignes
       {/* Zone */}
       <Select value={value?.zone_id || ""} onValueChange={(v) => recalc({ zone_id: v })}>
         <SelectTrigger>
-          <SelectValue placeholder="Zone" />
+          <span className="truncate">
+            {zones.find((z) => z.id === value?.zone_id)?.nom || "Zone"}
+          </span>
         </SelectTrigger>
         <SelectContent align="start" className="max-h-64 overflow-auto">
           <SelectItem value="">-</SelectItem>

--- a/src/components/ui/select.jsx
+++ b/src/components/ui/select.jsx
@@ -6,7 +6,6 @@ const cn = (...c) => c.filter(Boolean).join(" ");
 export const Select = SelectPrimitive.Root;
 
 export const SelectGroup = SelectPrimitive.Group;
-export const SelectValue = SelectPrimitive.Value; // <= manquait
 export const SelectLabel = SelectPrimitive.Label;
 export const SelectIcon = SelectPrimitive.Icon;
 export const SelectSeparator = SelectPrimitive.Separator;

--- a/src/pages/factures/FactureForm.jsx
+++ b/src/pages/factures/FactureForm.jsx
@@ -10,7 +10,7 @@ import { useZones } from "@/hooks/useZones";
 import FactureLigne from "@/components/FactureLigne";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from "@/components/ui/select";
+import { Select, SelectTrigger, SelectContent, SelectItem } from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
 
 const today = () => format(new Date(), "yyyy-MM-dd");
@@ -196,9 +196,17 @@ export default function FactureForm() {
             name="fournisseur_id"
             render={({ field }) => (
               <Select value={field.value ?? ''} onValueChange={v => field.onChange(v)}>
-                <SelectTrigger><SelectValue placeholder="Sélectionner" /></SelectTrigger>
+                <SelectTrigger>
+                  <span className="truncate">
+                    {fournisseurs.find(f => f.id === field.value)?.nom || "Sélectionner"}
+                  </span>
+                </SelectTrigger>
                 <SelectContent align="start" className="max-h-64 overflow-auto">
-                  {fournisseurs.map(f => <SelectItem key={f.id} value={f.id}>{f.nom}</SelectItem>)}
+                  {fournisseurs.map(f => (
+                    <SelectItem key={f.id} value={f.id}>
+                      {f.nom}
+                    </SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
             )}
@@ -225,7 +233,15 @@ export default function FactureForm() {
             name="statut"
             render={({ field }) => (
               <Select value={field.value} onValueChange={field.onChange}>
-                <SelectTrigger><SelectValue placeholder="Statut" /></SelectTrigger>
+                <SelectTrigger>
+                  <span className="truncate">
+                    {field.value === "brouillon"
+                      ? "Brouillon"
+                      : field.value === "valide"
+                        ? "Validée"
+                        : "Statut"}
+                  </span>
+                </SelectTrigger>
                 <SelectContent align="start">
                   <SelectItem value="brouillon">Brouillon</SelectItem>
                   {ecart_ht === 0 && <SelectItem value="valide">Validée</SelectItem>}


### PR DESCRIPTION
## Summary
- remove SelectValue export from select wrapper
- display selected labels manually in facture forms
- show zone name in facture line select

## Testing
- `npm test` *(fails: TypeError fetch failed)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5a0961028832d8f15da1139c95f09