### PR TITLE
fix: use default usePeriodes in transferts hook

### DIFF
--- a/src/hooks/useTransferts.js
+++ b/src/hooks/useTransferts.js
@@ -2,12 +2,11 @@
 import { useState, useCallback } from "react";
 import supabase from '@/lib/supabase';
 import { useAuth } from '@/hooks/useAuth';
-import * as PeriodesMod from '@/hooks/usePeriodes';
+import usePeriodes from '@/hooks/usePeriodes';
 
 export function useTransferts() {
   const { mama_id, user_id } = useAuth();
-  const periodesFn = PeriodesMod.default || PeriodesMod.usePeriodes || PeriodesMod.useAuth || (() => ({}));
-  const { checkCurrentPeriode } = periodesFn();
+  const { checkCurrentPeriode } = usePeriodes();
   const [transferts, setTransferts] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);


### PR DESCRIPTION
## Summary
- simplify usePeriodes usage in useTransferts
- keep queries chained and filtered by mama_id

## Testing
- `npm test test/useTransferts.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a8a26425d0832d851545cc19352701