### PR TITLE
Fix Supabase queries for schema alignment

### DIFF
--- a/src/hooks/data/useFamilles.js
+++ b/src/hooks/data/useFamilles.js
@@ -5,10 +5,11 @@ import useMamaSettings from '@/hooks/useMamaSettings';
 
 export const useFamilles = () => {
   const { mamaId } = useMamaSettings();
-  return useQuery({
-    queryKey: ['familles', mamaId],
-    queryFn: async () => {
-      const { data, error } = await supabase
+    return useQuery({
+      queryKey: ['familles', mamaId],
+      enabled: !!mamaId,
+      queryFn: async () => {
+        const { data, error } = await supabase
         .from('familles')
         .select('id, nom, actif')
         .eq('mama_id', mamaId)

--- a/src/hooks/data/useProduits.js
+++ b/src/hooks/data/useProduits.js
@@ -7,7 +7,7 @@ import useMamaSettings from '@/hooks/useMamaSettings';
  * Liste paginée des produits avec filtres.
  * - statut: 'tous' | 'actif' | 'inactif'
  * - sousFamilleId: UUID ou null
- * Note: on n'utilise PAS de join PostgREST pour la sous-famille.
+ * Inclut familles et sous-familles via FKs nommées.
  */
 export const useProduits = ({
   search = '',
@@ -18,10 +18,11 @@ export const useProduits = ({
   sousFamilleId = null,
 }) => {
   const { mamaId } = useMamaSettings();
-  return useQuery({
-    queryKey: ['produits', mamaId, search, page, pageSize, statut, familleId, sousFamilleId],
-    queryFn: async () => {
-      let q = supabase
+    return useQuery({
+      queryKey: ['produits', mamaId, search, page, pageSize, statut, familleId, sousFamilleId],
+      enabled: !!mamaId,
+      queryFn: async () => {
+        let q = supabase
         .from('produits')
         .select(
           `

--- a/src/hooks/data/useSousFamilles.js
+++ b/src/hooks/data/useSousFamilles.js
@@ -5,10 +5,11 @@ import useMamaSettings from '@/hooks/useMamaSettings';
 
 export const useSousFamilles = () => {
   const { mamaId } = useMamaSettings();
-  return useQuery({
-    queryKey: ['sous-familles', mamaId],
-    queryFn: async () => {
-      const { data, error } = await supabase
+    return useQuery({
+      queryKey: ['sous-familles', mamaId],
+      enabled: !!mamaId,
+      queryFn: async () => {
+        const { data, error } = await supabase
         .from('sous_familles')
         .select('id, nom, actif, famille_id')
         .eq('mama_id', mamaId)


### PR DESCRIPTION
## Summary
- useSupabase data hooks for products, families and sub-families now wait for current mamaId before querying
- document product hook using explicit FK joins

## Testing
- `npm test test/useAlerteStockFaible.test.js test/useRuptureAlerts.test.js test/sousFamilles.hook.test.jsx`

------
https://chatgpt.com/codex/tasks/task_e_68ab61b1da60832d9a72577ed72328fa