### PR TITLE
Align stock alert hooks with Supabase schema

### DIFF
--- a/src/hooks/gadgets/useAlerteStockFaible.js
+++ b/src/hooks/gadgets/useAlerteStockFaible.js
@@ -16,7 +16,9 @@ export default function useAlerteStockFaible() {
     try {
       const { data: rows, error } = await supabase
         .from('v_alertes_rupture')
-        .select('produit_id, nom, unite, fournisseur_nom, stock_actuel, stock_min, manque')
+        .select(
+          'mama_id, produit_id, nom, unite, fournisseur_nom, stock_actuel, stock_min, manque'
+        )
         .eq('mama_id', mama_id)
         .order('manque', { ascending: false })
         .limit(50);

--- a/src/hooks/useAlerteStockFaible.js
+++ b/src/hooks/useAlerteStockFaible.js
@@ -28,7 +28,7 @@ export function useAlerteStockFaible({ page = 1, pageSize = 20 } = {}) {
         const { data: rows, count, error } = await supabase
           .from('v_alertes_rupture')
           .select(
-            'produit_id, nom, unite, fournisseur_nom, stock_actuel, stock_min, manque',
+            'mama_id, produit_id, nom, unite, fournisseur_nom, stock_actuel, stock_min, manque',
             { count: 'exact' }
           )
           .eq('mama_id', mama_id)

--- a/src/hooks/useMamaSettings.js
+++ b/src/hooks/useMamaSettings.js
@@ -36,7 +36,7 @@ const defaults = {
 const localEnabledModules = {};
 const localFeatureFlags = {};
 
-export function useMamaSettings() {
+export const useMamaSettings = () => {
   const { userData } = useAuth();
   const mamaId = userData?.mama_id;
   const queryClient = safeQueryClient();
@@ -107,6 +107,6 @@ export function useMamaSettings() {
     fetchMamaSettings: query.refetch,
     updateMamaSettings,
   };
-}
+};
 
 export default useMamaSettings;

--- a/src/hooks/useRuptureAlerts.js
+++ b/src/hooks/useRuptureAlerts.js
@@ -11,7 +11,7 @@ export function useRuptureAlerts() {
     try {
       const { data, error } = await supabase
         .from('v_alertes_rupture')
-        .select('produit_id, nom, unite, fournisseur_nom, stock_actuel, stock_min, manque')
+        .select('mama_id, produit_id, nom, unite, fournisseur_nom, stock_actuel, stock_min, manque')
         .eq('mama_id', mama_id)
         .order('manque', { ascending: false });
       if (error) throw error;

--- a/test/useAlerteStockFaible.test.js
+++ b/test/useAlerteStockFaible.test.js
@@ -25,38 +25,39 @@ beforeEach(async () => {
   queryBuilder.select.mockClear();
 });
 
-test('useAlerteStockFaible queries v_alertes_rupture without mama filter', async () => {
+test('useAlerteStockFaible queries v_alertes_rupture with mama filter', async () => {
   const { result } = renderHook(() => useAlerteStockFaible());
   await waitFor(() => !result.current.loading);
   expect(fromMock).toHaveBeenCalledWith('v_alertes_rupture');
   expect(queryBuilder.select).toHaveBeenCalledWith(
-    'id:produit_id, produit_id, nom, unite, fournisseur_id, fournisseur_nom, stock_actuel, stock_min, manque, consommation_prevue, receptions, stock_projete',
+    'mama_id, produit_id, nom, unite, fournisseur_nom, stock_actuel, stock_min, manque',
     { count: 'exact' }
   );
-  expect(queryBuilder.eq).not.toHaveBeenCalled();
+  expect(queryBuilder.eq).toHaveBeenCalledWith('mama_id', 'm1');
   expect(queryBuilder.order).toHaveBeenCalledWith('manque', { ascending: false });
   expect(queryBuilder.range).toHaveBeenCalledWith(0, 19);
 });
 
-test('useAlerteStockFaible falls back when stock_projete missing', async () => {
-  queryBuilder.range
-    .mockResolvedValueOnce({ data: null, count: 0, error: { code: '42703' } })
-    .mockResolvedValueOnce({
-      data: [
-        {
-          produit_id: 1,
-          nom: 'p',
-          stock_actuel: 5,
-          consommation_prevue: 3,
-          receptions: 2,
-        },
-      ],
-      count: 1,
-      error: null,
-    });
+test('useAlerteStockFaible returns fetched rows', async () => {
+  queryBuilder.range.mockResolvedValueOnce({
+    data: [
+      {
+        mama_id: 'm1',
+        produit_id: 1,
+        nom: 'p',
+        unite: 'u',
+        fournisseur_nom: 'f',
+        stock_actuel: 5,
+        stock_min: 10,
+        manque: 5,
+      },
+    ],
+    count: 1,
+    error: null,
+  });
 
   const { result } = renderHook(() => useAlerteStockFaible());
   await waitFor(() => !result.current.loading);
-  expect(queryBuilder.range).toHaveBeenCalledTimes(2);
-  expect(result.current.data[0].stock_projete).toBe(4);
+  expect(queryBuilder.range).toHaveBeenCalledTimes(1);
+  expect(result.current.data[0].nom).toBe('p');
 });

--- a/test/useRuptureAlerts.test.js
+++ b/test/useRuptureAlerts.test.js
@@ -28,27 +28,28 @@ beforeEach(async () => {
 
 test('fetchAlerts selects expected view columns', async () => {
   const { fetchAlerts } = useRuptureAlerts();
-  await fetchAlerts('rupture');
+  await fetchAlerts();
   expect(fromMock).toHaveBeenCalledWith('v_alertes_rupture');
   expect(queryBuilder.select).toHaveBeenCalledWith(
-    'id:produit_id, produit_id, nom, unite, fournisseur_nom, stock_actuel, stock_min, consommation_prevue, receptions, manque, type'
+    'mama_id, produit_id, nom, unite, fournisseur_nom, stock_actuel, stock_min, manque'
   );
-  expect(queryBuilder.eq).toHaveBeenNthCalledWith(1, 'mama_id', 'm1');
-  expect(queryBuilder.eq).toHaveBeenNthCalledWith(2, 'type', 'rupture');
+  expect(queryBuilder.eq).toHaveBeenCalledWith('mama_id', 'm1');
+  expect(queryBuilder.order).toHaveBeenCalledWith('manque', { ascending: false });
 });
 
-test('fetchAlerts computes stock_projete', async () => {
+test('fetchAlerts returns data', async () => {
   queryBuilder.then.mockImplementation((resolve) =>
     resolve({
       data: [
         {
+          mama_id: 'm1',
           produit_id: 1,
           nom: 'p',
+          unite: 'u',
+          fournisseur_nom: 'f',
           stock_actuel: 5,
-          consommation_prevue: 3,
-          receptions: 2,
-          manque: 0,
-          type: 'rupture',
+          stock_min: 10,
+          manque: 5,
         },
       ],
       error: null,
@@ -56,5 +57,5 @@ test('fetchAlerts computes stock_projete', async () => {
   );
   const { fetchAlerts } = useRuptureAlerts();
   const data = await fetchAlerts();
-  expect(data[0].stock_projete).toBe(4);
+  expect(data[0].nom).toBe('p');
 });


### PR DESCRIPTION
## Summary
- align stock alert hooks with actual v_alertes_rupture columns and mama filtering
- expose `useMamaSettings` as named export
- update unit tests for new queries

## Testing
- `npm test` *(fails: numerous unrelated suite errors)*
- `npm test test/useAlerteStockFaible.test.js test/useRuptureAlerts.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68ab3125c454832da94ed63bdb8f3ffc