### PR TITLE
fix: align product queries with supabase schema

### DIFF
--- a/src/hooks/useDashboard.js
+++ b/src/hooks/useDashboard.js
@@ -32,7 +32,7 @@ export function useDashboard() {
     try {
       const { data: produitsRaw, error: errorProd } = await supabase.
       from("v_produits_dernier_prix").
-      select("id, nom, unite_id, unite:unite_id (nom), famille, stock_reel, stock_min").
+      select("id, nom, unite_id, unite:unites!fk_produits_unite(nom), famille, stock_reel, stock_min").
       eq("mama_id", mama_id);
       if (errorProd) throw errorProd;
       const { data: pmpData } = await supabase.

--- a/src/hooks/useEnrichedProducts.js
+++ b/src/hooks/useEnrichedProducts.js
@@ -17,7 +17,7 @@ export function useEnrichedProducts() {
       const { data, error } = await supabase.
       from("produits").
       select(
-        "id, nom, famille_id, sous_famille_id, famille:famille_id(nom), sous_famille:sous_familles!fk_produits_sous_famille(nom), liaisons:fournisseur_produits!fournisseur_produits_produit_id_fkey(*, fournisseur:fournisseurs!fk_fournisseur_produits_fournisseur_id(*))"
+        "id, nom, unite_id, unite:unites!fk_produits_unite(nom), famille_id, sous_famille_id, famille:familles!fk_produits_famille(nom), sous_famille:sous_familles!fk_produits_sous_famille(nom), liaisons:fournisseur_produits!fournisseur_produits_produit_id_fkey(*, fournisseur:fournisseurs!fk_fournisseur_produits_fournisseur_id(*))"
       ).
       eq("mama_id", mama_id);
 

--- a/src/hooks/useExport.js
+++ b/src/hooks/useExport.js
@@ -45,7 +45,7 @@ export default function useExport() {
         const res = await supabase.
         from('produits').
         select(
-          'id, nom, famille_id, sous_famille_id, famille:famille_id(nom), sous_famille:sous_familles!fk_produits_sous_famille(nom), fournisseur_produits:fournisseur_produits!fournisseur_produits_produit_id_fkey(*, fournisseur:fournisseurs!fk_fournisseur_produits_fournisseur_id(nom))'
+          'id, nom, unite_id, unite:unites!fk_produits_unite(nom), famille_id, sous_famille_id, famille:familles!fk_produits_famille(nom), sous_famille:sous_familles!fk_produits_sous_famille(nom), fournisseur_produits:fournisseur_produits!fournisseur_produits_produit_id_fkey(*, fournisseur:fournisseurs!fk_fournisseur_produits_fournisseur_id(nom))'
         ).
         eq('mama_id', mama_id);
         data = res.data || [];

--- a/src/hooks/useInventaires.js
+++ b/src/hooks/useInventaires.js
@@ -49,7 +49,7 @@ export function useInventaires() {
     let query = supabase.
     from("inventaires").
     select(
-      "*, zone:inventaire_zones!inventaires_zone_id_fkey(nom), lignes:produits_inventaire!inventaire_id(*, produit:produits!produits_inventaire_produit_id_fkey(id, nom, unite_id, unite:unite_id (nom), pmp))"
+      "*, zone:inventaire_zones!inventaires_zone_id_fkey(nom), lignes:produits_inventaire!inventaire_id(*, produit:produits!produits_inventaire_produit_id_fkey(id, nom, unite_id, unite:unites!fk_produits_unite(nom), pmp))"
     ).
     eq("mama_id", mama_id);
     if (zoneId) query = query.eq("zone_id", zoneId);
@@ -138,7 +138,7 @@ export function useInventaires() {
     const { data, error } = await supabase.
     from("inventaires").
     select(
-      "*, zone:inventaire_zones!inventaires_zone_id_fkey(nom), lignes:produits_inventaire!inventaire_id(*, produit:produits!produits_inventaire_produit_id_fkey(id, nom, unite_id, unite:unite_id (nom), pmp))"
+      "*, zone:inventaire_zones!inventaires_zone_id_fkey(nom), lignes:produits_inventaire!inventaire_id(*, produit:produits!produits_inventaire_produit_id_fkey(id, nom, unite_id, unite:unites!fk_produits_unite(nom), pmp))"
     ).
     eq("id", id).
     eq("mama_id", mama_id).

--- a/src/hooks/useInvoiceItems.js
+++ b/src/hooks/useInvoiceItems.js
@@ -19,7 +19,7 @@ export function useInvoiceItems() {
     const { data, error } = await supabase.
     from("facture_lignes").
     select(
-      "*, produit:produits!facture_lignes_produit_id_fkey(id, nom, unite_id, unite:unite_id (nom), famille:familles(nom))"
+      "*, produit:produits!facture_lignes_produit_id_fkey(id, nom, unite_id, unite:unites!fk_produits_unite(nom), famille:familles!fk_produits_famille(nom))"
     ).
     eq("facture_id", invoiceId).
     eq("mama_id", mama_id).
@@ -36,7 +36,7 @@ export function useInvoiceItems() {
     const { data, error } = await supabase.
     from("facture_lignes").
     select(
-      "*, produit:produits!facture_lignes_produit_id_fkey(id, nom, unite_id, unite:unite_id (nom), famille:familles(nom))"
+      "*, produit:produits!facture_lignes_produit_id_fkey(id, nom, unite_id, unite:unites!fk_produits_unite(nom), famille:familles!fk_produits_famille(nom))"
     ).
     eq("id", id).
     eq("mama_id", mama_id).

--- a/src/hooks/useProduitsAutocomplete.js
+++ b/src/hooks/useProduitsAutocomplete.js
@@ -17,7 +17,7 @@ export function useProduitsAutocomplete() {
     setError(null);
     let q = supabase.
     from("produits").
-    select("id, nom, tva, dernier_prix, unite_id, unite:unite_id (nom)").
+    select("id, nom, tva, dernier_prix, unite_id, unite:unites!fk_produits_unite(nom)").
     eq("mama_id", mama_id).
     eq("actif", true);
     q = applyIlikeOr(q, query);

--- a/src/hooks/useProduitsFournisseur.js
+++ b/src/hooks/useProduitsFournisseur.js
@@ -22,7 +22,7 @@ export function useProduitsFournisseur() {
       const { data, error } = await supabase.
       from("fournisseur_produits").
       select(
-        "*, produit:produits!fournisseur_produits_produit_id_fkey(id, nom, unite_id, unite:unite_id (nom), famille:famille_id(id, nom))"
+        "*, produit:produits!fournisseur_produits_produit_id_fkey(id, nom, unite_id, unite:unites!fk_produits_unite(nom), famille:familles!fk_produits_famille(id, nom))"
       ).
       eq("fournisseur_id", fournisseur_id).
       eq("mama_id", mama_id);
@@ -42,7 +42,7 @@ export function useProduitsFournisseur() {
       const { data } = await supabase.
       from("fournisseur_produits").
       select(
-        "*, produit:produits!fournisseur_produits_produit_id_fkey(id, nom, unite_id, unite:unite_id (nom), famille:famille_id(id, nom))"
+        "*, produit:produits!fournisseur_produits_produit_id_fkey(id, nom, unite_id, unite:unites!fk_produits_unite(nom), famille:familles!fk_produits_famille(id, nom))"
       ).
       eq("fournisseur_id", fournisseur_id).
       eq("mama_id", mama_id);

--- a/src/hooks/useProduitsInventaire.js
+++ b/src/hooks/useProduitsInventaire.js
@@ -18,7 +18,7 @@ export function useProduitsInventaire() {
       setError(null);
       let query = supabase.
       from('v_produits_dernier_prix').
-      select('id, nom, unite_id, unite:unite_id (nom), famille').
+      select('id, nom, unite_id, unite:unites!fk_produits_unite(nom), famille').
       eq('mama_id', mama_id).
       eq('actif', true);
       if (famille) query = query.ilike('famille', `%${famille}%`);

--- a/src/hooks/useStock.js
+++ b/src/hooks/useStock.js
@@ -18,7 +18,7 @@ export function useStock() {
     const { data, error } = await supabase.
     from("produits").
     select(
-      "id, nom, unite_id, unite:unite_id (nom), stock_reel, stock_min, pmp, famille_id, sous_famille_id, famille:famille_id(nom), sous_famille:sous_familles!fk_produits_sous_famille(nom)"
+      "id, nom, unite_id, unite:unites!fk_produits_unite(nom), stock_reel, stock_min, pmp, famille_id, sous_famille_id, famille:familles!fk_produits_famille(nom), sous_famille:sous_familles!fk_produits_sous_famille(nom)"
     ).
     eq("mama_id", mama_id);
     setLoading(false);

--- a/src/pages/mobile/MobileInventaire.jsx
+++ b/src/pages/mobile/MobileInventaire.jsx
@@ -18,7 +18,7 @@ export default function MobileInventaire() {
     supabase.
     from("produits").
     select(
-      "id, nom, famille_id, sous_famille_id, famille:famille_id(nom), sous_famille:sous_familles!fk_produits_sous_famille(nom)"
+      "id, nom, unite_id, unite:unites!fk_produits_unite(nom), famille_id, sous_famille_id, famille:familles!fk_produits_famille(nom), sous_famille:sous_familles!fk_produits_sous_famille(nom)"
     ).
     eq("mama_id", mama_id).
     then(({ data }) => setProduits(data || []));

--- a/src/pages/produits/Produits.jsx
+++ b/src/pages/produits/Produits.jsx
@@ -2,7 +2,6 @@
 import { useEffect, useState, useCallback, useMemo } from "react";
 import { useProducts } from "@/hooks/useProducts";
 import { useFamilles } from "@/hooks/useFamilles";
-import { useUnites } from "@/hooks/useUnites";
 import { useSousFamilles } from "@/hooks/useSousFamilles";
 import { useZonesStock } from "@/hooks/useZonesStock";
 import { supabase } from '@/lib/supa/client'
@@ -41,7 +40,6 @@ export default function Produits() {
   const [page, setPage] = useState(1);
   const [sortField, setSortField] = useState("famille");
   const [sortOrder, setSortOrder] = useState("asc");
-  const { data: unites = [] } = useUnites(mama_id);
   const { data: familles = [] } = useFamilles(mama_id);
   const {
     data: productsResult = { data: [], count: 0 },
@@ -60,22 +58,14 @@ export default function Produits() {
   const canView = hasAccess("produits", "peut_voir");
   const [showImport, setShowImport] = useState(false);
 
-  const uniteById = useMemo(
-    () => Object.fromEntries(unites.map((u) => [u.id, u])),
-    [unites]
-  );
-  const familleById = useMemo(
-    () => Object.fromEntries(familles.map((f) => [f.id, f])),
-    [familles]
-  );
   const rows = useMemo(
     () =>
       (products || []).map((p) => ({
         ...p,
-        unite_nom: uniteById[p.unite_id]?.nom ?? '',
-        famille_nom: familleById[p.famille_id]?.nom ?? '',
+        unite_nom: p.unite?.nom ?? p.unite_nom ?? '',
+        famille_nom: p.famille?.nom ?? p.famille_nom ?? '',
       })),
-    [products, uniteById, familleById]
+    [products]
   );
 
   const refreshList = useCallback(() => {

--- a/src/utils/exportExcelProduits.js
+++ b/src/utils/exportExcelProduits.js
@@ -30,7 +30,7 @@ export async function exportExcelProduits(mama_id) {
   const { data, error } = await supabase.
   from("produits").
   select(
-    `nom, unite_id, unite:unite_id (nom), famille:familles(nom), sous_famille:sous_familles(nom), zone_stock:zones_stock(nom), stock_theorique, pmp, actif, seuil_min`
+    `nom, unite_id, unite:unites!fk_produits_unite(nom), famille:familles!fk_produits_famille(nom), sous_famille:sous_familles!fk_produits_sous_famille(nom), zone_stock:zones_stock(nom), stock_theorique, pmp, actif, seuil_min`
   ).
   eq("mama_id", mama_id);
 


### PR DESCRIPTION
## Summary
- refactor product fetch hooks to use correct Supabase FK embeddings
- default hook params and zone fallbacks for robustness
- update stock/export hooks to request unit & family labels via proper constraints

## Testing
- `npm test` *(fails: No QueryClient set / supabase mock default export missing)*

------
https://chatgpt.com/codex/tasks/task_e_68baf6923dc0832d8836a92b68419d95