### PR TITLE
feat(router): single BrowserRouter at entry, secure AuthProvider navigation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,5 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import router from "@/router";
-import { RouterProvider } from 'react-router-dom';
+import AppRouter from "@/router";
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import nprogress from 'nprogress';
 import { useEffect } from 'react';
@@ -66,7 +65,7 @@ export default function App() {
         <MultiMamaProvider>
           <ThemeProvider>
             <ToastRoot />
-            <RouterProvider router={router} />
+            <AppRouter />
             <CookieConsent />
           </ThemeProvider>
         </MultiMamaProvider>

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -87,6 +87,12 @@ function AuthProvider({ children }) {
     return () => { sub?.subscription?.unsubscribe?.(); if (pollTimerRef.current) window.clearInterval(pollTimerRef.current) }
   }, [navigate, userData])
 
+  useEffect(() => {
+    if (session === null) {
+      navigate('/login', { replace: true })
+    }
+  }, [session, navigate])
+
   const hasAccess = useMemo(() => {
     return (key) => {
       const k = normalizeAccessKey(key)

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import "./globals.css";
 import 'nprogress/nprogress.css';
@@ -37,8 +38,10 @@ if (import.meta?.env?.DEV) {
 const root = createRoot(document.getElementById("root"));
 root.render(
   <StrictMode>
-    <AuthProvider>
+    <BrowserRouter>
+      <AuthProvider>
         <App />
       </AuthProvider>
-    </StrictMode>
+    </BrowserRouter>
+  </StrictMode>
 );

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -1,5 +1,5 @@
 import React, { lazy, Suspense } from 'react';
-import { createBrowserRouter, Navigate } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom';
 import routes from './config/routes.js';
 import Layout from './layout/Layout.jsx';
 import PrivateOutlet from './router/PrivateOutlet.jsx';
@@ -7,7 +7,7 @@ import Login from './pages/auth/Login.jsx';
 import NotFound from './pages/NotFound.jsx';
 import PageSkeleton from './components/ui/PageSkeleton.jsx';
 
-const routeObjects = routes.map(r => ({
+const routeObjects = routes.map((r) => ({
   path: r.path,
   element: (
     <PrivateOutlet access={r.access}>
@@ -35,7 +35,31 @@ const routerConfig = [
   { path: '*', element: <NotFound /> },
 ];
 
-const router = createBrowserRouter(routerConfig);
+export default function AppRouter() {
+  return (
+    <Suspense fallback={<div className="p-6">Chargement…</div>}>
+      <Routes>
+        <Route path="/login" element={<Login />} />
+        <Route path="/" element={<PrivateOutlet><Layout /></PrivateOutlet>}>
+          <Route index element={<Navigate to="/dashboard" replace />} />
+          {routes.map((r) => (
+            <Route
+              key={r.path}
+              path={r.path}
+              element={
+                <PrivateOutlet access={r.access}>
+                  <Suspense fallback={<PageSkeleton />}>
+                    {React.createElement(lazy(r.element))}
+                  </Suspense>
+                </PrivateOutlet>
+              }
+            />
+          ))}
+        </Route>
+        <Route path="*" element={<NotFound />} />
+      </Routes>
+    </Suspense>
+  );
+}
 
 export { routerConfig };
-export default router;

--- a/test/ImportFactures.test.jsx
+++ b/test/ImportFactures.test.jsx
@@ -1,6 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { screen, fireEvent, act } from '@testing-library/react';
 import { vi } from 'vitest';
+import { renderWithRouter } from './utils/renderWithRouter.jsx';
 
 let hook;
 vi.mock('@/hooks/useInvoiceImport', () => ({
@@ -22,7 +23,7 @@ test('uploads file and calls hook', async () => {
   const importFromFile = vi.fn(() => Promise.resolve('id'));
   hook = { importFromFile, loading: false, error: null };
   await act(async () => {
-    render(<ImportFactures />);
+    renderWithRouter(<ImportFactures />);
   });
   const fileInput = document.querySelector('input[type="file"]');
   const file = new File(['{}'], 'facture.json', { type: 'application/json' });

--- a/test/utils/renderWithRouter.jsx
+++ b/test/utils/renderWithRouter.jsx
@@ -1,0 +1,11 @@
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import AuthProvider from '../../src/contexts/AuthContext.jsx';
+
+export function renderWithRouter(ui, { route = '/', historyEntries = [route] } = {}) {
+  return render(
+    <MemoryRouter initialEntries={historyEntries}>
+      <AuthProvider>{ui}</AuthProvider>
+    </MemoryRouter>
+  );
+}


### PR DESCRIPTION
## Summary
- centralize routing by wrapping `<AuthProvider>` and `<App>` with a single `<BrowserRouter>` in `main.jsx`
- refactor router to render `<Routes>` only and export `AppRouter` component
- safeguard `AuthProvider` redirects using `useEffect`
- add testing utility for routing context and update `ImportFactures` test

## Testing
- `npm test` *(fails: Expected "]" but found "'**/.git/**'" in vitest.config.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b7df9c93e4832d93373fb749eb0ea5