### PR TITLE
feat: align fiches/menus data with Supabase schema

### DIFF
--- a/db/policies_fix.sql
+++ b/db/policies_fix.sql
@@ -1,0 +1,20 @@
+-- Suggested RLS policies for missing tables
+-- Ensure each policy is created in the database if not already present.
+
+CREATE POLICY "select_fiches_techniques_mama" ON public.fiches_techniques
+FOR SELECT USING (mama_id = request.jwt.claims->>'mama_id');
+
+CREATE POLICY "select_fiche_lignes_mama" ON public.fiche_lignes
+FOR SELECT USING (mama_id = request.jwt.claims->>'mama_id');
+
+CREATE POLICY "select_menus_mama" ON public.menus
+FOR SELECT USING (mama_id = request.jwt.claims->>'mama_id');
+
+CREATE POLICY "select_menu_fiches_mama" ON public.menu_fiches
+FOR SELECT USING (mama_id = request.jwt.claims->>'mama_id');
+
+CREATE POLICY "select_menus_jour_mama" ON public.menus_jour
+FOR SELECT USING (mama_id = request.jwt.claims->>'mama_id');
+
+CREATE POLICY "select_menus_jour_fiches_mama" ON public.menus_jour_fiches
+FOR SELECT USING (mama_id = request.jwt.claims->>'mama_id');

--- a/src/hooks/useFicheCoutHistory.js
+++ b/src/hooks/useFicheCoutHistory.js
@@ -22,7 +22,14 @@ export function useFicheCoutHistory() {
         .order("changed_at", { ascending: false });
 
       if (error) throw error;
-      setHistory(Array.isArray(data) ? data : []);
+      const rows = Array.isArray(data)
+        ? data.map((d) => ({
+            ...d,
+            cout_portion: d.cout_portion ? Number(d.cout_portion) : null,
+            prix_vente: d.prix_vente ? Number(d.prix_vente) : null,
+          }))
+        : [];
+      setHistory(rows);
     } catch (err) {
       setError(err.message || "Erreur chargement historique coût fiche.");
       setHistory([]);

--- a/src/hooks/useFichesAutocomplete.js
+++ b/src/hooks/useFichesAutocomplete.js
@@ -27,8 +27,14 @@ export function useFichesAutocomplete() {
       setError(error);
       return [];
     }
-    setResults(Array.isArray(data) ? data : []);
-    return data || [];
+    const rows = Array.isArray(data)
+      ? data.map((d) => ({
+          ...d,
+          cout_par_portion: d.cout_par_portion ? Number(d.cout_par_portion) : null,
+        }))
+      : [];
+    setResults(rows);
+    return rows;
   }, [mama_id]);
 
   return { results, loading, error, searchFiches };

--- a/src/pages/fiches/Fiches.jsx
+++ b/src/pages/fiches/Fiches.jsx
@@ -27,7 +27,7 @@ const PAGE_SIZE = 20;
 export default function Fiches() {
   const queryClient = useQueryClient();
   const { deleteFiche, duplicateFiche } = useFiches();
-  const { mama_id, loading: authLoading, access_rights, hasAccess } = useAuth();
+  const { mama_id, loading: authLoading, access_rights } = useAuth();
   const [showForm, setShowForm] = useState(false);
   const [showDetail, setShowDetail] = useState(false);
   const [selected, setSelected] = useState(null);
@@ -37,7 +37,7 @@ export default function Fiches() {
   const [statut, setStatut] = useState("actif");
   const [familleFilter, setFamilleFilter] = useState("");
   const { familles, fetchFamilles } = useFamilles();
-  const canEdit = hasAccess("fiches_techniques", "peut_modifier");
+  const canEdit = access_rights?.fiches?.peut_modifier;
 
   const debouncedSearch = useDebounce(search, 300);
 
@@ -110,7 +110,7 @@ export default function Fiches() {
     return <div className="p-6">Erreur chargement fiches techniques.</div>;
   }
 
-  if (!access_rights?.fiches_techniques?.peut_voir) {
+  if (!access_rights?.fiches?.peut_voir) {
     return <Navigate to="/unauthorized" replace />;
   }
 

--- a/src/pages/menu/MenuDuJour.jsx
+++ b/src/pages/menu/MenuDuJour.jsx
@@ -2,6 +2,8 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { useMenuDuJour } from "@/hooks/useMenuDuJour";
+import { useAuth } from "@/hooks/useAuth";
+import { Navigate } from "react-router-dom";
 
 function getMonday(date) {
   const d = new Date(date);
@@ -13,6 +15,7 @@ function getMonday(date) {
 
 export default function MenuDuJour() {
   const { fetchWeek } = useMenuDuJour();
+  const { access_rights } = useAuth();
   const [startDate, setStartDate] = useState(getMonday(new Date()));
   const [resume, setResume] = useState([]);
 
@@ -33,6 +36,10 @@ export default function MenuDuJour() {
     const info = resume.find((r) => r.date_menu === iso) || {};
     return { date: iso, info };
   });
+
+  if (!access_rights?.menus_jour?.peut_voir) {
+    return <Navigate to="/unauthorized" replace />;
+  }
 
   return (
     <div className="p-4">

--- a/src/pages/menu/MenuDuJourJour.jsx
+++ b/src/pages/menu/MenuDuJourJour.jsx
@@ -2,17 +2,22 @@
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { useMenuDuJour } from "@/hooks/useMenuDuJour";
+import { useAuth } from "@/hooks/useAuth";
+import { Navigate } from "react-router-dom";
 
 const categories = ["entree", "plat", "dessert", "boisson"];
 
 export default function MenuDuJourJour() {
   const { date } = useParams();
   const { fetchDay, createOrUpdateMenu } = useMenuDuJour();
+  const { access_rights } = useAuth();
   const [lignes, setLignes] = useState([]);
 
   useEffect(() => {
     fetchDay(date).then(({ lignes }) => setLignes(lignes || []));
   }, [date, fetchDay]);
+
+  const canEdit = access_rights?.menus_jour?.peut_modifier;
 
   const addLine = () => {
     setLignes([...lignes, { categorie: "entree", fiche_id: "", portions: 1 }]);
@@ -32,11 +37,17 @@ export default function MenuDuJourJour() {
 
   const total = lignes.reduce((s, l) => s + Number(l.cout_ligne_total || 0), 0);
 
+  if (!access_rights?.menus_jour?.peut_voir) {
+    return <Navigate to="/unauthorized" replace />;
+  }
+
   return (
     <div className="p-4">
       <h1 className="text-xl font-bold mb-4">Menu du {date}</h1>
       <div className="mb-4">Coût total: {total.toFixed(2)} €</div>
-      <button onClick={addLine} className="mb-4 border px-2 py-1 rounded">Ajouter une fiche</button>
+      {canEdit && (
+        <button onClick={addLine} className="mb-4 border px-2 py-1 rounded">Ajouter une fiche</button>
+      )}
       {lignes.map((l, idx) => (
         <div key={idx} className="border p-2 mb-2 rounded">
           <div className="flex gap-2 mb-2">
@@ -44,6 +55,7 @@ export default function MenuDuJourJour() {
               value={l.categorie}
               onChange={(e) => updateLine(idx, "categorie", e.target.value)}
               className="border px-1"
+              disabled={!canEdit}
             >
               {categories.map((c) => (
                 <option key={c} value={c}>{c}</option>
@@ -55,21 +67,27 @@ export default function MenuDuJourJour() {
               value={l.fiche_id}
               onChange={(e) => updateLine(idx, "fiche_id", e.target.value)}
               className="border px-1 flex-1"
+              disabled={!canEdit}
             />
             <input
               type="number"
               value={l.portions}
               onChange={(e) => updateLine(idx, "portions", e.target.value)}
               className="border w-20 px-1"
+              disabled={!canEdit}
             />
-            <button onClick={() => removeLine(idx)} className="text-red-500">X</button>
+            {canEdit && (
+              <button onClick={() => removeLine(idx)} className="text-red-500">X</button>
+            )}
           </div>
           {l.cout_par_portion && (
             <div className="text-sm">{l.cout_par_portion.toFixed(2)} € / portion</div>
           )}
         </div>
       ))}
-      <button onClick={save} className="mt-4 border px-3 py-1 rounded">Sauvegarder</button>
+      {canEdit && (
+        <button onClick={save} className="mt-4 border px-3 py-1 rounded">Sauvegarder</button>
+      )}
     </div>
   );
 }

--- a/src/pages/menus/MenuDuJour.jsx
+++ b/src/pages/menus/MenuDuJour.jsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { useMenuDuJour } from "@/hooks/useMenuDuJour";
 import { useFiches } from "@/hooks/useFiches";
 import { useAuth } from '@/hooks/useAuth';
+import { Navigate } from 'react-router-dom';
 import MenuDuJourForm from "./MenuDuJourForm.jsx";
 import MenuDuJourDetail from "./MenuDuJourDetail.jsx";
 import { Button } from "@/components/ui/button";
@@ -13,7 +14,7 @@ import { motion as Motion } from "framer-motion";
 export default function MenuDuJour() {
   const { menusDuJour, fetchMenusDuJour, deleteMenuDuJour, exportMenusDuJourToExcel } = useMenuDuJour();
   const { fiches, fetchFiches } = useFiches();
-  const { mama_id, loading: authLoading } = useAuth();
+  const { mama_id, loading: authLoading, access_rights } = useAuth();
   const [showForm, setShowForm] = useState(false);
   const [showDetail, setShowDetail] = useState(false);
   const [selected, setSelected] = useState(null);
@@ -44,6 +45,10 @@ export default function MenuDuJour() {
     }
   };
 
+  if (!access_rights?.menus_jour?.peut_voir) {
+    return <Navigate to="/unauthorized" replace />;
+  }
+
   return (
     <div className="p-6 container mx-auto">
             <div className="flex flex-wrap gap-4 items-center mb-4">
@@ -60,9 +65,11 @@ export default function MenuDuJour() {
           onChange={e => setDateFilter(e.target.value)}
           className="form-input"
         />
-        <Button onClick={() => { setSelected(null); setShowForm(true); }}>
-          Ajouter un menu du jour
-        </Button>
+        {access_rights?.menus_jour?.peut_modifier && (
+          <Button onClick={() => { setSelected(null); setShowForm(true); }}>
+            Ajouter un menu du jour
+          </Button>
+        )}
         <Button variant="outline" onClick={exportExcel}>Export Excel</Button>
       </div>
       <TableContainer as={Motion.table} initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="mt-2">
@@ -96,22 +103,26 @@ export default function MenuDuJour() {
               <td className="border px-4 py-2">{menu.cout_total?.toFixed(2)} €</td>
               <td className="border px-4 py-2">{menu.marge != null ? `${menu.marge.toFixed(1)}%` : '-'}</td>
               <td className="border px-4 py-2">
-                <Button
-                  size="sm"
-                  variant="outline"
-                  className="mr-2"
-                  onClick={() => { setSelected(menu); setShowForm(true); }}
-                >
-                  Modifier
-                </Button>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  className="mr-2"
-                  onClick={() => handleDelete(menu)}
-                >
-                  Supprimer
-                </Button>
+                {access_rights?.menus_jour?.peut_modifier && (
+                  <>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="mr-2"
+                      onClick={() => { setSelected(menu); setShowForm(true); }}
+                    >
+                      Modifier
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="mr-2"
+                      onClick={() => handleDelete(menu)}
+                    >
+                      Supprimer
+                    </Button>
+                  </>
+                )}
               </td>
             </tr>
           ))}

--- a/src/pages/menus/Menus.jsx
+++ b/src/pages/menus/Menus.jsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { useMenus } from '@/hooks/useMenus';
 import { useFiches } from '@/hooks/useFiches';
 import { useAuth } from '@/hooks/useAuth';
+import { Navigate } from 'react-router-dom';
 import MenuForm from './MenuForm.jsx';
 import MenuDetail from './MenuDetail.jsx';
 import { Button } from '@/components/ui/button';
@@ -19,7 +20,7 @@ import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 export default function Menus() {
   const { menus, total, getMenus, deleteMenu, loading } = useMenus();
   const { fiches, fetchFiches } = useFiches();
-  const { mama_id, loading: authLoading } = useAuth();
+  const { mama_id, loading: authLoading, access_rights } = useAuth();
   const [showForm, setShowForm] = useState(false);
   const [showDetail, setShowDetail] = useState(false);
   const [selected, setSelected] = useState(null);
@@ -82,6 +83,10 @@ export default function Menus() {
 
   if (authLoading || loading) {
     return <LoadingSpinner message="Chargement..." />;
+  }
+
+  if (!access_rights?.menus?.peut_voir) {
+    return <Navigate to="/unauthorized" replace />;
   }
 
   const exportExcel = () => {
@@ -195,36 +200,40 @@ export default function Menus() {
                   {menu.actif ? '✔' : '✖'}
                 </td>
                 <td className="border px-4 py-2">
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    className="mr-2"
-                    onClick={() => {
-                      setSelected(menu);
-                      setShowForm(true);
-                    }}
-                  >
-                    Modifier
-                  </Button>
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    className="mr-2"
-                    onClick={() => {
-                      setSelected({ ...menu, date: '' });
-                      setShowForm(true);
-                    }}
-                  >
-                    Dupliquer
-                  </Button>
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    className="mr-2"
-                    onClick={() => handleDelete(menu)}
-                  >
-                    Supprimer
-                  </Button>
+                  {access_rights?.menus?.peut_modifier && (
+                    <>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="mr-2"
+                        onClick={() => {
+                          setSelected(menu);
+                          setShowForm(true);
+                        }}
+                      >
+                        Modifier
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="mr-2"
+                        onClick={() => {
+                          setSelected({ ...menu, date: '' });
+                          setShowForm(true);
+                        }}
+                      >
+                        Dupliquer
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="mr-2"
+                        onClick={() => handleDelete(menu)}
+                      >
+                        Supprimer
+                      </Button>
+                    </>
+                  )}
                 </td>
               </tr>
             ))}


### PR DESCRIPTION
## Summary
- align fiche and menu hooks to real tables and joins
- gate fiches, menus and menu du jour pages by access_rights
- normalize numeric fields in fiche history and autocomplete hooks

## Testing
- `npm test` *(fails: Unable to find an accessible element, missing mocks, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0b5218bc832d89a20218a7b8f82f