### PR TITLE
Fix 2FA user retrieval and upsert

### DIFF
--- a/src/hooks/useTwoFactorAuth.js
+++ b/src/hooks/useTwoFactorAuth.js
@@ -12,11 +12,11 @@ export function useTwoFactorAuth() {
   async function refresh() {
     setLoading(true);
     setError(null);
-    const { data: { user } = {} } = await supabase.auth.getUser();
+    const { data: { user } } = await supabase.auth.getUser();
     const { data, error } = await supabase
       .from("auth_double_facteur")
       .select("enabled, secret")
-      .eq("id", user?.id)
+      .eq("id", user.id)
       .single();
     if (error) setError(error);
     else {
@@ -37,10 +37,8 @@ export function useTwoFactorAuth() {
     if (!secret) return;
     setLoading(true);
     setError(null);
-    const { data: { user } = {} } = await supabase.auth.getUser();
-    const { error } = await supabase
-      .from("auth_double_facteur")
-      .upsert({ id: user?.id, secret, enabled: true });
+    const { data: { user } } = await supabase.auth.getUser();
+    const { error } = await supabase.from('auth_double_facteur').upsert({ id: user.id, secret, enabled: true });
     if (error) setError(error);
     else setEnabled(true);
     setLoading(false);
@@ -48,11 +46,11 @@ export function useTwoFactorAuth() {
 
   async function disable() {
     setLoading(true);
-    const { data: { user } = {} } = await supabase.auth.getUser();
+    const { data: { user } } = await supabase.auth.getUser();
     const { error } = await supabase
       .from("auth_double_facteur")
       .update({ enabled: false, secret: null })
-      .eq("id", user?.id);
+      .eq("id", user.id);
     if (error) setError(error);
     else {
       setSecret(null);


### PR DESCRIPTION
## Summary
- use Supabase's nested `user` structure when retrieving the current user
- upsert two-factor auth record with explicit `user.id` and enable flag

## Testing
- `npm test` *(fails: useMenuGroupe is not a function, Login.jsx mock missing default export)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a16e86bc832d96f922a5cf91355e