### PR TITLE
Use plain date in evolution achats filter

### DIFF
--- a/src/hooks/gadgets/useEvolutionAchats.js
+++ b/src/hooks/gadgets/useEvolutionAchats.js
@@ -15,7 +15,7 @@ export default function useEvolutionAchats() {
       setState((s) => ({ ...s, loading: true, error: null }));
       const start = new Date();
       start.setMonth(start.getMonth() - 12);
-      const filterDate = new Date(start.getFullYear(), start.getMonth(), 1).toISOString();
+      const filterDate = `${start.getFullYear()}-${String(start.getMonth() + 1).padStart(2, '0')}-01`;
       const { data, error } = await run(
         supabase
           .from('v_evolution_achats')


### PR DESCRIPTION
## Summary
- format minimum-month filter as `YYYY-MM-01` to match new date column in analytics view

## Testing
- `npm test` *(fails: No "default" export is defined on the "@/lib/supabase" mock, 59 failed / 14 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68baabf48144832d91fd00badfbe4dc0