### PR TITLE
chore: handle fiche supabase errors

### DIFF
--- a/src/hooks/useFiches.js
+++ b/src/hooks/useFiches.js
@@ -79,7 +79,7 @@ export function useFiches() {
       console.error('createFiche error:', insertError);
       setLoading(false);
       setError(insertError);
-      throw insertError;
+      return { error: insertError };
     }
     const ficheId = data.id;
     if (lignes.length > 0) {
@@ -95,11 +95,12 @@ export function useFiches() {
         console.error('createFiche lignes error:', lignesError);
         setLoading(false);
         setError(lignesError);
-        throw lignesError;
+        return { error: lignesError };
       }
     }
+    setFiches(prev => [...prev, { id: ficheId, ...fiche }]);
+    setTotal(prev => prev + 1);
     setLoading(false);
-    await getFiches();
     return { data: ficheId };
   }
 
@@ -117,7 +118,7 @@ export function useFiches() {
       console.error('updateFiche error:', updateError);
       setLoading(false);
       setError(updateError);
-      throw updateError;
+      return { error: updateError };
     }
     const { error: deleteError } = await supabase
       .from("fiche_lignes")
@@ -128,7 +129,7 @@ export function useFiches() {
       console.error('updateFiche delete lines error:', deleteError);
       setLoading(false);
       setError(deleteError);
-      throw deleteError;
+      return { error: deleteError };
     }
     if (lignes.length > 0) {
       const toInsert = lignes.map(l => ({
@@ -143,11 +144,11 @@ export function useFiches() {
         console.error('updateFiche lines insert error:', insertError);
         setLoading(false);
         setError(insertError);
-        throw insertError;
+        return { error: insertError };
       }
     }
+    setFiches(prev => prev.map(f => f.id === id ? { ...f, ...fiche } : f));
     setLoading(false);
-    await getFiches();
     return { data: id };
   }
 
@@ -165,10 +166,11 @@ export function useFiches() {
       console.error('deleteFiche error:', deleteError);
       setLoading(false);
       setError(deleteError);
-      throw deleteError;
+      return { error: deleteError };
     }
+    setFiches(prev => prev.filter(f => f.id !== id));
+    setTotal(prev => Math.max(prev - 1, 0));
     setLoading(false);
-    await getFiches();
     return { data: id };
   }
 
@@ -186,7 +188,7 @@ export function useFiches() {
       console.error('duplicateFiche fetch error:', fetchError);
       setLoading(false);
       setError(fetchError);
-      throw fetchError;
+      return { error: fetchError };
     }
     const { lignes = [], ...rest } = fiche || {};
     const { data: inserted, error: insertError } = await supabase
@@ -198,7 +200,7 @@ export function useFiches() {
       console.error('duplicateFiche insert error:', insertError);
       setLoading(false);
       setError(insertError);
-      throw insertError;
+      return { error: insertError };
     }
     const newId = inserted.id;
     if (lignes.length) {
@@ -214,11 +216,12 @@ export function useFiches() {
         console.error('duplicateFiche lines insert error:', lineErr);
         setLoading(false);
         setError(lineErr);
-        throw lineErr;
+        return { error: lineErr };
       }
     }
+    setFiches(prev => [...prev, { ...rest, id: newId, nom: `${rest.nom} (copie)` }]);
+    setTotal(prev => prev + 1);
     setLoading(false);
-    await getFiches();
     return { data: newId };
   }
 

--- a/src/hooks/useFichesTechniques.js
+++ b/src/hooks/useFichesTechniques.js
@@ -34,18 +34,21 @@ export function useFichesTechniques() {
     if (!mama_id) return { error: "Aucun mama_id" };
     setLoading(true);
     setError(null);
-    const { error } = await supabase
+    const { data, error } = await supabase
       .from("fiches_techniques")
-      .insert([{ ...ft, mama_id }]);
+      .insert([{ ...ft, mama_id }])
+      .select("id")
+      .single();
     if (error) {
       console.error('addFicheTechnique error:', error);
       setLoading(false);
       setError(error);
-      throw error;
+      return { error };
     }
-    await fetchFichesTechniques();
+    const fiche = { ...ft, id: data?.id };
+    setFichesTechniques(prev => [...prev, fiche]);
     setLoading(false);
-    return { data: true };
+    return { data: fiche.id };
   }
 
   async function updateFicheTechnique(id, updateFields) {
@@ -61,9 +64,9 @@ export function useFichesTechniques() {
       console.error('updateFicheTechnique error:', error);
       setLoading(false);
       setError(error);
-      throw error;
+      return { error };
     }
-    await fetchFichesTechniques();
+    setFichesTechniques(prev => prev.map(f => f.id === id ? { ...f, ...updateFields } : f));
     setLoading(false);
     return { data: id };
   }
@@ -81,9 +84,9 @@ export function useFichesTechniques() {
       console.error('deleteFicheTechnique error:', error);
       setLoading(false);
       setError(error);
-      throw error;
+      return { error };
     }
-    await fetchFichesTechniques();
+    setFichesTechniques(prev => prev.filter(f => f.id !== id));
     setLoading(false);
     return { data: id };
   }

--- a/test/useFiches.test.js
+++ b/test/useFiches.test.js
@@ -53,3 +53,21 @@ test('createFiche inserts fiche and lines', async () => {
   expect(insertMainMock).toHaveBeenCalled();
   expect(insertLinesMock).toHaveBeenCalled();
 });
+
+test('createFiche updates local state', async () => {
+  const { result } = renderHook(() => useFiches());
+  await act(async () => {
+    await result.current.createFiche({ nom: 'f', lignes: [] });
+  });
+  expect(result.current.fiches).toHaveLength(1);
+  expect(result.current.fiches[0].nom).toBe('f');
+});
+
+test('createFiche returns error on failure', async () => {
+  insertMainMock.mockImplementationOnce(() => ({
+    select: () => ({ single: () => Promise.resolve({ data: null, error: { message: 'denied' } }) })
+  }));
+  const { result } = renderHook(() => useFiches());
+  const res = await result.current.createFiche({ nom: 'x', lignes: [] });
+  expect(res.error).toBeTruthy();
+});


### PR DESCRIPTION
## Summary
- handle Supabase errors in fiches hooks without throwing
- update local state after fiche create/update/delete
- test local state update and error return for createFiche

## Testing
- `npm test` *(fails: useExport is not a function, No QueryClient set, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a8a6eda5a8832db1ff3b190e149272