### PR TITLE
Fix product hooks and zone queries

### DIFF
--- a/src/components/produits/ProduitForm.jsx
+++ b/src/components/produits/ProduitForm.jsx
@@ -32,7 +32,8 @@ export default function ProduitForm({
     error: sousFamillesError,
   } = useSousFamilles();
   const { data: unites = [], refetch: fetchUnites } = useUnites(mama_id);
-  const { data: zones = [] } = useZonesStock(mama_id);
+  const { data: zonesData } = useZonesStock(mama_id);
+  const zones = zonesData ?? [];
 
   const [nom, setNom] = useState(produit?.nom || "");
   const [familleId, setFamilleId] = useState(produit?.famille_id || "");

--- a/src/hooks/gadgets/useEvolutionAchats.js
+++ b/src/hooks/gadgets/useEvolutionAchats.js
@@ -15,7 +15,7 @@ export default function useEvolutionAchats() {
       setState((s) => ({ ...s, loading: true, error: null }));
       const start = new Date();
       start.setMonth(start.getMonth() - 12);
-      const filterDate = `${start.getFullYear()}-${String(start.getMonth() + 1).padStart(2, '0')}-01`;
+      const filterDate = start.toISOString().slice(0, 10);
       const { data, error } = await run(
         supabase
           .from('v_evolution_achats')

--- a/src/hooks/useProducts.js
+++ b/src/hooks/useProducts.js
@@ -1,6 +1,6 @@
 import { useCallback, useState, useEffect, useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { supabase } from '@/lib/supa/client'
+import { supabase } from '@/lib/supabaseClient'
 import { useAuth } from '@/hooks/useAuth'
 
 export async function fetchProducts({ mamaId, limit = 100, offset = 0, search = '', filters = {} } = {}) {
@@ -31,13 +31,14 @@ export async function fetchProducts({ mamaId, limit = 100, offset = 0, search = 
   return { data: enriched, count: count ?? 0 }
 }
 
-export function useProducts({
-  mamaId,
-  limit = 50,
-  offset = 0,
-  filters = {},
-  search = '',
-} = {}) {
+export function useProducts(options = {}) {
+  const {
+    mamaId,
+    limit = 50,
+    offset = 0,
+    filters = {},
+    search = '',
+  } = options
   const { mama_id } = useAuth()
   const [loading, setLoading] = useState(false)
 
@@ -140,7 +141,7 @@ export function useProducts({
     count,
     products: data,
     isLoading: query.isLoading || loading,
-    error: query.error,
+    error: query.error ?? null,
     refetch: query.refetch,
     addProduct,
     updateProduct,

--- a/src/hooks/useZonesStock.js
+++ b/src/hooks/useZonesStock.js
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
-import { supabase } from '@/lib/supa/client'
+import { supabase } from '@/lib/supabaseClient'
 
 /**
  * Hook zones de stock (plat, sans embed).
@@ -46,3 +46,5 @@ export async function fetchZonesStock(mamaId, { onlyActive = true } = {}) {
   }
   return data ?? []
 }
+
+export default useZonesStock

--- a/src/pages/produits/ProduitDetail.jsx
+++ b/src/pages/produits/ProduitDetail.jsx
@@ -52,7 +52,8 @@ export default function ProduitDetailPage() {
     };
   }, [id, fetchProductPrices]);
 
-  const chartData = buildPriceData(history);
+  const historyData = history ?? [];
+  const chartData = buildPriceData(historyData);
 
   const handleToggle = async () => {
     if (product) {
@@ -63,7 +64,7 @@ export default function ProduitDetailPage() {
   };
 
   const summary = Object.values(
-    history.reduce((acc, h) => {
+    historyData.reduce((acc, h) => {
       const idF = h.fournisseur?.id || "";
       if (!acc[idF]) {
         acc[idF] = {
@@ -158,12 +159,12 @@ export default function ProduitDetailPage() {
                 </tr>
               </thead>
               <tbody>
-                {history.length === 0 ? (
+                {historyData.length === 0 ? (
                   <tr>
                     <td colSpan={4} className="py-4 text-center">Aucune donnée</td>
                   </tr>
                 ) : (
-                  history.map((h, i) => (
+                  historyData.map((h, i) => (
                     <tr key={i}>
                       <td>{h.created_at?.slice(0, 10) || '-'}</td>
                       <td>{h.fournisseur?.nom || '-'}</td>

--- a/src/pages/produits/Produits.jsx
+++ b/src/pages/produits/Produits.jsx
@@ -4,7 +4,7 @@ import { useProducts } from "@/hooks/useProducts";
 import { useFamilles } from "@/hooks/useFamilles";
 import { useSousFamilles } from "@/hooks/useSousFamilles";
 import { useZonesStock } from "@/hooks/useZonesStock";
-import { supabase } from '@/lib/supa/client'
+import { supabase } from '@/lib/supabaseClient'
 import LoadingSkeleton from "@/components/ui/LoadingSkeleton";
 import ProduitFormModal from "@/components/produits/ProduitFormModal";
 import ProduitDetail from "@/components/produits/ProduitDetail";
@@ -40,19 +40,22 @@ export default function Produits() {
   const [page, setPage] = useState(1);
   const [sortField, setSortField] = useState("famille");
   const [sortOrder, setSortOrder] = useState("asc");
-  const { data: familles = [] } = useFamilles(mama_id);
+  const { data: famillesData } = useFamilles(mama_id);
+  const familles = famillesData ?? [];
   const {
-    data: products = [],
+    data,
     count: total = 0,
     refetch,
   } = useProducts({ mamaId: mama_id, limit: PAGE_SIZE, offset: (page - 1) * PAGE_SIZE });
+  const products = data ?? [];
   const {
     sousFamilles: rawSousFamilles,
     list: listSousFamilles,
     isLoading,
   } = useSousFamilles();
   const safeSousFamilles = Array.isArray(rawSousFamilles) ? rawSousFamilles : [];
-  const { data: zones = [] } = useZonesStock(mama_id);
+  const { data: zonesData } = useZonesStock(mama_id);
+  const zones = zonesData ?? [];
   const canEdit = hasAccess("produits", "peut_modifier");
   const canView = hasAccess("produits", "peut_voir");
   const [showImport, setShowImport] = useState(false);


### PR DESCRIPTION
## Summary
- ensure product hook parameters are optional and return stable structure
- align zone stock hook with `inventaire_zones` and add default export
- guard product pages against undefined data
- use singleton Supabase client and date-safe filters

## Testing
- `npm test` *(fails: No QueryClient set, missing supabase mocks)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb0129ecb8832d91b52ed785a32d64