### PR TITLE
refactor: stabilize product and supplier selects

### DIFF
--- a/src/hooks/useProducts.js
+++ b/src/hooks/useProducts.js
@@ -47,8 +47,8 @@ export function useProducts() {
       .select(
         `id, nom, mama_id, actif, famille_id, unite_id, code, image,
         pmp, stock_reel, stock_min, stock_theorique, created_at, updated_at,
-        unite:unites!fk_produits_unite ( nom ),
-        famille:familles!fk_produits_famille ( nom )`,
+        unite:unite_id(nom),
+        famille:famille_id(nom)`,
         { count: 'exact' }
       )
       .eq('mama_id', mama_id)
@@ -270,14 +270,14 @@ export function useProducts() {
   const getProduct = useCallback(
     async (id) => {
       if (!mama_id) return null;
-      const { data, error } = await supabase.
-      from("produits").
-      select(
-        "*, famille:familles!fk_produits_famille(nom), sous_famille:sous_familles!fk_produits_sous_famille(nom), main_fournisseur:fournisseur_id(id, nom), unite:unite_id (nom)"
-      ).
-      eq("id", id).
-      eq("mama_id", mama_id).
-      single();
+      const { data, error } = await supabase
+        .from("produits")
+        .select(
+          "*, famille:famille_id(nom), sous_famille:sous_famille_id(nom), main_fournisseur:fournisseur_id(id, nom), unite:unite_id(nom)"
+        )
+        .eq("id", id)
+        .eq("mama_id", mama_id)
+        .single();
       if (error) {
         setError(error);
         toast.error(error.message);

--- a/src/utils/exportExcelProduits.js
+++ b/src/utils/exportExcelProduits.js
@@ -30,7 +30,7 @@ export async function exportExcelProduits(mama_id) {
   const { data, error } = await supabase.
   from("produits").
   select(
-    `nom, unite_id, unite:unite_id (nom), famille:familles(nom), sous_famille:sous_familles(nom), zone_stock:zones_stock(nom), stock_theorique, pmp, actif, seuil_min`
+    `nom, unite_id, unite:unite_id (nom), famille:famille_id(nom), sous_famille:sous_famille_id(nom), zone_stock:zones_stock(nom), stock_theorique, pmp, actif, seuil_min`
   ).
   eq("mama_id", mama_id);
 


### PR DESCRIPTION
## Summary
- align product queries with new foreign key embed syntax
- fetch supplier contacts via embedded select and handle missing contact
- update product export to match revised schema

## Testing
- `npm test` *(fails: No "default" export is defined on the "@/lib/supabase" mock)*

------
https://chatgpt.com/codex/tasks/task_e_68baac3b581c832d975eccf4b881d8ae