### PR TITLE
fix: export SelectValue and harden Select component

### DIFF
--- a/src/components/ui/select.jsx
+++ b/src/components/ui/select.jsx
@@ -1,67 +1,135 @@
 // src/components/ui/select.jsx
 import * as React from "react";
 import * as SelectPrimitive from "@radix-ui/react-select";
-const cn = (...c) => c.filter(Boolean).join(" ");
+import { Check, ChevronDown, ChevronUp } from "lucide-react";
+
+// Remplace ce helper par ton utilitaire de classes si besoin.
+// Si tu as déjà un utilitaire "cn" dans "@/lib/utils", importe-le et utilise-le.
+// Sinon, garde cette version minimale.
+function cn(...classes) {
+  return classes.filter(Boolean).join(" ");
+}
 
 export const Select = SelectPrimitive.Root;
-
 export const SelectGroup = SelectPrimitive.Group;
-export const SelectLabel = SelectPrimitive.Label;
-export const SelectIcon = SelectPrimitive.Icon;
-export const SelectSeparator = SelectPrimitive.Separator;
+export const SelectValue = SelectPrimitive.Value;
 
-export const SelectTrigger = React.forwardRef(({ className, children, ...props }, ref) => (
-  <SelectPrimitive.Trigger
-    ref={ref}
-    className={cn(
-      "inline-flex w-full items-center justify-between rounded-md border border-border bg-background px-3 py-2 text-sm",
-      "focus:outline-none focus:ring-2 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
-      className
-    )}
-    {...props}
-  >
-    {children}
-    <SelectPrimitive.Icon className="ml-2 opacity-60">▾</SelectPrimitive.Icon>
-  </SelectPrimitive.Trigger>
-));
-SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
-
-export const SelectContent = React.forwardRef(({ className, children, position = "popper", ...props }, ref) => (
-  <SelectPrimitive.Portal>
-    <SelectPrimitive.Content
+export const SelectTrigger = React.forwardRef(
+  ({ className, children, ...props }, ref) => (
+    <SelectPrimitive.Trigger
       ref={ref}
       className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-md border border-border bg-popover text-popover-foreground shadow-md",
-        "data-[state=open]:animate-in data-[state=closed]:animate-out",
-        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
-        "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
-        "data-[side=bottom]:slide-in-from-top-2 data-[side=top]:slide-in-from-bottom-2",
+        "flex h-10 w-full items-center justify-between rounded-md border bg-background px-3 py-2 text-sm shadow-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
-      position={position}
       {...props}
     >
-      <SelectPrimitive.Viewport className="p-1">
-        {children}
-      </SelectPrimitive.Viewport>
-    </SelectPrimitive.Content>
-  </SelectPrimitive.Portal>
-));
+      {children ?? <SelectValue />}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDown className="h-4 w-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  )
+);
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
+
+export const SelectScrollUpButton = React.forwardRef(
+  ({ className, ...props }, ref) => (
+    <SelectPrimitive.ScrollUpButton
+      ref={ref}
+      className={cn("flex cursor-default items-center justify-center py-1", className)}
+      {...props}
+    >
+      <ChevronUp className="h-4 w-4" />
+    </SelectPrimitive.ScrollUpButton>
+  )
+);
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
+
+export const SelectScrollDownButton = React.forwardRef(
+  ({ className, ...props }, ref) => (
+    <SelectPrimitive.ScrollDownButton
+      ref={ref}
+      className={cn("flex cursor-default items-center justify-center py-1", className)}
+      {...props}
+    >
+      <ChevronDown className="h-4 w-4" />
+    </SelectPrimitive.ScrollDownButton>
+  )
+);
+SelectScrollDownButton.displayName = SelectPrimitive.ScrollDownButton.displayName;
+
+export const SelectContent = React.forwardRef(
+  ({ className, children, position = "popper", ...props }, ref) => (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        ref={ref}
+        className={cn(
+          "relative z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md",
+          position === "popper" ? "translate-y-1" : "",
+          className
+        )}
+        position={position}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport className="p-1">
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  )
+);
 SelectContent.displayName = SelectPrimitive.Content.displayName;
 
-export const SelectItem = React.forwardRef(({ className, children, ...props }, ref) => (
-  <SelectPrimitive.Item
+export const SelectLabel = React.forwardRef(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label
     ref={ref}
-    className={cn(
-      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none",
-      "focus:bg-accent focus:text-accent-foreground",
-      "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-      className
-    )}
+    className={cn("px-2 py-1.5 text-sm font-semibold", className)}
     {...props}
-  >
-    <span className="absolute left-2">✓</span>
-    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
-  </SelectPrimitive.Item>
+  />
 ));
+SelectLabel.displayName = SelectPrimitive.Label.displayName;
+
+export const SelectItem = React.forwardRef(
+  ({ className, children, ...props }, ref) => {
+    // Interdiction de value vide : Radix lève une erreur si value === ""
+    if (props && typeof props.value === "string" && props.value.trim() === "") {
+      // Force un value non vide, ou retourne null pour ne pas rendre un item invalide.
+      return null;
+    }
+    return (
+      <SelectPrimitive.Item
+        ref={ref}
+        className={cn(
+          "relative flex w-full cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none",
+          "focus:bg-accent focus:text-accent-foreground",
+          "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+          className
+        )}
+        {...props}
+      >
+        <span className="mr-2 h-4 w-4">
+          <SelectPrimitive.ItemIndicator>
+            <Check className="h-4 w-4" />
+          </SelectPrimitive.ItemIndicator>
+        </span>
+        <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+      </SelectPrimitive.Item>
+    );
+  }
+);
 SelectItem.displayName = SelectPrimitive.Item.displayName;
+
+export const SelectSeparator = React.forwardRef(
+  ({ className, ...props }, ref) => (
+    <SelectPrimitive.Separator
+      ref={ref}
+      className={cn("my-1 h-px bg-muted", className)}
+      {...props}
+    />
+  )
+);
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
+

--- a/src/pages/factures/FactureForm.jsx
+++ b/src/pages/factures/FactureForm.jsx
@@ -323,7 +323,7 @@ export default function FactureForm({ facture = null, onSaved } = {}) {
             render={({ field }) => (
               <Select value={field.value} onValueChange={field.onChange}>
                 <SelectTrigger>
-                  <span className="truncate">{field.value || 'Statut'}</span>
+                  <SelectValue placeholder="Statut" />
                 </SelectTrigger>
                 <SelectContent align="start">
                   <SelectItem value="Brouillon">Brouillon</SelectItem>


### PR DESCRIPTION
## Summary
- expose `SelectValue` and extra Radix helpers in Select component
- guard against empty `SelectItem` values
- use `<SelectValue>` placeholder for invoice status field

## Testing
- `npm test test/useInvoices.test.js` *(fails: expected "spy" to be called with arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d48dad28832d8bfaf3d9af11a7f3