### PR TITLE
chore: add page inventory script

### DIFF
--- a/pages_report.json
+++ b/pages_report.json
@@ -1,0 +1,2354 @@
+{
+  "generatedAt": "2025-09-03T07:06:18.870Z",
+  "totals": {
+    "pages": 188,
+    "routes": 0,
+    "orphanRoutes": 0
+  },
+  "pages": [
+    {
+      "pageFile": "pages/Accueil.jsx",
+      "component": "Accueil",
+      "inferredTitle": "\n              Simplifiez votre gestion F&amp;B\n            ",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/AideContextuelle.jsx",
+      "component": "Aide",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/BarManager.jsx",
+      "component": "BarManager",
+      "inferredTitle": "Bar Manager — Analyses avancées",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [
+          "fiches_techniques",
+          "ventes_boissons"
+        ],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/CartePlats.jsx",
+      "component": "CartePlats",
+      "inferredTitle": "Carte des plats actifs",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [
+          "fiches_techniques",
+          "familles"
+        ],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/Consentements.jsx",
+      "component": "Consentements",
+      "inferredTitle": "Historique des consentements",
+      "inferredDescription": null,
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/Dashboard.jsx",
+      "component": "Dashboard",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/EngineeringMenu.jsx",
+      "component": "EngineeringMenu",
+      "inferredTitle": "Engineering Menu",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/Feedback.jsx",
+      "component": "Feedback",
+      "inferredTitle": "Feedback utilisateur",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/HelpCenter.jsx",
+      "component": "HelpCenter",
+      "inferredTitle": "Aide & FAQ",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/Journal.jsx",
+      "component": "Journal",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/NotFound.jsx",
+      "component": "NotFound",
+      "inferredTitle": "404",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/Onboarding.jsx",
+      "component": "Onboarding",
+      "inferredTitle": "Onboarding",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/Parametres/Familles.jsx",
+      "component": "Familles",
+      "inferredTitle": "Familles de produits",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [
+          "familles",
+          "sous_familles"
+        ],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/Pertes.jsx",
+      "component": "Pertes",
+      "inferredTitle": "Pertes / Casses / Dons",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/Planning.jsx",
+      "component": "Planning",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/PlanningDetail.jsx",
+      "component": "PlanningDetail",
+      "inferredTitle": "{planning.nom}",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/PlanningForm.jsx",
+      "component": "PlanningForm",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/PlanningModule.jsx",
+      "component": "PlanningModule",
+      "inferredTitle": "Planning",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/Rgpd.jsx",
+      "component": "Rgpd",
+      "inferredTitle": "Données &amp; Confidentialité",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/Validations.jsx",
+      "component": "Validations",
+      "inferredTitle": "Validations",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/achats/AchatDetail.jsx",
+      "component": "AchatDetail",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/achats/AchatForm.jsx",
+      "component": "AchatForm",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/achats/Achats.jsx",
+      "component": "Achats",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/aide/Aide.jsx",
+      "component": "Aide",
+      "inferredTitle": "Aide",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/aide/AideForm.jsx",
+      "component": "AideForm",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/analyse/Analyse.jsx",
+      "component": "Analyse",
+      "inferredTitle": "Analyse avancée",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/analyse/AnalyseCostCenter.jsx",
+      "component": "AnalyseCostCenter",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/analyse/MenuEngineering.jsx",
+      "component": "MenuEngineering",
+      "inferredTitle": "Menu Engineering",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/analyse/TableauxDeBord.jsx",
+      "component": "TableauxDeBord",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/analytique/AnalytiqueDashboard.jsx",
+      "component": "AnalytiqueDashboard",
+      "inferredTitle": "Dashboard analytique",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/auth/Blocked.jsx",
+      "component": "Blocked",
+      "inferredTitle": "🚫 Compte bloqué",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/auth/CreateMama.jsx",
+      "component": "CreateMama",
+      "inferredTitle": "Votre établissement",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [
+          "mamas",
+          "utilisateurs"
+        ],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/auth/Login.jsx",
+      "component": "Login",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/auth/Logout.jsx",
+      "component": "Logout",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/auth/Pending.jsx",
+      "component": "Pending",
+      "inferredTitle": "Compte en cours de création…",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/auth/ResetPassword.jsx",
+      "component": "ResetPassword",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/auth/RoleError.jsx",
+      "component": "RoleError",
+      "inferredTitle": "Erreur de permission",
+      "inferredDescription": null,
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/auth/Unauthorized.jsx",
+      "component": "Unauthorized",
+      "inferredTitle": "🚫 Accès refusé",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/auth/UpdatePassword.jsx",
+      "component": "UpdatePassword",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/bons_livraison/BLCreate.jsx",
+      "component": "BLCreate",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/bons_livraison/BLDetail.jsx",
+      "component": "BLDetail",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/bons_livraison/BLForm.jsx",
+      "component": "BLForm",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/bons_livraison/BonsLivraison.jsx",
+      "component": "BonsLivraison",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/carte/Carte.jsx",
+      "component": "Carte",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/catalogue/CatalogueSyncViewer.jsx",
+      "component": "CatalogueSyncViewer",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [
+          "catalogue_updates",
+          "fournisseur_produits"
+        ],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/commandes/CommandeDetail.jsx",
+      "component": "CommandeDetail",
+      "inferredTitle": "Commande {commande.reference}",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/commandes/CommandeForm.jsx",
+      "component": "CommandeForm",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/commandes/Commandes.jsx",
+      "component": "Commandes",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/commandes/CommandesEnvoyees.jsx",
+      "component": "CommandesEnvoyees",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [
+          "commandes"
+        ],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/consolidation/AccessMultiSites.jsx",
+      "component": "AccessMultiSites",
+      "inferredTitle": "Sites accessibles",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [
+          "mamas"
+        ],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/consolidation/Consolidation.jsx",
+      "component": "Consolidation",
+      "inferredTitle": "Consolidation",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/costboisson/CostBoisson.jsx",
+      "component": "CostBoissons",
+      "inferredTitle": "Cost Boissons",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [
+          "v_boissons",
+          "ventes_boissons",
+          "produits",
+          "fiches_techniques"
+        ],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/costing/CostingCarte.jsx",
+      "component": "CostingCarte",
+      "inferredTitle": "Costing Carte",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/cuisine/MenuDuJour.jsx",
+      "component": "MenuDuJour",
+      "inferredTitle": "Menu du jour",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/dashboard/DashboardBuilder.jsx",
+      "component": "DashboardBuilder",
+      "inferredTitle": "Mes tableaux de bord",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/debug/AccessExample.jsx",
+      "component": "AccessExample",
+      "inferredTitle": null,
+      "inferredDescription": null,
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/debug/AuthDebug.jsx",
+      "component": "AuthDebug",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/debug/Debug.jsx",
+      "component": "Debug",
+      "inferredTitle": "🧪 Debug AuthContext",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/debug/DebugAuth.jsx",
+      "component": "DebugAuth",
+      "inferredTitle": null,
+      "inferredDescription": null,
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/debug/DebugRights.jsx",
+      "component": "DebugRights",
+      "inferredTitle": null,
+      "inferredDescription": null,
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/debug/DebugUser.jsx",
+      "component": "DebugUser",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/documents/DocumentForm.jsx",
+      "component": "DocumentForm",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/documents/Documents.jsx",
+      "component": "Documents",
+      "inferredTitle": "Documents",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/ecarts/Ecarts.jsx",
+      "component": "Ecarts",
+      "inferredTitle": "Écarts d'inventaire",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/emails/EmailsEnvoyes.jsx",
+      "component": "EmailsEnvoyes",
+      "inferredTitle": "Emails envoyés",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/engineering/MenuEngineering.jsx",
+      "component": "MenuEngineering",
+      "inferredTitle": "Menu Engineering",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/factures/FactureCreate.jsx",
+      "component": "FactureCreate",
+      "inferredTitle": null,
+      "inferredDescription": null,
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/factures/FactureDetail.jsx",
+      "component": "FactureDetail",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [
+          "factures"
+        ],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/factures/FactureForm.jsx",
+      "component": "FactureForm",
+      "inferredTitle": null,
+      "inferredDescription": "src/pages/factures/FactureForm.jsx",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/factures/Factures.jsx",
+      "component": "Factures",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/factures/ImportFactures.jsx",
+      "component": "ImportFactures",
+      "inferredTitle": "Import e-facture",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/fiches/FicheDetail.jsx",
+      "component": "FicheDetail",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/fiches/FicheForm.jsx",
+      "component": "FicheForm",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/fiches/Fiches.jsx",
+      "component": "Fiches",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/fournisseurs/ApiFournisseurForm.jsx",
+      "component": null,
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/fournisseurs/ApiFournisseurs.jsx",
+      "component": "ApiFournisseurs",
+      "inferredTitle": "API Fournisseurs",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/fournisseurs/FournisseurApiSettingsForm.jsx",
+      "component": "FournisseurApiSettingsForm",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/fournisseurs/FournisseurCreate.jsx",
+      "component": "FournisseurCreate",
+      "inferredTitle": null,
+      "inferredDescription": null,
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/fournisseurs/FournisseurDetail.jsx",
+      "component": "FournisseurDetail",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [
+          "facture_lignes",
+          "fournisseurs"
+        ],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/fournisseurs/FournisseurDetailPage.jsx",
+      "component": "FournisseurDetailPage",
+      "inferredTitle": null,
+      "inferredDescription": null,
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/fournisseurs/FournisseurForm.jsx",
+      "component": "FournisseurForm",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/fournisseurs/Fournisseurs.jsx",
+      "component": "Fournisseurs",
+      "inferredTitle": "Gestion des fournisseurs",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/fournisseurs/comparatif/ComparatifPrix.jsx",
+      "component": "ComparatifPrix",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [
+          "produits"
+        ],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/fournisseurs/comparatif/PrixFournisseurs.jsx",
+      "component": "PrixFournisseurs",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/inventaire/EcartInventaire.jsx",
+      "component": "EcartInventaire",
+      "inferredTitle": "Écarts d'inventaire – Zone : ${zone}",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/inventaire/Inventaire.jsx",
+      "component": "Inventaire",
+      "inferredTitle": "Inventaires",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/inventaire/InventaireDetail.jsx",
+      "component": "InventaireDetail",
+      "inferredTitle": "Inventaire du {inventaire.date_inventaire}",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/inventaire/InventaireForm.jsx",
+      "component": "InventaireForm",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/inventaire/InventaireZones.jsx",
+      "component": "InventaireZones",
+      "inferredTitle": "Zones d'inventaire",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/legal/Cgu.jsx",
+      "component": "Cgu",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/legal/Cgv.jsx",
+      "component": "Cgv",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/legal/Confidentialite.jsx",
+      "component": "Confidentialite",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [
+          "mamas"
+        ],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/legal/Contact.jsx",
+      "component": "Contact",
+      "inferredTitle": "Nous contacter",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/legal/Licence.jsx",
+      "component": "Licence",
+      "inferredTitle": "Licence et abonnement",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/legal/MentionsLegales.jsx",
+      "component": "MentionsLegales",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [
+          "mamas"
+        ],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/menu/MenuDuJour.jsx",
+      "component": "MenuDuJour",
+      "inferredTitle": "Menu du jour",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/menu/MenuDuJourJour.jsx",
+      "component": "MenuDuJourJour",
+      "inferredTitle": "Menu du {date}",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/menus/MenuDetail.jsx",
+      "component": "MenuDetail",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/menus/MenuDuJour.jsx",
+      "component": "MenuDuJour",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/menus/MenuDuJourDetail.jsx",
+      "component": "MenuDuJourDetail",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/menus/MenuDuJourForm.jsx",
+      "component": "MenuDuJourForm",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/menus/MenuForm.jsx",
+      "component": "MenuForm",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/menus/MenuGroupeDetail.jsx",
+      "component": "MenuGroupeDetail",
+      "inferredTitle": "{menu.nom}",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/menus/MenuGroupeForm.jsx",
+      "component": "MenuGroupeForm",
+      "inferredTitle": "Formule groupe",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/menus/MenuGroupes.jsx",
+      "component": "MenuGroupes",
+      "inferredTitle": "Menu groupe",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/menus/MenuPDF.jsx",
+      "component": "MenuPDF",
+      "inferredTitle": "Menu du jour : ${menu.nom}",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [
+          "menus",
+          "menu_fiches",
+          "fiches_techniques"
+        ],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/menus/Menus.jsx",
+      "component": "Menus",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/mobile/MobileAccueil.jsx",
+      "component": "MobileAccueil",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/mobile/MobileInventaire.jsx",
+      "component": "MobileInventaire",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [
+          "produits"
+        ],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/mobile/MobileRequisition.jsx",
+      "component": "MobileRequisition",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [
+          "produits",
+          "requisitions"
+        ],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/notifications/NotificationSettingsForm.jsx",
+      "component": "NotificationSettingsForm",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/notifications/NotificationsInbox.jsx",
+      "component": "NotificationsInbox",
+      "inferredTitle": "Notifications",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/onboarding/OnboardingUtilisateur.jsx",
+      "component": "OnboardingUtilisateur",
+      "inferredTitle": "Utilisateur introuvable",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/parametrage/APIKeys.jsx",
+      "component": "APIKeys",
+      "inferredTitle": "Clés API",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/parametrage/AccessRights.jsx",
+      "component": "AccessRights",
+      "inferredTitle": "\n        Droits personnalisés par utilisateur\n      ",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/parametrage/CentreCoutForm.jsx",
+      "component": "CentreCoutForm",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [
+          "centres_de_cout"
+        ],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/parametrage/ExportComptaPage.jsx",
+      "component": "ExportComptaPage",
+      "inferredTitle": "Export comptable",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/parametrage/ExportUserData.jsx",
+      "component": "ExportUserData",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/parametrage/Familles.jsx",
+      "component": "Familles",
+      "inferredTitle": "Familles",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/parametrage/InvitationsEnAttente.jsx",
+      "component": "InvitationsEnAttente",
+      "inferredTitle": "\n        Invitations en attente\n      ",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [
+          "mamas",
+          "roles",
+          "utilisateurs"
+        ],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/parametrage/InviteUser.jsx",
+      "component": "InviteUser",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [
+          "mamas",
+          "roles",
+          "utilisateurs"
+        ],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/parametrage/MamaForm.jsx",
+      "component": "MamaForm",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [
+          "mamas"
+        ],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/parametrage/MamaSettingsForm.jsx",
+      "component": "MamaSettingsForm",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/parametrage/Mamas.jsx",
+      "component": "Mamas",
+      "inferredTitle": "Établissements (MAMA)",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [
+          "mamas"
+        ],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/parametrage/Parametrage.jsx",
+      "component": "Parametrage",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/parametrage/ParametresCommandes.jsx",
+      "component": "ParametresCommandes",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [
+          "parametres_commandes"
+        ],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/parametrage/Periodes.jsx",
+      "component": "Periodes",
+      "inferredTitle": "Périodes comptables",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/parametrage/Permissions.jsx",
+      "component": "Permissions",
+      "inferredTitle": "\n        Permissions des rôles\n      ",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [
+          "roles"
+        ],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/parametrage/PermissionsAdmin.jsx",
+      "component": "PermissionsAdmin",
+      "inferredTitle": "\n        Permissions globales (superadmin)\n      ",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [
+          "mamas",
+          "roles"
+        ],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/parametrage/PermissionsForm.jsx",
+      "component": "PermissionsForm",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [
+          "permissions"
+        ],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/parametrage/RGPDConsentForm.jsx",
+      "component": "RGPDConsentForm",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [
+          "consentements_utilisateur"
+        ],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/parametrage/RoleForm.jsx",
+      "component": "RoleForm",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/parametrage/Roles.jsx",
+      "component": "Roles",
+      "inferredTitle": "Gestion des rôles",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/parametrage/SousFamilles.jsx",
+      "component": "SousFamilles",
+      "inferredTitle": null,
+      "inferredDescription": "all | actifs | inactifs",
+      "hooks": [],
+      "supabase": {
+        "tables": [
+          "sous_familles"
+        ],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/parametrage/TemplateCommandeForm.jsx",
+      "component": "TemplateCommandeForm",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [
+          "public"
+        ],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/parametrage/TemplatesCommandes.jsx",
+      "component": "TemplatesCommandes",
+      "inferredTitle": "Templates de commandes",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/parametrage/Unites.jsx",
+      "component": "Unites",
+      "inferredTitle": "Unités",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/parametrage/Utilisateurs.jsx",
+      "component": "Utilisateurs",
+      "inferredTitle": "Utilisateurs",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [
+          "utilisateurs"
+        ],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/parametrage/ZoneAccess.jsx",
+      "component": "ZoneAccess",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/parametrage/ZoneForm.jsx",
+      "component": "ZoneForm",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/parametrage/Zones.jsx",
+      "component": "Zones",
+      "inferredTitle": "Zones de stock",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/planning/SimulationPlanner.jsx",
+      "component": "SimulationPlanner",
+      "inferredTitle": "Simulation planning",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/produits/ProduitDetail.jsx",
+      "component": "ProduitDetailPage",
+      "inferredTitle": "\n            Détails produit {productName && `- ${productName}`}\n          ",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/produits/ProduitForm.jsx",
+      "component": "ProduitFormPage",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/produits/Produits.jsx",
+      "component": "Produits",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/promotions/PromotionForm.jsx",
+      "component": "PromotionForm",
+      "inferredTitle": null,
+      "inferredDescription": null,
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/promotions/Promotions.jsx",
+      "component": "Promotions",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/public/LandingPage.jsx",
+      "component": "LandingPage",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/public/Onboarding.jsx",
+      "component": "Onboarding",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/public/Signup.jsx",
+      "component": "Signup",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/receptions/Receptions.jsx",
+      "component": "Receptions",
+      "inferredTitle": "Réceptions",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/recettes/Recettes.jsx",
+      "component": "Recettes",
+      "inferredTitle": "Recettes",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/reporting/GraphCost.jsx",
+      "component": "GraphCost",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/reporting/Reporting.jsx",
+      "component": "Reporting",
+      "inferredTitle": "\n        Reporting analytique\n      ",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/reporting/ReportingPDF.jsx",
+      "component": "ReportingPDF",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/requisitions/RequisitionDetail.jsx",
+      "component": "RequisitionDetail",
+      "inferredTitle": "Détail de la réquisition",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/requisitions/RequisitionForm.jsx",
+      "component": "RequisitionForm",
+      "inferredTitle": "Nouvelle réquisition",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/requisitions/Requisitions.jsx",
+      "component": "Requisitions",
+      "inferredTitle": "\n        Réquisitions (sortie stock)\n      ",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/signalements/SignalementDetail.jsx",
+      "component": "SignalementDetail",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/signalements/SignalementForm.jsx",
+      "component": "SignalementForm",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/signalements/Signalements.jsx",
+      "component": "Signalements",
+      "inferredTitle": "Signalements",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/simulation/Simulation.jsx",
+      "component": "Simulation",
+      "inferredTitle": "Simulation (test signalements)",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/simulation/SimulationForm.jsx",
+      "component": "SimulationForm",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [
+          "fiches"
+        ],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/simulation/SimulationMenu.jsx",
+      "component": "SimulationMenu",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/simulation/SimulationResult.jsx",
+      "component": "SimulationResult",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/stats/Stats.jsx",
+      "component": "Stats",
+      "inferredTitle": "Stats",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/stats/StatsAdvanced.jsx",
+      "component": "StatsAdvanced",
+      "inferredTitle": "Analytique avancée",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/stats/StatsConsolidation.jsx",
+      "component": "StatsConsolidation",
+      "inferredTitle": "Consolidation multi-sites",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/stats/StatsCostCenters.jsx",
+      "component": "StatsCostCenters",
+      "inferredTitle": "Ventilation par Cost Center",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/stats/StatsCostCentersPivot.jsx",
+      "component": "StatsCostCentersPivot",
+      "inferredTitle": "Ventilation mensuelle par Cost Center",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/stats/StatsFiches.jsx",
+      "component": "StatsFiches",
+      "inferredTitle": "Statistiques fiches techniques",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [
+          "fiches_techniques",
+          "familles"
+        ],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/stats/StatsStock.jsx",
+      "component": "StatsStock",
+      "inferredTitle": "Stocks produits",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/stock/AlertesRupture.jsx",
+      "component": "AlertesRupture",
+      "inferredTitle": "Alertes rupture",
+      "inferredDescription": null,
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/stock/Inventaire.jsx",
+      "component": "InventairePage",
+      "inferredTitle": "Inventaires",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/stock/InventaireForm.jsx",
+      "component": "InventaireFormPage",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/stock/TransfertForm.jsx",
+      "component": "TransfertForm",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/stock/Transferts.jsx",
+      "component": "Transferts",
+      "inferredTitle": "Transferts",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/supervision/ComparateurFiches.jsx",
+      "component": "ComparateurFiches",
+      "inferredTitle": "Comparateur de fiches",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/supervision/GroupeParamForm.jsx",
+      "component": "GroupeParamForm",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [
+          "mamas",
+          "groupes"
+        ],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/supervision/Logs.jsx",
+      "component": "Logs",
+      "inferredTitle": "Logs activité",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/supervision/Rapports.jsx",
+      "component": "Rapports",
+      "inferredTitle": "Rapports générés",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/supervision/SupervisionGroupe.jsx",
+      "component": "SupervisionGroupe",
+      "inferredTitle": "Supervision Groupe",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": [
+          "stats_multi_mamas"
+        ]
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/surcouts/Surcouts.jsx",
+      "component": "Surcouts",
+      "inferredTitle": "Surcoûts",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/taches/Alertes.jsx",
+      "component": "Alertes",
+      "inferredTitle": "Alertes",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [
+          "v_alertes_rupture"
+        ],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/taches/TacheDetail.jsx",
+      "component": "TacheDetail",
+      "inferredTitle": "{tache.titre}",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/taches/TacheForm.jsx",
+      "component": "TacheForm",
+      "inferredTitle": null,
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/taches/TacheNew.jsx",
+      "component": "TacheNew",
+      "inferredTitle": "Nouvelle tâche",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    },
+    {
+      "pageFile": "pages/taches/Taches.jsx",
+      "component": "Taches",
+      "inferredTitle": "Tâches planifiées",
+      "inferredDescription": "MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.",
+      "hooks": [],
+      "supabase": {
+        "tables": [],
+        "rpcs": []
+      },
+      "routes": []
+    }
+  ],
+  "orphanRoutes": []
+}

--- a/pages_report.md
+++ b/pages_report.md
@@ -1,0 +1,1233 @@
+# Inventaire des pages (généré)
+- Généré: 2025-09-03T07:06:18.870Z
+- Pages: 188 — Routes: 0 — Routes orphelines: 0
+
+## pages/Accueil.jsx
+- Composant: `Accueil`
+- Titre deviné: **
+              Simplifiez votre gestion F&amp;B
+            **
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/AideContextuelle.jsx
+- Composant: `Aide`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/BarManager.jsx
+- Composant: `BarManager`
+- Titre deviné: **Bar Manager — Analyses avancées**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = `fiches_techniques`, `ventes_boissons`, rpc = -
+
+## pages/CartePlats.jsx
+- Composant: `CartePlats`
+- Titre deviné: **Carte des plats actifs**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = `fiches_techniques`, `familles`, rpc = -
+
+## pages/Consentements.jsx
+- Composant: `Consentements`
+- Titre deviné: **Historique des consentements**
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/Dashboard.jsx
+- Composant: `Dashboard`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/EngineeringMenu.jsx
+- Composant: `EngineeringMenu`
+- Titre deviné: **Engineering Menu**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/Feedback.jsx
+- Composant: `Feedback`
+- Titre deviné: **Feedback utilisateur**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/HelpCenter.jsx
+- Composant: `HelpCenter`
+- Titre deviné: **Aide & FAQ**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/Journal.jsx
+- Composant: `Journal`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/NotFound.jsx
+- Composant: `NotFound`
+- Titre deviné: **404**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/Onboarding.jsx
+- Composant: `Onboarding`
+- Titre deviné: **Onboarding**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/Parametres/Familles.jsx
+- Composant: `Familles`
+- Titre deviné: **Familles de produits**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = `familles`, `sous_familles`, rpc = -
+
+## pages/Pertes.jsx
+- Composant: `Pertes`
+- Titre deviné: **Pertes / Casses / Dons**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/Planning.jsx
+- Composant: `Planning`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/PlanningDetail.jsx
+- Composant: `PlanningDetail`
+- Titre deviné: **{planning.nom}**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/PlanningForm.jsx
+- Composant: `PlanningForm`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/PlanningModule.jsx
+- Composant: `PlanningModule`
+- Titre deviné: **Planning**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/Rgpd.jsx
+- Composant: `Rgpd`
+- Titre deviné: **Données &amp; Confidentialité**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/Validations.jsx
+- Composant: `Validations`
+- Titre deviné: **Validations**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/achats/AchatDetail.jsx
+- Composant: `AchatDetail`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/achats/AchatForm.jsx
+- Composant: `AchatForm`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/achats/Achats.jsx
+- Composant: `Achats`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/aide/Aide.jsx
+- Composant: `Aide`
+- Titre deviné: **Aide**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/aide/AideForm.jsx
+- Composant: `AideForm`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/analyse/Analyse.jsx
+- Composant: `Analyse`
+- Titre deviné: **Analyse avancée**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/analyse/AnalyseCostCenter.jsx
+- Composant: `AnalyseCostCenter`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/analyse/MenuEngineering.jsx
+- Composant: `MenuEngineering`
+- Titre deviné: **Menu Engineering**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/analyse/TableauxDeBord.jsx
+- Composant: `TableauxDeBord`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/analytique/AnalytiqueDashboard.jsx
+- Composant: `AnalytiqueDashboard`
+- Titre deviné: **Dashboard analytique**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/auth/Blocked.jsx
+- Composant: `Blocked`
+- Titre deviné: **🚫 Compte bloqué**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/auth/CreateMama.jsx
+- Composant: `CreateMama`
+- Titre deviné: **Votre établissement**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = `mamas`, `utilisateurs`, rpc = -
+
+## pages/auth/Login.jsx
+- Composant: `Login`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/auth/Logout.jsx
+- Composant: `Logout`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/auth/Pending.jsx
+- Composant: `Pending`
+- Titre deviné: **Compte en cours de création…**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/auth/ResetPassword.jsx
+- Composant: `ResetPassword`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/auth/RoleError.jsx
+- Composant: `RoleError`
+- Titre deviné: **Erreur de permission**
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/auth/Unauthorized.jsx
+- Composant: `Unauthorized`
+- Titre deviné: **🚫 Accès refusé**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/auth/UpdatePassword.jsx
+- Composant: `UpdatePassword`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/bons_livraison/BLCreate.jsx
+- Composant: `BLCreate`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/bons_livraison/BLDetail.jsx
+- Composant: `BLDetail`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/bons_livraison/BLForm.jsx
+- Composant: `BLForm`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/bons_livraison/BonsLivraison.jsx
+- Composant: `BonsLivraison`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/carte/Carte.jsx
+- Composant: `Carte`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/catalogue/CatalogueSyncViewer.jsx
+- Composant: `CatalogueSyncViewer`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = `catalogue_updates`, `fournisseur_produits`, rpc = -
+
+## pages/commandes/CommandeDetail.jsx
+- Composant: `CommandeDetail`
+- Titre deviné: **Commande {commande.reference}**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/commandes/CommandeForm.jsx
+- Composant: `CommandeForm`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/commandes/Commandes.jsx
+- Composant: `Commandes`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/commandes/CommandesEnvoyees.jsx
+- Composant: `CommandesEnvoyees`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = `commandes`, rpc = -
+
+## pages/consolidation/AccessMultiSites.jsx
+- Composant: `AccessMultiSites`
+- Titre deviné: **Sites accessibles**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = `mamas`, rpc = -
+
+## pages/consolidation/Consolidation.jsx
+- Composant: `Consolidation`
+- Titre deviné: **Consolidation**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/costboisson/CostBoisson.jsx
+- Composant: `CostBoissons`
+- Titre deviné: **Cost Boissons**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = `v_boissons`, `ventes_boissons`, `produits`, `fiches_techniques`, rpc = -
+
+## pages/costing/CostingCarte.jsx
+- Composant: `CostingCarte`
+- Titre deviné: **Costing Carte**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/cuisine/MenuDuJour.jsx
+- Composant: `MenuDuJour`
+- Titre deviné: **Menu du jour**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/dashboard/DashboardBuilder.jsx
+- Composant: `DashboardBuilder`
+- Titre deviné: **Mes tableaux de bord**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/debug/AccessExample.jsx
+- Composant: `AccessExample`
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/debug/AuthDebug.jsx
+- Composant: `AuthDebug`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/debug/Debug.jsx
+- Composant: `Debug`
+- Titre deviné: **🧪 Debug AuthContext**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/debug/DebugAuth.jsx
+- Composant: `DebugAuth`
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/debug/DebugRights.jsx
+- Composant: `DebugRights`
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/debug/DebugUser.jsx
+- Composant: `DebugUser`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/documents/DocumentForm.jsx
+- Composant: `DocumentForm`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/documents/Documents.jsx
+- Composant: `Documents`
+- Titre deviné: **Documents**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/ecarts/Ecarts.jsx
+- Composant: `Ecarts`
+- Titre deviné: **Écarts d'inventaire**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/emails/EmailsEnvoyes.jsx
+- Composant: `EmailsEnvoyes`
+- Titre deviné: **Emails envoyés**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/engineering/MenuEngineering.jsx
+- Composant: `MenuEngineering`
+- Titre deviné: **Menu Engineering**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/factures/FactureCreate.jsx
+- Composant: `FactureCreate`
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/factures/FactureDetail.jsx
+- Composant: `FactureDetail`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = `factures`, rpc = -
+
+## pages/factures/FactureForm.jsx
+- Composant: `FactureForm`
+- Description: src/pages/factures/FactureForm.jsx
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/factures/Factures.jsx
+- Composant: `Factures`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/factures/ImportFactures.jsx
+- Composant: `ImportFactures`
+- Titre deviné: **Import e-facture**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/fiches/FicheDetail.jsx
+- Composant: `FicheDetail`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/fiches/FicheForm.jsx
+- Composant: `FicheForm`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/fiches/Fiches.jsx
+- Composant: `Fiches`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/fournisseurs/ApiFournisseurForm.jsx
+- Composant: `N/A`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/fournisseurs/ApiFournisseurs.jsx
+- Composant: `ApiFournisseurs`
+- Titre deviné: **API Fournisseurs**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/fournisseurs/FournisseurApiSettingsForm.jsx
+- Composant: `FournisseurApiSettingsForm`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/fournisseurs/FournisseurCreate.jsx
+- Composant: `FournisseurCreate`
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/fournisseurs/FournisseurDetail.jsx
+- Composant: `FournisseurDetail`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = `facture_lignes`, `fournisseurs`, rpc = -
+
+## pages/fournisseurs/FournisseurDetailPage.jsx
+- Composant: `FournisseurDetailPage`
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/fournisseurs/FournisseurForm.jsx
+- Composant: `FournisseurForm`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/fournisseurs/Fournisseurs.jsx
+- Composant: `Fournisseurs`
+- Titre deviné: **Gestion des fournisseurs**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/fournisseurs/comparatif/ComparatifPrix.jsx
+- Composant: `ComparatifPrix`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = `produits`, rpc = -
+
+## pages/fournisseurs/comparatif/PrixFournisseurs.jsx
+- Composant: `PrixFournisseurs`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/inventaire/EcartInventaire.jsx
+- Composant: `EcartInventaire`
+- Titre deviné: **Écarts d'inventaire – Zone : ${zone}**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/inventaire/Inventaire.jsx
+- Composant: `Inventaire`
+- Titre deviné: **Inventaires**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/inventaire/InventaireDetail.jsx
+- Composant: `InventaireDetail`
+- Titre deviné: **Inventaire du {inventaire.date_inventaire}**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/inventaire/InventaireForm.jsx
+- Composant: `InventaireForm`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/inventaire/InventaireZones.jsx
+- Composant: `InventaireZones`
+- Titre deviné: **Zones d'inventaire**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/legal/Cgu.jsx
+- Composant: `Cgu`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/legal/Cgv.jsx
+- Composant: `Cgv`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/legal/Confidentialite.jsx
+- Composant: `Confidentialite`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = `mamas`, rpc = -
+
+## pages/legal/Contact.jsx
+- Composant: `Contact`
+- Titre deviné: **Nous contacter**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/legal/Licence.jsx
+- Composant: `Licence`
+- Titre deviné: **Licence et abonnement**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/legal/MentionsLegales.jsx
+- Composant: `MentionsLegales`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = `mamas`, rpc = -
+
+## pages/menu/MenuDuJour.jsx
+- Composant: `MenuDuJour`
+- Titre deviné: **Menu du jour**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/menu/MenuDuJourJour.jsx
+- Composant: `MenuDuJourJour`
+- Titre deviné: **Menu du {date}**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/menus/MenuDetail.jsx
+- Composant: `MenuDetail`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/menus/MenuDuJour.jsx
+- Composant: `MenuDuJour`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/menus/MenuDuJourDetail.jsx
+- Composant: `MenuDuJourDetail`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/menus/MenuDuJourForm.jsx
+- Composant: `MenuDuJourForm`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/menus/MenuForm.jsx
+- Composant: `MenuForm`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/menus/MenuGroupeDetail.jsx
+- Composant: `MenuGroupeDetail`
+- Titre deviné: **{menu.nom}**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/menus/MenuGroupeForm.jsx
+- Composant: `MenuGroupeForm`
+- Titre deviné: **Formule groupe**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/menus/MenuGroupes.jsx
+- Composant: `MenuGroupes`
+- Titre deviné: **Menu groupe**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/menus/MenuPDF.jsx
+- Composant: `MenuPDF`
+- Titre deviné: **Menu du jour : ${menu.nom}**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = `menus`, `menu_fiches`, `fiches_techniques`, rpc = -
+
+## pages/menus/Menus.jsx
+- Composant: `Menus`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/mobile/MobileAccueil.jsx
+- Composant: `MobileAccueil`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/mobile/MobileInventaire.jsx
+- Composant: `MobileInventaire`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = `produits`, rpc = -
+
+## pages/mobile/MobileRequisition.jsx
+- Composant: `MobileRequisition`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = `produits`, `requisitions`, rpc = -
+
+## pages/notifications/NotificationSettingsForm.jsx
+- Composant: `NotificationSettingsForm`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/notifications/NotificationsInbox.jsx
+- Composant: `NotificationsInbox`
+- Titre deviné: **Notifications**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/onboarding/OnboardingUtilisateur.jsx
+- Composant: `OnboardingUtilisateur`
+- Titre deviné: **Utilisateur introuvable**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/parametrage/APIKeys.jsx
+- Composant: `APIKeys`
+- Titre deviné: **Clés API**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/parametrage/AccessRights.jsx
+- Composant: `AccessRights`
+- Titre deviné: **
+        Droits personnalisés par utilisateur
+      **
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/parametrage/CentreCoutForm.jsx
+- Composant: `CentreCoutForm`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = `centres_de_cout`, rpc = -
+
+## pages/parametrage/ExportComptaPage.jsx
+- Composant: `ExportComptaPage`
+- Titre deviné: **Export comptable**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/parametrage/ExportUserData.jsx
+- Composant: `ExportUserData`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/parametrage/Familles.jsx
+- Composant: `Familles`
+- Titre deviné: **Familles**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/parametrage/InvitationsEnAttente.jsx
+- Composant: `InvitationsEnAttente`
+- Titre deviné: **
+        Invitations en attente
+      **
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = `mamas`, `roles`, `utilisateurs`, rpc = -
+
+## pages/parametrage/InviteUser.jsx
+- Composant: `InviteUser`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = `mamas`, `roles`, `utilisateurs`, rpc = -
+
+## pages/parametrage/MamaForm.jsx
+- Composant: `MamaForm`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = `mamas`, rpc = -
+
+## pages/parametrage/MamaSettingsForm.jsx
+- Composant: `MamaSettingsForm`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/parametrage/Mamas.jsx
+- Composant: `Mamas`
+- Titre deviné: **Établissements (MAMA)**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = `mamas`, rpc = -
+
+## pages/parametrage/Parametrage.jsx
+- Composant: `Parametrage`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/parametrage/ParametresCommandes.jsx
+- Composant: `ParametresCommandes`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = `parametres_commandes`, rpc = -
+
+## pages/parametrage/Periodes.jsx
+- Composant: `Periodes`
+- Titre deviné: **Périodes comptables**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/parametrage/Permissions.jsx
+- Composant: `Permissions`
+- Titre deviné: **
+        Permissions des rôles
+      **
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = `roles`, rpc = -
+
+## pages/parametrage/PermissionsAdmin.jsx
+- Composant: `PermissionsAdmin`
+- Titre deviné: **
+        Permissions globales (superadmin)
+      **
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = `mamas`, `roles`, rpc = -
+
+## pages/parametrage/PermissionsForm.jsx
+- Composant: `PermissionsForm`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = `permissions`, rpc = -
+
+## pages/parametrage/RGPDConsentForm.jsx
+- Composant: `RGPDConsentForm`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = `consentements_utilisateur`, rpc = -
+
+## pages/parametrage/RoleForm.jsx
+- Composant: `RoleForm`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/parametrage/Roles.jsx
+- Composant: `Roles`
+- Titre deviné: **Gestion des rôles**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/parametrage/SousFamilles.jsx
+- Composant: `SousFamilles`
+- Description: all | actifs | inactifs
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = `sous_familles`, rpc = -
+
+## pages/parametrage/TemplateCommandeForm.jsx
+- Composant: `TemplateCommandeForm`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = `public`, rpc = -
+
+## pages/parametrage/TemplatesCommandes.jsx
+- Composant: `TemplatesCommandes`
+- Titre deviné: **Templates de commandes**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/parametrage/Unites.jsx
+- Composant: `Unites`
+- Titre deviné: **Unités**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/parametrage/Utilisateurs.jsx
+- Composant: `Utilisateurs`
+- Titre deviné: **Utilisateurs**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = `utilisateurs`, rpc = -
+
+## pages/parametrage/ZoneAccess.jsx
+- Composant: `ZoneAccess`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/parametrage/ZoneForm.jsx
+- Composant: `ZoneForm`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/parametrage/Zones.jsx
+- Composant: `Zones`
+- Titre deviné: **Zones de stock**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/planning/SimulationPlanner.jsx
+- Composant: `SimulationPlanner`
+- Titre deviné: **Simulation planning**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/produits/ProduitDetail.jsx
+- Composant: `ProduitDetailPage`
+- Titre deviné: **
+            Détails produit {productName && `- ${productName}`}
+          **
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/produits/ProduitForm.jsx
+- Composant: `ProduitFormPage`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/produits/Produits.jsx
+- Composant: `Produits`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/promotions/PromotionForm.jsx
+- Composant: `PromotionForm`
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/promotions/Promotions.jsx
+- Composant: `Promotions`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/public/LandingPage.jsx
+- Composant: `LandingPage`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/public/Onboarding.jsx
+- Composant: `Onboarding`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/public/Signup.jsx
+- Composant: `Signup`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/receptions/Receptions.jsx
+- Composant: `Receptions`
+- Titre deviné: **Réceptions**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/recettes/Recettes.jsx
+- Composant: `Recettes`
+- Titre deviné: **Recettes**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/reporting/GraphCost.jsx
+- Composant: `GraphCost`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/reporting/Reporting.jsx
+- Composant: `Reporting`
+- Titre deviné: **
+        Reporting analytique
+      **
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/reporting/ReportingPDF.jsx
+- Composant: `ReportingPDF`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/requisitions/RequisitionDetail.jsx
+- Composant: `RequisitionDetail`
+- Titre deviné: **Détail de la réquisition**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/requisitions/RequisitionForm.jsx
+- Composant: `RequisitionForm`
+- Titre deviné: **Nouvelle réquisition**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/requisitions/Requisitions.jsx
+- Composant: `Requisitions`
+- Titre deviné: **
+        Réquisitions (sortie stock)
+      **
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/signalements/SignalementDetail.jsx
+- Composant: `SignalementDetail`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/signalements/SignalementForm.jsx
+- Composant: `SignalementForm`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/signalements/Signalements.jsx
+- Composant: `Signalements`
+- Titre deviné: **Signalements**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/simulation/Simulation.jsx
+- Composant: `Simulation`
+- Titre deviné: **Simulation (test signalements)**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/simulation/SimulationForm.jsx
+- Composant: `SimulationForm`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = `fiches`, rpc = -
+
+## pages/simulation/SimulationMenu.jsx
+- Composant: `SimulationMenu`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/simulation/SimulationResult.jsx
+- Composant: `SimulationResult`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/stats/Stats.jsx
+- Composant: `Stats`
+- Titre deviné: **Stats**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/stats/StatsAdvanced.jsx
+- Composant: `StatsAdvanced`
+- Titre deviné: **Analytique avancée**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/stats/StatsConsolidation.jsx
+- Composant: `StatsConsolidation`
+- Titre deviné: **Consolidation multi-sites**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/stats/StatsCostCenters.jsx
+- Composant: `StatsCostCenters`
+- Titre deviné: **Ventilation par Cost Center**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/stats/StatsCostCentersPivot.jsx
+- Composant: `StatsCostCentersPivot`
+- Titre deviné: **Ventilation mensuelle par Cost Center**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/stats/StatsFiches.jsx
+- Composant: `StatsFiches`
+- Titre deviné: **Statistiques fiches techniques**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = `fiches_techniques`, `familles`, rpc = -
+
+## pages/stats/StatsStock.jsx
+- Composant: `StatsStock`
+- Titre deviné: **Stocks produits**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/stock/AlertesRupture.jsx
+- Composant: `AlertesRupture`
+- Titre deviné: **Alertes rupture**
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/stock/Inventaire.jsx
+- Composant: `InventairePage`
+- Titre deviné: **Inventaires**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/stock/InventaireForm.jsx
+- Composant: `InventaireFormPage`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/stock/TransfertForm.jsx
+- Composant: `TransfertForm`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/stock/Transferts.jsx
+- Composant: `Transferts`
+- Titre deviné: **Transferts**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/supervision/ComparateurFiches.jsx
+- Composant: `ComparateurFiches`
+- Titre deviné: **Comparateur de fiches**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/supervision/GroupeParamForm.jsx
+- Composant: `GroupeParamForm`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = `mamas`, `groupes`, rpc = -
+
+## pages/supervision/Logs.jsx
+- Composant: `Logs`
+- Titre deviné: **Logs activité**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/supervision/Rapports.jsx
+- Composant: `Rapports`
+- Titre deviné: **Rapports générés**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/supervision/SupervisionGroupe.jsx
+- Composant: `SupervisionGroupe`
+- Titre deviné: **Supervision Groupe**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = `stats_multi_mamas`
+
+## pages/surcouts/Surcouts.jsx
+- Composant: `Surcouts`
+- Titre deviné: **Surcoûts**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/taches/Alertes.jsx
+- Composant: `Alertes`
+- Titre deviné: **Alertes**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = `v_alertes_rupture`, rpc = -
+
+## pages/taches/TacheDetail.jsx
+- Composant: `TacheDetail`
+- Titre deviné: **{tache.titre}**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/taches/TacheForm.jsx
+- Composant: `TacheForm`
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/taches/TacheNew.jsx
+- Composant: `TacheNew`
+- Titre deviné: **Nouvelle tâche**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -
+
+## pages/taches/Taches.jsx
+- Composant: `Taches`
+- Titre deviné: **Tâches planifiées**
+- Description: MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
+- ⚠️ Aucune route trouvée pour ce fichier page.
+- Supabase: tables = -, rpc = -

--- a/scripts/inventory_pages.js
+++ b/scripts/inventory_pages.js
@@ -1,0 +1,281 @@
+/* eslint-disable */
+import fs from 'fs';
+import path from 'path';
+
+const ROOT = process.cwd();
+const SRC = path.join(ROOT, 'src');
+
+const PAGES_DIR = path.join(SRC, 'pages');
+const ROUTES_FILES = [
+  path.join(SRC, 'config', 'routes.js'),
+  path.join(SRC, 'router.jsx'),
+];
+const LOCALES = [
+  path.join(SRC, 'i18n', 'locales', 'fr.json'),
+  path.join(SRC, 'i18n', 'locales', 'en.json'),
+];
+
+// ---------- utils fs
+function ls(dir) {
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir).map(n => path.join(dir, n));
+}
+function read(file) {
+  try { return fs.readFileSync(file, 'utf8'); } catch { return ''; }
+}
+function isPageFile(f) {
+  return /\.(jsx?|tsx?)$/.test(f) && f.includes(`${path.sep}pages${path.sep}`);
+}
+function walk(dir, acc = []) {
+  for (const p of ls(dir)) {
+    const st = fs.statSync(p);
+    if (st.isDirectory()) walk(p, acc);
+    else acc.push(p);
+  }
+  return acc;
+}
+function uniq(a) { return Array.from(new Set(a)); }
+
+// ---------- parse i18n
+function loadI18n() {
+  const out = {};
+  for (const f of LOCALES) {
+    const raw = read(f);
+    if (!raw) continue;
+    try { out[path.basename(f, '.json')] = JSON.parse(raw); } catch {}
+  }
+  return out;
+}
+
+// ---------- parse routes config
+function parseRoutesFromSource(src, srcFile) {
+  // Tolérant: on récupère path + import('../pages/...') + labelKey + icon + showInSidebar + access
+  const records = [];
+  // capture blocs { path: '...', element: lazy(() => import('../pages/..')), labelKey:'..', icon:'..', showInSidebar:true, access:'..' }
+  const blockRegex = /\{[^{}]*path\s*:\s*['"`]([^'"`]+)['"`][\s\S]*?element\s*:\s*(?:lazy\s*\(\s*\(\s*=>\s*)?import\s*\(\s*['"`]\.\.\/pages\/([^'"`]+)['"`]\s*\)\)?[\s\S]*?\}/g;
+  let m;
+  while ((m = blockRegex.exec(src))) {
+    const [block, pathVal, importRel] = m;
+    const grab = (key) => {
+      const r = new RegExp(`${key}\s*:\s*['"\`]([^'"\`]+)['"\`]`);
+      const sm = block.match(r);
+      return sm ? sm[1] : undefined;
+    };
+    const bool = (key) => {
+      const r = new RegExp(`${key}\\s*:\\s*(true|false)`);
+      const sm = block.match(r);
+      return sm ? sm[1] === 'true' : undefined;
+    };
+    records.push({
+      routePath: pathVal,
+      importRel: importRel.replace(/^\.\//, ''),
+      labelKey: grab('labelKey'),
+      icon: grab('icon'),
+      showInSidebar: bool('showInSidebar'),
+      access: grab('access'),
+      __src: srcFile,
+    });
+  }
+  return records;
+}
+
+function collectRoutes() {
+  const routes = [];
+  for (const f of ROUTES_FILES) {
+    const src = read(f);
+    if (!src) continue;
+    routes.push(...parseRoutesFromSource(src, path.relative(ROOT, f)));
+  }
+  // map par importRel normalisé
+  const map = new Map();
+  for (const r of routes) {
+    const key = r.importRel.replace(/\.(jsx?|tsx?)$/, '');
+    const arr = map.get(key) || [];
+    arr.push(r);
+    map.set(key, arr);
+  }
+  return { routes, routesByImport: map };
+}
+
+// ---------- parse page source for info
+function parsePage(file) {
+  const src = read(file);
+  const rel = path.relative(SRC, file).replace(/\\/g, '/'); // e.g. pages/produits/Produits.jsx
+  const compName = (() => {
+    const m = src.match(/export\s+default\s+function\s+([A-Za-z0-9_]+)/)
+          || src.match(/function\s+([A-Za-z0-9_]+)\s*\(/)
+          || src.match(/export\s+default\s+([A-Za-z0-9_]+)/);
+    return m ? m[1] : null;
+  })();
+
+  // deviner titre / usage
+  const title =
+    (src.match(/<h1[^>]*>([^<]+)<\/h1>/)?.[1]) ||
+    (src.match(/const\s+title\s*=\s*['"`]([^'"`]+)['"`]/)?.[1]) ||
+    (src.match(/PageTitle[^'\"]*['"`]([^'"`]+)['"`]/)?.[1]) ||
+    null;
+
+  const description = (() => {
+    const comment = src.match(/\/\*\*([\s\S]*?)\*\//)?.[1]
+                 || src.match(/\/\/\s*(.+)/)?.[1];
+    return comment ? comment.trim().split('\n').map(s=>s.trim()).slice(0,2).join(' ') : null;
+  })();
+
+  // hooks importés
+  const hooks = Array.from(src.matchAll(/from\s+['"`]\.\.{1,2}\/hooks\/([^'"`]+)['"`]/g)).map(m => m[1]);
+
+  // tables/rpc supabase (sur la page)
+  const tables = Array.from(src.matchAll(/\.from\s*\(\s*['"`]([a-z0-9_]+)['"`]\s*\)/gi)).map(m=>m[1]);
+  const rpcs   = Array.from(src.matchAll(/\.rpc\s*\(\s*['"`]([a-z0-9_]+)['"`]\s*\)/gi)).map(m=>m[1]);
+
+  return {
+    pageFile: rel,
+    component: compName,
+    inferredTitle: title,
+    inferredDescription: description,
+    hooks: uniq(hooks),
+    supabase: { tables: uniq(tables), rpcs: uniq(rpcs) },
+  };
+}
+
+// ---------- parse hooks to find extra supabase usage
+function parseHook(file) {
+  const src = read(file);
+  const rel = path.relative(SRC, file).replace(/\\/g, '/');
+  const tables = Array.from(src.matchAll(/\.from\s*\(\s*['"`]([a-z0-9_]+)['"`]\s*\)/gi)).map(m=>m[1]);
+  const rpcs   = Array.from(src.matchAll(/\.rpc\s*\(\s*['"`]([a-z0-9_]+)['"`]\s*\)/gi)).map(m=>m[1]);
+  return { hookFile: rel, tables: uniq(tables), rpcs: uniq(rpcs) };
+}
+
+// ---------- main
+(async function main() {
+  const i18n = loadI18n();
+  const allFiles = walk(PAGES_DIR).filter(isPageFile);
+  const { routes, routesByImport } = collectRoutes();
+
+  // index des hooks pour scan supabase complémentaire
+  const allHookFiles = walk(path.join(SRC, 'hooks')).filter(f => /\.(jsx?|tsx?)$/.test(f));
+  const hookIndex = new Map();
+  for (const hf of allHookFiles) {
+    hookIndex.set(path.relative(SRC, hf).replace(/\\/g,'/'), parseHook(hf));
+  }
+
+  const pages = [];
+  for (const file of allFiles) {
+    const info = parsePage(file);
+
+    // retrouver la/les routes associées via importRel
+    // ex: routesByImport key: 'pages/produits/Produits'
+    const key = info.pageFile.replace(/\.(jsx?|tsx?)$/, '');
+    const rs = routesByImport.get(key) || [];
+
+    // compléter supabase depuis hooks importés
+    const extraTables = [];
+    const extraRpcs = [];
+    for (const h of info.hooks) {
+      // normaliser '../hooks/data/useX.js' -> 'hooks/data/useX.js'
+      const guess = h.replace(/^\.{1,2}\//, '').replace(/\\/g,'/');
+      const hf = 'src/' + guess;
+      const rel = guess.startsWith('hooks') ? guess : null;
+      const found = hookIndex.get(rel || '');
+      if (found) {
+        extraTables.push(...found.tables);
+        extraRpcs.push(...found.rpcs);
+      }
+    }
+
+    const label = rs.map(r => {
+      const key = r.labelKey;
+      const fr = key ? (i18n.fr?.[key] ?? null) : null;
+      return { key, fr };
+    });
+
+    pages.push({
+      ...info,
+      routes: rs.map(r => ({
+        path: r.routePath,
+        labelKey: r.labelKey,
+        labelFR: r.labelKey ? (i18n.fr?.[r.labelKey] ?? null) : null,
+        icon: r.icon,
+        showInSidebar: r.showInSidebar,
+        access: r.access,
+        definedIn: r.__src,
+      })),
+      supabase: {
+        tables: uniq([...(info.supabase.tables||[]), ...extraTables]),
+        rpcs: uniq([...(info.supabase.rpcs||[]), ...extraRpcs]),
+      }
+    });
+  }
+
+  // pages orphelines / routes orphelines
+  const pageKeys = new Set(pages.map(p => p.pageFile.replace(/\.(jsx?|tsx?)$/,'')));
+  const orphanRoutes = routes.filter(r => !pageKeys.has(`pages/${r.importRel.replace(/\.(jsx?|tsx?)$/, '')}`));
+
+  const routesByPath = new Map();
+  for (const r of routes) {
+    const arr = routesByPath.get(r.routePath) || [];
+    arr.push(r);
+    routesByPath.set(r.routePath, arr);
+  }
+
+  const missingInSidebar = pages
+    .flatMap(p => p.routes.length ? p.routes : [{ path:null, labelKey:null, icon:null, showInSidebar:false, access:null }])
+    .filter(r => r.path && r.showInSidebar === false);
+
+  // -------- outputs
+  const report = {
+    generatedAt: new Date().toISOString(),
+    totals: {
+      pages: pages.length,
+      routes: routes.length,
+      orphanRoutes: orphanRoutes.length,
+    },
+    pages,
+    orphanRoutes,
+  };
+
+  const outJson = path.join(ROOT, 'pages_report.json');
+  fs.writeFileSync(outJson, JSON.stringify(report, null, 2), 'utf8');
+
+  // Markdown
+  const md = [];
+  md.push(`# Inventaire des pages (généré)`);
+  md.push(`- Généré: ${report.generatedAt}`);
+  md.push(`- Pages: ${report.totals.pages} — Routes: ${report.totals.routes} — Routes orphelines: ${report.totals.orphanRoutes}`);
+  md.push('');
+  for (const p of pages) {
+    md.push(`## ${p.pageFile}`);
+    md.push(`- Composant: \`${p.component || 'N/A'}\``);
+    if (p.inferredTitle) md.push(`- Titre deviné: **${p.inferredTitle}**`);
+    if (p.inferredDescription) md.push(`- Description: ${p.inferredDescription}`);
+    if (p.routes.length) {
+      md.push(`- Routes:`);
+      for (const r of p.routes) {
+        md.push(`  - \`${r.path}\` • labelKey: \`${r.labelKey || '-'}\` (${r.labelFR || '-'}) • icon: \`${r.icon || '-'}\` • sidebar: ${r.showInSidebar === true ? 'oui' : r.showInSidebar === false ? 'non' : 'indéfini'} • access: \`${r.access || '-'}\` • défini dans: \`${r.definedIn}\``);
+      }
+    } else {
+      md.push(`- ⚠️ Aucune route trouvée pour ce fichier page.`);
+    }
+    if (p.hooks?.length) md.push(`- Hooks importés: \`${p.hooks.join('`, `')}\``);
+    const t = p.supabase?.tables || [];
+    const r = p.supabase?.rpcs || [];
+    md.push(`- Supabase: tables = ${t.length ? '\`' + t.join('`, `') + '\`' : '-'}, rpc = ${r.length ? '\`' + r.join('`, `') + '\`' : '-'}`);
+    md.push('');
+  }
+  if (orphanRoutes.length) {
+    md.push(`### Routes orphelines (référencent un import de page introuvable)`);
+    for (const r of orphanRoutes) {
+      md.push(`- \`${r.routePath}\` → import('../pages/${r.importRel}') (défini dans \`${r.__src}\`)`);
+    }
+  }
+  if (missingInSidebar.length) {
+    md.push(`\n### Pages non affichées dans la sidebar`);
+    uniq(missingInSidebar.map(r => r.path)).forEach(p => md.push(`- ${p}`));
+  }
+
+  const outMd = path.join(ROOT, 'pages_report.md');
+  fs.writeFileSync(outMd, md.join('\n'), 'utf8');
+
+  console.log(`\n✅ Rapport généré:\n- ${outJson}\n- ${outMd}\n`);
+})();


### PR DESCRIPTION
## Summary
- add standalone `inventory_pages.js` script to collect page and route metadata
- generate `pages_report.json` and `pages_report.md`

## Testing
- `node scripts/inventory_pages.js`
- `npm test` *(fails: 6 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e854aad8832d9c1737d5f1c02f0c