### PR TITLE
Fix top supplier dashboard and supplier hooks

### DIFF
--- a/src/components/gadgets/GadgetTopFournisseurs.jsx
+++ b/src/components/gadgets/GadgetTopFournisseurs.jsx
@@ -2,23 +2,25 @@ import { motion as Motion } from 'framer-motion';
 import useTopFournisseurs from '@/hooks/gadgets/useTopFournisseurs';
 import useFournisseurs from '@/hooks/data/useFournisseurs';
 import LoadingSkeleton from '@/components/ui/LoadingSkeleton';
+import Card from '@/components/ui/Card';
 
 export default function GadgetTopFournisseurs() {
-  const { data, loading } = useTopFournisseurs();
-  const { data: fournisseurs = [] } = useFournisseurs({ actif: true });
+  const { data, loading, error: errTop } = useTopFournisseurs();
+  const {
+    data: fournisseurs = [],
+    isLoading: loadingFourn,
+    error: errFourn,
+  } = useFournisseurs({ actif: true });
 
-  const nameFor = (id) =>
-    fournisseurs.find((f) => f.id === id)?.nom || `Fournisseur ${id}`;
+  const nameFor = (id) => (fournisseurs.find?.((f) => f.id === id) || {}).nom ?? '—';
 
-  if (loading) {
+  if (loading || loadingFourn) {
     return <LoadingSkeleton className="h-32 w-full rounded-2xl" />;
   }
+  if (errTop) return <Card>Erreur chargement top fournisseurs</Card>;
+  if (errFourn) return <Card>Erreur chargement fournisseurs</Card>;
   if (!data.length) {
-    return (
-      <div className="bg-white/10 rounded-2xl p-4 text-center text-white">
-        Aucune donnée
-      </div>
-    );
+    return <Card className="p-4 text-center">Aucune donnée</Card>;
   }
 
   return (
@@ -26,11 +28,11 @@ export default function GadgetTopFournisseurs() {
       <h3 className="font-bold mb-2">Top fournisseurs du mois</h3>
       <Motion.ul initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="space-y-2 text-sm">
         {data.map((f) => (
-          <li key={f.id} className="flex items-center justify-between">
+          <li key={f.fournisseur_id} className="flex items-center justify-between">
             <div className="flex items-center gap-2">
-              <span>{nameFor(f.id)}</span>
+              <span>{nameFor(f.fournisseur_id)}</span>
             </div>
-            <span className="font-semibold">{f.montant_total.toFixed(2)} €</span>
+            <span className="font-semibold">{Number(f.montant).toFixed(2)} €</span>
           </li>
         ))}
       </Motion.ul>

--- a/src/hooks/data/useFournisseurs.js
+++ b/src/hooks/data/useFournisseurs.js
@@ -23,7 +23,7 @@ export function useFournisseurs(params = {}) {
     queryFn: async () => {
       let query = supabase
         .from('fournisseurs')
-        .select('id, nom, actif, contact:fournisseur_contacts(nom,email,tel)', { count: 'exact' })
+        .select('id, nom, actif, contact:fournisseur_contacts(nom,email,tel)')
         .eq('mama_id', mama_id)
         .order('nom', { ascending: true })
         .range((page - 1) * limit, page * limit - 1);
@@ -31,13 +31,13 @@ export function useFournisseurs(params = {}) {
       if (search) query = query.ilike('nom', `%${search}%`);
       if (actif !== null && actif !== undefined) query = query.eq('actif', actif);
 
-      const { data, error, count } = await query;
+      const { data, error } = await query;
       if (error) throw error;
       const list = (data || []).map((f) => ({
         ...f,
         contact: Array.isArray(f.contact) ? f.contact[0] : f.contact,
       }));
-      return { data: list, count: count || 0 };
+      return Array.isArray(list) ? list : [];
     },
   });
 }

--- a/src/hooks/gadgets/useTopFournisseurs.js
+++ b/src/hooks/gadgets/useTopFournisseurs.js
@@ -16,19 +16,13 @@ export default function useTopFournisseurs() {
       try {
         const { data, error } = await supabase
           .from('v_top_fournisseurs')
-          .select('fournisseur_id, montant_total, nombre_achats')
+          .select('fournisseur_id, montant, mois')
           .eq('mama_id', mama_id)
-          .order('montant_total', { ascending: false })
+          .order('montant', { ascending: false })
           .limit(5);
         if (error) throw error;
-        const list = (data || []).map((r) => ({
-          id: r.fournisseur_id,
-          montant_total: Number(r.montant_total) || 0,
-          nombre_achats: Number(r.nombre_achats) || 0,
-        }));
-        setTopFournisseurs(list);
+        setTopFournisseurs(Array.isArray(data) ? data : []);
       } catch (e) {
-        console.warn('[gadgets] vue manquante ou colonne absente:', e?.message || e);
         setError(e);
         setTopFournisseurs([]);
       } finally {

--- a/src/hooks/useFournisseursBrowse.js
+++ b/src/hooks/useFournisseursBrowse.js
@@ -24,7 +24,7 @@ export default function useFournisseursBrowse({
       try {
         let req = supabase
           .from('fournisseurs')
-          .select('id, nom, ville', { count: 'exact' })
+          .select('id, nom', { count: 'exact' })
           .eq('mama_id', mama_id)
           .eq('actif', true);
         const t = term.trim();

--- a/src/hooks/useFournisseursList.js
+++ b/src/hooks/useFournisseursList.js
@@ -2,8 +2,8 @@ import useFournisseurs from '@/hooks/data/useFournisseurs';
 
 export function useFournisseursList(params = {}) {
   const query = useFournisseurs(params);
-  const list = Array.isArray(query.data?.data) ? query.data.data : [];
-  const count = query.data?.count ?? 0;
+  const list = Array.isArray(query.data) ? query.data : [];
+  const count = list.length;
   return { ...query, data: list, count };
 }
 

--- a/supabase/migrations/20240812000000_v_top_fournisseurs.sql
+++ b/supabase/migrations/20240812000000_v_top_fournisseurs.sql
@@ -1,0 +1,27 @@
+-- Create view for top fournisseurs
+create or replace view public.v_top_fournisseurs as
+select
+  mama_id,
+  fournisseur_id,
+  mois,
+  montant
+from public.fournisseur_achats_mois;
+
+-- Enable RLS on aggregated table
+alter table if exists public.fournisseur_achats_mois enable row level security;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'fournisseur_achats_mois'
+      and policyname = 'fournisseur_achats_mois_select'
+  ) then
+    create policy fournisseur_achats_mois_select on public.fournisseur_achats_mois
+      for select using (mama_id::text = auth.jwt()->>'mama_id');
+  end if;
+end $$;
+
+grant select on public.fournisseur_achats_mois to authenticated;
+grant select on public.v_top_fournisseurs to authenticated;


### PR DESCRIPTION
## Summary
- query top suppliers from new `v_top_fournisseurs` view and surface errors
- drop non-existent `ville` column in supplier queries and ensure arrays are returned
- handle loading and error states in `GadgetTopFournisseurs`
- create SQL migration for `v_top_fournisseurs` with RLS on `fournisseur_achats_mois`

## Testing
- `npm test` *(fails: 14 failed, 79 passed)*
- `npm run lint` *(fails: react-hooks/rules-of-hooks in useTemplatesCommandes.js)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1b4f7f4c832db8d122f784e4af21