### PR TITLE
feat: improve numeric input UX

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,6 +27,38 @@ export default function App() {
   useEffect(() => {
     nprogress.configure({ showSpinner: false });
   }, []);
+  useEffect(() => {
+    const normalize = (e) => {
+      if (e.target instanceof HTMLInputElement && e.target.type === 'number') {
+        if (e.target.value.includes(',')) {
+          e.target.value = e.target.value.replace(',', '.');
+        }
+      }
+    };
+    const applyAttrs = (el) => {
+      if (el instanceof HTMLInputElement && el.type === 'number') {
+        el.setAttribute('inputmode', 'decimal');
+        el.setAttribute('pattern', '[0-9]*[.,]?[0-9]*');
+      }
+    };
+    document.querySelectorAll('input[type="number"]').forEach(applyAttrs);
+    const observer = new MutationObserver((muts) => {
+      muts.forEach((m) =>
+        m.addedNodes.forEach((node) => {
+          if (node instanceof HTMLElement) {
+            if (node.matches('input[type="number"]')) applyAttrs(node);
+            node.querySelectorAll?.('input[type="number"]').forEach(applyAttrs);
+          }
+        })
+      );
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+    document.addEventListener('change', normalize, true);
+    return () => {
+      document.removeEventListener('change', normalize, true);
+      observer.disconnect();
+    };
+  }, []);
   return (
     <QueryClientProvider client={queryClient}>
       <HelpProvider>

--- a/src/components/FactureLigne.jsx
+++ b/src/components/FactureLigne.jsx
@@ -13,6 +13,7 @@ import ProductPickerModal from "@/components/forms/ProductPickerModal";
 export default function FactureLigne({ value, onChange, onRemove, mamaId, lignes, zones = [] }) {
   const [pickerOpen, setPickerOpen] = useState(false);
   const produitRef = useRef(null);
+  const lineRef = useRef(null);
 
   const excludeIds = useMemo(
     () => (Array.isArray(lignes) ? lignes.map((l) => l.produit_id).filter(Boolean) : []),
@@ -56,7 +57,11 @@ export default function FactureLigne({ value, onChange, onRemove, mamaId, lignes
       : "";
 
   return (
-    <div className="grid gap-3 items-center overflow-x-hidden grid-cols-[minmax(260px,1fr)_90px_110px_140px_140px_110px_110px_180px_60px]">
+    <div
+      ref={lineRef}
+      tabIndex={-1}
+      className="grid gap-3 items-center grid-cols-[repeat(auto-fit,minmax(140px,1fr))] xl:grid-cols-[minmax(260px,1fr)_90px_110px_140px_140px_110px_110px_180px_60px]"
+    >
       {/* Produit (picker) */}
       <div className="flex items-center gap-2">
         <Input
@@ -65,6 +70,10 @@ export default function FactureLigne({ value, onChange, onRemove, mamaId, lignes
           value={value?.produit_nom || ""}
           placeholder="Choisir un produit…"
           onClick={() => setPickerOpen(true)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') { e.preventDefault(); setPickerOpen(true); }
+            else if (e.key === 'Escape') { e.preventDefault(); lineRef.current?.focus(); }
+          }}
           autoComplete="off"
           name="no-autofill"
           className="cursor-pointer"
@@ -79,7 +88,6 @@ export default function FactureLigne({ value, onChange, onRemove, mamaId, lignes
         type="number"
         min="0"
         step="0.01"
-        className="[appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
         value={qte}
         onChange={(e) => recalc({ quantite: e.target.value })}
         placeholder="Qté"
@@ -95,7 +103,6 @@ export default function FactureLigne({ value, onChange, onRemove, mamaId, lignes
         type="number"
         min="0"
         step="0.01"
-        className="[appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
         value={total.toFixed(2)}
         onChange={(e) => recalc({ prix_total_ht: e.target.value })}
         placeholder="Total HT (€)"
@@ -114,7 +121,6 @@ export default function FactureLigne({ value, onChange, onRemove, mamaId, lignes
         type="number"
         min="0"
         step="0.01"
-        className="[appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
         value={tva.toFixed(2)}
         onChange={(e) => recalc({ tva: e.target.value })}
         placeholder="TVA %"
@@ -155,7 +161,7 @@ export default function FactureLigne({ value, onChange, onRemove, mamaId, lignes
         open={pickerOpen}
         onOpenChange={(v) => {
           setPickerOpen(v);
-          if (!v) produitRef.current?.focus();
+          if (!v) lineRef.current?.focus();
         }}
         mamaId={mamaId}
         onPick={onPick}

--- a/src/components/ui/input.jsx
+++ b/src/components/ui/input.jsx
@@ -17,18 +17,25 @@ const Input = React.forwardRef(
     },
     ref
   ) => {
+    const handleChange = (e) => {
+      if (type === 'number') {
+        e.target.value = e.target.value.replace(',', '.');
+      }
+      onChange?.(e);
+    };
     return (
       <input
         ref={ref}
         type={type}
         value={value}
-        onChange={onChange}
+        onChange={handleChange}
         placeholder={placeholder}
         disabled={disabled}
         aria-label={ariaLabel || placeholder || 'Champ de saisie'}
         className={`w-full px-4 py-2 font-semibold text-white placeholder-white/50 bg-white/10 backdrop-blur rounded-md shadow-lg
 border border-white/20 ring-1 ring-white/20 focus:outline-none hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed
  ${className}`}
+        {...(type === 'number' ? { inputMode: 'decimal', pattern: '[0-9]*[.,]?[0-9]*' } : {})}
         {...props}
         id="fld-field-a16p"
       />

--- a/src/globals.css
+++ b/src/globals.css
@@ -309,3 +309,13 @@ html.dark body {
 .sonner-toaster {
   z-index: 9999 !important;
 }
+
+/* Remove spinners from numeric inputs */
+input[type="number"] {
+  appearance: textfield;
+}
+input[type="number"]::-webkit-outer-spin-button,
+input[type="number"]::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}

--- a/src/pages/factures/FactureForm.jsx
+++ b/src/pages/factures/FactureForm.jsx
@@ -288,9 +288,9 @@ export default function FactureForm({ facture = null, onSaved } = {}) {
           <Button type="button" variant="secondary" onClick={addLigne}>+ Ajouter une ligne</Button>
         </div>
 
-        <div className="rounded-xl border border-border bg-card p-3 space-y-4 overflow-x-hidden">
+        <div className="rounded-xl border border-border bg-card p-3 space-y-4 lignes-produits">
           {/* En-têtes colonnes */}
-          <div className="grid grid-cols-[minmax(260px,1fr)_90px_110px_140px_140px_110px_110px_180px_60px] gap-3 text-xs text-muted-foreground px-1">
+          <div className="grid gap-3 text-xs text-muted-foreground px-1 grid-cols-[repeat(auto-fit,minmax(140px,1fr))] xl:grid-cols-[minmax(260px,1fr)_90px_110px_140px_140px_110px_110px_180px_60px]">
             <div>Produit</div>
             <div>Qté</div>
             <div>Unité</div>


### PR DESCRIPTION
## Summary
- hide number input spinners and normalise decimal input across the app
- enable keyboard shortcuts on invoice line product field
- keep invoice line area responsive without horizontal scroll

## Testing
- `npm run lint`
- `npm test` *(fails: useExport is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ba4d03c8832d9c533607beb25140