### PR TITLE
fix: guard produit arrays

### DIFF
--- a/src/components/produits/ProduitForm.jsx
+++ b/src/components/produits/ProduitForm.jsx
@@ -23,18 +23,22 @@ export default function ProduitForm({
   const { data: fournisseursData } = useFournisseurs({ actif: true });
   const fournisseurs = fournisseursData?.data || [];
   const {
-    familles,
+    familles: dataFamilles,
     fetchFamilles,
     error: famillesError,
   } = useFamilles();
+  const familles = dataFamilles ?? [];
   const {
-    sousFamilles,
+    sousFamilles: dataSousFamilles,
     list: listSousFamilles,
     loading: sousFamillesLoading,
     error: sousFamillesError,
   } = useSousFamilles();
-  const { unites, fetchUnites } = useUnites();
-  const { zones } = useZonesStock();
+  const sousFamilles = dataSousFamilles ?? [];
+  const { unites: dataUnites, fetchUnites } = useUnites();
+  const unites = dataUnites ?? [];
+  const { zones: dataZones } = useZonesStock();
+  const zones = dataZones ?? [];
 
   const [nom, setNom] = useState(produit?.nom || "");
   const [familleId, setFamilleId] = useState(produit?.famille_id || "");

--- a/src/pages/produits/Produits.jsx
+++ b/src/pages/produits/Produits.jsx
@@ -29,7 +29,13 @@ export default function Produits() {
   const canEdit = hasAccess("produits", "peut_modifier");
   const canView = hasAccess("produits", "peut_voir");
 
-  const { products, total, fetchProducts, toggleProductActive } = useProductsView();
+  const {
+    products: dataProducts,
+    total,
+    fetchProducts,
+    toggleProductActive,
+  } = useProductsView();
+  const products = dataProducts ?? [];
 
   const [searchParams, setSearchParams] = useSearchParams();
 


### PR DESCRIPTION
## Summary
- ensure product list defaults to empty before mapping
- default famille, sous-famille, unité and zone arrays in product form

## Testing
- `npm test` *(fails: Cannot destructure property 'user' of 'useAuth(...)' as it is null.)*

------
https://chatgpt.com/codex/tasks/task_e_68aac17284cc832da6f2d098dae74790