### PR TITLE
fix: avoid empty search ilike filters

### DIFF
--- a/src/api/public/produits.js
+++ b/src/api/public/produits.js
@@ -2,6 +2,7 @@
 /* eslint-env node */
 import express from 'express';
 import supabase from '@/lib/supabase';
+import { applyIlikeOr } from '@/lib/supa/textSearch';
 
 const router = express.Router();
 
@@ -24,7 +25,7 @@ router.get('/', async (req, res) => {
       .select('*')
       .eq('mama_id', mama_id);
     if (famille) query = query.ilike('famille', `%${famille}%`);
-    if (search) query = query.ilike('nom', `%${search}%`);
+    query = applyIlikeOr(query, search);
     if (actif !== undefined) query = query.eq('actif', actif === 'true');
     let sortField = sortBy;
     let ascending = order !== 'desc';

--- a/src/hooks/data/useFournisseurs.js
+++ b/src/hooks/data/useFournisseurs.js
@@ -5,7 +5,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useAuth } from '@/hooks/useAuth';
 import { run } from '@/lib/supa/fetcher';
 import { logError } from '@/lib/supa/logError';
-import { normalizeSearchTerm } from '@/lib/supa/textSearch';
+import { normalizeSearchTerm, applyIlikeOr } from '@/lib/supa/textSearch';
 
 
 export function useFournisseurs(params = {}) {
@@ -36,7 +36,7 @@ export function useFournisseurs(params = {}) {
         .range((page - 1) * limit, page * limit - 1)
         .abortSignal(signal);
 
-      if (term) q1 = q1.ilike('nom', `%${term}%`);
+      q1 = applyIlikeOr(q1, term);
       if (actif !== null && actif !== undefined) q1 = q1.eq('actif', actif);
 
       const { data: fournisseurs, error: e1 } = await run(q1);

--- a/src/hooks/useFournisseursBrowse.js
+++ b/src/hooks/useFournisseursBrowse.js
@@ -3,6 +3,7 @@ import supabase from '@/lib/supabase';
 import { useEffect, useState } from 'react';
 
 import { useAuth } from '@/hooks/useAuth';
+import { applyIlikeOr } from '@/lib/supa/textSearch';
 
 export default function useFournisseursBrowse({
   page = 1,
@@ -28,8 +29,7 @@ export default function useFournisseursBrowse({
         select('id, nom, ville', { count: 'exact' }).
         eq('mama_id', mama_id).
         eq('actif', true);
-        const t = term.trim();
-        if (t) req = req.ilike('nom', `%${t}%`);
+        req = applyIlikeOr(req, term);
         Object.entries(filters || {}).forEach(([k, v]) => {
           if (v !== undefined && v !== null && v !== '') {
             req = req.eq(k, v);

--- a/src/hooks/useGlobalSearch.js
+++ b/src/hooks/useGlobalSearch.js
@@ -2,6 +2,7 @@
 import supabase from '@/lib/supabase';
 import { useState } from 'react';
 import { useAuth } from '@/hooks/useAuth';
+import { applyIlikeOr } from '@/lib/supa/textSearch';
 
 
 export function useGlobalSearch() {
@@ -14,10 +15,16 @@ export function useGlobalSearch() {
       return [];
     }
 
-    const [{ data: produits }, { data: fiches }] = await Promise.all([
-      supabase.from('produits').select('id, nom').eq('mama_id', mama_id).ilike('nom', `%${q}%`),
-      supabase.from('fiches').select('id, nom').eq('mama_id', mama_id).ilike('nom', `%${q}%`)
-    ]);
+    const prodReq = applyIlikeOr(
+      supabase.from('produits').select('id, nom').eq('mama_id', mama_id),
+      q
+    );
+    const ficheReq = supabase
+      .from('fiches')
+      .select('id, nom')
+      .eq('mama_id', mama_id)
+      .ilike('nom', `%${q}%`);
+    const [{ data: produits }, { data: fiches }] = await Promise.all([prodReq, ficheReq]);
 
     const merged = [
       ...(produits || []).map((p) => ({ type: 'produit', id: p.id, nom: p.nom })),

--- a/src/hooks/useProduitsAutocomplete.js
+++ b/src/hooks/useProduitsAutocomplete.js
@@ -3,6 +3,7 @@ import supabase from '@/lib/supabase';
 import { useState, useCallback } from "react";
 
 import { useAuth } from '@/hooks/useAuth';
+import { applyIlikeOr } from '@/lib/supa/textSearch';
 
 export function useProduitsAutocomplete() {
   const { mama_id } = useAuth();
@@ -19,7 +20,7 @@ export function useProduitsAutocomplete() {
     select("id, nom, tva, dernier_prix, unite_id, unite:unite_id (nom)").
     eq("mama_id", mama_id).
     eq("actif", true);
-    if (query) q = q.ilike("nom", `%${query}%`);
+    q = applyIlikeOr(q, query);
     q = q.order("nom", { ascending: true }).limit(10);
     const { data, error } = await q;
     setLoading(false);

--- a/src/hooks/useProduitsInventaire.js
+++ b/src/hooks/useProduitsInventaire.js
@@ -3,6 +3,7 @@ import supabase from '@/lib/supabase';
 import { useState, useCallback } from 'react';
 
 import { useAuth } from '@/hooks/useAuth';
+import { applyIlikeOr } from '@/lib/supa/textSearch';
 
 export function useProduitsInventaire() {
   const { mama_id } = useAuth();
@@ -21,7 +22,7 @@ export function useProduitsInventaire() {
       eq('mama_id', mama_id).
       eq('actif', true);
       if (famille) query = query.ilike('famille', `%${famille}%`);
-      if (search) query = query.ilike('nom', `%${search}%`);
+      query = applyIlikeOr(query, search);
       const { data, error } = await query.order('nom', { ascending: true });
       setLoading(false);
       if (error) {

--- a/src/hooks/useProduitsSearch.js
+++ b/src/hooks/useProduitsSearch.js
@@ -5,6 +5,7 @@ import useDebounce from '@/hooks/useDebounce';
 
 import { getQueryClient } from '@/lib/react-query';
 import { useAuth } from '@/hooks/useAuth';
+import { applyIlikeOr } from '@/lib/supa/textSearch';
 
 function normalize(list = []) {
   return list.map((p) => ({
@@ -36,12 +37,13 @@ mamaIdParam,
       const from = (page - 1) * pageSize;
       const to = from + pageSize - 1;
       try {
-        const { data, count, error } = await supabase.
+        let req = supabase.
         from('produits').
         select('id, nom, unite_id, tva, zone_stock_id', { count: 'exact' }).
         eq('mama_id', mamaId).
-        eq('actif', true).
-        ilike('nom', `%${q}%`).
+        eq('actif', true);
+        req = applyIlikeOr(req, q);
+        const { data, count, error } = await req.
         order('nom', { ascending: true }).
         range(from, to);
         if (error) throw error;

--- a/src/lib/supa/textSearch.ts
+++ b/src/lib/supa/textSearch.ts
@@ -1,15 +1,12 @@
-// fix: avoid ilike.%% on empty search.
 export function normalizeSearchTerm(q?: string) {
   return (q ?? '').trim();
 }
 
-// For supabase-js v2 (SDK)
 export function applyIlikeOr(
   req: import('@supabase/supabase-js').PostgrestFilterBuilder<any, any, any>,
   term: string
 ) {
   const t = normalizeSearchTerm(term);
-  if (!t) return req; // do not add filter when empty
-  // Supabase-js encodes params automatically; we use % wildcards directly
+  if (!t) return req; // pas de filtre si vide
   return req.or(`nom.ilike.%${t}%,code.ilike.%${t}%`);
 }

--- a/test/mocks/supabaseClient.js
+++ b/test/mocks/supabaseClient.js
@@ -1,3 +1,5 @@
+import { vi } from 'vitest';
+
 export function makeSupabaseMock(init = { data: [], error: null, count: 0 }) {
   const result = Promise.resolve({
     data: init.data,
@@ -6,20 +8,23 @@ export function makeSupabaseMock(init = { data: [], error: null, count: 0 }) {
   });
 
   const chain = {
-    from() { return chain; },
-    select() { return chain; },
-    insert() { return chain; },
-    update() { return chain; },
-    delete() { return chain; },
-    order() { return chain; },
-    eq() { return chain; },
-    in() { return chain; },
-    range() { return chain; },
-    single() { return result; },
-    maybeSingle() { return result; },
+    from: vi.fn(() => chain),
+    select: vi.fn(() => chain),
+    insert: vi.fn(() => chain),
+    update: vi.fn(() => chain),
+    delete: vi.fn(() => chain),
+    order: vi.fn(() => chain),
+    eq: vi.fn(() => chain),
+    ilike: vi.fn(() => chain),
+    or: vi.fn(() => chain),
+    in: vi.fn(() => chain),
+    range: vi.fn(() => chain),
+    limit: vi.fn(() => chain),
+    single: vi.fn(() => result),
+    maybeSingle: vi.fn(() => result),
     then: result.then.bind(result),
     catch: result.catch.bind(result),
-    finally: result.finally?.bind(result) ?? ((f)=>result)
+    finally: result.finally?.bind(result) ?? ((f) => result)
   };
   return chain;
 }

--- a/test/public_api.test.js
+++ b/test/public_api.test.js
@@ -89,7 +89,7 @@ describe('public API router', () => {
     await request(app)
       .get('/produits?mama_id=m1&search=choc&actif=false&page=2&limit=20')
       .set('x-api-key', 'dev_key');
-    expect(chain.ilike).toHaveBeenCalledWith('nom', '%choc%');
+    expect(chain.or).toHaveBeenCalledWith('nom.ilike.%choc%,code.ilike.%choc%');
     expect(chain.eq).toHaveBeenCalledWith('actif', false);
     expect(chain.range).toHaveBeenCalledWith(20, 39);
   });

--- a/test/useFournisseursAutocomplete.test.js
+++ b/test/useFournisseursAutocomplete.test.js
@@ -6,21 +6,21 @@ var queryBuilder, selectMock, fromMock;
 vi.mock('@/lib/supabase', () => {
   queryBuilder = {
     eq: vi.fn(() => queryBuilder),
-    ilike: vi.fn(() => queryBuilder),
+    or: vi.fn(() => queryBuilder),
     order: vi.fn(() => queryBuilder),
     limit: vi.fn(() => queryBuilder),
     then: vi.fn((resolve) => resolve({ data: [], error: null })),
   };
   selectMock = vi.fn(() => queryBuilder);
   fromMock = vi.fn(() => ({ select: selectMock }));
-  return { getSupabaseClient: () => ({ from: fromMock }) };
+  return { default: { from: fromMock } };
 });
 
 beforeEach(() => {
   fromMock.mockClear();
   selectMock.mockClear();
   queryBuilder.eq.mockClear();
-  queryBuilder.ilike.mockClear();
+  queryBuilder.or.mockClear();
   queryBuilder.order.mockClear();
   queryBuilder.limit.mockClear();
 });
@@ -31,7 +31,7 @@ test('searchFournisseurs filters by mama_id and query', async () => {
   expect(selectMock).toHaveBeenCalledWith('id, nom, ville');
   expect(queryBuilder.eq).toHaveBeenNthCalledWith(1, 'mama_id', 'm1');
   expect(queryBuilder.eq).toHaveBeenNthCalledWith(2, 'actif', true);
-  expect(queryBuilder.ilike).toHaveBeenCalledWith('nom', '%paris%');
+  expect(queryBuilder.or).toHaveBeenCalledWith('nom.ilike.%paris%,code.ilike.%paris%');
   expect(queryBuilder.order).toHaveBeenCalledWith('nom', { ascending: true });
   expect(queryBuilder.limit).toHaveBeenCalledWith(20);
 });

--- a/test/useGlobalSearch.test.js
+++ b/test/useGlobalSearch.test.js
@@ -2,15 +2,18 @@
 import { renderHook, act } from '@testing-library/react';
 import { vi, beforeEach, test, expect } from 'vitest';
 
-const prodIlike = vi.fn(() => Promise.resolve({ data: [{ id: 'p1', nom: 'Prod' }], error: null }));
+const prodOr = vi.fn(() => Promise.resolve({ data: [{ id: 'p1', nom: 'Prod' }], error: null }));
+const prodEq = vi.fn(() => ({ or: prodOr }));
+const prodSelect = vi.fn(() => ({ eq: prodEq }));
 const ficheIlike = vi.fn(() => Promise.resolve({ data: [{ id: 'f1', nom: 'Fiche' }], error: null }));
-const prodSelect = vi.fn(() => ({ ilike: prodIlike }));
-const ficheSelect = vi.fn(() => ({ ilike: ficheIlike }));
+const ficheEq = vi.fn(() => ({ ilike: ficheIlike }));
+const ficheSelect = vi.fn(() => ({ eq: ficheEq }));
 const fromMock = vi.fn()
   .mockReturnValueOnce({ select: prodSelect })
   .mockReturnValueOnce({ select: ficheSelect });
 
-vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
+vi.mock('@/lib/supabase', () => ({ default: { from: fromMock } }));
+vi.mock('@/hooks/useAuth', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
 
 let useGlobalSearch;
 
@@ -18,8 +21,10 @@ beforeEach(async () => {
   ({ useGlobalSearch } = await import('@/hooks/useGlobalSearch'));
   fromMock.mockClear();
   prodSelect.mockClear();
+  prodEq.mockClear();
+  prodOr.mockClear();
   ficheSelect.mockClear();
-  prodIlike.mockClear();
+  ficheEq.mockClear();
   ficheIlike.mockClear();
 });
 
@@ -30,6 +35,7 @@ test('search queries produits and fiches and returns max two results', async () 
   });
   expect(fromMock).toHaveBeenCalledWith('produits');
   expect(fromMock).toHaveBeenCalledWith('fiches');
+  expect(prodOr).toHaveBeenCalledWith('nom.ilike.%boeuf%,code.ilike.%boeuf%');
   expect(result.current.results).toEqual([
     { type: 'produit', id: 'p1', nom: 'Prod' },
     { type: 'fiche', id: 'f1', nom: 'Fiche' },

--- a/test/useProduitsAutocomplete.test.js
+++ b/test/useProduitsAutocomplete.test.js
@@ -25,5 +25,5 @@ test('searchProduits filters by mama_id and query', async () => {
   expect(query.select).toHaveBeenCalledWith('id, nom, tva, dernier_prix, unite_id, unite:unite_id (nom)');
   expect(query.eq).toHaveBeenCalledWith('mama_id', 'm1');
   expect(query.eq).toHaveBeenCalledWith('actif', true);
-  expect(query.ilike).toHaveBeenCalledWith('nom', '%car%');
+  expect(query.or).toHaveBeenCalledWith('nom.ilike.%car%,code.ilike.%car%');
 });

--- a/test/useProduitsInventaire.test.js
+++ b/test/useProduitsInventaire.test.js
@@ -3,12 +3,13 @@ import { renderHook, act } from '@testing-library/react';
 import { vi, beforeEach, test, expect } from 'vitest';
 
 const orderMock = vi.fn(() => Promise.resolve({ data: [], error: null }));
-const ilikeMock = vi.fn(() => ({ eq: eqMock, ilike: ilikeMock, order: orderMock }));
-const eqMock = vi.fn(() => ({ eq: eqMock, ilike: ilikeMock, order: orderMock }));
-const selectMock = vi.fn(() => ({ eq: eqMock, ilike: ilikeMock, order: orderMock }));
+const orMock = vi.fn(() => ({ eq: eqMock, ilike: ilikeMock, or: orMock, order: orderMock }));
+const ilikeMock = vi.fn(() => ({ eq: eqMock, ilike: ilikeMock, or: orMock, order: orderMock }));
+const eqMock = vi.fn(() => ({ eq: eqMock, ilike: ilikeMock, or: orMock, order: orderMock }));
+const selectMock = vi.fn(() => ({ eq: eqMock, ilike: ilikeMock, or: orMock, order: orderMock }));
 const fromMock = vi.fn(() => ({ select: selectMock }));
 
-vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
+vi.mock('@/lib/supabase', () => ({ default: { from: fromMock } }));
 vi.mock('@/hooks/useAuth', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
 
 let useProduitsInventaire;
@@ -19,6 +20,7 @@ beforeEach(async () => {
   selectMock.mockClear();
   eqMock.mockClear();
   ilikeMock.mockClear();
+  orMock.mockClear();
   orderMock.mockClear();
 });
 
@@ -34,6 +36,6 @@ test('fetchProduits filters by family and search', async () => {
   expect(eqMock).toHaveBeenCalledWith('mama_id', 'm1');
   expect(eqMock).toHaveBeenCalledWith('actif', true);
   expect(ilikeMock).toHaveBeenCalledWith('famille', '%Viande%');
-  expect(ilikeMock).toHaveBeenCalledWith('nom', '%boeuf%');
+  expect(orMock).toHaveBeenCalledWith('nom.ilike.%boeuf%,code.ilike.%boeuf%');
   expect(orderMock).toHaveBeenCalledWith('nom', { ascending: true });
 });

--- a/test/useProduitsSearch.test.jsx
+++ b/test/useProduitsSearch.test.jsx
@@ -5,7 +5,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 const queryBuilder = {
   eq: vi.fn(() => queryBuilder),
-  ilike: vi.fn(() => queryBuilder),
+  or: vi.fn(() => queryBuilder),
   order: vi.fn(() => queryBuilder),
   range: vi.fn(() => Promise.resolve({ data: [], count: 0, error: null })),
   select: vi.fn(() => queryBuilder),
@@ -13,7 +13,7 @@ const queryBuilder = {
 
 const fromMock = vi.fn(() => queryBuilder);
 
-vi.mock('@/lib/supabase', () => ({ supabase: { from: fromMock } }));
+vi.mock('@/lib/supabase', () => ({ default: { from: fromMock } }));
 vi.mock('@/hooks/useAuth', () => ({ useAuth: () => ({ mama_id: 'm1' }) }));
 
 let useProduitsSearch;
@@ -22,7 +22,7 @@ beforeEach(async () => {
   ({ useProduitsSearch } = await import('@/hooks/useProduitsSearch'));
   fromMock.mockClear();
   queryBuilder.eq.mockClear();
-  queryBuilder.ilike.mockClear();
+  queryBuilder.or.mockClear();
   queryBuilder.order.mockClear();
   queryBuilder.range.mockClear();
   queryBuilder.select.mockClear();
@@ -41,7 +41,7 @@ test('useProduitsSearch queries produits with pagination', async () => {
   expect(queryBuilder.select).toHaveBeenCalledWith('id, nom, unite_id, tva, zone_stock_id', { count: 'exact' });
   expect(queryBuilder.eq).toHaveBeenCalledWith('mama_id', 'm1');
   expect(queryBuilder.eq).toHaveBeenCalledWith('actif', true);
-  expect(queryBuilder.ilike).toHaveBeenCalledWith('nom', '%car%');
+  expect(queryBuilder.or).toHaveBeenCalledWith('nom.ilike.%car%,code.ilike.%car%');
   expect(queryBuilder.order).toHaveBeenCalledWith('nom', { ascending: true });
   expect(queryBuilder.range).toHaveBeenCalledWith(10, 19);
   expect(result.current.total).toBe(0);


### PR DESCRIPTION
## Summary
- add helper to skip ilike when search is empty
- use helper across product and supplier search hooks
- update tests for new search behaviour

## Testing
- `npx vitest test/useFournisseursAutocomplete.test.js test/useProduitsAutocomplete.test.js test/useProduitsSearch.test.jsx test/useProduitsInventaire.test.js test/useGlobalSearch.test.js --run`


------
https://chatgpt.com/codex/tasks/task_e_68baabdcafe0832db1f64348daa76c81