### PR TITLE
fix: alias rupture alert view and famille validation

### DIFF
--- a/src/hooks/gadgets/useAlerteStockFaible.js
+++ b/src/hooks/gadgets/useAlerteStockFaible.js
@@ -19,7 +19,8 @@ export default function useAlerteStockFaible() {
       const { data, error } = await supabase
         .from('v_alertes_rupture')
         .select(
-          `produit_id,
+          `id:produit_id,
+          produit_id,
           nom,
           unite,
           fournisseur_nom,

--- a/src/hooks/useAlerteStockFaible.js
+++ b/src/hooks/useAlerteStockFaible.js
@@ -28,7 +28,7 @@ export function useAlerteStockFaible({ page = 1, pageSize = 20 } = {}) {
         const { data: rows, count, error } = await supabase
           .from('v_alertes_rupture')
           .select(
-            'produit_id, nom, unite, fournisseur_id, fournisseur_nom, stock_actuel, stock_min, manque',
+            'id:produit_id, produit_id, nom, unite, fournisseur_id, fournisseur_nom, stock_actuel, stock_min, manque',
             { count: 'exact' }
           )
           .order('manque', { ascending: false })

--- a/src/hooks/useFamilles.js
+++ b/src/hooks/useFamilles.js
@@ -89,4 +89,15 @@ export function useFamilles() {
   };
 }
 
+// export minimal attendu par importExcelProduits.js
+export async function fetchFamillesForValidation(supabase, mama_id) {
+  const { data, error } = await supabase
+    .from('familles')
+    .select('id, nom, actif')
+    .eq('mama_id', mama_id)
+    .order('nom', { ascending: true });
+  if (error) throw error;
+  return data ?? [];
+}
+
 export default useFamilles;

--- a/src/hooks/useRuptureAlerts.js
+++ b/src/hooks/useRuptureAlerts.js
@@ -12,7 +12,7 @@ export function useRuptureAlerts() {
       let query = supabase
         .from('v_alertes_rupture')
         .select(
-          'id, produit_id, nom, unite, fournisseur_nom, stock_actuel, stock_min, stock_projete, manque, type'
+          'id:produit_id, produit_id, nom, unite, fournisseur_nom, stock_actuel, stock_min, stock_projete, manque, type'
         )
         .order('manque', { ascending: false });
 

--- a/src/utils/importExcelProduits.js
+++ b/src/utils/importExcelProduits.js
@@ -60,7 +60,7 @@ export async function parseProduitsFile(file, mama_id) {
     fournisseursRes,
     produitsRes,
   ] = await Promise.all([
-    fetchFamillesForValidation(mama_id),
+    fetchFamillesForValidation(supabase, mama_id),
     supabase.from("sous_familles").select("id, nom").eq("mama_id", mama_id),
     fetchUnitesForValidation(mama_id),
     fetchZonesForValidation(mama_id),

--- a/test/useAlerteStockFaible.test.js
+++ b/test/useAlerteStockFaible.test.js
@@ -30,7 +30,7 @@ test('useAlerteStockFaible queries v_alertes_rupture without mama filter', async
   await waitFor(() => !result.current.loading);
   expect(fromMock).toHaveBeenCalledWith('v_alertes_rupture');
   expect(queryBuilder.select).toHaveBeenCalledWith(
-    'produit_id, nom, unite, fournisseur_id, fournisseur_nom, stock_actuel, stock_min, manque',
+    'id:produit_id, produit_id, nom, unite, fournisseur_id, fournisseur_nom, stock_actuel, stock_min, manque',
     { count: 'exact' }
   );
   expect(queryBuilder.eq).not.toHaveBeenCalled();

--- a/test/useRuptureAlerts.test.js
+++ b/test/useRuptureAlerts.test.js
@@ -27,7 +27,7 @@ test('fetchAlerts selects expected view columns', async () => {
   await fetchAlerts('rupture');
   expect(fromMock).toHaveBeenCalledWith('v_alertes_rupture');
   expect(queryBuilder.select).toHaveBeenCalledWith(
-    'id, produit_id, nom, unite, fournisseur_nom, stock_actuel, stock_min, stock_projete, manque, type'
+    'id:produit_id, produit_id, nom, unite, fournisseur_nom, stock_actuel, stock_min, stock_projete, manque, type'
   );
   expect(queryBuilder.eq).toHaveBeenCalledTimes(1);
   expect(queryBuilder.eq).toHaveBeenCalledWith('type', 'rupture');


### PR DESCRIPTION
## Summary
- alias `produit_id` as `id` in all `v_alertes_rupture` selects
- expose `fetchFamillesForValidation` helper and adjust Excel import
- sync tests with alias column

## Testing
- `npm test` *(fails: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a877f1503c832d91125b7007f32a44