### PR TITLE
chore: assert Supabase env variables

### DIFF
--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,8 +1,17 @@
 import { createClient } from '@supabase/supabase-js';
 
-export const supabase = createClient(
-  import.meta.env.VITE_SUPABASE_URL,
-  import.meta.env.VITE_SUPABASE_ANON_KEY
-);
+const url = import.meta.env.VITE_SUPABASE_URL as string;
+const anon = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
+
+if (!url || !anon) {
+  console.error(
+    'Missing Supabase env. Check VITE_SUPABASE_URL / VITE_SUPABASE_ANON_KEY.'
+  );
+  // Option: afficher une bannière Dev
+}
+
+export const supabase = createClient(url, anon, {
+  auth: { persistSession: true },
+});
 
 export default supabase;


### PR DESCRIPTION
## Summary
- add guard for missing Supabase env vars and enable session persistence

## Testing
- `npm test` *(fails: No "default" export is defined on the "@/lib/supabase" mock)*

------
https://chatgpt.com/codex/tasks/task_e_68baac7a40d8832d97228e0af58a5868