### PR TITLE
refactor: simplify top products fetch

### DIFF
--- a/src/hooks/useTopProducts.js
+++ b/src/hooks/useTopProducts.js
@@ -1,19 +1,17 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import supabase from '@/lib/supabase';
+import { supabase } from '@/lib/supabase';
 import { useAuth } from '@/hooks/useAuth';
 
 export function useTopProducts() {
   const { mama_id } = useAuth();
 
-  async function fetchTop({ debut = null, fin = null, limit = 5 } = {}) {
-    const { data, error } = await supabase.rpc('top_produits', {
+  async function fetchTop({ debut, fin, limit } = {}) {
+    return supabase.rpc('top_produits', {
       mama_id_param: mama_id,
       debut_param: debut,
       fin_param: fin,
       limit_param: limit,
     });
-    if (error) return [];
-    return data || [];
   }
 
   return { fetchTop };


### PR DESCRIPTION
## Summary
- streamline top products hook to directly call RPC and pass required parameters

## Testing
- `npm test test/useTopProducts.test.js`
- `npx eslint src/hooks/useTopProducts.js`


------
https://chatgpt.com/codex/tasks/task_e_68a8a25f5b20832dab418150ba3e1d6a