### PR TITLE
fix: guard top supplier lookup

### DIFF
--- a/src/components/gadgets/GadgetTopFournisseurs.jsx
+++ b/src/components/gadgets/GadgetTopFournisseurs.jsx
@@ -7,8 +7,11 @@ export default function GadgetTopFournisseurs() {
   const { data, loading } = useTopFournisseurs();
   const { data: fournisseurs = [] } = useFournisseurs({ actif: true });
 
-  const nameFor = (id) =>
-    fournisseurs.find((f) => f.id === id)?.nom || `Fournisseur ${id}`;
+  const nameFor = (id) => {
+    const list = Array.isArray(fournisseurs) ? fournisseurs : [];
+    const item = list.find((f) => f.id === id);
+    return item?.nom ?? '—';
+  };
 
   if (loading) {
     return <LoadingSkeleton className="h-32 w-full rounded-2xl" />;


### PR DESCRIPTION
## Summary
- avoid crash when fournisseurs list is not an array in top suppliers gadget

## Testing
- `npm test` *(fails: TypeError in PrivateOutlet and others)*
- `npm run lint` *(fails: React hook misuse and exhaust-deps warnings/errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1c360ab4832d98ee57e3197b01fb