### PR TITLE
fix: forwardRef button to support Radix slot ref

### DIFF
--- a/src/components/ui/button.jsx
+++ b/src/components/ui/button.jsx
@@ -1,11 +1,13 @@
-/* @ts-nocheck */
-import React from 'react';
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { cn } from '@/lib/utils'; // keep your local cn helper
 
-/** Minimal button wrapper, compatible with previous usage. */
-export function Button({ asChild = false, className = '', ...props }) {
-  const Comp = asChild ? 'span' : 'button';
-  return <Comp className={className} {...props} />;
-}
+const Button = React.forwardRef(function Button(
+  { className, asChild = false, ...props },
+  ref
+) {
+  const Comp = asChild ? Slot : 'button';
+  return <Comp ref={ref} className={cn('inline-flex items-center justify-center', className)} {...props} />;
+});
 
-/** Compat: allow `import Button from ...` */
 export default Button;

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -4,3 +4,7 @@ export function hasAccess(module, access_rights) {
   if (!mod || typeof mod !== "object") return false;
   return mod.peut_voir === true || mod === true;
 }
+
+export function cn(...classes) {
+  return classes.filter(Boolean).join(" ");
+}


### PR DESCRIPTION
## Summary
- convert Button to forwardRef and pass ref to native element
- add simple `cn` helper in utils

## Testing
- `npm test` *(fails: No "default" export is defined on the "@/lib/supabase" mock)*

------
https://chatgpt.com/codex/tasks/task_e_68bacb3e43cc832dbb44a6425a338eeb