### PR TITLE
feat: tighten multi-site access schema and query

### DIFF
--- a/scripts/schema.json
+++ b/scripts/schema.json
@@ -2806,6 +2806,25 @@
         }
       ]
     },
+    "user_mama_access": {
+      "columns": [
+        "id",
+        "user_id",
+        "mama_id",
+        "role",
+        "created_at"
+      ],
+      "foreignKeys": [
+        {
+          "name": "user_mama_access_mama_id_fkey",
+          "column": "mama_id",
+          "references": {
+            "table": "mamas",
+            "column": "id"
+          }
+        }
+      ]
+    },
     "users": {
       "columns": [
         "id",

--- a/src/pages/consolidation/AccessMultiSites.jsx
+++ b/src/pages/consolidation/AccessMultiSites.jsx
@@ -1,10 +1,13 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useEffect, useState } from "react";
-import { supabase } from '@/lib/supabase';
+import { supabase } from "@/lib/supabase";
 import TableContainer from "@/components/ui/TableContainer";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
+import { useAuth } from "@/contexts/AuthContext";
+import { toast } from "sonner";
 
 export default function AccessMultiSites() {
+  const { mama_id: mamaId } = useAuth();
   const [rows, setRows] = useState([]);
   const [loading, setLoading] = useState(false);
 
@@ -12,12 +15,23 @@ export default function AccessMultiSites() {
     setLoading(true);
     supabase
       .from("user_mama_access")
-      .select("*")
-      .then(({ data }) => {
-        setRows(Array.isArray(data) ? data : []);
+      .select("id, user_id, mama_id, role")
+      .eq("mama_id", mamaId)
+      .then(({ data, error }) => {
+        if (error) {
+          if (error.code === "42P01") {
+            toast.error("Table user_mama_access introuvable");
+          } else {
+            toast.error("Erreur de chargement");
+            console.error(error);
+          }
+          setRows([]);
+        } else {
+          setRows(Array.isArray(data) ? data : []);
+        }
         setLoading(false);
       });
-  }, []);
+  }, [mamaId]);
 
   return (
     <div className="p-4 space-y-4">


### PR DESCRIPTION
## Summary
- add `user_mama_access` table to schema map
- limit columns and handle RLS in multi-site access page

## Testing
- `npm test` *(fails: many test failures)*
- `npm run lint` *(fails: 5 errors, 5 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b064bb4468832d84ae36e0baf62ae2