### PR TITLE
fix(front): align src with current Supabase schema

### DIFF
--- a/src/components/FactureLigne.jsx
+++ b/src/components/FactureLigne.jsx
@@ -10,13 +10,8 @@ import {
 } from '@/components/ui/select';
 import { Trash2 } from 'lucide-react';
 import ProduitSearchModal from '@/components/factures/ProduitSearchModal';
-import {
-  toNumberSafe,
-  formatCurrencyEUR,
-  formatQty,
-  safeDiv,
-  formatPercent,
-} from '@/lib/numberFormat';
+import { formatQty, safeDiv } from '@/lib/numberFormat';
+import { toNumberSafeFR, formatCurrencyEUR, formatPercent } from '@/utils/numberFR.js';
 import { Badge } from '@/components/ui/badge';
 
 export default function FactureLigne({
@@ -54,14 +49,14 @@ export default function FactureLigne({
     );
   }, [line.total_ht]);
 
-  const qte = round3(toNumberSafe(qteInput));
-  const totalHT = round2(toNumberSafe(totalHtInput));
+  const qte = round3(toNumberSafeFR(qteInput));
+  const totalHT = round2(toNumberSafeFR(totalHtInput));
   const tva = Number(line.tva || 0);
   const puHT = safeDiv(totalHT, qte);
   const pmp = Number(line.pmp ?? 0);
-  const variationPct = pmp > 0 ? ((puHT - pmp) / pmp) * 100 : 0;
+  const variation = pmp > 0 ? (puHT - pmp) / pmp : 0;
   const varBadgeColor =
-    variationPct < 0 ? 'green' : variationPct > 0 ? 'red' : 'gray';
+    variation < 0 ? 'green' : variation > 0 ? 'red' : 'gray';
 
   function update(nQte = qte, nTotalHT = totalHT, tv = tva) {
     const q = Number.isFinite(nQte) ? nQte : 0;
@@ -157,17 +152,18 @@ export default function FactureLigne({
         />
       </div>
       <input
+        type="text"
         inputMode="decimal"
         step="0.001"
         value={qteInput}
         onChange={(e) => {
           const v = e.target.value;
           setQteInput(v);
-          const n = toNumberSafe(v);
+          const n = toNumberSafeFR(v);
           update(Number.isFinite(n) ? round3(n) : NaN, totalHT);
         }}
         onBlur={() => {
-          const n = toNumberSafe(qteInput);
+          const n = toNumberSafeFR(qteInput);
           const q = Number.isFinite(n) ? round3(n) : NaN;
           setQteInput(Number.isFinite(n) ? formatQty(q) : '');
         }}
@@ -177,17 +173,18 @@ export default function FactureLigne({
       />
       <Input readOnly disabled value={line.unite || ''} placeholder="Unité" />
       <input
+        type="text"
         inputMode="decimal"
         step="0.01"
         value={totalHtInput}
         onChange={(e) => {
           const v = e.target.value;
           setTotalHtInput(v);
-          const n = toNumberSafe(v);
+          const n = toNumberSafeFR(v);
           update(qte, Number.isFinite(n) ? round2(n) : NaN);
         }}
         onBlur={() => {
-          const n = toNumberSafe(totalHtInput);
+          const n = toNumberSafeFR(totalHtInput);
           const t = Number.isFinite(n) ? round2(n) : NaN;
           setTotalHtInput(Number.isFinite(n) ? formatCurrencyEUR(t) : '');
         }}
@@ -204,13 +201,14 @@ export default function FactureLigne({
           placeholder="PU HT"
         />
         <Badge className="ml-2" color={varBadgeColor} ariaLabel="Écart vs PMP">
-          {pmp > 0 ? formatPercent(variationPct) : '—'}
+          {pmp > 0 ? formatPercent(variation) : '—'}
         </Badge>
       </div>
       <Input
         readOnly
         disabled
         value={formatCurrencyEUR(pmp)}
+        className="w-28 text-right opacity-60"
         placeholder="PMP"
       />
       <Select

--- a/src/components/gadgets/GadgetTopFournisseurs.jsx
+++ b/src/components/gadgets/GadgetTopFournisseurs.jsx
@@ -2,7 +2,7 @@ import { motion as Motion } from 'framer-motion';
 import useTopFournisseurs from '@/hooks/gadgets/useTopFournisseurs';
 import LoadingSkeleton from '@/components/ui/LoadingSkeleton';
 import Card from '@/components/ui/Card';
-import { formatCurrencyEUR } from '@/lib/numberFormat';
+import { formatCurrencyEUR } from '@/utils/numberFR.js';
 
 export default function GadgetTopFournisseurs() {
   const { data, loading, error: errTop } = useTopFournisseurs();

--- a/src/config/routes.js
+++ b/src/config/routes.js
@@ -1,0 +1,21 @@
+import generated from './routes.generated.json' assert { type: 'json' };
+
+export const ROUTES = [
+  { path:'/dashboard', element: () => import('../pages/Dashboard.jsx'), labelKey:'menu.dashboard', icon:'LayoutDashboard', access:'view_dashboard', showInSidebar:true },
+  { path:'/produits', element:() => import('../pages/produits/Produits.jsx'), labelKey:'menu.produits', icon:'Package', access:'view_produits', showInSidebar:true },
+  { path:'/factures', element:() => import('../pages/factures/Factures.jsx'), labelKey:'menu.factures', icon:'Receipt', access:'view_factures', showInSidebar:true },
+  { path:'/fiches', element:() => import('../pages/fiches/Fiches.jsx'), labelKey:'menu.fiches', icon:'BookOpen', access:'view_fiches', showInSidebar:true },
+  { path:'/menus', element:() => import('../pages/menus/Menus.jsx'), labelKey:'menu.menus', icon:'Utensils', access:'view_menus', showInSidebar:true },
+  { path:'/menu-jour', element:() => import('../pages/menus/MenuDuJour.jsx'), labelKey:'menu.menuDuJour', icon:'CalendarClock', access:'view_menu_jour', showInSidebar:true },
+  { path:'/stock', element:() => import('../pages/stock/Stock.jsx'), labelKey:'menu.stock', icon:'Boxes', access:'view_stock', showInSidebar:true },
+  { path:'/parametrage/familles', element:() => import('../pages/parametrage/Familles.jsx'), labelKey:'menu.familles', icon:'TreeDeciduous', access:'view_parametrage', showInSidebar:true },
+  { path:'/parametrage/sous-familles', element:() => import('../pages/parametrage/SousFamilles.jsx'), labelKey:'menu.sousFamilles', icon:'GitBranch', access:'view_parametrage', showInSidebar:true },
+  { path:'/parametrage/unites', element:() => import('../pages/parametrage/Unites.jsx'), labelKey:'menu.unites', icon:'Ruler', access:'view_parametrage', showInSidebar:true },
+  { path:'/parametrage/zones', element:() => import('../pages/parametrage/Zones.jsx'), labelKey:'menu.zones', icon:'Warehouse', access:'view_parametrage', showInSidebar:true },
+];
+
+for (const r of generated) {
+  if (!ROUTES.some(x => x.path === r.path)) ROUTES.push(r);
+}
+
+export default ROUTES;

--- a/src/hooks/gadgets/useTopFournisseurs.js
+++ b/src/hooks/gadgets/useTopFournisseurs.js
@@ -17,7 +17,7 @@ export default function useTopFournisseurs() {
         const { data, error } = await supabase
           .from('v_top_fournisseurs')
           .select(
-            'fournisseur_id, montant:montant_total, nombre_achats, mama_id'
+            'mama_id,fournisseur_id,fournisseur,nombre_achats,montant:montant_total'
           )
           .eq('mama_id', mama_id)
           .order('montant_total', { ascending: false })
@@ -25,27 +25,23 @@ export default function useTopFournisseurs() {
         if (error) throw error;
         const rows = Array.isArray(data) ? data : [];
 
-        let fournisseursById = {};
-        if (rows.length) {
-          const ids = rows.map(r => r.fournisseur_id);
+        const ids = rows.map(r => r.fournisseur_id);
+        let fournisseursMap = new Map();
+        if (ids.length) {
           const { data: fournisseurs, error: errF } = await supabase
             .from('fournisseurs')
             .select('id, nom')
             .eq('mama_id', mama_id)
             .in('id', ids);
           if (errF) throw errF;
-          fournisseursById = (Array.isArray(fournisseurs)
-            ? fournisseurs
-            : []
-          ).reduce((acc, f) => {
-            acc[f.id] = f.nom;
-            return acc;
-          }, {});
+          fournisseursMap = new Map(
+            (Array.isArray(fournisseurs) ? fournisseurs : []).map(f => [f.id, f.nom])
+          );
         }
 
         const merged = rows.map(r => ({
           ...r,
-          nom: fournisseursById[r.fournisseur_id] || '',
+          nom: fournisseursMap.get(r.fournisseur_id) || r.fournisseur || '',
         }));
         setTopFournisseurs(merged);
       } catch (e) {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -44,5 +44,16 @@
   "supplierSearch.noResult": "No result",
   "pagination.prev": "Prev.",
   "pagination.next": "Next",
-  "common.close": "Close"
+  "common.close": "Close",
+  "menu.dashboard": "Dashboard",
+  "menu.produits": "Products",
+  "menu.factures": "Invoices",
+  "menu.fiches": "Sheets",
+  "menu.menus": "Menus",
+  "menu.menuDuJour": "Menu of the day",
+  "menu.stock": "Stock",
+  "menu.familles": "Families",
+  "menu.sousFamilles": "Sub-families",
+  "menu.unites": "Units",
+  "menu.zones": "Zones"
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -44,5 +44,16 @@
   "supplierSearch.noResult": "Sin resultados",
   "pagination.prev": "Ant.",
   "pagination.next": "Sig.",
-  "common.close": "Cerrar"
+  "common.close": "Cerrar",
+  "menu.dashboard": "Panel",
+  "menu.produits": "Productos",
+  "menu.factures": "Facturas",
+  "menu.fiches": "Fichas",
+  "menu.menus": "Menús",
+  "menu.menuDuJour": "Menú del día",
+  "menu.stock": "Stock",
+  "menu.familles": "Familias",
+  "menu.sousFamilles": "Subfamilias",
+  "menu.unites": "Unidades",
+  "menu.zones": "Zonas"
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -44,5 +44,16 @@
   "supplierSearch.noResult": "Aucun résultat",
   "pagination.prev": "Préc.",
   "pagination.next": "Suiv.",
-  "common.close": "Fermer"
+  "common.close": "Fermer",
+  "menu.dashboard": "Tableau de bord",
+  "menu.produits": "Produits",
+  "menu.factures": "Factures",
+  "menu.fiches": "Fiches",
+  "menu.menus": "Menus",
+  "menu.menuDuJour": "Menu du jour",
+  "menu.stock": "Stock",
+  "menu.familles": "Familles",
+  "menu.sousFamilles": "Sous-familles",
+  "menu.unites": "Unités",
+  "menu.zones": "Zones"
 }

--- a/src/layout/Sidebar.jsx
+++ b/src/layout/Sidebar.jsx
@@ -1,8 +1,9 @@
 import { NavLink, useLocation } from 'react-router-dom';
-import routes from '../config/routes.merged.js';
-import { hasAccess } from '../lib/access.js';
+import routes from '../config/routes.js';
+import { hasRight } from '../lib/access.js';
 import { useAuth } from '../contexts/AuthContext.jsx';
 import * as Icons from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 
 function Icon({ name }) {
   const Cmp = Icons[name] || Icons.Square;
@@ -12,46 +13,30 @@ function Icon({ name }) {
 export default function Sidebar() {
   const { user } = useAuth?.() || { user: null };
   const location = useLocation();
+  const { t } = useTranslation();
 
-  // Grouper par r.group
-  const groups = routes
-    .filter(r => r.showInSidebar !== false)
-    .filter(r => hasAccess ? hasAccess(user, r.accessKey) : true)
-    .reduce((acc, r) => {
-      const g = r.group || 'Général';
-      acc[g] = acc[g] || [];
-      acc[g].push(r);
-      return acc;
-    }, {});
+  const items = routes.filter(r => r.showInSidebar && hasRight(user, r.access));
 
   return (
     <aside className="w-64 flex-shrink-0 border-r bg-background text-foreground">
-      <nav className="p-2 space-y-4">
-        {Object.entries(groups).map(([group, items]) => (
-          <div key={group}>
-            <div className="px-3 py-2 text-xs uppercase tracking-wider text-muted-foreground">{group}</div>
-            <ul className="space-y-1">
-              {items.map((r) => (
-                <li key={r.path}>
-                  <NavLink
-                    to={r.path}
-                    end={r.exact}
-                    className={({ isActive }) =>
-                      [
-                        'flex items-center gap-2 rounded-md px-3 py-2 text-sm transition',
-                        'hover:bg-accent hover:text-accent-foreground focus:outline-none focus:ring-2 focus:ring-ring',
-                        isActive ? 'bg-accent text-accent-foreground' : 'text-muted-foreground'
-                      ].join(' ')
-                    }
-                    aria-current={location.pathname === r.path ? 'page' : undefined}
-                  >
-                    <Icon name={r.icon || 'Square'} />
-                    <span data-i18n-key={r.labelKey || ''}>{r.labelKey || r.path.replace('/','')}</span>
-                  </NavLink>
-                </li>
-              ))}
-            </ul>
-          </div>
+      <nav className="p-2 space-y-1">
+        {items.map(r => (
+          <NavLink
+            key={r.path}
+            to={r.path}
+            end={r.exact}
+            className={({ isActive }) =>
+              [
+                'flex items-center gap-2 rounded-md px-3 py-2 text-sm transition',
+                'hover:bg-accent hover:text-accent-foreground focus:outline-none focus:ring-2 focus:ring-ring',
+                isActive ? 'bg-accent text-accent-foreground' : 'text-muted-foreground'
+              ].join(' ')
+            }
+            aria-current={location.pathname === r.path ? 'page' : undefined}
+          >
+            <Icon name={r.icon || 'Square'} />
+            <span>{t(r.labelKey)}</span>
+          </NavLink>
         ))}
       </nav>
     </aside>

--- a/src/lib/access.js
+++ b/src/lib/access.js
@@ -27,3 +27,8 @@ export function hasAccess(user, accessKey) {
   const key = normalizeAccessKey(accessKey)
   return !!rights[key]
 }
+
+// Alias used by the new routing config
+export function hasRight(user, access) {
+  return hasAccess(user, access)
+}

--- a/src/pages/factures/FactureForm.jsx
+++ b/src/pages/factures/FactureForm.jsx
@@ -21,7 +21,7 @@ import { mapUILineToPayload } from '@/features/factures/invoiceMappers';
 import useProduitLineDefaults from '@/hooks/useProduitLineDefaults';
 import useZonesStock from '@/hooks/useZonesStock';
 import { formatMoneyFR, formatMoneyFromCents } from '@/utils/numberFormat';
-import { parseDecimal, formatMoneyEUR } from '@/lib/numberFormat';
+import { toNumberSafeFR, formatCurrencyEUR } from '@/utils/numberFR.js';
 
 
 const today = () => format(new Date(), 'yyyy-MM-dd');
@@ -121,11 +121,11 @@ export default function FactureForm({ facture = null, onSaved } = {}) {
   const round2 = (n) =>
     Number.isFinite(n) ? Math.round(n * 100) / 100 : NaN;
   const [totalAttenduInput, setTotalAttenduInput] = useState(
-    totalHTAttendu ? formatMoneyEUR(round2(totalHTAttendu)) : ''
+    totalHTAttendu ? formatCurrencyEUR(round2(totalHTAttendu)) : ''
   );
   useEffect(() => {
     setTotalAttenduInput(
-      totalHTAttendu ? formatMoneyEUR(round2(totalHTAttendu)) : ''
+    totalHTAttendu ? formatCurrencyEUR(round2(totalHTAttendu)) : ''
     );
   }, [totalHTAttendu]);
 
@@ -317,15 +317,16 @@ export default function FactureForm({ facture = null, onSaved } = {}) {
           <label className="text-sm font-medium">Total HT attendu (€)</label>
           <div className="flex items-center gap-2">
             <input
+              type="text"
               inputMode="decimal"
               step="0.01"
               value={totalAttenduInput}
               onChange={(e) => setTotalAttenduInput(e.target.value)}
               onBlur={() => {
-                const n = parseDecimal(totalAttenduInput);
+                const n = toNumberSafeFR(totalAttenduInput);
                 const t = Number.isFinite(n) ? round2(n) : NaN;
                 setTotalAttenduInput(
-                  Number.isFinite(n) ? formatMoneyEUR(t) : ''
+                  Number.isFinite(n) ? formatCurrencyEUR(t) : ''
                 );
                 setValue('total_ht_attendu', Number.isFinite(n) ? t : null, {
                   shouldDirty: true,

--- a/src/pages/reporting/Reporting.jsx
+++ b/src/pages/reporting/Reporting.jsx
@@ -6,7 +6,7 @@ import { useReporting } from '@/hooks/useReporting';
 import StatCard from '@/components/ui/StatCard';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import GlassCard from '@/components/ui/GlassCard';
-import { formatCurrencyEUR, formatPercent } from '@/lib/numberFormat';
+import { formatCurrencyEUR, formatPercent } from '@/utils/numberFR.js';
 import {
   ResponsiveContainer,
   LineChart,

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -1,22 +1,18 @@
 import React, { lazy, Suspense } from 'react';
 import { createBrowserRouter, Navigate } from 'react-router-dom';
-import routes from './config/routes.merged.js';
+import routes from './config/routes.js';
 import Layout from './layout/Layout.jsx';
 import PrivateOutlet from './router/PrivateOutlet.jsx';
 import Login from './pages/auth/Login.jsx';
 import NotFound from './pages/NotFound.jsx';
 import PageSkeleton from './components/ui/PageSkeleton.jsx';
 
-function lazyPage(file) {
-  return lazy(() => import(`./pages/${file}`));
-}
-
 const routeObjects = routes.map(r => ({
   path: r.path,
   element: (
-    <PrivateOutlet accessKey={r.accessKey}>
+    <PrivateOutlet access={r.access}>
       <Suspense fallback={<PageSkeleton />}>
-        {React.createElement(lazyPage(r.file))}
+        {React.createElement(lazy(r.element))}
       </Suspense>
     </PrivateOutlet>
   ),

--- a/src/router/PrivateOutlet.jsx
+++ b/src/router/PrivateOutlet.jsx
@@ -1,9 +1,9 @@
 import { Navigate, Outlet } from 'react-router-dom';
 import { useAuth } from '@/hooks/useAuth';
 
-export default function PrivateOutlet({ accessKey, children }) {
+export default function PrivateOutlet({ access, children }) {
   const { session, isAuthenticated, hasAccess } = useAuth();
   if (!(session?.user || isAuthenticated)) return <Navigate to="/login" replace />;
-  if (accessKey && hasAccess && !hasAccess(accessKey)) return <Navigate to="/dashboard" replace />;
+  if (access && hasAccess && !hasAccess(access)) return <Navigate to="/dashboard" replace />;
   return children ? children : <Outlet />;
 }

--- a/src/utils/numberFR.js
+++ b/src/utils/numberFR.js
@@ -1,0 +1,14 @@
+export function toNumberSafeFR(input) {
+  if (typeof input !== 'string') return Number(input) || 0;
+  const s = input.trim().replace(/\s/g, '').replace(',', '.');
+  const n = Number(s);
+  return Number.isFinite(n) ? n : 0;
+}
+export function formatCurrencyEUR(n) {
+  try { return new Intl.NumberFormat('fr-FR',{style:'currency',currency:'EUR'}).format(n ?? 0); }
+  catch { return `${(n ?? 0).toFixed(2)} \u20AC`; }
+}
+export function formatPercent(delta) {
+  const v = (delta ?? 0) * 100;
+  return new Intl.NumberFormat('fr-FR',{minimumFractionDigits:2,maximumFractionDigits:2}).format(v) + ' %';
+}


### PR DESCRIPTION
## Summary
- add number formatting helpers and use them across invoices, reporting, and dashboard
- centralize routing and sidebar from single route config with access control
- simplify product queries and join data in UI only
- ensure invoice decimal inputs parse French format and keep PU/PMP read-only
- translate new sidebar labels for all locales

## Testing
- `npm test` (fails: Expected "]" but found "'**/.git/**'")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b71f68f114832db33ca84a040f35e3