### PR TITLE
refactor(utils): migrate numberFormat to TS & unify imports

### DIFF
--- a/src/components/forms/MoneyInputFR.jsx
+++ b/src/components/forms/MoneyInputFR.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import Input from '@/components/ui/input.jsx';
-import { formatMoneyFR, parseMoneyToNumberFR } from '@/utils/numberFormat.js';
+import { formatMoneyFR, parseMoneyToNumberFR } from '@/utils/numberFormat';
 
 function isTrailing(raw) {
   const t = (raw ?? '').trim();

--- a/src/utils/__tests__/numberFormat.test.ts
+++ b/src/utils/__tests__/numberFormat.test.ts
@@ -1,4 +1,9 @@
-import { formatMoneyFR, parseMoneyToNumberFR, normalizeDecimalFR } from '../numberFormat';
+import {
+  formatMoneyFR,
+  parseMoneyToNumberFR,
+  normalizeDecimalFR,
+  roundTo,
+} from '@/utils/numberFormat';
 
 describe('numberFormat', () => {
   test('formatMoneyFR', () => {
@@ -21,5 +26,11 @@ describe('numberFormat', () => {
     expect(normalizeDecimalFR('1 205,00 €')).toBe('1205,00');
     expect(normalizeDecimalFR('1 205,50 €')).toBe('1205,50');
     expect(normalizeDecimalFR('1 205.5 €')).toBe('1205,5');
+  });
+
+  test('roundTo', () => {
+    expect(roundTo(1.234)).toBe(1.23);
+    expect(roundTo(1.235)).toBe(1.24);
+    expect(roundTo(1.234, 1)).toBe(1.2);
   });
 });

--- a/src/utils/numberFormat.d.ts
+++ b/src/utils/numberFormat.d.ts
@@ -1,5 +1,0 @@
-declare module '../numberFormat' {
-  export function formatMoneyFR(n: number): string;
-  export function parseMoneyToNumberFR(s: string): number;
-  export function normalizeDecimalFR(s: string): string;
-}

--- a/src/utils/numberFormat.ts
+++ b/src/utils/numberFormat.ts
@@ -1,16 +1,19 @@
-export function formatMoneyFR(value) {
+export function formatMoneyFR(n: number | string, opts?: Intl.NumberFormatOptions): string {
+  const value = typeof n === 'string' ? Number(n) : n;
   const formatter = new Intl.NumberFormat('fr-FR', {
     style: 'currency',
     currency: 'EUR',
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,
+    ...opts,
   });
   return formatter.format(value).replace(/[\u202F\u00A0]/g, ' ');
 }
 
-export function parseMoneyToNumberFR(str) {
-  if (typeof str !== 'string') return 0;
-  const cleaned = str
+export function parseMoneyToNumberFR(v: string | number | null | undefined): number {
+  if (typeof v === 'number') return v;
+  if (typeof v !== 'string') return 0;
+  const cleaned = v
     .replace(/[\u202F\u00A0]/g, ' ')
     .replace(/€/g, '')
     .replace(/\s+/g, '')
@@ -18,14 +21,15 @@ export function parseMoneyToNumberFR(str) {
     .replace(',', '.');
   if (cleaned === '') return 0;
   const parts = cleaned.split('.');
-  const last = parts.pop();
+  const last = parts.pop() as string;
   const numberString = parts.length ? parts.join('') + '.' + last : last;
   const n = Number(numberString);
   return Number.isFinite(n) ? n : 0;
 }
 
-export function normalizeDecimalFR(str) {
-  if (typeof str !== 'string') return '';
+export function normalizeDecimalFR(v: string | number | null | undefined): string {
+  if (v === null || v === undefined) return '';
+  const str = typeof v === 'number' ? String(v) : v;
   const replaced = str
     .replace(/[\u202F\u00A0]/g, ' ')
     .replace(/€/g, '')
@@ -43,3 +47,9 @@ export function normalizeDecimalFR(str) {
   }
   return result;
 }
+
+export function roundTo(n: number, decimals = 2): number {
+  const factor = 10 ** decimals;
+  return Math.round(n * factor) / factor;
+}
+


### PR DESCRIPTION
## Summary
- migrate `src/utils/numberFormat` to TypeScript with typed helpers and new `roundTo`
- enforce named imports from `@/utils/numberFormat`
- clean up tests to use new helpers

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: File appears to be binary)*
- `npm run build`
- `npm test` *(fails: No "default" export is defined on the "@/lib/supabase" mock)*

------
https://chatgpt.com/codex/tasks/task_e_68b96fbf7f74832da9b7e46de933f69d