### PR TITLE
feat: improve Supabase error logging

### DIFF
--- a/src/hooks/useProducts.js
+++ b/src/hooks/useProducts.js
@@ -5,6 +5,7 @@ import supabase from '@/lib/supabase';
 import { useState, useCallback, useEffect } from "react";
 import { applyIlikeOr, normalizeSearchTerm } from '@/lib/supa/textSearch';
 import { applyRange } from '@/lib/supa/applyRange';
+import { logError } from '@/lib/supa/logError';
 
 import { useAuth } from '@/hooks/useAuth';
 import * as XLSX from "xlsx";
@@ -83,7 +84,8 @@ export function useProducts() {
     setLoading(false);
     if (error) {
       setError(error);
-      toast.error(error.message);
+      logError('useProducts.fetch', error, { endpoint: 'produits' });
+      toast.error('Erreur lors du chargement des produits');
     }
     return data || [];
   }, [mama_id]);

--- a/src/lib/supa/logError.js
+++ b/src/lib/supa/logError.js
@@ -1,9 +1,14 @@
-export function logError(ctx, error) {
+export function logError(scope, error, extra = {}) {
   if (!error) return;
-  console.warn(`[supa] ${ctx}`, {
-    code: error.code,
-    message: error.message,
-    details: error.details,
-    hint: error.hint,
-  });
+  const payload = {
+    scope,
+    code: error?.code ?? '',
+    message: error?.message ?? String(error),
+    details: error?.details ?? '',
+    hint: error?.hint ?? '',
+    status: error?.status ?? '',
+    ...extra,
+  };
+  console.error('[supa]', payload);
+  // Option: afficher un toast plus propre selon code
 }


### PR DESCRIPTION
## Summary
- add scope-aware logError including status and extra context
- log product fetching failures with endpoint context and user-friendly toast

## Testing
- `npm test` *(fails: No "default" export is defined on the "@/lib/supabase" mock)*

------
https://chatgpt.com/codex/tasks/task_e_68bac666acdc832da4828d5b24a6e457