### PR TITLE
fix(reporting): switch to v_cost_center_monthly; remove placeholder view usage

### DIFF
--- a/src/hooks/useCostCenterMonthlyStats.js
+++ b/src/hooks/useCostCenterMonthlyStats.js
@@ -8,12 +8,11 @@ export function useCostCenterMonthlyStats() {
 
   async function fetchMonthly({ debut = null, fin = null } = {}) {
     if (!mama_id) return [];
-    let query = supabase.
-    from('v_cost_center_monthly').
-    select('*').
-    eq('mama_id', mama_id).
-    order('mois', { ascending: true }).
-    order('nom', { ascending: true });
+    let query = supabase
+      .from('v_cost_center_monthly')
+      .select('mama_id, nom, mois, montant')
+      .eq('mama_id', mama_id)
+      .order('mois', { ascending: true });
     if (debut) query = query.gte('mois', debut);
     if (fin) query = query.lte('mois', fin);
     const { data, error } = await query;

--- a/src/hooks/useReporting.js
+++ b/src/hooks/useReporting.js
@@ -45,7 +45,11 @@ export function useReporting() {
         query = applyFilters(query, filters);
         break;
       case 'cost_center':
-        query = supabase.from('v_cost_center_month').select('*').eq('mama_id', mama_id);
+        query = supabase
+          .from('v_cost_center_monthly')
+          .select('mama_id, nom, mois, montant')
+          .eq('mama_id', mama_id)
+          .order('mois', { ascending: true });
         if (filters.date_start) query = query.gte('mois', filters.date_start);
         if (filters.date_end) query = query.lte('mois', filters.date_end);
         break;
@@ -78,9 +82,13 @@ export function useReporting() {
 
   async function getCostCenterBreakdown(filters = {}) {
     if (!mama_id) return [];
-    let query = supabase.from("v_cost_center_month").select("*").eq("mama_id", mama_id);
-    if (filters.date_start) query = query.gte("mois", filters.date_start);
-    if (filters.date_end) query = query.lte("mois", filters.date_end);
+    let query = supabase
+      .from('v_cost_center_monthly')
+      .select('mama_id, nom, mois, montant')
+      .eq('mama_id', mama_id)
+      .order('mois', { ascending: true });
+    if (filters.date_start) query = query.gte('mois', filters.date_start);
+    if (filters.date_end) query = query.lte('mois', filters.date_end);
     const { data, error } = await query;
     if (error) {
       console.error("getCostCenterBreakdown", error);

--- a/src/pages/reporting/Reporting.jsx
+++ b/src/pages/reporting/Reporting.jsx
@@ -218,7 +218,7 @@ export default function Reporting() {
               <XAxis dataKey="mois" />
               <YAxis />
               <Tooltip />
-              <Line type="monotone" dataKey="valeur" stroke="#0f1c2e" />
+                <Line type="monotone" dataKey="montant" stroke="#0f1c2e" />
             </LineChart>
           </ResponsiveContainer>
         </GlassCard>

--- a/src/pages/stats/StatsCostCentersPivot.jsx
+++ b/src/pages/stats/StatsCostCentersPivot.jsx
@@ -30,12 +30,12 @@ export default function StatsCostCentersPivot() {
       const moisSet = new Set();
       data.forEach(d => moisSet.add(d.mois.slice(0,7)));
       const sortedMonths = Array.from(moisSet).sort();
-      const grouped = {};
-      data.forEach(d => {
-        const key = d.cost_center_id;
-        if (!grouped[key]) grouped[key] = { nom: d.nom };
-        grouped[key][d.mois.slice(0,7)] = Number(d.valeur);
-      });
+        const grouped = {};
+        data.forEach(d => {
+          const key = d.nom;
+          if (!grouped[key]) grouped[key] = { nom: d.nom };
+          grouped[key][d.mois.slice(0,7)] = Number(d.montant);
+        });
       setMonths(sortedMonths);
       setRows(Object.values(grouped));
     });


### PR DESCRIPTION
## Summary
- query cost center stats from `v_cost_center_monthly` with explicit columns
- update reporting components to expect `montant` instead of `valeur`
- adjust stats pivot view aggregation for new schema

## Testing
- `npm test` *(fails: No "default" export is defined on the "@/lib/supabase" mock)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b97ee7b01c832d845f476b788f05c2