### PR TITLE
feat: map product subfamilies in frontend

### DIFF
--- a/src/pages/produits/Produits.jsx
+++ b/src/pages/produits/Produits.jsx
@@ -16,6 +16,10 @@ export default function Produits() {
 
   const { data: familles = [] } = useFamilles();
   const { data: allSousFamilles = [] } = useSousFamilles();
+  const sousFamillesMap = useMemo(
+    () => Object.fromEntries((allSousFamilles ?? []).map(sf => [sf.id, sf.nom])),
+    [allSousFamilles]
+  );
   const sousFamilles = useMemo(
     () => (familleId ? allSousFamilles.filter(sf => sf.famille_id === familleId) : allSousFamilles),
     [familleId, allSousFamilles]
@@ -99,7 +103,9 @@ export default function Produits() {
               <div className="table-cell py-2">{p.nom}</div>
               <div className="table-cell py-2">{p.unite ?? '—'}</div>
               <div className="table-cell py-2">{(p.pmp ?? 0).toFixed(2)}</div>
-              <div className="table-cell py-2">{p.sous_famille?.nom ?? '—'}</div>
+              <div className="table-cell py-2">
+                {sousFamillesMap[p.sous_famille_id ?? p.sous_famille] ?? '—'}
+              </div>
               <div className="table-cell py-2">{p.zone_stockage ?? '—'}</div>
               <div className="table-cell py-2">{p.actif ? 'Actif' : 'Inactif'}</div>
               <div className="table-cell py-2"> {/* actions existantes */}</div>


### PR DESCRIPTION
## Summary
- avoid PostgREST join and select both `sous_famille_id` and `sous_famille`
- map subfamily ids to names on the produits page and display lookup
- filter by subfamily id using `.or()` to support both column variants

## Testing
- `npm test` (fails: tests failed)
- `npm run lint` (fails: React Hook "useAuth" is called in function "fetchTemplates" that is neither a React function component nor a custom React Hook function)


------
https://chatgpt.com/codex/tasks/task_e_68ab108afae0832dae4cd164abfcd857