### PR TITLE
test: mock auth and periodes hooks

### DIFF
--- a/src/hooks/useTemplatesCommandes.js
+++ b/src/hooks/useTemplatesCommandes.js
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import supabase from '@/lib/supabase';
-import useAuth from '@/hooks/useAuth';
+import { useAuth } from '@/hooks/useAuth';
 
 export async function getTemplatesCommandesActifs() {
   const { data, error } = await supabase

--- a/test/setupTests.ts
+++ b/test/setupTests.ts
@@ -6,11 +6,21 @@ vi.mock("@/license", () => ({ default: { validateLicense: () => true } }));
 vi.mock("@/db/license-keys.json", () => ({ default: [] }));
 vi.mock("@/utils/watermark", () => ({ addWatermark: (pdf: any) => pdf, clearWatermark: (pdf: any) => pdf }));
 
-// Default auth hook mock
-vi.mock("@/hooks/useAuth", async () => {
-  const mod = await import("./__mocks__/hooks/useAuth");
-  return { useAuth: mod.useAuth };
-});
+// Global mocks for auth and periodes hooks
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({
+    mama_id: "m1",
+    user_id: "u1",
+    role: "admin",
+    hasAccess: () => true,
+  }),
+}));
+
+vi.mock("@/hooks/usePeriodes", () => ({
+  default: () => ({
+    checkCurrentPeriode: vi.fn().mockResolvedValue({ id: "p1" }),
+  }),
+}));
 
 // Polyfills Node pour jsdom/tests
 // TextEncoder/TextDecoder (si nécessaire)

--- a/test/useInventaires.test.js
+++ b/test/useInventaires.test.js
@@ -14,9 +14,14 @@ const query = {
   then: vi.fn(),
 };
 const fromMock = vi.fn(() => query);
-vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
+vi.mock('@/lib/supabase', () => {
+  const supabase = { from: fromMock };
+  return { supabase, default: supabase };
+});
 vi.mock('@/hooks/useAuth', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
-vi.mock('@/hooks/usePeriodes', () => ({ useAuth: () => ({ checkCurrentPeriode: vi.fn(() => ({ error: null, data: { id: 'per1' } })) }) }));
+vi.mock('@/hooks/usePeriodes', () => ({
+  default: () => ({ checkCurrentPeriode: vi.fn(() => ({ error: null, data: { id: 'per1' } })) }),
+}));
 
 let useInventaires;
 let insertCount = 0;

--- a/test/useTemplatesCommandes.test.js
+++ b/test/useTemplatesCommandes.test.js
@@ -8,8 +8,11 @@ const query = {
 const fromMock = vi.fn(() => query);
 const rpcMock = vi.fn();
 
-vi.mock("@/lib/supabase", () => ({ supabase: { from: fromMock, rpc: rpcMock } }));
-vi.mock("@/hooks/useAuth", () => ({ default: () => ({ mama_id: "m1" }) }));
+vi.mock("@/lib/supabase", () => {
+  const supabase = { from: fromMock, rpc: rpcMock };
+  return { supabase, default: supabase };
+});
+vi.mock("@/hooks/useAuth", () => ({ useAuth: () => ({ mama_id: "m1" }) }));
 
 let useTemplatesCommandes;
 
@@ -18,7 +21,9 @@ beforeEach(async () => {
   fromMock.mockClear();
   rpcMock.mockClear();
   Object.values(query).forEach((fn) => fn.mockClear && fn.mockClear());
-  rpcMock.mockResolvedValue({ data: { id: "t1" }, error: null });
+  rpcMock.mockReturnValue({
+    single: vi.fn(() => Promise.resolve({ data: { id: "t1" }, error: null })),
+  });
 });
 
 test("fetchTemplates applies filter", async () => {

--- a/test/useTransferts.test.js
+++ b/test/useTransferts.test.js
@@ -30,9 +30,14 @@ const fromMock = vi.fn((table) => {
   return baseQuery;
 });
 
-vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
+vi.mock('@/lib/supabase', () => {
+  const supabase = { from: fromMock };
+  return { supabase, default: supabase };
+});
 vi.mock('@/hooks/useAuth', () => ({ useAuth: () => ({ mama_id: 'm1', user_id: 'u1' }) }));
-vi.mock('@/hooks/usePeriodes', () => ({ useAuth: () => ({ checkCurrentPeriode: vi.fn(() => ({})) }) }));
+vi.mock('@/hooks/usePeriodes', () => ({
+  default: () => ({ checkCurrentPeriode: vi.fn(() => ({})) }),
+}));
 
 let useTransferts;
 


### PR DESCRIPTION
## Summary
- add global mocks for `useAuth` and `usePeriodes` in Vitest setup
- switch `useTemplatesCommandes` to named `useAuth` import
- align hook tests with new mock export shapes

## Testing
- `npm test test/useTemplatesCommandes.test.js test/useInventaires.test.js test/useTransferts.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68a89b6461a4832d8e3cc08de595846e