### PR TITLE
chore: drop stock alert processing

### DIFF
--- a/src/components/gadgets/GadgetAlerteStockFaible.jsx
+++ b/src/components/gadgets/GadgetAlerteStockFaible.jsx
@@ -1,3 +1,8 @@
+/**
+ * CLEANUP:
+ * - src/hooks/useAlerteStockFaible.js
+ * - test/useAlerteStockFaible.test.js
+ */
 import { motion as Motion } from 'framer-motion';
 import useAlerteStockFaible from '@/hooks/gadgets/useAlerteStockFaible';
 import LoadingSkeleton from '@/components/ui/LoadingSkeleton';

--- a/src/hooks/useAlerteStockFaible.js
+++ b/src/hooks/useAlerteStockFaible.js
@@ -8,9 +8,8 @@ import { useAuth } from '@/hooks/useAuth';
  * @param {Object} params
  * @param {number} [params.page=1]
  * @param {number} [params.pageSize=20]
- * @param {'manque'|'stock_actuel'|'stock_min'} [params.orderBy='manque']
  */
-export function useAlerteStockFaible({ page = 1, pageSize = 20, orderBy = 'manque' } = {}) {
+export function useAlerteStockFaible({ page = 1, pageSize = 20 } = {}) {
   const { mama_id } = useAuth();
   const [data, setData] = useState([]);
   const [total, setTotal] = useState(0);
@@ -28,8 +27,11 @@ export function useAlerteStockFaible({ page = 1, pageSize = 20, orderBy = 'manqu
       try {
         const { data: rows, count, error } = await supabase
           .from('v_alertes_rupture')
-          .select('produit_id, nom, stock_min, stock_actuel, manque', { count: 'exact' })
-          .order(orderBy, { ascending: false })
+          .select(
+            'produit_id, nom, unite, fournisseur_id, fournisseur_nom, stock_actuel, stock_min, manque',
+            { count: 'exact' }
+          )
+          .order('manque', { ascending: false })
           .range(from, to);
         if (error) throw error;
         if (!aborted) {
@@ -51,7 +53,7 @@ export function useAlerteStockFaible({ page = 1, pageSize = 20, orderBy = 'manqu
     return () => {
       aborted = true;
     };
-  }, [mama_id, page, pageSize, orderBy]);
+  }, [mama_id, page, pageSize]);
 
   return { data, total, page, pageSize, loading, error };
 }

--- a/test/useAlerteStockFaible.test.js
+++ b/test/useAlerteStockFaible.test.js
@@ -29,7 +29,10 @@ test('useAlerteStockFaible queries v_alertes_rupture without mama filter', async
   const { result } = renderHook(() => useAlerteStockFaible());
   await waitFor(() => !result.current.loading);
   expect(fromMock).toHaveBeenCalledWith('v_alertes_rupture');
-  expect(queryBuilder.select).toHaveBeenCalledWith('produit_id, nom, stock_min, stock_actuel, manque', { count: 'exact' });
+  expect(queryBuilder.select).toHaveBeenCalledWith(
+    'produit_id, nom, unite, fournisseur_id, fournisseur_nom, stock_actuel, stock_min, manque',
+    { count: 'exact' }
+  );
   expect(queryBuilder.eq).not.toHaveBeenCalled();
   expect(queryBuilder.order).toHaveBeenCalledWith('manque', { ascending: false });
   expect(queryBuilder.range).toHaveBeenCalledWith(0, 19);


### PR DESCRIPTION
## Summary
- ensure low stock alert hook queries read-only view without processing logic
- adjust test expectations for read-only hook
- document cleanup in stock alert gadget

## Testing
- `npx vitest run test/useAlerteStockFaible.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a86edcd4e0832d85dd190fb3581b92