### PR TITLE
refactor: centralize react query

### DIFF
--- a/src/hooks/useFamilles.js
+++ b/src/hooks/useFamilles.js
@@ -1,26 +1,12 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback } from 'react';
-import { useQuery, useMutation } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/lib/supabase';
-import { useQueryClient } from '@tanstack/react-query';
 import { useAuth } from '@/hooks/useAuth';
-
-function safeQueryClient() {
-  try {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    return useQueryClient();
-  } catch {
-    return {
-      invalidateQueries: () => {},
-      setQueryData: () => {},
-      fetchQuery: async () => {},
-    };
-  }
-}
 
 export function useFamilles() {
   const { mama_id } = useAuth();
-  const queryClient = safeQueryClient();
+  const queryClient = useQueryClient();
   const [params, setParams] = useState({ search: '', page: 1, limit: 50 });
 
   const query = useQuery({

--- a/src/hooks/useFournisseurs.js
+++ b/src/hooks/useFournisseurs.js
@@ -9,23 +9,9 @@ import { toast } from 'sonner';
 import { safeImportXLSX } from '@/lib/xlsx/safeImportXLSX';
 import { useQueryClient } from '@tanstack/react-query';
 
-function safeQueryClient() {
-  try {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    return useQueryClient();
-  } catch {
-    return {
-      invalidateQueries: () => {},
-      setQueryData: () => {},
-      setQueriesData: () => {},
-      fetchQuery: async () => {},
-    };
-  }
-}
-
 export function useFournisseurs() {
   const { mama_id } = useAuth();
-  const queryClient = safeQueryClient();
+  const queryClient = useQueryClient();
   const [fournisseurs, setFournisseurs] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);

--- a/src/hooks/useMamaSettings.js
+++ b/src/hooks/useMamaSettings.js
@@ -1,22 +1,8 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useCallback, useMemo } from "react";
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/lib/supabase';
-import { useQueryClient } from '@tanstack/react-query';
 import { useAuth } from '@/hooks/useAuth';
-
-function safeQueryClient() {
-  try {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    return useQueryClient();
-  } catch {
-    return {
-      invalidateQueries: () => {},
-      setQueryData: () => {},
-      fetchQuery: async () => {},
-    };
-  }
-}
 
 const defaults = {
   logo_url: "",
@@ -38,7 +24,7 @@ const localFeatureFlags = {};
 export const useMamaSettings = () => {
   const { userData } = useAuth() || {};
   const mamaId = userData?.mama_id;
-  const queryClient = safeQueryClient();
+  const queryClient = useQueryClient();
 
   const query = useQuery({
     queryKey: ['mama-settings', mamaId],

--- a/src/hooks/useProducts.js
+++ b/src/hooks/useProducts.js
@@ -9,22 +9,9 @@ import { saveAs } from "file-saver";
 import { toast } from 'sonner';
 import { useQueryClient } from '@tanstack/react-query';
 
-function safeQueryClient() {
-  try {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    return useQueryClient();
-  } catch {
-    return {
-      invalidateQueries: () => {},
-      setQueryData: () => {},
-      fetchQuery: async () => {},
-    };
-  }
-}
-
 export function useProducts() {
   const { mama_id } = useAuth();
-  const queryClient = safeQueryClient();
+  const queryClient = useQueryClient();
   const [products, setProducts] = useState([]);
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(false);

--- a/src/hooks/useProduitLineDefaults.js
+++ b/src/hooks/useProduitLineDefaults.js
@@ -3,22 +3,9 @@ import { supabase } from '@/lib/supabase';
 import { useQueryClient } from '@tanstack/react-query';
 import { useAuth } from '@/hooks/useAuth';
 
-function safeQueryClient() {
-  try {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    return useQueryClient();
-  } catch {
-    return {
-      invalidateQueries: () => {},
-      setQueryData: () => {},
-      fetchQuery: async () => {},
-    };
-  }
-}
-
 export function useProduitLineDefaults() {
   const { mama_id } = useAuth();
-  const queryClient = safeQueryClient();
+  const queryClient = useQueryClient();
 
   const fetchDefaults = async ({ produit_id } = {}) => {
     if (!mama_id || !produit_id) {

--- a/src/hooks/useProduitsSearch.js
+++ b/src/hooks/useProduitsSearch.js
@@ -2,7 +2,6 @@
 import { useQuery } from '@tanstack/react-query';
 import useDebounce from '@/hooks/useDebounce';
 import { supabase } from '@/lib/supabase';
-import { getQueryClient } from '@/lib/react-query';
 import { useAuth } from '@/hooks/useAuth';
 
 function normalize(list = []) {
@@ -55,7 +54,7 @@ export function useProduitsSearch(
         return { rows: [], total: 0 };
       }
     },
-  }, getQueryClient());
+  });
 
   return {
     data: query.data?.rows || [],

--- a/src/hooks/useUnites.js
+++ b/src/hooks/useUnites.js
@@ -1,26 +1,12 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState, useCallback } from 'react';
-import { useQuery, useMutation } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/lib/supabase';
-import { useQueryClient } from '@tanstack/react-query';
 import { useAuth } from '@/hooks/useAuth';
-
-function safeQueryClient() {
-  try {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    return useQueryClient();
-  } catch {
-    return {
-      invalidateQueries: () => {},
-      setQueryData: () => {},
-      fetchQuery: async () => {},
-    };
-  }
-}
 
 export function useUnites() {
   const { mama_id } = useAuth();
-  const queryClient = safeQueryClient();
+  const queryClient = useQueryClient();
   const [params, setParams] = useState({ search: '', page: 1, limit: 50 });
 
   const query = useQuery({

--- a/src/hooks/useZonesStock.js
+++ b/src/hooks/useZonesStock.js
@@ -1,7 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { useAuth } from '@/hooks/useAuth';
 import { supabase } from '@/lib/supabase';
-import { getQueryClient } from '@/lib/react-query';
 
 export async function fetchZonesForValidation(mama_id) {
   const { data, error } = await supabase
@@ -27,7 +26,7 @@ export default function useZonesStock() {
       if (error) throw error;
       return data ?? [];
     },
-  }, getQueryClient());
+  });
   return { ...query, zones: query.data ?? [] };
 }
 

--- a/src/lib/react-query.js
+++ b/src/lib/react-query.js
@@ -1,12 +1,13 @@
-import { QueryClient, useQueryClient } from '@tanstack/react-query'
+import { QueryClient } from '@tanstack/react-query';
 
-let client
-export function getQueryClient() {
-  try {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    return useQueryClient()
-  } catch {
-    if (!client) client = new QueryClient()
-    return client
-  }
-}
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: true,
+      retry: 1,
+      staleTime: 5 * 60 * 1000, // 5 minutes
+    },
+    mutations: { retry: 0 },
+  },
+});

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -1,40 +1,44 @@
 import { Suspense } from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
-import { routes, homePath } from './config/routes.js';
 import Layout from './layout/Layout.jsx';
+import { routes, homePath } from './config/routes.js';
 import AuthProvider from './contexts/AuthContext.jsx';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { queryClient } from './lib/react-query.js';
+// Optionnel debug devtools :
+// import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
 const Loader = () => <div style={{ padding: 24 }}>Chargement…</div>;
 
 export default function AppRouter() {
   return (
     <BrowserRouter>
-      <AuthProvider>
-        <Suspense fallback={<Loader />}>
-          <Routes>
-            {/* public routes (login/landing/404) */}
-            {routes.filter(r => !r.private).map(r => (
-              <Route
-                key={r.path}
-                path={r.path}
-                element={<r.element />}
-              />
-            ))}
-
-            {/* private app shell with persistent layout */}
-            <Route element={<Layout />}>
-              <Route index element={<Navigate to={homePath} replace />} />
-              {routes.filter(r => r.private).map(r => (
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>
+          <Suspense fallback={<Loader />}>
+            <Routes>
+              {/* Routes publiques */}
+              {routes.filter(r => !r.private).map(r => (
                 <Route key={r.path} path={r.path} element={<r.element />} />
               ))}
-            </Route>
 
-            {/* catch-all */}
-            <Route path="*" element={<Navigate to={homePath} replace />} />
-          </Routes>
-        </Suspense>
-      </AuthProvider>
+              {/* Shell persistant : Layout (Sidebar + Outlet) pour les routes privées */}
+              <Route element={<Layout />}>
+                <Route index element={<Navigate to={homePath} replace />} />
+                {routes.filter(r => r.private).map(r => (
+                  <Route key={r.path} path={r.path} element={<r.element />} />
+                ))}
+              </Route>
+
+              {/* Fallback */}
+              <Route path="*" element={<Navigate to={homePath} replace />} />
+            </Routes>
+
+            {/* Devtools optionnel en dev */}
+            {/* {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />} */}
+          </Suspense>
+        </AuthProvider>
+      </QueryClientProvider>
     </BrowserRouter>
   );
 }
-

--- a/test/FactureLigne.format.test.jsx
+++ b/test/FactureLigne.format.test.jsx
@@ -1,17 +1,22 @@
 import { render, fireEvent } from '@testing-library/react';
 import { vi, test, expect } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import FactureLigne from '@/components/FactureLigne';
 
-const renderLine = (value = {}, onChange = vi.fn()) =>
-  render(
-    <FactureLigne
-      value={value}
-      onChange={onChange}
-      onRemove={() => {}}
-      zones={[]}
-      index={0}
-    />
+const renderLine = (value = {}, onChange = vi.fn()) => {
+  const qc = new QueryClient();
+  return render(
+    <QueryClientProvider client={qc}>
+      <FactureLigne
+        value={value}
+        onChange={onChange}
+        onRemove={() => {}}
+        zones={[]}
+        index={0}
+      />
+    </QueryClientProvider>
   );
+};
 
 test('typing 12,5 in qty keeps display and numeric value', () => {
   const onChange = vi.fn();
@@ -49,40 +54,47 @@ test('pasting formatted currency parses numeric value', () => {
 });
 
 test('delta percent vs PMP shows with colors', () => {
+  const qc = new QueryClient();
   const { container, rerender } = render(
-    <FactureLigne
-      value={{ quantite: 1, total_ht: 1.8, pmp: 2 }}
-      onChange={() => {}}
-      onRemove={() => {}}
-      zones={[]}
-      index={0}
-    />
+    <QueryClientProvider client={qc}>
+      <FactureLigne
+        value={{ quantite: 1, total_ht: 1.8, pmp: 2 }}
+        onChange={() => {}}
+        onRemove={() => {}}
+        zones={[]}
+        index={0}
+      />
+    </QueryClientProvider>
   );
   let badge = container.querySelector('[aria-label="Écart vs PMP"]');
   expect(badge?.textContent).toBe('-10,00%');
   expect(badge?.classList.contains('bg-green-500')).toBe(true);
 
   rerender(
-    <FactureLigne
-      value={{ quantite: 1, total_ht: 2.3, pmp: 2 }}
-      onChange={() => {}}
-      onRemove={() => {}}
-      zones={[]}
-      index={0}
-    />
+    <QueryClientProvider client={qc}>
+      <FactureLigne
+        value={{ quantite: 1, total_ht: 2.3, pmp: 2 }}
+        onChange={() => {}}
+        onRemove={() => {}}
+        zones={[]}
+        index={0}
+      />
+    </QueryClientProvider>
   );
   badge = container.querySelector('[aria-label="Écart vs PMP"]');
   expect(badge?.textContent).toBe('15,00%');
   expect(badge?.classList.contains('bg-red-500')).toBe(true);
 
   rerender(
-    <FactureLigne
-      value={{ quantite: 1, total_ht: 2.3, pmp: 0 }}
-      onChange={() => {}}
-      onRemove={() => {}}
-      zones={[]}
-      index={0}
-    />
+    <QueryClientProvider client={qc}>
+      <FactureLigne
+        value={{ quantite: 1, total_ht: 2.3, pmp: 0 }}
+        onChange={() => {}}
+        onRemove={() => {}}
+        zones={[]}
+        index={0}
+      />
+    </QueryClientProvider>
   );
   badge = container.querySelector('[aria-label="Écart vs PMP"]');
   expect(badge?.textContent).toBe('—');

--- a/test/duplicateProduct.test.js
+++ b/test/duplicateProduct.test.js
@@ -1,5 +1,6 @@
 import { renderHook, act } from '@testing-library/react';
 import { vi, beforeEach, test, expect } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 let fromMock;
 let insertMock;
@@ -23,15 +24,20 @@ function setup(initial = []) {
 }
 
 let useProducts;
+let wrapper;
 
 beforeEach(async () => {
   insertMock = vi.fn(() => query);
   setup([{ id: '1', nom: 'P', famille: 'F', unite: 'kg', pmp: 5 }]);
   ({ useProducts } = await import('@/hooks/useProducts'));
+  const qc = new QueryClient();
+  wrapper = ({ children }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  );
 });
 
 test('duplicateProduct omits pmp field', async () => {
-  const { result } = renderHook(() => useProducts());
+  const { result } = renderHook(() => useProducts(), { wrapper });
   await act(async () => {
     await result.current.fetchProducts();
   });

--- a/test/useProductsPrices.test.js
+++ b/test/useProductsPrices.test.js
@@ -1,22 +1,28 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { renderHook, act } from '@testing-library/react';
 import { vi, beforeEach, test, expect } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { makeSupabaseMock } from './mocks/supabaseClient.js';
 
 vi.mock('@/hooks/useAuth', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
 
 let useProducts;
 let client;
+let wrapper;
 
 beforeEach(async () => {
   globalThis.__SUPABASE_TEST_CLIENT__ = makeSupabaseMock({ data: [], error: null });
   client = globalThis.__SUPABASE_TEST_CLIENT__;
   ({ useProducts } = await import('@/hooks/useProducts'));
+  const queryClient = new QueryClient();
+  wrapper = ({ children }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
   vi.clearAllMocks();
 });
 
 test('fetchProductPrices selects fields with last delivery alias', async () => {
-  const { result } = renderHook(() => useProducts());
+  const { result } = renderHook(() => useProducts(), { wrapper });
   await act(async () => {
     await result.current.fetchProductPrices('p1');
   });

--- a/test/useProductsView.test.js
+++ b/test/useProductsView.test.js
@@ -1,21 +1,27 @@
 import { renderHook, act } from '@testing-library/react';
 import { vi, beforeEach, test, expect } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { makeSupabaseMock } from './mocks/supabaseClient.js';
 
 vi.mock('@/hooks/useAuth', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
 
 let useProducts;
 let client;
+let wrapper;
 
 beforeEach(async () => {
   globalThis.__SUPABASE_TEST_CLIENT__ = makeSupabaseMock({ data: [], count: 0, error: null });
   client = globalThis.__SUPABASE_TEST_CLIENT__;
   ({ useProducts } = await import('@/hooks/useProducts'));
+  const queryClient = new QueryClient();
+  wrapper = ({ children }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
   vi.clearAllMocks();
 });
 
 test('fetchProducts queries table with mama_id filter', async () => {
-  const { result } = renderHook(() => useProducts());
+  const { result } = renderHook(() => useProducts(), { wrapper });
   await act(async () => {
     await result.current.fetchProducts();
   });

--- a/test/visual_update.test.js
+++ b/test/visual_update.test.js
@@ -2,6 +2,8 @@
 import { renderHook, act } from '@testing-library/react';
 import { beforeAll, afterEach, test, expect, vi } from 'vitest';
 import fs from 'fs';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 // reset log file before tests
 beforeAll(() => {
@@ -67,7 +69,10 @@ let useProducts;
 test('produits creation and disable refresh list', async () => {
   setup({ produits: [], v_produits_dernier_prix: [] });
   ({ useProducts } = await import('@/hooks/useProducts'));
-  const { result } = renderHook(() => useProducts());
+  const qc = new QueryClient();
+  const wrapper = ({ children }) =>
+    React.createElement(QueryClientProvider, { client: qc, children });
+  const { result } = renderHook(() => useProducts(), { wrapper });
 
   await act(async () => {
     await result.current.addProduct({ nom: 'P', famille: 'F', unite_id: 'u1' });
@@ -92,7 +97,10 @@ let useFournisseurs;
 test('fournisseurs update name refresh list', async () => {
   setup({ fournisseurs: [{ id: '1', nom: 'Old', actif: true }] });
   ({ useFournisseurs } = await import('@/hooks/useFournisseurs'));
-  const { result } = renderHook(() => useFournisseurs());
+  const qc = new QueryClient();
+  const wrapper = ({ children }) =>
+    React.createElement(QueryClientProvider, { client: qc, children });
+  const { result } = renderHook(() => useFournisseurs(), { wrapper });
 
   await act(async () => {
     await result.current.updateFournisseur('1', { nom: 'New' });


### PR DESCRIPTION
## Summary
- centralize React Query with a singleton query client and router-level provider
- simplify hooks to use global QueryClient
- adjust tests to wrap hooks/components with QueryClientProvider

## Testing
- `npm test` *(fails: No QueryClient set in some tests, layout expectations)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f06c5e34832dad7e5da776425002