### PR TITLE
feat: exclude already selected products from picker

### DIFF
--- a/src/components/FactureLigne.jsx
+++ b/src/components/FactureLigne.jsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import {
@@ -10,15 +10,10 @@ import {
 import { Trash2 } from "lucide-react";
 import ProductPickerModal from "@/components/forms/ProductPickerModal";
 
-export default function FactureLigne({ value, onChange, onRemove, mamaId, lignes, zones = [] }) {
+export default function FactureLigne({ value, onChange, onRemove, mamaId, excludeIds = [], zones = [] }) {
   const [pickerOpen, setPickerOpen] = useState(false);
   const produitRef = useRef(null);
   const lineRef = useRef(null);
-
-  const excludeIds = useMemo(
-    () => (Array.isArray(lignes) ? lignes.map((l) => l.produit_id).filter(Boolean) : []),
-    [lignes]
-  );
 
   const qte = Number(value?.quantite || 0);
   const total = Number(value?.prix_total_ht || 0);

--- a/src/pages/factures/FactureForm.jsx
+++ b/src/pages/factures/FactureForm.jsx
@@ -93,6 +93,10 @@ export default function FactureForm({ facture = null, onSaved } = {}) {
   const lignes = watch('lignes');
   const totalHTAttendu = watch('total_ht_attendu');
   const statut = watch('statut');
+  const excludeIds = useMemo(
+    () => (lignes || []).map((l) => l.produit_id).filter(Boolean),
+    [lignes]
+  );
 
   const sommeLignesHT = useMemo(() => {
     let sum = 0;
@@ -377,7 +381,7 @@ export default function FactureForm({ facture = null, onSaved } = {}) {
               onChange={(patch) => updateLigne(i, patch)}
               onRemove={() => remove(i)}
               mamaId={mamaId}
-              lignes={lignes}
+              excludeIds={excludeIds}
               zones={zones}
             />
           ))}


### PR DESCRIPTION
## Summary
- prevent duplicate product selection by passing `excludeIds` from invoice form to product picker
- product picker filters out already selected products

## Testing
- `npm test` *(fails: fetch failed ENETUNREACH, missing mocks, etc.)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5be68dbf8832d875c0b2fa07e8247