### PR TITLE
Specify task columns in useTasks

### DIFF
--- a/src/hooks/useTasks.js
+++ b/src/hooks/useTasks.js
@@ -3,7 +3,7 @@ import { useState, useCallback } from "react";
 import { supabase } from '@/lib/supabase';
 import { useAuth } from '@/hooks/useAuth';
 
-const SELECT = '*, assigned:utilisateurs!taches_assigned_to_fkey(nom)';
+const SELECT = 'id, mama_id, titre, description, statut, next_echeance, assigned:utilisateurs!taches_assigned_to_fkey(nom)';
 
 export function useTasks() {
   const { mama_id } = useAuth();

--- a/test/useTasks.test.js
+++ b/test/useTasks.test.js
@@ -28,7 +28,7 @@ test('fetchTasks queries Supabase and stores result', async () => {
     await result.current.fetchTasks();
   });
   expect(fromMock).toHaveBeenCalledWith('taches');
-  expect(selectMock).toHaveBeenCalledWith('*, assigned:utilisateurs!taches_assigned_to_fkey(nom)');
+  expect(selectMock).toHaveBeenCalledWith('id, mama_id, titre, description, statut, next_echeance, assigned:utilisateurs!taches_assigned_to_fkey(nom)');
   expect(queryChain.eq).toHaveBeenCalledWith('mama_id', 'm1');
   expect(orderMock).toHaveBeenCalledWith('next_echeance', { ascending: true });
   expect(result.current.tasks).toEqual([{ id: 't1' }]);
@@ -40,7 +40,7 @@ test('fetchTaskById queries Supabase with id and mama_id', async () => {
     await result.current.fetchTaskById('t1');
   });
   expect(fromMock).toHaveBeenCalledWith('taches');
-  expect(selectMock).toHaveBeenCalledWith('*, assigned:utilisateurs!taches_assigned_to_fkey(nom)');
+  expect(selectMock).toHaveBeenCalledWith('id, mama_id, titre, description, statut, next_echeance, assigned:utilisateurs!taches_assigned_to_fkey(nom)');
   expect(queryChain.eq).toHaveBeenNthCalledWith(1, 'id', 't1');
   expect(queryChain.eq).toHaveBeenNthCalledWith(2, 'mama_id', 'm1');
   expect(singleMock).toHaveBeenCalled();
@@ -52,7 +52,7 @@ test('fetchTasksByStatus filters by status', async () => {
     await result.current.fetchTasksByStatus('fait');
   });
   expect(fromMock).toHaveBeenCalledWith('taches');
-  expect(selectMock).toHaveBeenCalledWith('*, assigned:utilisateurs!taches_assigned_to_fkey(nom)');
+  expect(selectMock).toHaveBeenCalledWith('id, mama_id, titre, description, statut, next_echeance, assigned:utilisateurs!taches_assigned_to_fkey(nom)');
   expect(queryChain.eq).toHaveBeenNthCalledWith(1, 'mama_id', 'm1');
   expect(queryChain.eq).toHaveBeenNthCalledWith(2, 'statut', 'fait');
   expect(orderMock).toHaveBeenCalledWith('next_echeance', { ascending: true });


### PR DESCRIPTION
## Summary
- Enumerate task fields in SELECT to avoid phantom columns
- Update useTasks tests to check explicit column list

## Testing
- `npm test test/useTasks.test.js -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b1ae138acc832d94598eeeb9958a5c