### PR TITLE
Cross-platform test paths and backup script hardening

### DIFF
--- a/scripts/backup_db.js
+++ b/scripts/backup_db.js
@@ -1,6 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 /* eslint-env node */
 import { mkdirSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { gzipSync } from 'zlib';
 import {
@@ -97,10 +98,9 @@ export async function backupDb(
     file = output;
     ensureDirForFile(file);
   } else {
-    let dir = process.env.BACKUP_DIR ?? '/tmp';
-    dir = path.isAbsolute(dir) ? dir : path.resolve(dir);
+    const dir = path.resolve(process.env.BACKUP_DIR || os.tmpdir());
     mkdirSync(dir, { recursive: true });
-    file = path.resolve(dir, defName);
+    file = path.join(dir, defName);
   }
   const data = JSON.stringify(result, null, pretty ? 2 : 0);
   if (gzip) {

--- a/scripts/weekly_report.js
+++ b/scripts/weekly_report.js
@@ -1,6 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+import os from 'node:os';
 import path from 'node:path';
-import { writeFileSync, mkdirSync } from 'node:fs';
+import { mkdirSync, writeFileSync } from 'node:fs';
 import { strict as assert } from 'node:assert';
 import { createClient } from '@supabase/supabase-js';
 import * as XLSX from 'xlsx';
@@ -59,14 +60,10 @@ export async function generateWeeklyCostCenterReport(
   const fmt = (format ?? process.env.WEEKLY_REPORT_FORMAT ?? 'xlsx').toLowerCase();
   assert(['xlsx', 'csv', 'json'].includes(fmt), `Unknown format: ${fmt}`);
 
-  let file;
-  if (outPath) {
-    file = outPath;
-  } else {
-    const dirEnv = process.env.REPORT_DIR ?? '.';
-    const dir = path.isAbsolute(dirEnv) ? dirEnv : dirEnv;
-    file = path.join(dir, `weekly_cost_centers.${fmt}`);
-  }
+  const reportDir = path.resolve(process.env.REPORT_DIR || os.tmpdir());
+  const file = outPath
+    ? path.resolve(outPath)
+    : path.join(reportDir, `weekly_cost_centers.${fmt}`);
   mkdirSync(path.dirname(file), { recursive: true });
   const ext = path.extname(file).toLowerCase();
   if (ext && ext !== `.${fmt}`) {

--- a/test/backup_db.test.js
+++ b/test/backup_db.test.js
@@ -1,6 +1,8 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { vi, test, expect, beforeEach } from 'vitest';
 import { writeFileSync } from 'fs';
+import path from 'node:path';
+import os from 'node:os';
 
 process.env.VITE_SUPABASE_URL = 'https://example.supabase.co';
 process.env.VITE_SUPABASE_ANON_KEY = 'key';
@@ -78,7 +80,10 @@ test('backupDb writes to BACKUP_DIR when set', async () => {
   vi.resetModules();
   ({ backupDb } = await import('../scripts/backup_db.js'));
   const result = await backupDb();
-  expect(result).toMatch(/^\/tmp\/backup_\d{8}\.json$/);
+  const resultDir = path.resolve(path.dirname(result));
+  const expectedDir = path.resolve(process.env.BACKUP_DIR || os.tmpdir());
+  expect(resultDir).toBe(expectedDir);
+  expect(path.basename(result)).toMatch(/^backup_\d{8}\.json$/);
   delete process.env.BACKUP_DIR;
 });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,17 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     setupFiles: ["./test/setupTests.ts"],
-    exclude: ["e2e/**", "playwright.config.*", "node_modules/**", "dist/**"]
+    include: ["test/**/*.{test,spec}.{js,jsx,ts,tsx}"],
+    exclude: [
+      "e2e/**",
+      "playwright.config.*",
+      "node_modules/**",
+      "**/dist/**",
+      "**/.git/**",
+      "**/.history/**",
+      "**/.idea/**",
+      "**/.vscode/**"
+    ]
   },
   resolve: {
     alias: { "@": path.resolve(__dirname, "src") },


### PR DESCRIPTION
## Summary
- ignore `.git` and other folders during Vitest runs
- make backup and weekly report paths cross-platform and absolute
- adjust tests to resolve paths via `os.tmpdir()` and ensure directories are created

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b70e7216c4832da79366c30408ff70