### PR TITLE
fix(front): route file exports through Tauri adapters

### DIFF
--- a/docs/reports/PR-036-WIN_report.json
+++ b/docs/reports/PR-036-WIN_report.json
@@ -7,7 +7,8 @@
     "src/lib/shutdown.ts",
     "src/lib/fsHelpers.ts",
     "src/lib/db.ts",
-    "src/main.jsx"
+    "src/main.jsx",
+    "src/lib/export/exportHelpers.js"
   ],
   "node_api_removed": [
     "fs",

--- a/docs/reports/PR-036-WIN_report.md
+++ b/docs/reports/PR-036-WIN_report.md
@@ -9,12 +9,14 @@
 - src/lib/fsHelpers.ts
 - src/lib/db.ts
 - src/main.jsx
+- src/lib/export/exportHelpers.js
 
 ## Node API Removal
 - Replaced `fs`, `path`, and `os` imports with Tauri FS and Path adapters.
 - Removed synchronous filesystem calls in favour of async Tauri plugin calls.
 - Substituted `process.pid` based IDs with `crypto.randomUUID()`.
 - Eliminated direct Node-based database layer and routed calls through Tauri `invoke` commands.
+- Redirected file export utilities to the centralized FS and Path adapters.
 
 ## Mapping to Tauri APIs
 - File operations -> `@tauri-apps/plugin-fs` via `src/adapters/fs.ts`.

--- a/src/adapters/fs.ts
+++ b/src/adapters/fs.ts
@@ -1,7 +1,18 @@
-import { readTextFile, writeTextFile, readFile, writeFile, exists, mkdir, remove } from '@tauri-apps/plugin-fs';
+import {
+  readTextFile,
+  writeTextFile,
+  readFile,
+  writeFile,
+  exists,
+  mkdir,
+  remove,
+} from '@tauri-apps/plugin-fs';
 
-export async function readText(path: string) {
-  return readTextFile(path);
+export const readText = readTextFile;
+export { writeFile, exists };
+
+export async function createDir(path: string) {
+  await mkdir(path, { recursive: true });
 }
 
 export async function writeText(path: string, data: string) {
@@ -22,7 +33,7 @@ export async function pathExists(path: string) {
 
 export async function ensureDir(path: string) {
   if (!(await exists(path))) {
-    await mkdir(path, { recursive: true });
+    await createDir(path);
   }
 }
 

--- a/src/lib/export/exportHelpers.js
+++ b/src/lib/export/exportHelpers.js
@@ -4,6 +4,8 @@ import autoTable from 'jspdf-autotable';
 import * as XLSX from 'xlsx';
 import { dump } from 'js-yaml';
 import { getConfig, defaultExportDir } from '@/lib/config';
+import { writeBinary, ensureDir } from '@/adapters/fs';
+import { join } from '@/adapters/path';
 
 function isTauri() {
   // @ts-ignore
@@ -12,13 +14,11 @@ function isTauri() {
 
 async function saveFile(blob, filename) {
   if (isTauri()) {
-    const fs = await import('@tauri-apps/plugin-fs');
-    const { join } = await import('@tauri-apps/api/path');
     const cfg = await getConfig();
     const dir = cfg.exportDir || (await defaultExportDir());
-    await fs.mkdir(dir, { recursive: true });
+    await ensureDir(dir);
     const filePath = await join(dir, filename);
-    await fs.writeFile(filePath, new Uint8Array(await blob.arrayBuffer()));
+    await writeBinary(filePath, new Uint8Array(await blob.arrayBuffer()));
     return filePath;
   }
   if (typeof window !== 'undefined') {


### PR DESCRIPTION
## Summary
- use fs/path adapters in export helpers instead of direct plugin imports
- expose createDir and re-export helpers in fs adapter
- document Node API replacements in PR-036 report

## Testing
- `npm run build`
- `npx tauri build` *(fails: Couldn't recognize the current folder as a Tauri project)*

------
https://chatgpt.com/codex/tasks/task_e_68bd99ed7ba8832dbdec208216802ac5