### PR TITLE
feat: add sous-famille filters to products page

### DIFF
--- a/src/hooks/data/useProduits.js
+++ b/src/hooks/data/useProduits.js
@@ -1,41 +1,53 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/lib/supabase';
+import { useMamaSettings } from '@/hooks/useMamaSettings';
 
-const PAGE_SIZE = 25;
-
-export function useProduits({ mamaId, search = '', statut = 'all', familleId, sousFamilleId, page = 1 }) {
-  const offset = (page - 1) * PAGE_SIZE;
-  const key = useMemo(
-    () => ['produits', { mamaId, search, statut, familleId, sousFamilleId, page }],
-    [mamaId, search, statut, familleId, sousFamilleId, page]
-  );
+export const useProduits = ({
+  search = '',
+  statut = 'tous',
+  familleId = null,
+  sousFamilleId = null,
+  page = 1,
+  pageSize = 25,
+}) => {
+  const { mamaId } = useMamaSettings();
 
   return useQuery({
-    queryKey: key,
+    queryKey: ['produits', mamaId, search, statut, familleId, sousFamilleId, page, pageSize],
     enabled: !!mamaId,
     queryFn: async () => {
-      let q = supabase
+      let query = supabase
         .from('produits')
-        .select('id, nom, unite, pmp, actif, zone_stockage, famille_id, sous_famille_id', { count: 'exact' })
-        .eq('mama_id', mamaId)
+        .select(
+          `
+          id, nom, unite, pmp, zone_stockage, actif, mama_id,
+          famille:familles ( id, nom ),
+          sous_famille:sous_familles ( id, nom )
+        `,
+          { count: 'exact' }
+        )
+        .eq('mama_id', mamaId);
+
+      if (search) {
+        query = query.ilike('nom', `%${search}%`);
+      }
+      if (statut === 'actif') query = query.eq('actif', true);
+      if (statut === 'inactif') query = query.eq('actif', false);
+      if (familleId) query = query.eq('famille_id', familleId);
+      if (sousFamilleId) query = query.eq('sous_famille_id', sousFamilleId);
+
+      query = query
         .order('nom', { ascending: true })
-        .range(offset, offset + PAGE_SIZE - 1);
+        .range((page - 1) * pageSize, page * pageSize - 1);
 
-      if (search?.trim()) q = q.ilike('nom', `%${search.trim()}%`);
-      if (statut === 'actifs') q = q.eq('actif', true);
-      if (statut === 'inactifs') q = q.eq('actif', false);
-      if (familleId) q = q.eq('famille_id', familleId);
-      if (sousFamilleId) q = q.eq('sous_famille_id', sousFamilleId);
-
-      const { data, error, count } = await q;
+      const { data, error, count } = await query;
       if (error) throw error;
-
-      return { rows: data ?? [], total: count ?? 0, pageSize: PAGE_SIZE };
+      return { data, count };
     },
     keepPreviousData: true,
     staleTime: 10_000,
   });
-}
+};
+
 

--- a/src/pages/produits/Produits.jsx
+++ b/src/pages/produits/Produits.jsx
@@ -1,60 +1,59 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { useState, useMemo } from 'react';
+import { useState } from 'react';
 import { useProduits } from '@/hooks/data/useProduits';
 import { useFamilles } from '@/hooks/data/useFamilles';
 import { useSousFamilles } from '@/hooks/data/useSousFamilles';
 import { useMamaSettings } from '@/hooks/useMamaSettings';
-import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 
 export default function Produits() {
   const { mamaId } = useMamaSettings(); // ou autre source
-  const [searchRaw, setSearchRaw] = useState('');
   const [search, setSearch] = useState('');
-  const [statut, setStatut] = useState('all'); // all | actifs | inactifs
+  const [statut, setStatut] = useState('tous'); // tous | actif | inactif
   const [familleId, setFamilleId] = useState(null);
   const [sousFamilleId, setSousFamilleId] = useState(null);
   const [page, setPage] = useState(1);
 
-  // debounce recherche
-  useMemo(() => {
-    const id = setTimeout(() => setSearch(searchRaw), 300);
-    return () => clearTimeout(id);
-  }, [searchRaw]);
+  const pageSize = 25;
 
   const { data: familles = [] } = useFamilles({ mamaId });
-  const { data: sousFamilles = [] } = useSousFamilles({ mamaId, familleId, enabled: !!familleId });
+  const { data: sousFamillesAll = [] } = useSousFamilles({ mamaId });
+  const sousFamillesOptions = familleId
+    ? sousFamillesAll.filter((sf) => sf.famille_id === familleId)
+    : sousFamillesAll;
 
-  const { data, isLoading, isError } = useProduits({
-    mamaId,
+  const { data, isLoading, error } = useProduits({
     search,
     statut,
     familleId,
     sousFamilleId,
     page,
+    pageSize,
   });
 
-  const rows = data?.rows ?? [];
-  const total = data?.total ?? 0;
-  const pageSize = data?.pageSize ?? 25;
-
-  const sousFamillesOptions = sousFamilles ?? [];
+  const rows = data?.data ?? [];
+  const total = data?.count ?? 0;
 
   return (
     <div className="space-y-4">
       {/* Filtres en 1 ligne */}
       <div className="flex flex-wrap gap-2 items-center">
-        <Input
+        <input
+          className="input min-w-[240px]"
           placeholder="Recherche nom"
-          value={searchRaw}
-          onChange={(e) => { setSearchRaw(e.target.value); setPage(1); }}
-          className="min-w-[240px]"
+          value={search}
+          onChange={(e) => { setSearch(e.target.value); setPage(1); }}
         />
 
         <select
           value={familleId ?? ''}
-          onChange={(e) => { const v = e.target.value || null; setFamilleId(v); setSousFamilleId(null); setPage(1); }}
-          className="h-9 rounded-xl px-3 bg-black/20 border border-white/10"
+          onChange={(e) => {
+            const v = e.target.value || null;
+            setFamilleId(v);
+            setSousFamilleId(null);
+            setPage(1);
+          }}
+          className="select"
         >
           <option value="">Toutes les familles</option>
           {(familles || []).map(f => <option key={f.id} value={f.id}>{f.nom}</option>)}
@@ -62,9 +61,12 @@ export default function Produits() {
 
         <select
           value={sousFamilleId ?? ''}
-          onChange={(e) => { const v = e.target.value || null; setSousFamilleId(v); setPage(1); }}
-          disabled={!familleId}
-          className="h-9 rounded-xl px-3 bg-black/20 border border-white/10 disabled:opacity-50"
+          onChange={(e) => {
+            const v = e.target.value || null;
+            setSousFamilleId(v);
+            setPage(1);
+          }}
+          className="select"
         >
           <option value="">Toutes les sous-familles</option>
           {sousFamillesOptions.map(sf => <option key={sf.id} value={sf.id}>{sf.nom}</option>)}
@@ -72,12 +74,15 @@ export default function Produits() {
 
         <select
           value={statut}
-          onChange={(e) => { setStatut(e.target.value); setPage(1); }}
-          className="h-9 rounded-xl px-3 bg-black/20 border border-white/10"
+          onChange={(e) => {
+            setStatut(e.target.value);
+            setPage(1);
+          }}
+          className="select"
         >
-          <option value="all">Tous</option>
-          <option value="actifs">Actifs</option>
-          <option value="inactifs">Inactifs</option>
+          <option value="tous">Tous</option>
+          <option value="actif">Actif</option>
+          <option value="inactif">Inactif</option>
         </select>
 
         <div className="ml-auto flex gap-2">
@@ -95,23 +100,28 @@ export default function Produits() {
               <th className="text-left p-3">Nom</th>
               <th className="text-left p-3">Unité</th>
               <th className="text-left p-3">PMP (€)</th>
+              <th className="text-left p-3">Sous-famille</th>
               <th className="text-left p-3">Zone de stockage</th>
               <th className="text-left p-3">Statut</th>
               <th className="text-left p-3">Actions</th>
             </tr>
           </thead>
           <tbody>
-            {isLoading && (
-              <tr><td className="p-4" colSpan={6}>Chargement…</td></tr>
+            {error && (
+              <tr><td className="p-4" colSpan={7}>Erreur lors du chargement des produits.</td></tr>
             )}
-            {(!isLoading && rows.length === 0) && (
-              <tr><td className="p-4" colSpan={6}>Aucun produit trouvé. Essayez d’ajouter un produit via le bouton ci-dessus.</td></tr>
+            {isLoading && !error && (
+              <tr><td className="p-4" colSpan={7}>Chargement…</td></tr>
             )}
-            {rows.map(p => (
+            {!isLoading && !error && rows.length === 0 && (
+              <tr><td className="p-4" colSpan={7}>Aucun produit trouvé. Essayez d’ajouter un produit via le bouton ci-dessus.</td></tr>
+            )}
+            {!error && rows.map(p => (
               <tr key={p.id} className="border-t border-white/10">
                 <td className="p-3">{p.nom}</td>
                 <td className="p-3">{p.unite ?? '—'}</td>
-                <td className="p-3">{(p.pmp ?? 0).toFixed(2)}</td>
+                <td className="p-3">{Number(p.pmp || 0).toFixed(2)}</td>
+                <td className="p-3">{p.sous_famille?.nom ?? '—'}</td>
                 <td className="p-3">{p.zone_stockage ?? '—'}</td>
                 <td className="p-3">{p.actif ? 'Actif' : 'Inactif'}</td>
                 <td className="p-3">
@@ -129,11 +139,17 @@ export default function Produits() {
 
       {/* Pagination */}
       <div className="flex items-center justify-between text-sm">
-        <div>Total : {total}</div>
+        <div>Total : {rows.length}</div>
         <div className="flex gap-2">
-          <Button variant="secondary" disabled={page <= 1} onClick={() => setPage(p => p - 1)}>Précédent</Button>
+          <Button variant="secondary" disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>Précédent</Button>
           <div>Page {page} sur {Math.max(1, Math.ceil(total / pageSize))}</div>
-          <Button variant="secondary" disabled={page >= Math.ceil(total / pageSize)} onClick={() => setPage(p => p + 1)}>Suivant</Button>
+          <Button
+            variant="secondary"
+            disabled={page >= Math.ceil(total / pageSize)}
+            onClick={() => setPage((p) => p + 1)}
+          >
+            Suivant
+          </Button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- query products from `produits` table with famille & sous-famille joins
- add sous-famille column and filters to products list
- handle fetch errors and display loaded item count

## Testing
- `npm test` *(fails: 8 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68aafd74f52c832d8a4038a192d101f0