### PR TITLE
Fix zone prefill in invoice flow

### DIFF
--- a/src/components/FactureLigne.jsx
+++ b/src/components/FactureLigne.jsx
@@ -11,28 +11,6 @@ import {
 } from "@/components/ui/select";
 import { Trash2 } from "lucide-react";
 import ProduitSearchModal from "@/components/factures/ProduitSearchModal";
-import { useQuery } from "@tanstack/react-query";
-import supabase from "@/lib/supabaseClient";
-import { useAuth } from "@/hooks/useAuth";
-
-function useZones() {
-  const { mama_id } = useAuth();
-  return useQuery({
-    queryKey: ["zones_stock", mama_id],
-    enabled: !!mama_id,
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from("zones_stock")
-        .select("id, nom")
-        .eq("mama_id", mama_id)
-        .eq("actif", true)
-        .order("nom", { ascending: true });
-      if (error) throw error;
-      return data ?? [];
-    },
-  });
-}
-
 export default function FactureLigne({
   value: line,
   onChange,
@@ -40,9 +18,9 @@ export default function FactureLigne({
   allLines = [],
   invalidProduit = false,
   index,
+  zones = [],
 }) {
   const lineRef = useRef(null);
-  const { data: zones = [] } = useZones();
   const [modalOpen, setModalOpen] = useState(false);
 
   const qte = Number(line.quantite || 0);
@@ -110,13 +88,12 @@ export default function FactureLigne({
         open={modalOpen}
         onClose={() => setModalOpen(false)}
         onSelect={(p) => {
-          const z = p.zone_id ?? (zones.length === 1 ? zones[0].id : null);
           recalc({
-            produit_id: p.id,
+            produit_id: p.produit_id,
             produit_nom: p.nom,
             unite_id: p.unite_id ?? null,
             tva: p.tva ?? 0,
-            zone_id: z,
+            zone_id: p.zone_id ?? line.zone_id ?? null,
           });
         }}
         excludeIdsSameZone={excludeIdsSameZone}

--- a/src/components/factures/ProduitSearchModal.jsx
+++ b/src/components/factures/ProduitSearchModal.jsx
@@ -31,7 +31,13 @@ export default function ProduitSearchModal({
 
   const handleSelect = (prod) => {
     if (!prod) return;
-    onPick?.({ ...prod, zone_id: prod.zone_stock_id ?? null });
+    onPick?.({
+      produit_id: prod.id,
+      nom: prod.nom,
+      unite_id: prod.unite_id ?? null,
+      tva: prod.tva ?? 0,
+      zone_id: prod.zone_id ?? null,
+    });
     onClose?.();
   };
 

--- a/src/pages/factures/FactureForm.jsx
+++ b/src/pages/factures/FactureForm.jsx
@@ -20,6 +20,7 @@ import {
 import { Badge } from '@/components/ui/badge';
 import { mapUILineToPayload } from '@/features/factures/invoiceMappers';
 import useProduitLineDefaults from '@/hooks/useProduitLineDefaults';
+import useZonesStock from '@/hooks/useZonesStock';
 
 const FN_UPDATE_FACTURE_EXISTS = false;
 
@@ -84,6 +85,7 @@ export default function FactureForm({ facture = null, onSaved } = {}) {
     name: 'lignes',
   });
   const lignes = watch('lignes');
+  const { data: zones = [], isSuccess } = useZonesStock();
   const totalHTAttendu = watch('total_ht_attendu');
   const statut = watch('statut');
   const formId = watch('id');
@@ -156,6 +158,15 @@ export default function FactureForm({ facture = null, onSaved } = {}) {
     }
     update(i, merged);
   };
+
+  useEffect(() => {
+    lignes.forEach((l, i) => {
+      if (!l.zone_id && isSuccess && zones.length === 1) {
+        updateLigne(i, { zone_id: zones[0].id });
+      }
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isSuccess, zones, lignes]);
 
   const onSubmit = async (values) => {
     if (saving) return;
@@ -360,6 +371,7 @@ export default function FactureForm({ facture = null, onSaved } = {}) {
               allLines={lignes}
               invalidProduit={submitCount > 0 && !lignes[i]?.produit_id}
               index={i}
+              zones={zones}
             />
           ))}
         </div>

--- a/test/FactureLigne.test.jsx
+++ b/test/FactureLigne.test.jsx
@@ -11,31 +11,34 @@ vi.mock('@/components/factures/ProduitSearchModal', () => ({
   ),
 }));
 
-vi.mock('@tanstack/react-query', () => ({
-  useQuery: () => ({ data: [{ id: 'z1', nom: 'Zone 1' }] }),
-}));
-
-vi.mock('@/hooks/useAuth', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
-vi.mock('@/lib/supabaseClient', () => ({}));
-
 import FactureLigne from '@/components/FactureLigne';
 
 test('sets zone_id from product zone_stock_id when selecting product', () => {
-  currentProduct = { id: 'p1', nom: 'Prod', unite_id: 'u1', tva: 5.5, zone_id: 'zProd' };
+  currentProduct = { produit_id: 'p1', nom: 'Prod', unite_id: 'u1', tva: 5.5, zone_id: 'zProd' };
   const onChange = vi.fn();
-  const { getByText } = render(<FactureLigne value={{}} onChange={onChange} />);
+  const { getByText } = render(
+    <FactureLigne value={{}} onChange={onChange} zones={[]} index={0} />
+  );
   fireEvent.click(getByText('pick'));
   expect(onChange).toHaveBeenCalledWith(
     expect.objectContaining({ zone_id: 'zProd' })
   );
 });
 
-test('falls back to mama sole zone when product has no zone', () => {
-  currentProduct = { id: 'p2', nom: 'Prod2', unite_id: 'u1', tva: 5.5, zone_id: null };
+test('keeps existing zone when product has no zone', () => {
+  currentProduct = {
+    produit_id: 'p2',
+    nom: 'Prod2',
+    unite_id: 'u1',
+    tva: 5.5,
+    zone_id: null,
+  };
   const onChange = vi.fn();
-  const { getByText } = render(<FactureLigne value={{}} onChange={onChange} />);
+  const { getByText } = render(
+    <FactureLigne value={{ zone_id: 'zInit' }} onChange={onChange} zones={[]} index={0} />
+  );
   fireEvent.click(getByText('pick'));
   expect(onChange).toHaveBeenCalledWith(
-    expect.objectContaining({ zone_id: 'z1' })
+    expect.objectContaining({ zone_id: 'zInit' })
   );
 });


### PR DESCRIPTION
## Summary
- propagate product zone_id from search modal
- keep existing line zone when product lacks one
- auto-select sole stock zone in invoice form and add React Query hook

## Testing
- `npm test` *(fails: fetch failed, QueryClient missing)*
- `npx eslint src/hooks/useZonesStock.js src/components/FactureLigne.jsx src/components/factures/ProduitSearchModal.jsx src/pages/factures/FactureForm.jsx test/FactureLigne.test.jsx`

------
https://chatgpt.com/codex/tasks/task_e_68a871b3c148832da928922e1a4bad37