### PR TITLE
Fix supplier and product selections in invoice form

### DIFF
--- a/src/hooks/useFournisseurs.js
+++ b/src/hooks/useFournisseurs.js
@@ -32,6 +32,7 @@ export function useFournisseurs() {
     }
     if (error) toast.error(error.message);
     queryClient.invalidateQueries({ queryKey: ['fournisseurs', mama_id] });
+    queryClient.invalidateQueries({ queryKey: ['fournisseurs-autocomplete', mama_id] });
     return { data, error };
   }
 
@@ -54,6 +55,7 @@ export function useFournisseurs() {
     }
     if (error) toast.error(error.message);
     queryClient.invalidateQueries({ queryKey: ['fournisseurs', mama_id] });
+    queryClient.invalidateQueries({ queryKey: ['fournisseurs-autocomplete', mama_id] });
     return { error };
   }
 
@@ -67,6 +69,7 @@ export function useFournisseurs() {
       .eq('mama_id', mama_id);
     if (error) toast.error(error.message);
     queryClient.invalidateQueries({ queryKey: ['fournisseurs', mama_id] });
+    queryClient.invalidateQueries({ queryKey: ['fournisseurs-autocomplete', mama_id] });
     return { error };
   }
 

--- a/src/hooks/useProductSearch.js
+++ b/src/hooks/useProductSearch.js
@@ -11,14 +11,22 @@ export function useProductSearch(q) {
     queryFn: async () => {
       const { data, error } = await supabase
         .from("produits")
-        .select("id, nom, pmp")              // ne pas ajouter de colonnes non existantes
+        .select(
+          "id, nom, pmp, tva, unite_id, unite:unite_id(nom)"
+        )
         .eq("mama_id", currentMamaId)
         .eq("actif", true)
-        .ilike("nom", `%${q}%`)              // ILIKE sur produits.nom UNIQUEMENT
+        .ilike("nom", `%${q}%`)
         .order("nom", { ascending: true })
         .limit(50);
       if (error) throw error;
-      return data ?? [];
+      return (data ?? []).map((p) => ({
+        id: p.id,
+        nom: p.nom,
+        pmp: p.pmp,
+        tva: p.tva,
+        unite: p.unite?.nom || "",
+      }));
     },
   });
 }

--- a/src/hooks/useProducts.js
+++ b/src/hooks/useProducts.js
@@ -7,9 +7,11 @@ import * as XLSX from "xlsx";
 import { safeImportXLSX } from "@/lib/xlsx/safeImportXLSX";
 import { saveAs } from "file-saver";
 import { toast } from 'sonner';
+import { useQueryClient } from '@tanstack/react-query';
 
 export function useProducts() {
   const { mama_id } = useAuth();
+  const queryClient = useQueryClient();
   const [products, setProducts] = useState([]);
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(false);
@@ -116,6 +118,7 @@ export function useProducts() {
       toast.error(error.message);
     }
     if (refresh) await fetchProducts();
+    queryClient.invalidateQueries({ queryKey: ['product-search', mama_id] });
   }
 
   async function updateProduct(id, updateFields, { refresh = true } = {}) {
@@ -138,6 +141,7 @@ export function useProducts() {
       toast.error(error.message);
     }
     if (refresh) await fetchProducts();
+    queryClient.invalidateQueries({ queryKey: ['product-search', mama_id] });
   }
 
   async function toggleProductActive(id, actif, { refresh = true } = {}) {
@@ -155,6 +159,7 @@ export function useProducts() {
       toast.error(error.message);
     }
     if (refresh) await fetchProducts();
+    queryClient.invalidateQueries({ queryKey: ['product-search', mama_id] });
   }
 
   async function deleteProduct(id, { refresh = true } = {}) {
@@ -172,6 +177,7 @@ export function useProducts() {
       toast.error(error.message);
     }
     if (refresh) await fetchProducts();
+    queryClient.invalidateQueries({ queryKey: ['product-search', mama_id] });
   }
 
   const fetchProductPrices = useCallback(async (productId) => {


### PR DESCRIPTION
## Summary
- Refresh suppliers in invoice form by invalidating autocomplete cache after edits
- Refresh product search cache after product changes
- Include unit and VAT details in product search results

## Testing
- `npm run lint`
- `npm test` *(fails: fetch failed, No QueryClient set)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d3330558832db6636814f446e705