### PR TITLE
test: ensure onAuthStateChange forwards session

### DIFF
--- a/src/lib/loginUser.js
+++ b/src/lib/loginUser.js
@@ -85,13 +85,13 @@ export async function refreshSession(currentSession) {
   return { data, error };
 }
 
-export function onAuthStateChange(callback) {
-  supabase.auth.getSession().then(({ data }) => callback(data?.session ?? null));
-  const { data: listener } = supabase.auth.onAuthStateChange((_event, session) => {
-    callback(session);
-  });
-  return listener.subscription.unsubscribe;
-}
+export const onAuthStateChange = (cb) => {
+  const {
+    data: { subscription },
+  } = supabase.auth.onAuthStateChange((_event, session) => cb(session));
+  supabase.auth.getSession().then(({ data }) => cb(data?.session ?? null));
+  return () => subscription?.unsubscribe();
+};
 
 export async function getAccessToken() {
   const { data, error } = await supabase.auth.getSession();


### PR DESCRIPTION
## Summary
- refactor `onAuthStateChange` to expose unsubscribe and fetch current session
- improve supabase auth mocking and add coverage for forwarded session

## Testing
- `npm test test/loginUser.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68a8a29fdc44832da8254be901f555b5