### PR TITLE
feat: add supplier picker with search modal

### DIFF
--- a/src/components/factures/SupplierBrowserModal.jsx
+++ b/src/components/factures/SupplierBrowserModal.jsx
@@ -1,0 +1,134 @@
+import { useState, useEffect } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import { X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import useFournisseursBrowse from '@/hooks/useFournisseursBrowse';
+
+export default function SupplierBrowserModal({ open, onClose, onSelect }) {
+  const [query, setQuery] = useState('');
+  const [page, setPage] = useState(1);
+  const pageSize = 20;
+  const { data: results = [], total } = useFournisseursBrowse({
+    page,
+    limit: pageSize,
+    term: query,
+  });
+  const [active, setActive] = useState(-1);
+
+  useEffect(() => {
+    if (!open) {
+      setQuery('');
+      setActive(-1);
+      setPage(1);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    setActive(-1);
+    setPage(1);
+  }, [query]);
+  useEffect(() => {
+    setActive(-1);
+  }, [results]);
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setActive((a) => Math.min(a + 1, results.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActive((a) => Math.max(a - 1, 0));
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      const target = active >= 0 ? results[active] : results[0];
+      if (target) {
+        onSelect?.(target);
+        onClose?.();
+      }
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      onClose?.();
+    }
+  };
+
+  return (
+    <Dialog.Root open={open} onOpenChange={(v) => !v && onClose?.()}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-[#0B1220]/60 backdrop-blur-sm" />
+        <Dialog.Content
+          className="fixed left-1/2 top-1/2 z-50 w-[min(600px,95vw)] max-h-[70vh] -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-border bg-card shadow-2xl flex flex-col overflow-hidden"
+        >
+          <div className="flex items-center justify-between px-4 py-3 border-b border-border bg-muted/40">
+            <Dialog.Title className="text-sm font-semibold">Rechercher un fournisseur</Dialog.Title>
+            <Dialog.Close asChild>
+              <button className="p-2 rounded-md hover:bg-muted">
+                <X size={18} />
+              </button>
+            </Dialog.Close>
+          </div>
+          <div className="p-4 space-y-4 flex-1 overflow-y-auto">
+            <input
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="Rechercher un fournisseur…"
+              autoComplete="off"
+              autoCorrect="off"
+              autoCapitalize="none"
+              spellCheck={false}
+              className="w-full px-4 py-2 font-semibold text-white placeholder-white/50 bg-white/10 backdrop-blur rounded-md shadow-lg border border-white/20 ring-1 ring-white/20 focus:outline-none hover:bg-white/10"
+            />
+            <div className="border border-border rounded-lg max-h-60 overflow-y-auto">
+              {results.length === 0 ? (
+                <div className="p-4 text-sm text-muted-foreground">Aucun résultat</div>
+              ) : (
+                results.map((f, idx) => (
+                  <button
+                    key={f.id}
+                    type="button"
+                    onClick={() => {
+                      onSelect?.(f);
+                      onClose?.();
+                    }}
+                    className={`w-full text-left px-3 py-2 hover:bg-white/5 rounded ${idx === active ? 'bg-white/10' : ''}`}
+                  >
+                    {f.nom}
+                  </button>
+                ))
+              )}
+            </div>
+            <div className="flex justify-between items-center pt-2">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page === 1}
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+              >
+                Préc.
+              </Button>
+              <span className="text-xs text-muted-foreground">
+                {Math.min((page - 1) * pageSize + 1, total)}-
+                {Math.min(page * pageSize, total)} / {total}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page * pageSize >= total}
+                onClick={() => setPage((p) => p + 1)}
+              >
+                Suiv.
+              </Button>
+            </div>
+          </div>
+          <div className="px-4 py-3 border-t border-border bg-muted/40 flex justify-end">
+            <Button variant="secondary" onClick={() => onClose?.()}>
+              Fermer
+            </Button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+

--- a/src/components/factures/SupplierPicker.jsx
+++ b/src/components/factures/SupplierPicker.jsx
@@ -1,0 +1,146 @@
+import { useEffect, useRef, useState } from 'react';
+import { Input } from '@/components/ui/input';
+import useDebounce from '@/hooks/useDebounce';
+import supabase from '@/lib/supabaseClient';
+import { useAuth } from '@/hooks/useAuth';
+import { useFournisseursAutocomplete } from '@/hooks/useFournisseursAutocomplete';
+import useFournisseursRecents from '@/hooks/useFournisseursRecents';
+import SupplierBrowserModal from './SupplierBrowserModal';
+
+export default function SupplierPicker({ value, onChange, error }) {
+  const { mama_id } = useAuth();
+  const [inputValue, setInputValue] = useState('');
+  const [search, setSearch] = useState('');
+  const [open, setOpen] = useState(false);
+  const [active, setActive] = useState(-1);
+  const [modalOpen, setModalOpen] = useState(false);
+  const inputRef = useRef(null);
+
+  const debounced = useDebounce(search, 250);
+  const { options: autoOptions = [] } = useFournisseursAutocomplete({ term: debounced });
+  const { data: recents = [] } = useFournisseursRecents();
+
+  const options = search.trim() ? autoOptions : recents;
+
+  useEffect(() => {
+    setActive(-1);
+  }, [options]);
+
+  useEffect(() => {
+    if (!value) {
+      setInputValue('');
+      return;
+    }
+    let cancelled = false;
+    const fetch = async () => {
+      const { data } = await supabase
+        .from('fournisseurs')
+        .select('id, nom')
+        .eq('mama_id', mama_id)
+        .eq('id', value)
+        .single();
+      if (!cancelled) setInputValue(data?.nom || '');
+    };
+    fetch();
+    return () => {
+      cancelled = true;
+    };
+  }, [value, mama_id]);
+
+  const handleInput = (e) => {
+    const val = e.target.value;
+    setInputValue(val);
+    setSearch(val);
+    setOpen(true);
+  };
+
+  const select = (f) => {
+    setInputValue(f.nom);
+    setSearch('');
+    setOpen(false);
+    onChange?.(f.id);
+  };
+
+  const handleKey = (e) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setOpen(true);
+      setActive((i) => Math.min(i + 1, options.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActive((i) => Math.max(i - 1, 0));
+    } else if (e.key === 'Enter') {
+      if (open && active >= 0) {
+        e.preventDefault();
+        select(options[active]);
+      }
+    } else if (e.key === 'Escape') {
+      setOpen(false);
+    } else if (e.key === 'F2') {
+      e.preventDefault();
+      setModalOpen(true);
+    }
+  };
+
+  const handleBlur = () => {
+    setTimeout(() => {
+      setOpen(false);
+      setActive(-1);
+    }, 100);
+    if (!value || inputValue.trim() === '') {
+      setInputValue('');
+      setSearch('');
+      onChange?.(null);
+    }
+  };
+
+  return (
+    <div className="relative">
+      <Input
+        ref={inputRef}
+        value={inputValue}
+        onChange={handleInput}
+        onKeyDown={handleKey}
+        onBlur={handleBlur}
+        placeholder="Rechercher un fournisseur"
+        className={`${error ? 'border-destructive' : ''}`}
+        aria-invalid={error ? 'true' : 'false'}
+      />
+      <button
+        type="button"
+        aria-label="Sélecteur de fournisseurs"
+        className="absolute right-1 top-1/2 -translate-y-1/2 p-1"
+        onClick={() => setModalOpen(true)}
+      >
+        🔍
+      </button>
+      {open && options.length > 0 && (
+        <ul className="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md border border-white/20 bg-neutral-800 text-white">
+          {options.map((opt, idx) => (
+            <li
+              key={opt.id}
+              role="option"
+              aria-selected={idx === active}
+              className={`px-2 py-1 cursor-pointer ${idx === active ? 'bg-white/20' : ''}`}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                select(opt);
+              }}
+            >
+              {opt.nom}
+            </li>
+          ))}
+        </ul>
+      )}
+      <SupplierBrowserModal
+        open={modalOpen}
+        onClose={() => setModalOpen(false)}
+        onSelect={(f) => {
+          select(f);
+          setModalOpen(false);
+        }}
+      />
+    </div>
+  );
+}
+

--- a/src/hooks/useFournisseursAutocomplete.js
+++ b/src/hooks/useFournisseursAutocomplete.js
@@ -17,6 +17,12 @@ export function useFournisseursAutocomplete({ term = '', limit = 20 } = {}) {
   useEffect(() => {
     if (!mama_id) return;
     let aborted = false;
+    const s = search.trim();
+    if (s === '') {
+      setOptions([]);
+      setLoading(false);
+      return;
+    }
     const run = async () => {
       setLoading(true);
       setError(null);
@@ -27,8 +33,8 @@ export function useFournisseursAutocomplete({ term = '', limit = 20 } = {}) {
           .eq('mama_id', mama_id)
           .eq('actif', true)
           .order('nom', { ascending: true })
-          .limit(limit);
-        if (search.trim()) req = req.ilike('nom', `%${search.trim()}%`);
+          .limit(limit)
+          .ilike('nom', `%${s}%`);
         const { data, error } = await req;
         if (error) throw error;
         if (!aborted) setOptions(data || []);

--- a/src/hooks/useFournisseursBrowse.js
+++ b/src/hooks/useFournisseursBrowse.js
@@ -1,0 +1,66 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { useEffect, useState } from 'react';
+import supabase from '@/lib/supabaseClient';
+import { useAuth } from '@/hooks/useAuth';
+
+export default function useFournisseursBrowse({
+  page = 1,
+  limit = 20,
+  term = '',
+  filters = {},
+} = {}) {
+  const { mama_id } = useAuth();
+  const [data, setData] = useState([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!mama_id) return;
+    let aborted = false;
+    const run = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        let req = supabase
+          .from('fournisseurs')
+          .select('id, nom, ville', { count: 'exact' })
+          .eq('mama_id', mama_id)
+          .eq('actif', true);
+        const t = term.trim();
+        if (t) req = req.ilike('nom', `%${t}%`);
+        Object.entries(filters || {}).forEach(([k, v]) => {
+          if (v !== undefined && v !== null && v !== '') {
+            req = req.eq(k, v);
+          }
+        });
+        const start = (page - 1) * limit;
+        const end = start + limit - 1;
+        const { data, error, count } = await req
+          .order('nom', { ascending: true })
+          .range(start, end);
+        if (error) throw error;
+        if (!aborted) {
+          setData(data || []);
+          setTotal(count || 0);
+        }
+      } catch (err) {
+        console.error(err);
+        if (!aborted) {
+          setError(err);
+          setData([]);
+          setTotal(0);
+        }
+      } finally {
+        if (!aborted) setLoading(false);
+      }
+    };
+    run();
+    return () => {
+      aborted = true;
+    };
+  }, [mama_id, page, limit, term, JSON.stringify(filters)]);
+
+  return { data, total, loading, error };
+}
+

--- a/src/hooks/useFournisseursRecents.js
+++ b/src/hooks/useFournisseursRecents.js
@@ -1,0 +1,45 @@
+// MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import { useEffect, useState } from 'react';
+import supabase from '@/lib/supabaseClient';
+import { useAuth } from '@/hooks/useAuth';
+
+export default function useFournisseursRecents(limit = 10) {
+  const { mama_id } = useAuth();
+  const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!mama_id) return;
+    let aborted = false;
+    const run = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const { data, error } = await supabase
+          .from('fournisseurs_recents')
+          .select('id, nom, ville')
+          .eq('mama_id', mama_id)
+          .order('dernier_achat', { ascending: false })
+          .limit(limit);
+        if (error) throw error;
+        if (!aborted) setData(data || []);
+      } catch (err) {
+        console.error(err);
+        if (!aborted) {
+          setError(err);
+          setData([]);
+        }
+      } finally {
+        if (!aborted) setLoading(false);
+      }
+    };
+    run();
+    return () => {
+      aborted = true;
+    };
+  }, [mama_id, limit]);
+
+  return { data, loading, error };
+}
+

--- a/src/pages/factures/FactureForm.jsx
+++ b/src/pages/factures/FactureForm.jsx
@@ -5,8 +5,8 @@ import { toast } from 'sonner';
 import { format } from 'date-fns';
 import supabase from '@/lib/supabaseClient';
 import { useAuth } from '@/hooks/useAuth';
-import { useFournisseursAutocomplete } from '@/hooks/useFournisseursAutocomplete';
 import FactureLigne from '@/components/FactureLigne';
+import SupplierPicker from '@/components/factures/SupplierPicker';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import {
@@ -86,9 +86,6 @@ export default function FactureForm({ facture = null, onSaved } = {}) {
   const fournisseur_id = watch('fournisseur_id');
   const setFournisseurId = (val) =>
     setValue('fournisseur_id', val, { shouldDirty: true });
-  const [fSearch, setFSearch] = useState('');
-  const { options: fournisseurs = [], loading: fLoading } =
-    useFournisseursAutocomplete({ term: fSearch });
 
   const sum = (arr) => arr.reduce((acc, n) => acc + n, 0);
   const eur = (n) =>
@@ -212,31 +209,11 @@ export default function FactureForm({ facture = null, onSaved } = {}) {
         {/* Fournisseur */}
         <div className="flex flex-col gap-2">
           <label className="text-sm font-medium">Fournisseur</label>
-          <Input
-            value={fSearch}
-            onChange={(e) => setFSearch(e.target.value)}
-            placeholder="Rechercher un fournisseur"
+          <SupplierPicker
+            value={fournisseur_id}
+            onChange={setFournisseurId}
+            error={errors.fournisseur_id}
           />
-          <Select
-            value={fournisseur_id ? String(fournisseur_id) : ''}
-            onValueChange={setFournisseurId}
-            disabled={fLoading}
-          >
-            <SelectTrigger
-              aria-label="Fournisseur"
-              className={`w-full ${errors.fournisseur_id ? 'border-destructive' : ''}`}
-              aria-invalid={errors.fournisseur_id ? 'true' : 'false'}
-            >
-              <SelectValue placeholder="Sélectionner un fournisseur" />
-            </SelectTrigger>
-            <SelectContent>
-              {fournisseurs?.map((f) => (
-                <SelectItem key={f.id} value={String(f.id)}>
-                  {f.nom}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
         </div>
 
         {/* Date */}


### PR DESCRIPTION
## Summary
- add supplier picker component with autocomplete, recent list and browse modal
- support supplier browsing hooks for search, filters and pagination
- integrate new picker into facture form and refine supplier autocomplete

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a709ed14b8832d832f387933e6ccac