### PR TITLE
refactor(hooks): remove duplicate 'loading' state; unify async state handling

### DIFF
--- a/src/hooks/_shared/createAsyncState.ts
+++ b/src/hooks/_shared/createAsyncState.ts
@@ -1,0 +1,3 @@
+export function createAsyncState<T>(initial: T | null = null) {
+  return { data: initial as T | null, loading: false as boolean, error: null as unknown };
+}

--- a/src/hooks/gadgets/useEvolutionAchats.js
+++ b/src/hooks/gadgets/useEvolutionAchats.js
@@ -1,20 +1,18 @@
 import supabase from '@/lib/supabase';import { useEffect, useState } from 'react';
 
 import { useAuth } from '@/hooks/useAuth';
+import { createAsyncState } from '../_shared/createAsyncState';
 
 export default function useEvolutionAchats() {
   const { mama_id, loading: authLoading } = useAuth() || {};
-  const [data, setData] = useState([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState(null);
+  const [state, setState] = useState(() => createAsyncState([]));
 
   useEffect(() => {
     if (authLoading) return;
     if (!mama_id) return;
 
     const fetchData = async () => {
-      setIsLoading(true);
-      setError(null);
+      setState((s) => ({ ...s, loading: true, error: null }));
       try {
         const start = new Date();
         start.setMonth(start.getMonth() - 12);
@@ -28,19 +26,16 @@ export default function useEvolutionAchats() {
 
         if (error) throw error;
 
-        setData(data || []);
+        setState({ data: data || [], loading: false, error: null });
       } catch (e) {
-        setError(e);
-        setData([]);
-      } finally {
-        setIsLoading(false);
+        setState({ data: [], loading: false, error: e });
       }
     };
 
     fetchData();
   }, [authLoading, mama_id]);
 
-  const loading = [authLoading, isLoading].some(Boolean);
+  const loading = authLoading || state.loading;
 
-  return { data, loading, error };
+  return { data: state.data, loading, error: state.error };
 }

--- a/src/hooks/useEmailsEnvoyes.js
+++ b/src/hooks/useEmailsEnvoyes.js
@@ -1,29 +1,36 @@
 import supabase from '@/lib/supabase';import { useState } from 'react';
 
 import { useAuth } from '@/hooks/useAuth';
+import { createAsyncState } from './_shared/createAsyncState';
 
 export function useEmailsEnvoyes() {
   const { mama_id } = useAuth();
-  const [emails, setEmails] = useState([]);
+  const [state, setState] = useState(() => createAsyncState([]));
 
   async function fetchEmails({ statut, email, commande_id, date_start, date_end, page = 1, limit = 50 } = {}) {
-    let q = supabase.from('emails_envoyes').select('*');
-    q = q.eq('mama_id', mama_id);
-    if (statut) q = q.eq('statut', statut);
-    if (email) q = q.ilike('email', `%${email}%`);
-    if (commande_id) q = q.eq('commande_id', commande_id);
-    if (date_start) q = q.gte('envoye_le', date_start);
-    if (date_end) q = q.lte('envoye_le', date_end);
-    const start = (page - 1) * limit;
-    const end = start + limit - 1;
-    q = q.order('envoye_le', { ascending: false }).range(start, end);
-    const { data, error } = await q;
-    if (error) throw error;
-    setEmails(data || []);
-    return data;
+    setState((s) => ({ ...s, loading: true, error: null }));
+    try {
+      let q = supabase.from('emails_envoyes').select('*');
+      q = q.eq('mama_id', mama_id);
+      if (statut) q = q.eq('statut', statut);
+      if (email) q = q.ilike('email', `%${email}%`);
+      if (commande_id) q = q.eq('commande_id', commande_id);
+      if (date_start) q = q.gte('envoye_le', date_start);
+      if (date_end) q = q.lte('envoye_le', date_end);
+      const start = (page - 1) * limit;
+      const end = start + limit - 1;
+      q = q.order('envoye_le', { ascending: false }).range(start, end);
+      const { data, error } = await q;
+      if (error) throw error;
+      setState({ data: data || [], loading: false, error: null });
+      return data;
+    } catch (e) {
+      setState({ data: [], loading: false, error: e });
+      throw e;
+    }
   }
 
-  return { fetchEmails, emails };
+  return { fetchEmails, emails: state.data, loading: state.loading, error: state.error };
 }
 
 export default useEmailsEnvoyes;

--- a/src/hooks/useZonesStock.js
+++ b/src/hooks/useZonesStock.js
@@ -28,5 +28,5 @@ export default function useZonesStock() {
       return data ?? [];
     }
   }, getQueryClient());
-  return { ...query, zones: query.data ?? [] };
+  return { data: query.data ?? [], isLoading: query.isLoading, error: query.error };
 }


### PR DESCRIPTION
## Summary
- add `createAsyncState` helper to standardize async state objects
- refactor `useEvolutionAchats` and `useEmailsEnvoyes` to use unified `{data, loading, error}`
- simplify `useZonesStock` to return React Query's `{data, isLoading, error}`

## Testing
- `npm run build`
- `rg "loading" -n src/hooks/gadgets/useEvolutionAchats.js`
- `rg "loading" -n src/hooks/useEmailsEnvoyes.js`
- `rg "isLoading" -n src/hooks/useZonesStock.js`


------
https://chatgpt.com/codex/tasks/task_e_68b97ef0c090832d93269fd20abe567f