### PR TITLE
fix: refine invoice product search

### DIFF
--- a/src/components/FactureLigne.jsx
+++ b/src/components/FactureLigne.jsx
@@ -73,7 +73,12 @@ export default function FactureLigne({ value: line, onChange, onRemove, allLines
       ? n.toLocaleString("fr-FR", { minimumFractionDigits: 4, maximumFractionDigits: 4 })
       : "";
 
-  const excludeIds = allLines.filter((l) => l.produit_id).map((l) => `'${l.produit_id}'`);
+  const excludeIdsSameZone = allLines
+    .filter(
+      (l) =>
+        l.id !== line.id && (l.zone_id ?? null) === (line.zone_id ?? null) && !!l.produit_id
+    )
+    .map((l) => l.produit_id);
 
   const TVA_OPTIONS = [0, 5.5, 10, 20];
 
@@ -98,7 +103,6 @@ export default function FactureLigne({ value: line, onChange, onRemove, allLines
       <ProductPickerModal
         open={modalOpen}
         onOpenChange={setModalOpen}
-        excludeIds={excludeIds}
         onSelect={(p) => {
           recalc({
             produit_id: p.id,
@@ -109,6 +113,8 @@ export default function FactureLigne({ value: line, onChange, onRemove, allLines
           });
           setModalOpen(false);
         }}
+        excludeIdsSameZone={excludeIdsSameZone}
+        currentLineProductId={line.produit_id}
       />
       <Input
         type="number"


### PR DESCRIPTION
## Summary
- query produits by name only with new hook
- filter products already used in the same zone
- allow editing current product even if excluded

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a611b3f814832d8250f2fafa690622