### PR TITLE
feat: add front build report script

### DIFF
--- a/FRONT_BUILD_2025-09-04.md
+++ b/FRONT_BUILD_2025-09-04.md
@@ -1,0 +1,24 @@
+# Rapport build front 2025-09-04
+
+## Résumé
+- `npm run typecheck`: KO
+- `npm run lint`: OK
+- `npm run build`: OK (203 fichiers dans dist/)
+
+## Détails
+### npm run typecheck
+- > mamastock.com@0.0.0 typecheck
+- > tsc --noEmit
+- src/api/public/promotions.js(1,1): error TS1490: File appears to be binary.
+- src/components/parametrage/SousFamilleList.jsx(1,1): error TS1490: File appears to be binary.
+- src/hooks/useInvoiceOcr.js(1,1): error TS1490: File appears to be binary.
+- src/pages/signalements/Signalements.jsx(1,1): error TS1490: File appears to be binary.
+- src/pages/simulation/SimulationForm.jsx(1,1): error TS1490: File appears to be binary.
+- npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.
+
+### npm run lint
+- OK
+
+### npm run build
+- 203 fichiers dans `dist/`
+

--- a/scripts/fe-build-report.mjs
+++ b/scripts/fe-build-report.mjs
@@ -1,0 +1,80 @@
+import { exec } from 'node:child_process';
+import { promisify } from 'node:util';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const execAsync = promisify(exec);
+const rootDir = path.resolve(__dirname, '..');
+const cmds = ['npm run typecheck', 'npm run lint', 'npm run build'];
+
+const results = [];
+for (const cmd of cmds) {
+  try {
+    const { stdout, stderr } = await execAsync(cmd, {
+      cwd: rootDir,
+      env: { ...process.env, FORCE_COLOR: '0' },
+      maxBuffer: 10 * 1024 * 1024,
+    });
+    results.push({ cmd, ok: true, stdout, stderr });
+  } catch (err) {
+    results.push({ cmd, ok: false, stdout: err.stdout, stderr: err.stderr });
+  }
+}
+
+async function countFiles(dir) {
+  let count = 0;
+  try {
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        count += await countFiles(full);
+      } else {
+        count++;
+      }
+    }
+  } catch {
+    // ignore if dir does not exist
+  }
+  return count;
+}
+
+const today = new Date().toISOString().split('T')[0];
+let md = `# Rapport build front ${today}\n\n`;
+md += '## Résumé\n';
+for (const r of results) {
+  if (r.ok) {
+    if (r.cmd.includes('build')) {
+      const files = await countFiles(path.join(rootDir, 'dist'));
+      r.fileCount = files;
+      md += `- \`${r.cmd}\`: OK (${files} fichiers dans dist/)\n`;
+    } else {
+      md += `- \`${r.cmd}\`: OK\n`;
+    }
+  } else {
+    md += `- \`${r.cmd}\`: KO\n`;
+  }
+}
+md += '\n## Détails\n';
+for (const r of results) {
+  md += `### ${r.cmd}\n`;
+  if (r.ok) {
+    if (r.cmd.includes('build')) {
+      md += `- ${r.fileCount} fichiers dans \`dist/\`\n\n`;
+    } else {
+      md += '- OK\n\n';
+    }
+  } else {
+    const output = (r.stdout + r.stderr).split('\n').filter(Boolean);
+    for (const line of output) {
+      md += `- ${line}\n`;
+    }
+    md += '\n';
+  }
+}
+
+const reportPath = path.join(rootDir, `FRONT_BUILD_${today}.md`);
+await fs.writeFile(reportPath, md);
+console.log(`Rapport écrit dans ${reportPath}`);


### PR DESCRIPTION
## Summary
- add `fe-build-report.mjs` to run typecheck, lint and build then produce a markdown summary
- generate initial `FRONT_BUILD_2025-09-04.md` report

## Testing
- `node scripts/fe-build-report.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68b997670e30832da08140381345b195