### PR TITLE
Refactor facture filters with supplier autocomplete and selects

### DIFF
--- a/src/components/filters/SupplierFilter.jsx
+++ b/src/components/filters/SupplierFilter.jsx
@@ -1,0 +1,64 @@
+import { useEffect, useRef, useState } from 'react';
+import { useFournisseursAutocomplete } from '@/hooks/useFournisseursAutocomplete';
+
+export default function SupplierFilter({ value, onChange, placeholder = 'Rechercher un fournisseur' }) {
+  const [query, setQuery] = useState('');
+  const [open, setOpen] = useState(false);
+  const inputRef = useRef(null);
+
+  const { options: results = [], loading } = useFournisseursAutocomplete({ term: query });
+
+  useEffect(() => {
+    if (!value) setQuery('');
+  }, [value]);
+
+  const handleSelect = (item) => {
+    onChange?.(item); // { id, nom }
+    setOpen(false);
+  };
+
+  const clear = () => {
+    onChange?.(null);
+    setQuery('');
+    setOpen(false);
+    inputRef.current?.focus();
+  };
+
+  return (
+    <div className="relative w-full max-w-xs">
+      <div className="flex items-center gap-2 rounded-md border border-slate-600 bg-slate-800/60 px-3 h-10">
+        <span aria-hidden className="opacity-70">🔍</span>
+        <input
+          ref={inputRef}
+          value={value ? value.nom : query}
+          onChange={(e) => { setQuery(e.target.value); setOpen(true); }}
+          onFocus={() => setOpen(true)}
+          onBlur={() => setTimeout(() => setOpen(false), 150)}
+          placeholder={placeholder}
+          className="bg-transparent outline-none w-full placeholder:opacity-60"
+        />
+        {value && (
+          <button type="button" onClick={clear} className="opacity-70 hover:opacity-100">✕</button>
+        )}
+      </div>
+
+      {open && !value && (query.trim().length > 0 || loading) && (
+        <div className="absolute z-20 mt-1 w-full rounded-md border border-slate-600 bg-slate-800 shadow-lg max-h-56 overflow-auto">
+          {loading && <div className="px-3 py-2 text-sm opacity-70">Recherche…</div>}
+          {!loading && (results?.length ? results.map(r => (
+            <button
+              key={r.id}
+              type="button"
+              onMouseDown={(e)=>e.preventDefault()}
+              onClick={() => handleSelect({ id: r.id, nom: r.nom })}
+              className="w-full text-left px-3 py-2 hover:bg-slate-700"
+            >
+              {r.nom}
+            </button>
+          )) : <div className="px-3 py-2 text-sm opacity-70">Aucun résultat</div>)}
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/src/hooks/data/useFactures.js
+++ b/src/hooks/data/useFactures.js
@@ -1,0 +1,44 @@
+import { useQuery } from '@tanstack/react-query';
+import { useAuth } from '@/hooks/useAuth';
+import supabase from '@/lib/supabaseClient';
+
+export function useFactures(filters = {}) {
+  const { userData } = useAuth();
+  const mamaId = userData?.mama_id;
+  const { page = 1, pageSize = 20 } = filters;
+
+  return useQuery({
+    queryKey: ['factures', mamaId, filters],
+    enabled: !!mamaId,
+    keepPreviousData: true,
+    queryFn: async () => {
+      let q = supabase
+        .from('factures')
+        .select(
+          'id, numero, date_facture, fournisseur_id, montant_ttc:total_ttc, statut, actif, fournisseur:fournisseurs(nom)',
+          { count: 'exact' }
+        )
+        .eq('mama_id', mamaId)
+        .order('date_facture', { ascending: false })
+        .range((page - 1) * pageSize, page * pageSize - 1);
+
+      if (filters?.search) {
+        q = q.ilike('numero', `%${filters.search}%`);
+      }
+      if (filters?.fournisseur?.id) {
+        q = q.eq('fournisseur_id', filters.fournisseur.id);
+      }
+      if (filters?.statut) {
+        q = q.eq('statut', filters.statut);
+      }
+      if (filters?.actif === 'true') q = q.eq('actif', true);
+      if (filters?.actif === 'false') q = q.eq('actif', false);
+
+      const { data, error, count } = await q;
+      if (error) throw error;
+      return { factures: data ?? [], total: count || 0 };
+    },
+  });
+}
+
+export default useFactures;


### PR DESCRIPTION
## Summary
- replace duplicated supplier inputs with `SupplierFilter` autocomplete
- add status and activity selects for invoice list
- implement `useFactures` data hook applying filters

## Testing
- `npm test` (fails: fetch failed, query client missing, etc.)
- `npx eslint src/components/filters/SupplierFilter.jsx src/pages/factures/Factures.jsx src/hooks/data/useFactures.js`

------
https://chatgpt.com/codex/tasks/task_e_68a873212338832d9b44d39d7bb6441f