### PR TITLE
Expose named and default export for useMamaSettings

### DIFF
--- a/src/hooks/useMamaSettings.js
+++ b/src/hooks/useMamaSettings.js
@@ -36,7 +36,7 @@ const defaults = {
 const localEnabledModules = {};
 const localFeatureFlags = {};
 
-export default function useMamaSettings() {
+export function useMamaSettings() {
   const { userData } = useAuth();
   const mamaId = userData?.mama_id;
   const queryClient = safeQueryClient();
@@ -108,3 +108,5 @@ export default function useMamaSettings() {
     updateMamaSettings,
   };
 }
+
+export default useMamaSettings;


### PR DESCRIPTION
## Summary
- expose both named and default export for `useMamaSettings` hook

## Testing
- `npm test` *(fails: Tests failed. Watching for file changes...)*

------
https://chatgpt.com/codex/tasks/task_e_68aaf3606db8832da99329007a1f0f7a