### PR TITLE
feat: replace numeric input component

### DIFF
--- a/src/components/forms/NumericInput.jsx
+++ b/src/components/forms/NumericInput.jsx
@@ -1,45 +1,108 @@
-import { useCallback, useEffect, useState } from 'react';
-import { Input } from '@/components/ui/input';
-import { parseNumber, formatNumberFR } from '@/utils/number';
+// NumericInput.jsx — saisie FR tolérante, sans milliers, pas de reformatage en cours de frappe
+import { useEffect, useRef, useState } from 'react';
 
-export default function NumericInput({ value, onChange, decimals = 2, ...props }) {
-  const [display, setDisplay] = useState('');
+function normalize(raw) {
+  return raw
+    .replace(/\u00A0/g, ' ') // nbsp -> space
+    .replace(/\s+/g, '')     // remove spaces
+    .replace(/,/g, '.');     // comma -> dot
+}
+function isTrailingSep(raw) {
+  const t = (raw ?? '').trim();
+  return t.endsWith(',') || t.endsWith('.');
+}
+function parseLoose(raw) {
+  const s = normalize(raw ?? '');
+  if (!s || s === '-' || s === '.' || s === '-.') return null;
+  const n = Number(s);
+  return Number.isFinite(n) ? n : null;
+}
+// format sans séparateur de milliers, décimales fixes si demandées
+function formatFrNoGroup(n, decimals) {
+  if (n == null || Number.isNaN(n)) return '';
+  if (typeof decimals === 'number') {
+    return n.toFixed(decimals).replace('.', ','); // ex: 1200,00
+  }
+  return String(n).replace('.', ',');
+}
 
+export default function NumericInput({
+  value,                 // number | null
+  onValueChange,         // (n: number|null) => void
+  decimals,              // ex: 2
+  min, max,
+  allowNegative = false,
+  placeholder,
+  disabled,
+  name,
+  className = 'input input-bordered w-full',
+}) {
+  const [text, setText] = useState(value == null ? '' : String(value).replace('.', ','));
+  const focused = useRef(false);
+
+  // ne réécrit PAS le champ quand il a le focus
   useEffect(() => {
-    if (value === null || value === undefined || Number.isNaN(value)) {
-      setDisplay('');
-    } else {
-      setDisplay(formatNumberFR(value, decimals));
-    }
-  }, [value, decimals]);
+    if (focused.current) return;
+    setText(value == null ? '' : String(value).replace('.', ','));
+  }, [value]);
 
-  const handleChange = useCallback(
-    (e) => {
-      const raw = e.target.value;
-      setDisplay(raw);
-      const num = parseNumber(raw);
-      onChange?.(num);
-    },
-    [onChange]
-  );
+  const onFocus = (e) => {
+    focused.current = true;
+    // sélectionne pour faciliter la modif
+    queueMicrotask(() => e.target.select());
+  };
 
-  const handleBlur = useCallback(() => {
-    const num = parseNumber(display);
-    if (num === null) {
-      setDisplay('');
-    } else {
-      setDisplay(formatNumberFR(num, decimals));
+  const onChange = (e) => {
+    const raw = e.target.value ?? '';
+    const allowed = allowNegative ? /[^0-9.,\s-]/g : /[^0-9.,\s]/g;
+    const cleaned = raw.replace(allowed, '');
+    setText(cleaned);
+
+    // ne pousse pas vers le parent si la saisie se termine par , ou .
+    if (isTrailingSep(cleaned)) return;
+
+    const parsed = parseLoose(cleaned);
+    if (parsed === null) {
+      onValueChange?.(null);
+      return;
     }
-  }, [display, decimals]);
+    if (min !== undefined && parsed < min) return;
+    if (max !== undefined && parsed > max) return;
+    onValueChange?.(parsed);
+  };
+
+  const onBlur = () => {
+    focused.current = false;
+    const parsed = parseLoose(text);
+    if (parsed === null) {
+      setText('');
+      onValueChange?.(null);
+      return;
+    }
+    let n = parsed;
+    if (min !== undefined && n < min) n = min;
+    if (max !== undefined && n > max) n = max;
+    // format FR sans milliers
+    setText(formatFrNoGroup(n, typeof decimals === 'number' ? decimals : undefined));
+    onValueChange?.(n);
+  };
 
   return (
-    <Input
+    <input
       type="text"
       inputMode="decimal"
-      value={display}
-      onChange={handleChange}
-      onBlur={handleBlur}
-      {...props}
+      pattern={allowNegative ? "[0-9.,\\s-]*" : "[0-9.,\\s]*"}
+      name={name}
+      value={text}
+      onChange={onChange}
+      onFocus={onFocus}
+      onBlur={onBlur}
+      placeholder={placeholder}
+      disabled={disabled}
+      className={className}
+      lang="fr"
+      autoComplete="off"
     />
   );
 }
+


### PR DESCRIPTION
## Summary
- replace NumericInput with FR-tolerant version without thousands separators or mid-typing reformatting

## Testing
- `npm test` *(fails: fetch failed ENETUNREACH)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a72662d4c0832d9c6d8b61f86f1239