### PR TITLE
fix(front): forcer HashRouter pour éviter les échecs de navigation en local

### DIFF
--- a/docs/reports/PR-037-WIN_report.json
+++ b/docs/reports/PR-037-WIN_report.json
@@ -1,0 +1,6 @@
+{
+  "files_modified": [
+    "src/main.jsx"
+  ],
+  "reason": "Use HashRouter to ensure deep links render correctly without server route fallback."
+}

--- a/docs/reports/PR-037-WIN_report.md
+++ b/docs/reports/PR-037-WIN_report.md
@@ -1,0 +1,7 @@
+# PR-037-WIN Report
+
+## Files Modified
+- src/main.jsx
+
+## Rationale
+- Switch `BrowserRouter` to `HashRouter` to avoid blank screens when loading deep routes without a server fallback.

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -6,7 +6,7 @@ import "./globals.css";
 import 'nprogress/nprogress.css';
 import "@/i18n/i18n";
 import "./registerSW.js";
-import { BrowserRouter } from "react-router-dom";
+import { HashRouter } from "react-router-dom";
 import AuthProvider from "@/contexts/AuthContext";
 import { toast } from 'sonner';
 import { ensureSingleOwner, releaseLock } from '@/lib/lock';
@@ -47,10 +47,10 @@ window.addEventListener('beforeunload', () => {
 const root = createRoot(document.getElementById("root"));
 root.render(
   <StrictMode>
-    <BrowserRouter>
+    <HashRouter>
       <AuthProvider>
         <App />
       </AuthProvider>
-    </BrowserRouter>
+    </HashRouter>
   </StrictMode>
 );


### PR DESCRIPTION
## Summary
- replace `BrowserRouter` with `HashRouter` to support direct navigation to deep routes without server fallback
- document the router switch in PR-037 WIN report

## Testing
- `npm test` *(fails: No "default" export is defined on the "@/lib/supabase" mock)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8b65b770832dae82310738e135a3