### PR TITLE
refactor: centralize pagination with applyRange

### DIFF
--- a/src/api/public/produits.js
+++ b/src/api/public/produits.js
@@ -2,6 +2,7 @@
 /* eslint-env node */
 import express from 'express';
 import supabase from '@/lib/supabase';
+import { applyRange } from '@/lib/supa/range';
 
 const router = express.Router();
 
@@ -42,8 +43,7 @@ router.get('/', async (req, res) => {
     const p = Math.max(parseInt(page, 10), 1);
     const l = Math.max(parseInt(limit, 10), 1);
     const start = (p - 1) * l;
-    const end = start + l - 1;
-    const { data, error } = await query.range(start, end);
+    const { data, error } = await applyRange(query, start, l);
     if (error) throw error;
     res.json(data || []);
   } catch (err) {

--- a/src/api/public/stock.js
+++ b/src/api/public/stock.js
@@ -3,6 +3,7 @@
 import express from 'express';
 import { TABLES } from '@/constants/tables';
 import supabase from '@/lib/supabase';
+import { applyRange } from '@/lib/supa/range';
 
 const router = express.Router();
 
@@ -26,8 +27,7 @@ router.get('/', async (req, res) => {
     const p = Math.max(parseInt(page, 10), 1);
     const l = Math.max(parseInt(limit, 10), 1);
     const start = (p - 1) * l;
-    const end = start + l - 1;
-    const { data, error } = await query.range(start, end);
+    const { data, error } = await applyRange(query, start, l);
     if (error) throw error;
     res.json(data || []);
   } catch (err) {

--- a/src/hooks/data/useFactures.js
+++ b/src/hooks/data/useFactures.js
@@ -1,6 +1,7 @@
-import supabase from '@/lib/supabase';import { useQuery } from '@tanstack/react-query';
+import supabase from '@/lib/supabase';
+import { useQuery } from '@tanstack/react-query';
 import { useAuth } from '@/hooks/useAuth';
-
+import { applyRange } from '@/lib/supa/range';
 
 export function useFactures(filters = {}) {
   const { userData } = useAuth();
@@ -19,8 +20,8 @@ export function useFactures(filters = {}) {
           { count: 'exact' }
         )
         .eq('mama_id', mamaId)
-        .order('date_facture', { ascending: false })
-        .range((page - 1) * pageSize, page * pageSize - 1);
+        .order('date_facture', { ascending: false });
+      q = applyRange(q, (page - 1) * pageSize, pageSize);
 
       if (filters?.search) {
         q = q.ilike('numero', `%${filters.search}%`);

--- a/src/hooks/data/useFournisseurs.js
+++ b/src/hooks/data/useFournisseurs.js
@@ -6,6 +6,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { run } from '@/lib/supa/fetcher';
 import { logError } from '@/lib/supa/logError';
 import { normalizeSearchTerm } from '@/lib/supa/textSearch';
+import { applyRange } from '@/lib/supa/range';
 
 
 export function useFournisseurs(params = {}) {
@@ -32,9 +33,8 @@ export function useFournisseurs(params = {}) {
         .from('fournisseurs')
         .select('id, nom, actif')
         .eq('mama_id', mama_id)
-        .order('nom', { ascending: true })
-        .range((page - 1) * limit, page * limit - 1)
-        .abortSignal(signal);
+        .order('nom', { ascending: true });
+      q1 = applyRange(q1, (page - 1) * limit, limit).abortSignal(signal);
 
       if (term) q1 = q1.ilike('nom', `%${term}%`);
       if (actif !== null && actif !== undefined) q1 = q1.eq('actif', actif);

--- a/src/hooks/useAlerteStockFaible.js
+++ b/src/hooks/useAlerteStockFaible.js
@@ -3,6 +3,7 @@ import { useEffect, useState, useCallback } from 'react';
 import { useAuth } from '@/hooks/useAuth';
 import { run } from '@/lib/supa/fetcher';
 import { logError } from '@/lib/supa/logError';
+import { applyRange } from '@/lib/supa/range';
 
 /**
  * Hook for low stock alerts based on v_alertes_rupture_api view.
@@ -22,17 +23,18 @@ export function useAlerteStockFaible({ page = 1, pageSize = 20 } = {}) {
       if (!mama_id) return [];
       setLoading(true);
       setError(null);
-      const from = (page - 1) * pageSize;
-      const to = from + pageSize - 1;
+      const offset = (page - 1) * pageSize;
       const { data: rows, error: err } = await run(
-        supabase
-          .from('v_alertes_rupture_api')
-          .select(
-            'id:produit_id, produit_id, nom, unite, fournisseur_id, fournisseur_nom, stock_actuel, stock_min, manque, consommation_prevue, receptions, stock_projete'
-          )
-          .order('manque', { ascending: false })
-          .range(from, to)
-          .abortSignal(signal)
+        applyRange(
+          supabase
+            .from('v_alertes_rupture_api')
+            .select(
+              'id:produit_id, produit_id, nom, unite, fournisseur_id, fournisseur_nom, stock_actuel, stock_min, manque, consommation_prevue, receptions, stock_projete'
+            )
+            .order('manque', { ascending: false }),
+          offset,
+          pageSize
+        ).abortSignal(signal)
       );
       if (err) {
         logError('[v_alertes_rupture_api]', err);

--- a/src/hooks/useBonsLivraison.js
+++ b/src/hooks/useBonsLivraison.js
@@ -3,6 +3,7 @@ import supabase from '@/lib/supabase';
 import { useState } from "react";
 
 import { useAuth } from '@/hooks/useAuth';
+import { applyRange } from '@/lib/supa/range';
 
 export function useBonsLivraison() {
   const { mama_id } = useAuth();
@@ -22,8 +23,8 @@ export function useBonsLivraison() {
         { count: "exact" }
       )
       .eq("mama_id", mama_id)
-      .order("date_reception", { ascending: false })
-      .range((page - 1) * pageSize, page * pageSize - 1);
+      .order("date_reception", { ascending: false });
+    q = applyRange(q, (page - 1) * pageSize, pageSize);
     if (fournisseur) q = q.eq("fournisseur_id", fournisseur);
     if (actif !== null) q = q.eq("actif", actif);
     if (debut) q = q.gte("date_reception", debut);

--- a/src/hooks/useCommandes.js
+++ b/src/hooks/useCommandes.js
@@ -3,6 +3,7 @@ import supabase from '@/lib/supabase';
 import { useState, useCallback } from "react";
 
 import { useAuth } from '@/hooks/useAuth';
+import { applyRange } from '@/lib/supa/range';
 
 export function useCommandes() {
   const { mama_id, user_id } = useAuth();
@@ -24,8 +25,8 @@ export function useCommandes() {
           { count: "exact" }
         )
         .eq("mama_id", mama_id)
-        .order("date_commande", { ascending: false })
-        .range((page - 1) * limit, page * limit - 1);
+        .order("date_commande", { ascending: false });
+      query = applyRange(query, (page - 1) * limit, limit);
       if (fournisseur) query = query.eq("fournisseur_id", fournisseur);
       if (statut) query = query.eq("statut", statut);
       if (debut) query = query.gte("date_commande", debut);

--- a/src/hooks/useEmailsEnvoyes.js
+++ b/src/hooks/useEmailsEnvoyes.js
@@ -3,6 +3,7 @@ import { useState } from 'react';
 
 import { useAuth } from '@/hooks/useAuth';
 import { createAsyncState } from './_shared/createAsyncState';
+import { applyRange } from '@/lib/supa/range';
 
 export function useEmailsEnvoyes() {
   const { mama_id } = useAuth();
@@ -22,7 +23,6 @@ export function useEmailsEnvoyes() {
       const p = Number(page) || 1;
       const l = Number(limit) || 50;
       const start = (p - 1) * l;
-      const end = start + l - 1;
       let q = supabase
         .from('emails_envoyes')
         .select('*')
@@ -32,9 +32,8 @@ export function useEmailsEnvoyes() {
       if (commande_id) q = q.eq('commande_id', commande_id);
       if (date_start) q = q.gte('envoye_le', date_start);
       if (date_end) q = q.lte('envoye_le', date_end);
-      const { data, error } = await q
-        .order('envoye_le', { ascending: false })
-        .range(start, end);
+      q = q.order('envoye_le', { ascending: false });
+      const { data, error } = await applyRange(q, start, l);
       if (error) throw error;
       setState({ data: data || [], loading: false, error: null });
       return data;

--- a/src/hooks/useFactures.js
+++ b/src/hooks/useFactures.js
@@ -6,6 +6,7 @@ import { useState } from "react";
 import { useAuth } from '@/hooks/useAuth';
 import usePeriodes from "@/hooks/usePeriodes";
 import { normalizeSearchTerm } from '@/lib/supa/textSearch';
+import { applyRange } from '@/lib/supa/range';
 
 export function useFactures() {
   const { mama_id } = useAuth();
@@ -29,7 +30,7 @@ export function useFactures() {
       .order("date_reception", { ascending: false });
     const termBL = normalizeSearchTerm(search);
     if (termBL) q = q.ilike("numero_bl", `%${termBL}%`);
-    q = q.range((page - 1) * limit, page * limit - 1);
+    q = applyRange(q, (page - 1) * limit, limit);
     const { data, error, count } = await q;
     if (!error) {
       setFactures(data || []);
@@ -58,8 +59,8 @@ export function useFactures() {
         { count: "exact" }
       )
       .eq("mama_id", mama_id)
-      .order("date_facture", { ascending: false })
-      .range((page - 1) * pageSize, page * pageSize - 1);
+      .order("date_facture", { ascending: false });
+    query = applyRange(query, (page - 1) * pageSize, pageSize);
 
     const term = normalizeSearchTerm(search);
     if (term) {

--- a/src/hooks/useFacturesList.js
+++ b/src/hooks/useFacturesList.js
@@ -1,5 +1,7 @@
-import supabase from '@/lib/supabase';import { useQuery } from '@tanstack/react-query';
+import supabase from '@/lib/supabase';
+import { useQuery } from '@tanstack/react-query';
 import { useAuth } from '@/hooks/useAuth';
+import { applyRange } from '@/lib/supa/range';
 
 
 export function useFacturesList(params = {}) {
@@ -30,8 +32,8 @@ export function useFacturesList(params = {}) {
           { count: 'exact' }
         )
         .eq('mama_id', mamaId)
-        .order('date_facture', { ascending: false })
-        .range((page - 1) * pageSize, page * pageSize - 1);
+        .order('date_facture', { ascending: false });
+      query = applyRange(query, (page - 1) * pageSize, pageSize);
 
       if (search) {
         query = query.or(`numero.ilike.%${search}%,fournisseurs.nom.ilike.%${search}%`);

--- a/src/hooks/useFournisseurApiConfig.js
+++ b/src/hooks/useFournisseurApiConfig.js
@@ -4,6 +4,7 @@ import { useState } from 'react';
 
 import { useAuth } from '@/hooks/useAuth';
 import { toast } from 'sonner';
+import { applyRange } from '@/lib/supa/range';
 
 export function useFournisseurApiConfig() {
   const { mama_id } = useAuth();
@@ -68,7 +69,6 @@ export function useFournisseurApiConfig() {
     const p = Number(page) || 1;
     const l = Number(limit) || 20;
     const start = (p - 1) * l;
-    const end = start + l - 1;
     let query = supabase
       .from('fournisseurs_api_config')
       .select('*, fournisseur:fournisseur_id(id, nom)', { count: 'exact' })
@@ -76,7 +76,7 @@ export function useFournisseurApiConfig() {
       .order('fournisseur_id');
     if (fournisseur_id) query = query.eq('fournisseur_id', fournisseur_id);
     if (actif !== undefined && actif !== null) query = query.eq('actif', actif);
-    query = query.range(start, end);
+    query = applyRange(query, start, l);
     const { data, count, error } = await query;
     setLoading(false);
     if (error) {

--- a/src/hooks/useInventaireLignes.js
+++ b/src/hooks/useInventaireLignes.js
@@ -3,6 +3,7 @@ import supabase from '@/lib/supabase';
 import { useState } from "react";
 
 import { useAuth } from '@/hooks/useAuth';
+import { applyRange } from '@/lib/supa/range';
 
 export function useInventaireLignes() {
   const { mama_id } = useAuth();
@@ -41,8 +42,7 @@ export function useInventaireLignes() {
     if (search) {
       query = query.eq("produit_id", search);
     }
-    const from = (page - 1) * limit;
-    query = query.range(from, from + limit - 1);
+    query = applyRange(query, (page - 1) * limit, limit);
     const { data, error, count } = await query;
     setLoading(false);
     if (error) {

--- a/src/hooks/useProducts.js
+++ b/src/hooks/useProducts.js
@@ -4,6 +4,7 @@ import supabase from '@/lib/supabase';
 // src/hooks/useProducts.js
 import { useState, useCallback, useEffect } from "react";
 import { applyIlikeOr, normalizeSearchTerm } from '@/lib/supa/textSearch';
+import { applyRange } from '@/lib/supa/range';
 
 import { useAuth } from '@/hooks/useAuth';
 import * as XLSX from "xlsx";
@@ -56,9 +57,8 @@ export function useProducts() {
 
     req = applyIlikeOr(req, term);
 
-    const from = (page - 1) * limit;
-    const to = from + limit - 1;
-    const { data, error, count } = await req.range(from, to);
+    req = applyRange(req, (page - 1) * limit, limit);
+    const { data, error, count } = await req;
 
     const [
       { data: pmpData },

--- a/src/hooks/usePromotions.js
+++ b/src/hooks/usePromotions.js
@@ -3,6 +3,7 @@ import supabase from '@/lib/supabase';
 import { useState } from "react";
 
 import { useAuth } from '@/hooks/useAuth';
+import { applyRange } from '@/lib/supa/range';
 
 export function usePromotions() {
   const { mama_id } = useAuth();
@@ -20,9 +21,7 @@ export function usePromotions() {
     select("*", { count: "exact" }).
     eq("mama_id", mama_id).
     order("date_debut", { ascending: false });
-    if (typeof query.range === "function") {
-      query = query.range((page - 1) * limit, page * limit - 1);
-    }
+    query = applyRange(query, (page - 1) * limit, limit);
     if (search) query = query.ilike("nom", `%${search}%`);
     if (typeof actif === "boolean") query = query.eq("actif", actif);
     const { data, error, count } = await query;

--- a/src/lib/supa/range.ts
+++ b/src/lib/supa/range.ts
@@ -1,0 +1,10 @@
+export function applyRange(
+  req: import('@supabase/supabase-js').PostgrestFilterBuilder<any, any, any>,
+  offset = 0,
+  limit = 50
+) {
+  const from = Math.max(0, Number(offset) || 0);
+  const l = Math.max(1, Number(limit) || 1);
+  const to = Math.max(from, from + l - 1);
+  return req.range(from, to);
+}


### PR DESCRIPTION
## Summary
- add `applyRange` helper to normalize pagination bounds
- update hooks and API routes to apply consistent range and stable ordering

## Testing
- `npm test` *(fails: No "default" export defined on "@/lib/supabase" mock and others)*

------
https://chatgpt.com/codex/tasks/task_e_68baac500c58832d8ae60f1a8c9ab858