### PR TITLE
Align front Supabase queries with backend schema

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -2,7 +2,7 @@
 import { Link, NavLink, useLocation } from "react-router-dom";
 import { useMemo } from "react";
 import { useAuth } from "@/hooks/useAuth";
-import useMamaSettings from "@/hooks/useMamaSettings";
+import { useMamaSettings } from "@/hooks/useMamaSettings";
 import logo from "@/assets/logo-mamastock.png";
 import { normalizeAccessKey } from "@/lib/access";
 

--- a/src/components/fiches/FicheRow.jsx
+++ b/src/components/fiches/FicheRow.jsx
@@ -12,7 +12,7 @@ export default function FicheRow({ fiche, onEdit, onDetail, onDuplicate, onDelet
           {fiche.nom}
         </Button>
       </td>
-      <td className="border px-4 py-2">{fiche.famille_nom || "—"}</td>
+      <td className="border px-4 py-2">{fiche.famille || "—"}</td>
       <td className="border px-4 py-2 text-right">
         {Number(fiche.cout_par_portion).toLocaleString("fr-FR", {
           style: "currency",

--- a/src/context/ThemeProvider.jsx
+++ b/src/context/ThemeProvider.jsx
@@ -1,6 +1,6 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { createContext, useContext, useEffect } from "react";
-import useMamaSettings from "@/hooks/useMamaSettings";
+import { useMamaSettings } from "@/hooks/useMamaSettings";
 import { useAuth } from '@/hooks/useAuth';
 
 const ThemeContext = createContext({});

--- a/src/hooks/data/useFamilles.js
+++ b/src/hooks/data/useFamilles.js
@@ -10,7 +10,7 @@ export const useFamilles = () => {
     queryFn: async () => {
       const { data, error } = await supabase
         .from('familles')
-        .select('id, code, nom, actif')
+        .select('id, nom, actif')
         .eq('mama_id', mamaId)
         .order('nom', { ascending: true });
       if (error) throw error;

--- a/src/hooks/data/useFichesTechniques.js
+++ b/src/hooks/data/useFichesTechniques.js
@@ -6,29 +6,29 @@ import { useMamaSettings } from '@/hooks/useMamaSettings';
 const DEFAULT_PAGE_SIZE = 20;
 
 /**
- * Chargement paginé des fiches techniques depuis la table `fiches`.
- * Filtres possibles: recherche par nom, famille, statut (actif/inactif/tous).
+ * Chargement paginé des fiches techniques depuis la table `fiches_techniques`.
+ * Filtres possibles: recherche par nom, famille (texte), statut (actif/inactif/tous).
  */
 export function useFichesTechniques({
   search = '',
   page = 1,
   pageSize = DEFAULT_PAGE_SIZE,
-  familleId = null,
+  famille = null,
   statut = 'tous', // 'tous' | 'actif' | 'inactif'
   sortBy = 'nom',
 }) {
   const { mamaId } = useMamaSettings();
 
   return useQuery({
-    queryKey: ['fiches', { mamaId, search, page, pageSize, familleId, statut, sortBy }],
+    queryKey: ['fiches', { mamaId, search, page, pageSize, famille, statut, sortBy }],
     enabled: !!mamaId,
     keepPreviousData: true,
     staleTime: 10_000,
     queryFn: async () => {
       let q = supabase
-        .from('fiches')
+        .from('fiches_techniques')
         .select(
-          'id, nom, actif, cout_par_portion, famille_id, created_at, updated_at',
+          'id, nom, actif, cout_par_portion, portions, famille, prix_vente, type_carte, sous_type_carte, carte_actuelle, cout_total, rendement, created_at, updated_at',
           { count: 'exact' },
         )
         .eq('mama_id', mamaId)
@@ -36,7 +36,7 @@ export function useFichesTechniques({
         .range((page - 1) * pageSize, page * pageSize - 1);
 
       if (search) q = q.ilike('nom', `%${search}%`);
-      if (familleId) q = q.eq('famille_id', familleId);
+      if (famille) q = q.eq('famille', famille);
       if (statut === 'actif') q = q.eq('actif', true);
       if (statut === 'inactif') q = q.eq('actif', false);
 

--- a/src/hooks/gadgets/useAlerteStockFaible.js
+++ b/src/hooks/gadgets/useAlerteStockFaible.js
@@ -16,7 +16,7 @@ export default function useAlerteStockFaible() {
     setError(null);
     try {
       const select =
-        'mama_id,id:produit_id,produit_id,nom,unite,fournisseur_nom,stock_actuel,stock_min,consommation_prevue,receptions,manque,type,stock_projete';
+        'mama_id, id:produit_id, produit_id, nom, unite, fournisseur_nom, stock_actuel, stock_min, manque';
 
       const rows = await safeSelectWithFallback({
         client: supabase,

--- a/src/hooks/useAlerteStockFaible.js
+++ b/src/hooks/useAlerteStockFaible.js
@@ -25,34 +25,16 @@ export function useAlerteStockFaible({ page = 1, pageSize = 20 } = {}) {
       const from = (page - 1) * pageSize;
       const to = from + pageSize - 1;
       try {
-        const base = supabase.from('v_alertes_rupture');
-        const selectWith =
-          'id:produit_id, produit_id, nom, unite, fournisseur_id, fournisseur_nom, stock_actuel, stock_min, manque, consommation_prevue, receptions, stock_projete';
-
-        let { data: rows, count, error } = await base
-          .select(selectWith, { count: 'exact' }).eq('mama_id', mama_id)
+        const { data: rows, count, error } = await supabase
+          .from('v_alertes_rupture')
+          .select(
+            'mama_id, id:produit_id, produit_id, nom, unite, fournisseur_id, fournisseur_nom, stock_actuel, stock_min, manque',
+            { count: 'exact' }
+          )
+          .eq('mama_id', mama_id)
           .order('manque', { ascending: false })
           .range(from, to);
-
-        if (error && error.code === '42703') {
-          if (import.meta.env.DEV)
-            console.debug('v_alertes_rupture sans stock_projete');
-          const { data: d2, count: c2, error: e2 } = await base
-            .select('id:produit_id, produit_id, nom, unite, fournisseur_id, fournisseur_nom, stock_actuel, stock_min, manque, consommation_prevue, receptions, stock_previsionnel', { count: 'exact' }).eq('mama_id', mama_id)
-            .order('manque', { ascending: false })
-            .range(from, to);
-          if (e2) throw e2;
-          rows = (d2 ?? []).map((r) => ({
-            ...r,
-            stock_projete: r.stock_previsionnel ?? ((r.stock_actuel ?? 0) + (r.receptions ?? 0) - (r.consommation_prevue ?? 0)),
-          }));
-          count = c2 || 0;
-        } else {
-          if (error) throw error;
-          if (import.meta.env.DEV)
-            console.debug('v_alertes_rupture avec stock_projete');
-        }
-
+        if (error) throw error;
         if (!aborted) {
           setData(rows || []);
           setTotal(count || 0);

--- a/src/hooks/useFamilles.js
+++ b/src/hooks/useFamilles.js
@@ -29,7 +29,7 @@ export function useFamilles() {
     queryFn: async () => {
       let q = supabase
         .from('familles')
-        .select('id, code, nom, actif', { count: 'exact' })
+        .select('id, nom, actif', { count: 'exact' })
         .eq('mama_id', mama_id)
         .order('nom', { ascending: true })
         .range((params.page - 1) * params.limit, params.page * params.limit - 1);
@@ -51,7 +51,7 @@ export function useFamilles() {
       const { data, error } = await supabase
         .from('familles')
         .insert([body])
-        .select('id, code, nom, actif')
+        .select('id, nom, actif')
         .single();
       if (error) throw error;
       return data;
@@ -66,7 +66,7 @@ export function useFamilles() {
         .update(values)
         .eq('id', id)
         .eq('mama_id', mama_id)
-        .select('id, code, nom, actif')
+        .select('id, nom, actif')
         .single();
       if (error) throw error;
       return data;

--- a/src/hooks/useFiches.js
+++ b/src/hooks/useFiches.js
@@ -22,16 +22,13 @@ export function useFiches() {
     const sortField = ["nom", "cout_par_portion"].includes(sortBy) ? sortBy : "nom";
     let query = supabase
       .from("fiches_techniques")
-      .select(
-        "*, famille:familles!fiches_techniques_famille_id_fkey(id, nom), lignes:fiche_lignes!fiche_id(id)",
-        { count: "exact" }
-      )
+      .select("*, lignes:fiche_lignes!fiche_id(id)", { count: "exact" })
       .eq("mama_id", mama_id)
       .order(sortField, { ascending: asc })
       .range((page - 1) * limit, page * limit - 1);
     if (search) query = query.ilike("nom", `%${search}%`);
     if (typeof actif === "boolean") query = query.eq("actif", actif);
-    if (famille) query = query.eq("famille_id", famille);
+    if (famille) query = query.eq("famille", famille);
     const { data, error, count } = await query;
     setLoading(false);
     if (error) {
@@ -51,7 +48,7 @@ export function useFiches() {
     const { data, error } = await supabase
       .from("fiches_techniques")
       .select(
-        "*, famille:familles!fiches_techniques_famille_id_fkey(id, nom), lignes:v_fiche_lignes_complete!fiche_id(*, sous_fiche:sous_fiche_id(id, nom, cout_par_portion))"
+        "*, lignes:v_fiche_lignes_complete!fiche_id(*, sous_fiche:sous_fiche_id(id, nom, cout_par_portion))"
       )
       .eq("id", id)
       .eq("mama_id", mama_id)

--- a/src/hooks/useMamaSettings.js
+++ b/src/hooks/useMamaSettings.js
@@ -108,5 +108,3 @@ export function useMamaSettings() {
     updateMamaSettings,
   };
 }
-
-export default useMamaSettings;

--- a/src/hooks/useRuptureAlerts.js
+++ b/src/hooks/useRuptureAlerts.js
@@ -6,24 +6,18 @@ import { toast } from 'sonner';
 export function useRuptureAlerts() {
   const { mama_id } = useAuth();
 
-  async function fetchAlerts(type = null) {
+  async function fetchAlerts() {
     if (!mama_id) return [];
     try {
-      let q = supabase
+      const { data, error } = await supabase
         .from('v_alertes_rupture')
         .select(
-          'id:produit_id, produit_id, nom, unite, fournisseur_nom, stock_actuel, stock_min, consommation_prevue, receptions, manque, type'
+          'mama_id, id:produit_id, produit_id, nom, unite, fournisseur_nom, stock_actuel, stock_min, manque'
         )
         .eq('mama_id', mama_id)
         .order('manque', { ascending: false });
-      if (type) q = q.eq('type', type);
-      const { data, error } = await q;
       if (error) throw error;
-      return (data || []).map((r) => ({
-        ...r,
-        stock_projete:
-          (r.stock_actuel ?? 0) + (r.receptions ?? 0) - (r.consommation_prevue ?? 0),
-      }));
+      return data || [];
     } catch (error) {
       console.error(error);
       toast.error(error.message || 'Erreur chargement alertes rupture');

--- a/src/pages/fiches/FicheDetail.jsx
+++ b/src/pages/fiches/FicheDetail.jsx
@@ -85,8 +85,8 @@ export default function FicheDetail({ fiche: ficheProp, onClose }) {
       <div className="bg-white/10 backdrop-blur-lg text-white rounded-xl shadow-lg p-8 min-w-[400px] max-w-[95vw] flex flex-col gap-2 relative text-shadow">
         <Button variant="outline" className="absolute top-2 right-2" onClick={onClose}>Fermer</Button>
         <h2 className="font-bold text-xl mb-4">{fiche.nom}</h2>
-        {fiche.famille?.nom && (
-          <div><b>Famille :</b> {fiche.famille.nom}</div>
+        {fiche.famille && (
+          <div><b>Famille :</b> {fiche.famille}</div>
         )}
         {typeof fiche.rendement === 'number' && (
           <div><b>Rendement :</b> {fiche.rendement}</div>

--- a/src/pages/fiches/FicheForm.jsx
+++ b/src/pages/fiches/FicheForm.jsx
@@ -23,7 +23,7 @@ export default function FicheForm({ fiche, onClose }) {
   const { products, fetchProducts } = useProducts();
   const { familles, fetchFamilles } = useFamilles();
   const [nom, setNom] = useState(fiche?.nom || "");
-  const [famille, setFamille] = useState(fiche?.famille_id || "");
+  const [famille, setFamille] = useState(fiche?.famille || "");
   const [portions, setPortions] = useState(fiche?.portions || 1);
   const [rendement, setRendement] = useState(fiche?.rendement || 1);
   const [lignes, setLignes] = useState(
@@ -86,7 +86,7 @@ export default function FicheForm({ fiche, onClose }) {
     setLoading(true);
     const payload = {
       nom,
-      famille_id: famille || null,
+      famille: famille || null,
       portions,
       rendement,
       prix_vente: prixVente || null,
@@ -129,7 +129,7 @@ export default function FicheForm({ fiche, onClose }) {
         onChange={e => setFamille(e.target.value)}
       >
         <option value="">-- Famille --</option>
-        {(familles ?? []).map(f => <option key={f.id} value={f.id}>{f.nom}</option>)}
+        {(familles ?? []).map(f => <option key={f.id} value={f.nom}>{f.nom}</option>)}
       </Select>
       <div className="flex gap-2 mb-2">
         <Input

--- a/src/pages/fiches/Fiches.jsx
+++ b/src/pages/fiches/Fiches.jsx
@@ -41,21 +41,16 @@ export default function Fiches() {
 
   const debouncedSearch = useDebounce(search, 300);
 
+  const familleNom = familles.find(f => f.id === familleFilter)?.nom || null;
   const { data, isLoading, isError } = useFichesTechniques({
     page,
     search: debouncedSearch,
     statut,
-    familleId: familleFilter || null,
+    famille: familleNom,
     sortBy,
   });
   const rows = data?.rows || [];
   const total = data?.total || 0;
-
-  const familleMap = Object.fromEntries((familles || []).map((f) => [f.id, f.nom]));
-  const rowsWithFamille = rows.map((f) => ({
-    ...f,
-    famille_nom: familleMap[f.famille_id] || '—',
-  }));
 
   const [searchParams, setSearchParams] = useSearchParams();
   const firstSync = useRef(true);
@@ -85,7 +80,7 @@ export default function Fiches() {
   }, [search, page, setSearchParams]);
 
   const exportExcel = () => {
-    const datas = rowsWithFamille.map((f) => ({
+    const datas = rows.map((f) => ({
       id: f.id,
       nom: f.nom,
       cout_par_portion: f.cout_par_portion,
@@ -99,9 +94,9 @@ export default function Fiches() {
 
   const exportPdf = () => {
     const doc = new JSPDF();
-    const rowsPdf = rowsWithFamille.map((f) => [
+    const rowsPdf = rows.map((f) => [
       f.nom,
-      f.famille_nom || '',
+      f.famille || '',
       f.cout_par_portion,
     ]);
     doc.autoTable({ head: [["Nom", "Famille", "Coût/portion"]], body: rowsPdf });
@@ -165,7 +160,7 @@ export default function Fiches() {
           }}
         >
           <option value="">-- Famille --</option>
-          {(familles ?? []).map((f) => (
+            {(familles ?? []).map((f) => (
             <option key={f.id} value={f.id}>
               {f.nom}
             </option>
@@ -205,7 +200,7 @@ export default function Fiches() {
             </tr>
           </thead>
           <tbody>
-            {rowsWithFamille.map((fiche) => (
+            {rows.map((fiche) => (
               <FicheRow
                 key={fiche.id}
                 fiche={fiche}

--- a/src/pages/parametrage/MamaSettingsForm.jsx
+++ b/src/pages/parametrage/MamaSettingsForm.jsx
@@ -4,7 +4,7 @@ import { toast } from 'sonner';
 import PrimaryButton from "@/components/ui/PrimaryButton";
 import { Input } from "@/components/ui/input";
 import GlassCard from "@/components/ui/GlassCard";
-import useMamaSettings from "@/hooks/useMamaSettings";
+import { useMamaSettings } from "@/hooks/useMamaSettings";
 import { uploadFile, deleteFile, pathFromUrl } from "@/hooks/useStorage";
 import { useAuth } from '@/hooks/useAuth';
 

--- a/src/pages/produits/Produits.jsx
+++ b/src/pages/produits/Produits.jsx
@@ -27,6 +27,7 @@ export default function Produits() {
     pageSize,
     statut,
     sousFamilleId: sousFamilleId || null,
+    familleId: familleId || null,
   });
   const produits = data?.data ?? [];
   const total = data?.count ?? 0;
@@ -97,10 +98,10 @@ export default function Produits() {
           {produits.map((p) => (
             <div key={p.id} className="table-row">
               <div className="table-cell py-2">{p.nom}</div>
-              <div className="table-cell py-2">{p.unite ?? '—'}</div>
+              <div className="table-cell py-2">{p.unite?.nom ?? '—'}</div>
               <div className="table-cell py-2">{(p.pmp ?? 0).toFixed(2)}</div>
               <div className="table-cell py-2">{p.sous_famille?.nom ?? '—'}</div>
-              <div className="table-cell py-2">{p.zone_stockage ?? '—'}</div>
+              <div className="table-cell py-2">{p.zone_stock?.nom ?? '—'}</div>
               <div className="table-cell py-2">{p.actif ? 'Actif' : 'Inactif'}</div>
               <div className="table-cell py-2"> {/* actions existantes */}</div>
             </div>

--- a/src/pages/stock/AlertesRupture.jsx
+++ b/src/pages/stock/AlertesRupture.jsx
@@ -5,12 +5,11 @@ import { Button } from "@/components/ui/button";
 export default function AlertesRupture() {
   const { fetchAlerts, generateSuggestions } = useRuptureAlerts();
   const [alerts, setAlerts] = useState([]);
-  const [type, setType] = useState(null);
 
   const load = useCallback(async () => {
-    const data = await fetchAlerts(type);
+    const data = await fetchAlerts();
     setAlerts(data);
-  }, [fetchAlerts, type]);
+  }, [fetchAlerts]);
 
   useEffect(() => { load(); }, [load]);
 
@@ -18,25 +17,23 @@ export default function AlertesRupture() {
     <div className="p-6">
       <h1 className="text-2xl mb-4">Alertes rupture</h1>
       <div className="flex gap-2 mb-4">
-        <Button onClick={() => setType(null)}>Tous</Button>
-        <Button onClick={() => setType('rupture')}>Ruptures</Button>
-        <Button onClick={() => setType('prevision')}>Prévisions</Button>
         <Button onClick={() => generateSuggestions()}>Générer commande fournisseur</Button>
       </div>
       <table className="min-w-full text-sm">
         <thead>
-          <tr><th>Produit</th><th>Actuel</th><th>Proj.</th></tr>
+          <tr><th>Produit</th><th>Actuel</th><th>Min</th><th>Manque</th></tr>
         </thead>
         <tbody>
           {alerts.map(a => (
-            <tr key={a.id} className="border-t">
+            <tr key={a.produit_id || a.id} className="border-t">
               <td className="px-2 py-1">{a.nom}</td>
               <td className="px-2 py-1">{a.stock_actuel}</td>
-              <td className="px-2 py-1">{a.stock_projete}</td>
+              <td className="px-2 py-1">{a.stock_min}</td>
+              <td className="px-2 py-1">{a.manque}</td>
             </tr>
           ))}
           {alerts.length === 0 && (
-            <tr><td colSpan={3} className="text-center p-2">Aucune alerte</td></tr>
+            <tr><td colSpan={4} className="text-center p-2">Aucune alerte</td></tr>
           )}
         </tbody>
       </table>

--- a/test/Sidebar.parametrage.test.jsx
+++ b/test/Sidebar.parametrage.test.jsx
@@ -8,7 +8,7 @@ vi.mock('@/hooks/useAuth', () => ({
 }));
 
 vi.mock('@/hooks/useMamaSettings', () => ({
-  default: () => ({ loading: false, enabledModules: [] }),
+  useMamaSettings: () => ({ loading: false, enabledModules: [] }),
 }));
 
 import Sidebar from '@/components/Sidebar.jsx';

--- a/test/useAlerteStockFaible.test.js
+++ b/test/useAlerteStockFaible.test.js
@@ -25,38 +25,15 @@ beforeEach(async () => {
   queryBuilder.select.mockClear();
 });
 
-test('useAlerteStockFaible queries v_alertes_rupture without mama filter', async () => {
+test('useAlerteStockFaible queries v_alertes_rupture with mama filter', async () => {
   const { result } = renderHook(() => useAlerteStockFaible());
   await waitFor(() => !result.current.loading);
   expect(fromMock).toHaveBeenCalledWith('v_alertes_rupture');
   expect(queryBuilder.select).toHaveBeenCalledWith(
-    'id:produit_id, produit_id, nom, unite, fournisseur_id, fournisseur_nom, stock_actuel, stock_min, manque, consommation_prevue, receptions, stock_projete',
+    'mama_id, id:produit_id, produit_id, nom, unite, fournisseur_id, fournisseur_nom, stock_actuel, stock_min, manque',
     { count: 'exact' }
   );
-  expect(queryBuilder.eq).not.toHaveBeenCalled();
+  expect(queryBuilder.eq).toHaveBeenCalledWith('mama_id', 'm1');
   expect(queryBuilder.order).toHaveBeenCalledWith('manque', { ascending: false });
   expect(queryBuilder.range).toHaveBeenCalledWith(0, 19);
-});
-
-test('useAlerteStockFaible falls back when stock_projete missing', async () => {
-  queryBuilder.range
-    .mockResolvedValueOnce({ data: null, count: 0, error: { code: '42703' } })
-    .mockResolvedValueOnce({
-      data: [
-        {
-          produit_id: 1,
-          nom: 'p',
-          stock_actuel: 5,
-          consommation_prevue: 3,
-          receptions: 2,
-        },
-      ],
-      count: 1,
-      error: null,
-    });
-
-  const { result } = renderHook(() => useAlerteStockFaible());
-  await waitFor(() => !result.current.loading);
-  expect(queryBuilder.range).toHaveBeenCalledTimes(2);
-  expect(result.current.data[0].stock_projete).toBe(4);
 });

--- a/test/useRuptureAlerts.test.js
+++ b/test/useRuptureAlerts.test.js
@@ -28,33 +28,10 @@ beforeEach(async () => {
 
 test('fetchAlerts selects expected view columns', async () => {
   const { fetchAlerts } = useRuptureAlerts();
-  await fetchAlerts('rupture');
+  await fetchAlerts();
   expect(fromMock).toHaveBeenCalledWith('v_alertes_rupture');
   expect(queryBuilder.select).toHaveBeenCalledWith(
-    'id:produit_id, produit_id, nom, unite, fournisseur_nom, stock_actuel, stock_min, consommation_prevue, receptions, manque, type'
+    'mama_id, id:produit_id, produit_id, nom, unite, fournisseur_nom, stock_actuel, stock_min, manque'
   );
-  expect(queryBuilder.eq).toHaveBeenNthCalledWith(1, 'mama_id', 'm1');
-  expect(queryBuilder.eq).toHaveBeenNthCalledWith(2, 'type', 'rupture');
-});
-
-test('fetchAlerts computes stock_projete', async () => {
-  queryBuilder.then.mockImplementation((resolve) =>
-    resolve({
-      data: [
-        {
-          produit_id: 1,
-          nom: 'p',
-          stock_actuel: 5,
-          consommation_prevue: 3,
-          receptions: 2,
-          manque: 0,
-          type: 'rupture',
-        },
-      ],
-      error: null,
-    })
-  );
-  const { fetchAlerts } = useRuptureAlerts();
-  const data = await fetchAlerts();
-  expect(data[0].stock_projete).toBe(4);
+  expect(queryBuilder.eq).toHaveBeenCalledWith('mama_id', 'm1');
 });


### PR DESCRIPTION
## Summary
- fix useMamaSettings export and update imports
- realign product, family, fiche and stock alert queries with actual Supabase schema
- show fiche family text and remove stock projections from alerts

## Testing
- `npm test` *(fails: path expectations in script tests)*
- `npx vitest test/useAlerteStockFaible.test.js test/useRuptureAlerts.test.js test/Sidebar.parametrage.test.jsx`

------
https://chatgpt.com/codex/tasks/task_e_68ab13d13428832d9bcba5fdacaccf04