### PR TITLE
fix: replace non-breaking spaces in French number format

### DIFF
--- a/src/utils/__tests__/number.test.ts
+++ b/src/utils/__tests__/number.test.ts
@@ -14,7 +14,7 @@ describe('utils/number', () => {
   });
 
   test('formatNumberFR', () => {
-    expect(formatNumberFR(1234.5)).toBe('1 234,50');
+    expect(formatNumberFR(1234.5)).toBe('1 234,50');
     expect(formatNumberFR(null)).toBe('');
   });
 });

--- a/src/utils/number.ts
+++ b/src/utils/number.ts
@@ -19,5 +19,5 @@ export function formatNumberFR(value: number | null | undefined, decimals = 2): 
     maximumFractionDigits: decimals,
   })
     .format(value)
-    .replace(/\u202F/g, ' ');
+    .replace(/\u202F|\u00A0/g, ' ');
 }


### PR DESCRIPTION
## Summary
- replace U+202F and U+00A0 spaces with regular spaces in `formatNumberFR`
- adjust tests for updated formatting

## Testing
- `npm test` *(fails: 47 failed, 93 passed)*
- `npx eslint src/utils/number.ts src/utils/__tests__/number.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a8a281d244832dade66828da7c55e0