### PR TITLE
Fix range typo in useBonsLivraison pagination

### DIFF
--- a/src/hooks/useBonsLivraison.js
+++ b/src/hooks/useBonsLivraison.js
@@ -23,7 +23,7 @@ export function useBonsLivraison() {
       )
       .eq("mama_id", mama_id)
       .order("date_reception", { ascending: false })
-    range((page - 1) * pageSize, page * pageSize - 1);
+      .range((page - 1) * pageSize, page * pageSize - 1);
     if (fournisseur) q = q.eq("fournisseur_id", fournisseur);
     if (actif !== null) q = q.eq("actif", actif);
     if (debut) q = q.gte("date_reception", debut);


### PR DESCRIPTION
## Summary
- ensure `.range` is chained after `.order` in `useBonsLivraison` query

## Testing
- `npm test` *(fails: No "default" export is defined on the "@/lib/supabase" mock)*

------
https://chatgpt.com/codex/tasks/task_e_68b9971f5290832d8ee00561fc8b1627