### PR TITLE
feat: safe Supabase selects with fallback

### DIFF
--- a/src/components/ui/ImportPreviewTable.jsx
+++ b/src/components/ui/ImportPreviewTable.jsx
@@ -1,8 +1,7 @@
 import { validateProduitRow } from "@/utils/excelUtils";
 
-export default function ImportPreviewTable({ rows, onUpdate, maps, reference }) {
-  const { familles = [], sousFamilles = [], unites = [], zones = [] } =
-    reference || {};
+export default function ImportPreviewTable({ rows = [], onUpdate, maps, reference = {} }) {
+  const { familles = [], sousFamilles = [], unites = [], zones = [] } = reference;
 
   function handleChange(index, field, value) {
     const updated = [...rows];

--- a/src/hooks/gadgets/useAlerteStockFaible.js
+++ b/src/hooks/gadgets/useAlerteStockFaible.js
@@ -16,7 +16,7 @@ export default function useAlerteStockFaible() {
     setError(null);
     try {
       const select =
-        'id:produit_id,produit_id,nom,unite,fournisseur_nom,stock_actuel,stock_min,consommation_prevue,receptions,manque,type,stock_projete';
+        'mama_id,id:produit_id,produit_id,nom,unite,fournisseur_nom,stock_actuel,stock_min,consommation_prevue,receptions,manque,type,stock_projete';
 
       const rows = await safeSelectWithFallback({
         client: supabase,
@@ -24,6 +24,7 @@ export default function useAlerteStockFaible() {
         select,
         order: { column: 'manque', ascending: false },
         limit: 50,
+        transform: (rows) => (rows || []).filter(r => r.mama_id === mama_id),
       });
 
       const list = (rows || [])

--- a/src/hooks/useRuptureAlerts.js
+++ b/src/hooks/useRuptureAlerts.js
@@ -2,6 +2,7 @@
 import { supabase } from '@/lib/supabase';
 import { useAuth } from '@/hooks/useAuth';
 import { toast } from 'sonner';
+import { safeSelectWithFallback } from '@/lib/supa/safeSelect';
 
 export function useRuptureAlerts() {
   const { mama_id } = useAuth();
@@ -9,34 +10,19 @@ export function useRuptureAlerts() {
   async function fetchAlerts(type = null) {
     if (!mama_id) return [];
     try {
-      const base = supabase.from('v_alertes_rupture');
-      const selectWith =
-        'id:produit_id, produit_id, nom, unite, fournisseur_nom, stock_actuel, stock_min, consommation_prevue, receptions, stock_projete, manque, type';
-
-      let query = base.select(selectWith).eq('mama_id', mama_id).order('manque', { ascending: false });
-      if (type) query = query.eq('type', type);
-      let { data, error } = await query;
-
-      if (error && error.code === '42703') {
-        if (import.meta.env.DEV)
-          console.debug('v_alertes_rupture sans stock_projete');
-        let q2 = base
-          .select('id:produit_id, produit_id, nom, unite, fournisseur_nom, stock_actuel, stock_min, consommation_prevue, receptions, stock_previsionnel, manque, type').eq('mama_id', mama_id)
-          .order('manque', { ascending: false });
-        if (type) q2 = q2.eq('type', type);
-        const { data: d2, error: e2 } = await q2;
-        if (e2) throw e2;
-        data = (d2 ?? []).map((r) => ({
-          ...r,
-          stock_projete: r.stock_previsionnel ?? ((r.stock_actuel ?? 0) + (r.receptions ?? 0) - (r.consommation_prevue ?? 0)),
-        }));
-      } else {
-        if (error) throw error;
-        if (import.meta.env.DEV)
-          console.debug('v_alertes_rupture avec stock_projete');
-      }
-
-      return data || [];
+      const select =
+        'mama_id, id:produit_id, produit_id, nom, unite, fournisseur_nom, stock_actuel, stock_min, consommation_prevue, receptions, stock_projete, manque, type';
+      const rows = await safeSelectWithFallback({
+        client: supabase,
+        table: 'v_alertes_rupture',
+        select,
+        order: { column: 'manque', ascending: false },
+        transform: (data) =>
+          (data || [])
+            .filter(r => r.mama_id === mama_id && (!type || r.type === type))
+            .map(({ mama_id: _mama, ...rest }) => rest),
+      });
+      return rows;
     } catch (error) {
       console.error(error);
       toast.error(error.message || 'Erreur chargement alertes rupture');


### PR DESCRIPTION
## Summary
- add `safeSelectWithFallback` to handle missing view columns
- wrap rupture alerts and dashboard gadgets with new helper
- guard table maps in ImportPreviewTable to avoid undefined errors

## Testing
- `npm test` *(fails: @/pages/auth/Login.jsx mock missing default export)*
- `npm run lint` *(fails: react-hooks/rules-of-hooks in useTemplatesCommandes.js)*

------
https://chatgpt.com/codex/tasks/task_e_68aac5b445a8832d9ffbd04464ae5ddd