### PR TITLE
fix: enable products query

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
         "@radix-ui/react-select": "^2.2.6",
+        "@radix-ui/react-slot": "^1.2.3",
         "@react-pdf/renderer": "3.4.5",
         "@supabase/supabase-js": "^2.55.0",
         "@tailwindcss/cli": "^4.1.7",
@@ -2881,6 +2882,8 @@
     },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2"

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-select": "^2.2.6",
+    "@radix-ui/react-slot": "^1.2.3",
     "@react-pdf/renderer": "3.4.5",
     "@supabase/supabase-js": "^2.55.0",
     "@tailwindcss/cli": "^4.1.7",


### PR DESCRIPTION
## Summary
- ensure products fetch runs once mamaId is available
- add debug logging for query state and expose manual fetcher
- install missing Radix slot dependency for lint

## Testing
- `npm test` *(fails: No QueryClient set, multiple test failures)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68baef6a89c8832d8d9603a9e1bd9ccb