### PR TITLE
Fix product hook defaults and zone table usage

### DIFF
--- a/src/components/export/ExportManager.jsx
+++ b/src/components/export/ExportManager.jsx
@@ -1,7 +1,7 @@
 // MamaStock © 2025 - Licence commerciale obligatoire - Toute reproduction interdite sans autorisation.
 import { useState } from 'react';
 import ModalGlass from '@/components/ui/ModalGlass';
-import Button from '@/components/ui/button';
+import { Button } from '@/components/ui/button';
 
 export default function ExportManager({ open, onClose, onExport }) {
   const [format, setFormat] = useState('pdf');

--- a/src/components/produits/ProduitDetail.jsx
+++ b/src/components/produits/ProduitDetail.jsx
@@ -40,9 +40,11 @@ export default function ProduitDetail({ produitId, produit, open, onClose }) {
     };
   }, [open, produitId, fetchProductPrices, fetchProductMouvements, fetchProductStock]);
 
-  const chartData = buildPriceData(historique);
+  const histData = historique ?? [];
+  const mouvData = mouvements ?? [];
+  const chartData = buildPriceData(histData);
   const summary = Object.values(
-    historique.reduce((acc, h) => {
+    histData.reduce((acc, h) => {
       const idF = h.fournisseur?.id || "";
       if (!acc[idF]) {
         acc[idF] = {
@@ -134,14 +136,14 @@ export default function ProduitDetail({ produitId, produit, open, onClose }) {
               </tr>
             </thead>
             <tbody>
-              {historique.length === 0 ? (
+              {histData.length === 0 ? (
                 <tr>
                   <td colSpan={4} className="text-center py-4">
                     Aucune donnée
                   </td>
                 </tr>
               ) : (
-                historique.map((h, i) => (
+                histData.map((h, i) => (
                   <tr key={i}>
                     <td>{h.created_at?.slice(0, 10) || "-"}</td>
                     <td>{h.fournisseur?.nom || "-"}</td>
@@ -184,14 +186,14 @@ export default function ProduitDetail({ produitId, produit, open, onClose }) {
               </tr>
             </thead>
             <tbody>
-              {mouvements.length === 0 ? (
+              {mouvData.length === 0 ? (
                 <tr>
                   <td colSpan={5} className="text-center py-4">
                     Aucun mouvement
                   </td>
                 </tr>
               ) : (
-                mouvements.map((m) => (
+                mouvData.map((m) => (
                   <tr key={m.id}>
                     <td>{m.date?.slice(0, 10) || "-"}</td>
                     <td>{m.type}</td>

--- a/src/hooks/useProducts.js
+++ b/src/hooks/useProducts.js
@@ -2,7 +2,8 @@ import { useCallback, useState, useEffect, useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { supabase } from '@/lib/supa/client'
 import { useAuth } from '@/hooks/useAuth'
-export async function fetchProducts({ mamaId, limit = 100, offset = 0 } = {}) {
+
+export async function fetchProducts({ mamaId, limit = 100, offset = 0, search = '', filters = {} } = {}) {
   const { data, error, count } = await supabase
     .from('produits')
     .select(
@@ -131,9 +132,16 @@ export function useProducts({
     return data ?? []
   }, [resolvedMama])
 
+  const data = query.data?.data ?? []
+  const count = query.data?.count ?? 0
+
   return {
-    ...query,
-    loading: query.isFetching || loading,
+    data,
+    count,
+    products: data,
+    isLoading: query.isLoading || loading,
+    error: query.error,
+    refetch: query.refetch,
     addProduct,
     updateProduct,
     toggleProductActive,

--- a/src/hooks/useZonesStock.js
+++ b/src/hooks/useZonesStock.js
@@ -8,11 +8,11 @@ import { supabase } from '@/lib/supa/client'
  */
 export function useZonesStock(mamaId, { onlyActive = true } = {}) {
   return useQuery({
-    queryKey: ['zones_stock', mamaId, onlyActive],
+    queryKey: ['inventaire_zones', mamaId, onlyActive],
     queryFn: async () => {
       if (!mamaId) return []
       let q = supabase
-        .from('zones_stock')
+        .from('inventaire_zones')
         .select('id, nom, mama_id, actif')
         .eq('mama_id', mamaId)
         .order('nom', { ascending: true })
@@ -30,14 +30,11 @@ export function useZonesStock(mamaId, { onlyActive = true } = {}) {
   })
 }
 
-// ✅ Ajoute un export par défaut pour compat
-export default useZonesStock
-
 // (optionnel) utilitaire de fetch direct si besoin ailleurs
 export async function fetchZonesStock(mamaId, { onlyActive = true } = {}) {
   if (!mamaId) return []
   let q = supabase
-    .from('zones_stock')
+    .from('inventaire_zones')
     .select('id, nom, mama_id, actif')
     .eq('mama_id', mamaId)
     .order('nom', { ascending: true })

--- a/src/pages/factures/FactureForm.jsx
+++ b/src/pages/factures/FactureForm.jsx
@@ -20,7 +20,7 @@ import {
 import { Badge } from '@/components/ui/badge';
 import { mapUILineToPayload } from '@/features/factures/invoiceMappers';
 import useProduitLineDefaults from '@/hooks/useProduitLineDefaults';
-import useZonesStock from '@/hooks/useZonesStock';
+import { useZonesStock } from '@/hooks/useZonesStock';
 import { formatMoneyFR } from '@/utils/numberFormat';
 
 const FN_UPDATE_FACTURE_EXISTS = false;

--- a/src/pages/planning/SimulationPlanner.jsx
+++ b/src/pages/planning/SimulationPlanner.jsx
@@ -5,7 +5,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { useMenus } from '@/hooks/useMenus';
 import { useSimulation } from '@/hooks/useSimulation';
 import SimulationDetailsModal from '@/components/simulation/SimulationDetailsModal';
-import Button from '@/components/ui/button';
+import { Button } from '@/components/ui/button';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import TableContainer from '@/components/ui/TableContainer';
 

--- a/src/pages/produits/Produits.jsx
+++ b/src/pages/produits/Produits.jsx
@@ -42,11 +42,10 @@ export default function Produits() {
   const [sortOrder, setSortOrder] = useState("asc");
   const { data: familles = [] } = useFamilles(mama_id);
   const {
-    data: productsResult = { data: [], count: 0 },
+    data: products = [],
+    count: total = 0,
     refetch,
   } = useProducts({ mamaId: mama_id, limit: PAGE_SIZE, offset: (page - 1) * PAGE_SIZE });
-  const products = productsResult.data ?? [];
-  const total = productsResult.count ?? 0;
   const {
     sousFamilles: rawSousFamilles,
     list: listSousFamilles,

--- a/test/ProduitForm.subfam.test.jsx
+++ b/test/ProduitForm.subfam.test.jsx
@@ -40,7 +40,7 @@ vi.mock('@/hooks/useUnites', () => ({
 vi.mock('@/hooks/data/useFournisseurs', () => ({
   default: () => ({ data: [], isLoading: false }),
 }));
-vi.mock('@/hooks/useZonesStock', () => ({ default: () => ({ data: [] }) }));
+vi.mock('@/hooks/useZonesStock', () => ({ useZonesStock: () => ({ data: [] }) }));
 vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn(), loading: vi.fn() } }));
 
 beforeEach(() => {

--- a/test/ProduitForm.test.jsx
+++ b/test/ProduitForm.test.jsx
@@ -24,7 +24,7 @@ vi.mock('@/hooks/data/useFournisseurs', () => ({
   default: () => ({ data: [], isLoading: false })
 }));
 vi.mock('@/hooks/useZonesStock', () => ({
-  default: () => ({ data: [], isLoading: false })
+  useZonesStock: () => ({ data: [], isLoading: false })
 }));
 
 import ProduitForm from '@/components/produits/ProduitForm.jsx';


### PR DESCRIPTION
## Summary
- ensure useProducts returns stable data and uses correct FK embeds
- switch stock zone hook to `inventaire_zones` and harmonize imports
- update product pages and button consumers to handle new APIs

## Testing
- `npm test` *(fails: No QueryClient set and missing mocks, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68baf951e054832db2632db6e0669f5b