### PR TITLE
fix: correct fiche listing and rupture alert queries

### DIFF
--- a/src/hooks/data/useFichesTechniques.js
+++ b/src/hooks/data/useFichesTechniques.js
@@ -1,87 +1,50 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/lib/supabase';
+import { useMamaSettings } from '@/hooks/useMamaSettings';
 
-const PAGE_SIZE = 20;
+const DEFAULT_PAGE_SIZE = 20;
 
 /**
- * Chargement paginé des fiches techniques sans jointures cassées.
- * Récupère d'abord les fiches avec leur `famille_id`, puis charge les familles
- * correspondantes et merge côté front pour exposer `famille_nom`.
+ * Chargement paginé des fiches techniques depuis la table `fiches`.
+ * Filtres possibles: recherche par nom, famille, statut (actif/inactif/tous).
  */
 export function useFichesTechniques({
-  page = 1,
   search = '',
-  actif = 'true',
-  famille,
+  page = 1,
+  pageSize = DEFAULT_PAGE_SIZE,
+  familleId = null,
+  statut = 'tous', // 'tous' | 'actif' | 'inactif'
   sortBy = 'nom',
-  mamaId,
 }) {
-  const offset = (page - 1) * PAGE_SIZE;
-
-  // Clef de cache STABLE
-  const queryKey = useMemo(
-    () => [
-      'fiches-techniques',
-      { page, search, actif, famille, sortBy, mamaId },
-    ],
-    [page, search, actif, famille, sortBy, mamaId],
-  );
+  const { mamaId } = useMamaSettings();
 
   return useQuery({
-    queryKey,
-    // On ne lance la requête que si on connaît la mama
+    queryKey: ['fiches', { mamaId, search, page, pageSize, familleId, statut, sortBy }],
     enabled: !!mamaId,
+    keepPreviousData: true,
+    staleTime: 10_000,
     queryFn: async () => {
-      // 1) FICHES sans join familles
       let q = supabase
-        .from('fiches_techniques')
+        .from('fiches')
         .select(
           'id, nom, actif, cout_par_portion, famille_id, created_at, updated_at',
           { count: 'exact' },
         )
         .eq('mama_id', mamaId)
         .order(sortBy, { ascending: true })
-        .range(offset, offset + PAGE_SIZE - 1);
+        .range((page - 1) * pageSize, page * pageSize - 1);
 
-      if (search?.trim()) q = q.ilike('nom', `%${search.trim()}%`);
-      if (actif === 'true') q = q.eq('actif', true);
-      if (actif === 'false') q = q.eq('actif', false);
-      if (famille) q = q.eq('famille_id', famille);
+      if (search) q = q.ilike('nom', `%${search}%`);
+      if (familleId) q = q.eq('famille_id', familleId);
+      if (statut === 'actif') q = q.eq('actif', true);
+      if (statut === 'inactif') q = q.eq('actif', false);
 
-      const { data: fiches = [], error, count } = await q;
+      const { data, error, count } = await q;
       if (error) throw error;
 
-      // 2) Récup familles si besoin
-      const familleIds = [...new Set(fiches.map((f) => f.famille_id).filter(Boolean))];
-      let famillesById = {};
-      if (familleIds.length) {
-        const { data: familles = [], error: famErr } = await supabase
-          .from('familles')
-          .select('id, nom')
-          .in('id', familleIds);
-
-        if (famErr) {
-          // On ne jette pas, on renvoie juste sans les noms
-          console.warn('Chargement familles échoué:', famErr);
-        } else {
-          famillesById = Object.fromEntries(familles.map((f) => [f.id, f]));
-        }
-      }
-
-      // 3) Merge côté front : ajoute famille_nom
-      const rows = fiches.map((f) => ({
-        ...f,
-        famille_nom: f.famille_id
-          ? famillesById[f.famille_id]?.nom ?? '—'
-          : '—',
-      }));
-
-      return { rows, total: count ?? 0 };
+      return { rows: data ?? [], total: count ?? 0 };
     },
-    keepPreviousData: true,
-    staleTime: 10_000,
   });
 }
 

--- a/test/useRuptureAlerts.test.js
+++ b/test/useRuptureAlerts.test.js
@@ -31,41 +31,30 @@ test('fetchAlerts selects expected view columns', async () => {
   await fetchAlerts('rupture');
   expect(fromMock).toHaveBeenCalledWith('v_alertes_rupture');
   expect(queryBuilder.select).toHaveBeenCalledWith(
-    'id:produit_id, produit_id, nom, unite, fournisseur_nom, stock_actuel, stock_min, consommation_prevue, receptions, stock_projete, manque, type'
-  );
-  expect(queryBuilder.eq).toHaveBeenCalledTimes(1);
-  expect(queryBuilder.eq).toHaveBeenCalledWith('type', 'rupture');
-});
-
-test('fetchAlerts falls back when stock_projete missing', async () => {
-  queryBuilder.then
-    .mockImplementationOnce((resolve) =>
-      resolve({ data: null, error: { code: '42703' } })
-    )
-    .mockImplementationOnce((resolve) =>
-      resolve({
-        data: [
-          {
-            produit_id: 1,
-            nom: 'p',
-            stock_actuel: 5,
-            consommation_prevue: 3,
-            receptions: 2,
-          },
-        ],
-        error: null,
-      })
-    );
-
-  const { fetchAlerts } = useRuptureAlerts();
-  const data = await fetchAlerts();
-  expect(queryBuilder.select).toHaveBeenNthCalledWith(
-    1,
-    'id:produit_id, produit_id, nom, unite, fournisseur_nom, stock_actuel, stock_min, consommation_prevue, receptions, stock_projete, manque, type'
-  );
-  expect(queryBuilder.select).toHaveBeenNthCalledWith(
-    2,
     'id:produit_id, produit_id, nom, unite, fournisseur_nom, stock_actuel, stock_min, consommation_prevue, receptions, manque, type'
   );
+  expect(queryBuilder.eq).toHaveBeenNthCalledWith(1, 'mama_id', 'm1');
+  expect(queryBuilder.eq).toHaveBeenNthCalledWith(2, 'type', 'rupture');
+});
+
+test('fetchAlerts computes stock_projete', async () => {
+  queryBuilder.then.mockImplementation((resolve) =>
+    resolve({
+      data: [
+        {
+          produit_id: 1,
+          nom: 'p',
+          stock_actuel: 5,
+          consommation_prevue: 3,
+          receptions: 2,
+          manque: 0,
+          type: 'rupture',
+        },
+      ],
+      error: null,
+    })
+  );
+  const { fetchAlerts } = useRuptureAlerts();
+  const data = await fetchAlerts();
   expect(data[0].stock_projete).toBe(4);
 });


### PR DESCRIPTION
## Summary
- query fiches from real `fiches` table with reliable filters
- filter rupture alerts by `mama_id` and drop missing `stock_projete`

## Testing
- `npm test -- --run` *(fails: writes to a custom file, writes csv when format is csv, writes json when format is json, returns the default file name, honours WEEKLY_REPORT_FORMAT env variable, honours WEEKLY_REPORT_FORMAT when set to json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab08dc2ec8832daf9276b24f37b96c