### PR TITLE
fix: remove stray closing brace in globals.css

### DIFF
--- a/src/globals.css
+++ b/src/globals.css
@@ -320,4 +320,3 @@ input[type="number"]::-webkit-inner-spin-button {
   margin: 0;
 }
 
-}


### PR DESCRIPTION
## Summary
- remove stray closing brace at end of global styles to keep braces balanced

## Testing
- `npm run build` *(fails: default export missing in src/hooks/useMenuGroupe.js)*
- `node -e "const fs=require('fs'),postcss=require('postcss');postcss().process(fs.readFileSync('src/globals.css','utf8'),{from:'src/globals.css'}).then(()=>console.log('postcss parse ok')).catch(e=>console.error('postcss error',e));"`


------
https://chatgpt.com/codex/tasks/task_e_68aabe0ffa98832d9fb0dab46b2826b7