### PR TITLE
fix: align front queries with Supabase schema

### DIFF
--- a/src/hooks/data/useFamilles.js
+++ b/src/hooks/data/useFamilles.js
@@ -20,3 +20,5 @@ export const useFamilles = () => {
   });
 };
 
+export default useFamilles;
+

--- a/src/hooks/data/useSousFamilles.js
+++ b/src/hooks/data/useSousFamilles.js
@@ -11,7 +11,7 @@ export const useSousFamilles = () => {
       queryFn: async () => {
         const { data, error } = await supabase
         .from('sous_familles')
-        .select('id, nom, actif, famille_id')
+        .select('id, nom, famille_id, actif')
         .eq('mama_id', mamaId)
         .order('nom', { ascending: true });
       if (error) {

--- a/src/hooks/useMamaSettings.js
+++ b/src/hooks/useMamaSettings.js
@@ -99,6 +99,7 @@ export const useMamaSettings = () => {
   );
 
   return {
+    mamaId,
     settings,
     loading: query.isFetching,
     enabledModules,

--- a/src/pages/parametrage/SousFamilles.jsx
+++ b/src/pages/parametrage/SousFamilles.jsx
@@ -1,8 +1,8 @@
 import { useMemo, useState } from 'react';
 import { supabase } from '@/lib/supabase';
 import useMamaSettings from '@/hooks/useMamaSettings';
-import { useFamillesParametrage } from '@/hooks/data/useFamillesParametrage';
-import { useSousFamillesParametrage } from '@/hooks/data/useSousFamillesParametrage';
+import { useFamilles } from '@/hooks/data/useFamilles';
+import useSousFamilles from '@/hooks/data/useSousFamilles';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 
@@ -18,9 +18,25 @@ export default function SousFamilles() {
     return () => clearTimeout(id);
   }, [searchRaw]);
 
-  const { data: familles = [] } = useFamillesParametrage({ mamaId });
-  const { data: sousFamilles = [], refetch, isLoading } =
-    useSousFamillesParametrage({ mamaId, search, familleId: familleId || null, statut });
+  const { data: familles = [] } = useFamilles();
+  const {
+    data: sousFamillesData = [],
+    refetch,
+    isLoading,
+  } = useSousFamilles();
+
+  const sousFamilles = useMemo(() => {
+    return (sousFamillesData || [])
+      .filter(sf =>
+        search ? sf.nom.toLowerCase().includes(search.toLowerCase()) : true,
+      )
+      .filter(sf => (familleId ? sf.famille_id === familleId : true))
+      .filter(sf => {
+        if (statut === 'actifs') return sf.actif === true;
+        if (statut === 'inactifs') return sf.actif === false;
+        return true;
+      });
+  }, [sousFamillesData, search, familleId, statut]);
 
   // Helpers
   const famillesById = useMemo(() => {


### PR DESCRIPTION
## Summary
- expose mamaId from useMamaSettings for consistent filtering
- query familles and sous_familles using schema columns and apply client-side filters
- update Sous-familles settings page to reuse unified hooks and filter by mama_id

## Testing
- `npm test` (5 failed, 28 passed)
- `npm run lint` (6 errors, 5 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68ab63e9b5cc832d959a77d4e1de44dd