### PR TITLE
Remove stock alert processing hooks and UI

### DIFF
--- a/src/components/stock/AlertBadge.jsx
+++ b/src/components/stock/AlertBadge.jsx
@@ -9,7 +9,7 @@ export default function AlertBadge() {
 
   useEffect(() => {
     fetchAlerts()
-      .then((a) => setCount(a.filter((x) => !x.traite).length))
+      .then((a) => setCount(a.length))
       .catch(() => {});
   }, [fetchAlerts]);
 

--- a/src/hooks/useRuptureAlerts.js
+++ b/src/hooks/useRuptureAlerts.js
@@ -12,7 +12,7 @@ export function useRuptureAlerts() {
       let query = supabase
         .from('v_alertes_rupture')
         .select(
-          'id, produit_id, nom, unite, fournisseur_nom, stock_actuel, stock_min, stock_projete, manque, type, traite'
+          'id, produit_id, nom, unite, fournisseur_nom, stock_actuel, stock_min, stock_projete, manque, type'
         )
         .order('manque', { ascending: false });
 
@@ -25,21 +25,6 @@ export function useRuptureAlerts() {
       console.error(error);
       toast.error(error.message || 'Erreur chargement alertes rupture');
       return [];
-    }
-  }
-
-  async function markAsHandled(id) {
-    if (!mama_id) return;
-    try {
-      const { error } = await supabase
-        .from('v_alertes_rupture')
-        .update({ traite: true })
-        .eq('id', id)
-        .eq('mama_id', mama_id);
-      if (error) throw error;
-    } catch (error) {
-      console.error(error);
-      toast.error(error.message || 'Erreur mise à jour alerte');
     }
   }
 
@@ -59,5 +44,5 @@ export function useRuptureAlerts() {
     }
   }
 
-  return { fetchAlerts, markAsHandled, generateSuggestions };
+  return { fetchAlerts, generateSuggestions };
 }

--- a/src/pages/stock/AlertesRupture.jsx
+++ b/src/pages/stock/AlertesRupture.jsx
@@ -3,7 +3,7 @@ import { useRuptureAlerts } from "@/hooks/useRuptureAlerts";
 import { Button } from "@/components/ui/button";
 
 export default function AlertesRupture() {
-  const { fetchAlerts, markAsHandled, generateSuggestions } = useRuptureAlerts();
+  const { fetchAlerts, generateSuggestions } = useRuptureAlerts();
   const [alerts, setAlerts] = useState([]);
   const [type, setType] = useState(null);
 
@@ -25,7 +25,7 @@ export default function AlertesRupture() {
       </div>
       <table className="min-w-full text-sm">
         <thead>
-          <tr><th>Produit</th><th>Actuel</th><th>Proj.</th><th></th></tr>
+          <tr><th>Produit</th><th>Actuel</th><th>Proj.</th></tr>
         </thead>
         <tbody>
           {alerts.map(a => (
@@ -33,17 +33,10 @@ export default function AlertesRupture() {
               <td className="px-2 py-1">{a.nom}</td>
               <td className="px-2 py-1">{a.stock_actuel}</td>
               <td className="px-2 py-1">{a.stock_projete}</td>
-              <td className="px-2 py-1 text-right">
-                {!a.traite && (
-                  <Button size="sm" onClick={() => markAsHandled(a.id).then(load)}>
-                    Traiter
-                  </Button>
-                )}
-              </td>
             </tr>
           ))}
           {alerts.length === 0 && (
-            <tr><td colSpan={4} className="text-center p-2">Aucune alerte</td></tr>
+            <tr><td colSpan={3} className="text-center p-2">Aucune alerte</td></tr>
           )}
         </tbody>
       </table>

--- a/test/useRuptureAlerts.test.js
+++ b/test/useRuptureAlerts.test.js
@@ -22,12 +22,12 @@ beforeEach(async () => {
   queryBuilder.eq.mockClear();
 });
 
-test('fetchAlerts selects view columns without traite filter', async () => {
+test('fetchAlerts selects expected view columns', async () => {
   const { fetchAlerts } = useRuptureAlerts();
   await fetchAlerts('rupture');
   expect(fromMock).toHaveBeenCalledWith('v_alertes_rupture');
   expect(queryBuilder.select).toHaveBeenCalledWith(
-    'id, produit_id, nom, unite, fournisseur_nom, stock_actuel, stock_min, stock_projete, manque, type, traite'
+    'id, produit_id, nom, unite, fournisseur_nom, stock_actuel, stock_min, stock_projete, manque, type'
   );
   expect(queryBuilder.eq).toHaveBeenCalledTimes(1);
   expect(queryBuilder.eq).toHaveBeenCalledWith('type', 'rupture');


### PR DESCRIPTION
## Summary
- remove "Traiter" actions and state from stock alerts pages
- drop mutation logic from rupture alerts hook to make it read-only
- adjust tests and badge count accordingly

## Testing
- `npm run lint`
- `npm test` *(fails: No QueryClient set and network fetch errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a7677b8248832da8c32421827e2203