### PR TITLE
feat: add supabase diagnostics and fallback for fournisseurs

### DIFF
--- a/src/hooks/data/useFournisseurs.js
+++ b/src/hooks/data/useFournisseurs.js
@@ -22,24 +22,74 @@ export function useFournisseurs(params = {}) {
     gcTime: 10 * 60 * 1000,
     refetchOnWindowFocus: false,
     queryFn: async () => {
-      let query = supabase.
-      from('fournisseurs').
-      select('id, nom, actif, contact:fournisseur_contacts(nom,email,tel)', { count: 'exact' }).
-      eq('mama_id', mama_id).
-      order('nom', { ascending: true }).
-      range((page - 1) * limit, page * limit - 1);
+      // 1er fetch simple sans embed
+      let q1 = supabase
+        .from('fournisseurs')
+        .select('id, nom, actif', { count: 'exact' })
+        .eq('mama_id', mama_id)
+        .order('nom', { ascending: true })
+        .range((page - 1) * limit, page * limit - 1);
 
-      if (search) query = query.ilike('nom', `%${search}%`);
-      if (actif !== null && actif !== undefined) query = query.eq('actif', actif);
+      if (search) q1 = q1.ilike('nom', `%${search}%`);
+      if (actif !== null && actif !== undefined) q1 = q1.eq('actif', actif);
 
-      const { data, error, count } = await query;
-      if (error) throw error;
-      const list = (data || []).map((f) => ({
+      const { data: fournisseurs, error: err1, count } = await q1;
+      if (err1) {
+        console.error('[useFournisseurs] q1', err1); // [diag]
+        throw err1;
+      }
+
+      const ids = (fournisseurs || []).map((f) => f.id);
+      let contactsMap = {};
+      let embedError = null;
+
+      if (ids.length) {
+        // tentative avec embed
+        const { data: embedData, error: embedErr } = await supabase
+          .from('fournisseurs')
+          .select('id, fournisseur_contacts(nom,email,tel)')
+          .in('id', ids);
+
+        if (!embedErr) {
+          embedData.forEach((f) => {
+            const c = Array.isArray(f.fournisseur_contacts)
+              ? f.fournisseur_contacts[0]
+              : f.fournisseur_contacts;
+            if (c) contactsMap[f.id] = c;
+          });
+        } else {
+          console.warn('[useFournisseurs] embed', embedErr); // [diag]
+          if (embedErr.status === 500) {
+            // fallback en 2 requêtes
+            const { data: contacts, error: contactErr } = await supabase
+              .from('fournisseur_contacts')
+              .select('id, nom, email, tel, fournisseur_id')
+              .eq('mama_id', mama_id)
+              .in('fournisseur_id', ids);
+            if (!contactErr && contacts) {
+              contacts.forEach((c) => {
+                contactsMap[c.fournisseur_id] = {
+                  nom: c.nom,
+                  email: c.email,
+                  tel: c.tel,
+                };
+              });
+            } else {
+              embedError = contactErr || embedErr;
+            }
+          } else {
+            embedError = embedErr;
+          }
+        }
+      }
+
+      const list = (fournisseurs || []).map((f) => ({
         ...f,
-        contact: Array.isArray(f.contact) ? f.contact[0] : f.contact
+        contact: contactsMap[f.id] || null,
       }));
-      return { data: list, count: count || 0 };
-    }
+
+      return { data: list, count: count || 0, embedError };
+    },
   });
 }
 


### PR DESCRIPTION
## Summary
- add safer fournisseur fetch with fallback contact query when embedded join fails
- expose diagnostic button and banner on fournisseurs page

## Testing
- `npm test` *(fails: No "default" export is defined... and multiple other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68ba81c3c184832db2f56bde4a22d0ca