### PR TITLE
feat: enable duplicate products in picker and new search hook

### DIFF
--- a/src/hooks/useProductSearch.js
+++ b/src/hooks/useProductSearch.js
@@ -2,32 +2,28 @@ import { supabase } from "@/lib/supabaseClient";
 import { useQuery } from "@tanstack/react-query";
 import { useMultiMama } from "@/context/MultiMamaContext";
 
-export function useProductSearch(q) {
+export async function searchProductsBasic(mamaId, q) {
+  let query = supabase
+    .from("produits")
+    .select("id, nom, pmp")
+    .eq("mama_id", mamaId)
+    .eq("actif", true)
+    .order("nom", { ascending: true })
+    .limit(50);
+  if (q?.trim()) {
+    query = query.ilike("nom", `%${q}%`);
+  }
+  const { data, error } = await query;
+  if (error) throw error;
+  return data ?? [];
+}
+
+export default function useProductSearch(q) {
   const { currentMamaId } = useMultiMama();
 
   return useQuery({
     queryKey: ["product-search", currentMamaId, q],
-    enabled: !!currentMamaId && (q?.trim()?.length ?? 0) > 0,
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from("produits")
-        .select(
-          "id, nom, pmp, tva, unite_id, unite:unite_id(nom)"
-        )
-        .eq("mama_id", currentMamaId)
-        .eq("actif", true)
-        .ilike("nom", `%${q}%`)
-        .order("nom", { ascending: true })
-        .limit(50);
-      if (error) throw error;
-      return (data ?? []).map((p) => ({
-        id: p.id,
-        nom: p.nom,
-        pmp: p.pmp,
-        tva: p.tva,
-        unite: p.unite?.nom || "",
-      }));
-    },
+    enabled: !!currentMamaId,
+    queryFn: () => searchProductsBasic(currentMamaId, q),
   });
 }
-


### PR DESCRIPTION
## Summary
- add `useProductSearch` hook backed by Supabase `produits`
- wire `ProductPickerModal` to new hook and keep duplicates
- improve search input accessibility and disable browser autocomplete

## Testing
- `npm test` *(fails: fetch failed, missing QueryClient, etc.)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6d5f9b460832d9d67c29b8452b918