### PR TITLE
Autofill invoice line with selected product details

### DIFF
--- a/src/components/FactureLigne.jsx
+++ b/src/components/FactureLigne.jsx
@@ -41,8 +41,8 @@ export default function FactureLigne({ value, onChange, onRemove, mamaId, exclud
       produit_nom: p.nom,
       unite: p.unite ?? "",
       pmp: Number(p.pmp ?? 0),
-      tva: typeof p.tva === "number" ? p.tva : tva,
-      zone_id: p.default_zone_id ?? value?.zone_id ?? "",
+      tva: typeof p.tva === "number" ? p.tva : 0,
+      zone_id: p.zone_id ?? null,
     });
   };
 

--- a/src/components/forms/ProductPickerModal.jsx
+++ b/src/components/forms/ProductPickerModal.jsx
@@ -29,11 +29,11 @@ export default function ProductPickerModal({ open, onOpenChange, mamaId, onPick,
   async function search(term) {
     if (!mamaId || !term) { setRows([]); return; }
 
-    // 1/ Essaye la vue enrichie si disponible (unite, tva, default_zone_id)
+    // 1/ Essaye la vue enrichie si disponible (unite, tva, zone_id)
     let data = [];
     let { data: vData, error: vErr } = await supabase
       .from("v_produits_actifs")
-      .select("id, nom, unite, tva, default_zone_id, stock_reel, pmp")
+      .select("id, nom, unite, tva, zone_id, stock_reel, pmp")
       .eq("mama_id", mamaId)
       .ilike("nom", `%${term}%`)
       .order("nom", { ascending: true })
@@ -56,7 +56,7 @@ export default function ProductPickerModal({ open, onOpenChange, mamaId, onPick,
           ...p,
           unite: null,
           tva: null,
-          default_zone_id: null,
+          zone_id: null,
         }));
       }
     }
@@ -94,7 +94,7 @@ export default function ProductPickerModal({ open, onOpenChange, mamaId, onPick,
           unite: p.unite,
           pmp: p.pmp,
           tva: p.tva,
-          zone_id: p.default_zone_id,
+          zone_id: p.zone_id,
         });
         onOpenChange(false);
       }
@@ -149,7 +149,7 @@ export default function ProductPickerModal({ open, onOpenChange, mamaId, onPick,
                             unite: p.unite,
                             pmp: p.pmp,
                             tva: p.tva,
-                            zone_id: p.default_zone_id,
+                            zone_id: p.zone_id,
                           });
                           onOpenChange(false);
                         }}

--- a/src/pages/factures/FactureForm.jsx
+++ b/src/pages/factures/FactureForm.jsx
@@ -44,7 +44,7 @@ export default function FactureForm({ facture = null, onSaved } = {}) {
     ? fournisseursData
     : (fournisseursData?.data ?? []);
 
-  // Zones (liste globale, préremplie ligne par ligne si default_zone_id arrive du produit)
+// Zones (liste globale, préremplie ligne par ligne si zone_id arrive du produit)
   const { zones, fetchZones } = useZones();
   useEffect(() => {
     fetchZones();


### PR DESCRIPTION
## Summary
- auto-populate invoice lines with product unit, PMP, default TVA (0 if missing), and zone
- query and return `zone_id` from product picker instead of `default_zone_id`
- update comments accordingly

## Testing
- `npm test` *(fails: ENETUNREACH)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5bfa0775c832d9c3ecd7f1948ea7f