### PR TITLE
Use NumericInput for invoice line quantity and total

### DIFF
--- a/src/components/FactureLigne.jsx
+++ b/src/components/FactureLigne.jsx
@@ -33,7 +33,14 @@ function useZones() {
   });
 }
 
-export default function FactureLigne({ value: line, onChange, onRemove, allLines = [], invalidProduit = false }) {
+export default function FactureLigne({
+  value: line,
+  onChange,
+  onRemove,
+  allLines = [],
+  invalidProduit = false,
+  index,
+}) {
   const lineRef = useRef(null);
   const { data: zones = [] } = useZones();
   const [modalOpen, setModalOpen] = useState(false);
@@ -66,11 +73,10 @@ export default function FactureLigne({ value: line, onChange, onRemove, allLines
 
   const fmt = (n) =>
     Number.isFinite(n)
-      ? n.toLocaleString("fr-FR", { minimumFractionDigits: 2, maximumFractionDigits: 2 })
-      : "";
-  const fmt4 = (n) =>
-    Number.isFinite(n)
-      ? n.toLocaleString("fr-FR", { minimumFractionDigits: 4, maximumFractionDigits: 4 })
+      ? n.toLocaleString("fr-FR", {
+          minimumFractionDigits: 2,
+          maximumFractionDigits: 2,
+        })
       : "";
 
   const excludeIdsSameZone = allLines
@@ -117,19 +123,21 @@ export default function FactureLigne({ value: line, onChange, onRemove, allLines
         currentLineProductId={line.produit_id}
       />
       <NumericInput
+        name={`lignes.${index}.quantite`}
         value={qte}
         onValueChange={(n) => recalc({ quantite: n })}
         placeholder="0"
       />
       <Input readOnly disabled value={line.unite || ""} placeholder="Unité" />
       <NumericInput
+        name={`lignes.${index}.total_ht`}
         value={totalHt}
         decimals={2}
         min={0}
         onValueChange={(n) => recalc({ total_ht: n })}
         placeholder="0,00"
       />
-      <Input readOnly disabled value={fmt4(puHt)} placeholder="PU HT (€)" />
+      <Input readOnly disabled value={fmt(puHt)} placeholder="PU HT (€)" />
       <Input readOnly disabled value={fmt(Number(line.pmp ?? 0))} placeholder="PMP" />
       <Select value={String(tva)} onValueChange={(v) => recalc({ tva: v })}>
         <SelectTrigger className="w-28">

--- a/src/pages/factures/FactureForm.jsx
+++ b/src/pages/factures/FactureForm.jsx
@@ -359,6 +359,7 @@ export default function FactureForm({ facture = null, onSaved } = {}) {
               onRemove={() => remove(i)}
               allLines={lignes}
               invalidProduit={submitCount > 0 && !lignes[i]?.produit_id}
+              index={i}
             />
           ))}
         </div>


### PR DESCRIPTION
## Summary
- ensure invoice line quantity and total HT fields use shared NumericInput component
- display PU HT with two decimals and provide unique field names for line inputs

## Testing
- `npm test` *(fails: No QueryClient set / fetch failed)*
- `npx eslint src/components/FactureLigne.jsx src/pages/factures/FactureForm.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68a72c9d08ac832d89cfbfb7c0040410