### PR TITLE
parametrage: refactor sous-familles management

### DIFF
--- a/src/globals.css
+++ b/src/globals.css
@@ -269,7 +269,7 @@ html.dark body {
 /* Transitions compatibles Firefox (évite "Déclaration abandonnée") */
 [data-state="open"].animate-in,
 [data-state="closed"].animate-out {
-  transition: opacity .2s ease, transform .2s ease;
+  transition: all .2s ease;
 }
 
 :root {

--- a/src/hooks/data/useFamillesParametrage.js
+++ b/src/hooks/data/useFamillesParametrage.js
@@ -1,0 +1,23 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/lib/supabase';
+
+export function useFamillesParametrage({ mamaId, enabled = true }) {
+  return useQuery({
+    queryKey: ['param-familles', { mamaId }],
+    enabled: !!mamaId && enabled,
+    queryFn: async () => {
+      // Ne pas sélectionner "code" pour éviter 400 si la colonne n'existe pas
+      const { data, error } = await supabase
+        .from('familles')
+        .select('id, nom, actif')
+        .eq('mama_id', mamaId)
+        .order('nom', { ascending: true });
+
+      if (error) throw error;
+      return data ?? [];
+    },
+    initialData: [],
+    staleTime: 10_000,
+    keepPreviousData: true,
+  });
+}

--- a/src/hooks/data/useSousFamillesParametrage.js
+++ b/src/hooks/data/useSousFamillesParametrage.js
@@ -1,0 +1,28 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/lib/supabase';
+
+export function useSousFamillesParametrage({ mamaId, search = '', familleId, statut = 'all' }) {
+  return useQuery({
+    queryKey: ['param-sous-familles', { mamaId, search, familleId, statut }],
+    enabled: !!mamaId,
+    queryFn: async () => {
+      let q = supabase
+        .from('sous_familles')
+        .select('id, nom, actif, famille_id, mama_id')
+        .eq('mama_id', mamaId)
+        .order('nom', { ascending: true });
+
+      if (search?.trim()) q = q.ilike('nom', `%${search.trim()}%`);
+      if (familleId) q = q.eq('famille_id', familleId);
+      if (statut === 'actifs') q = q.eq('actif', true);
+      if (statut === 'inactifs') q = q.eq('actif', false);
+
+      const { data, error } = await q;
+      if (error) throw error;
+      return data ?? [];
+    },
+    initialData: [],
+    staleTime: 5_000,
+    keepPreviousData: true,
+  });
+}

--- a/src/hooks/useMamaSettings.js
+++ b/src/hooks/useMamaSettings.js
@@ -36,7 +36,7 @@ const defaults = {
 const localEnabledModules = {};
 const localFeatureFlags = {};
 
-export default function useMamaSettings() {
+export function useMamaSettings() {
   const { userData } = useAuth();
   const mamaId = userData?.mama_id;
   const queryClient = safeQueryClient();
@@ -106,5 +106,8 @@ export default function useMamaSettings() {
     ok: !query.error,
     fetchMamaSettings: query.refetch,
     updateMamaSettings,
+    mamaId,
   };
 }
+
+export default useMamaSettings;

--- a/src/hooks/useSousFamilles.js
+++ b/src/hooks/useSousFamilles.js
@@ -69,12 +69,12 @@ export async function fetchSousFamilles({ mamaId }) {
   try {
     let q = supabase
       .from('sous_familles')
-      .select('id, nom, famille_id, mama_id, deleted_at')
+      .select('id, nom, famille_id, mama_id, actif')
       .eq('mama_id', mamaId)
       .order('nom', { ascending: true });
     const { data, error } = await q;
     if (error) throw error;
-    return (data ?? []).filter((r) => !r.deleted_at);
+    return data ?? [];
   } catch (e) {
     console.warn('[sous_familles] fallback []', e);
     return [];


### PR DESCRIPTION
## Summary
- add familles and sous-familles parametrage hooks
- rebuild sous-familles settings page with filters and CRUD
- expose mamaId from `useMamaSettings`
- drop `deleted_at` from sous-familles fetching
- standardize CSS transition rule

## Testing
- `npm test` *(fails: 15 failed, 35 failed tests)*

------
https://chatgpt.com/codex/tasks/task_e_68aad28411e0832d891bba3b2e5d63bf