### PR TITLE
fix(front): forcer HashRouter pour un routage fiable en app locale

### DIFF
--- a/docs/reports/PR-037-WIN_report.json
+++ b/docs/reports/PR-037-WIN_report.json
@@ -2,5 +2,9 @@
   "files_modified": [
     "src/main.jsx"
   ],
-  "reason": "Use HashRouter to ensure deep links render correctly without server route fallback."
+  "reason": "Use HashRouter to ensure deep links render correctly without server route fallback.",
+  "tests": [
+    "npm run build",
+    "npx tauri build"
+  ]
 }

--- a/docs/reports/PR-037-WIN_report.md
+++ b/docs/reports/PR-037-WIN_report.md
@@ -5,3 +5,7 @@
 
 ## Rationale
 - Switch `BrowserRouter` to `HashRouter` to avoid blank screens when loading deep routes without a server fallback.
+
+## Tests
+- `npm run build`
+- `npx tauri build`

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -6,7 +6,7 @@ import "./globals.css";
 import 'nprogress/nprogress.css';
 import "@/i18n/i18n";
 import "./registerSW.js";
-import { HashRouter } from "react-router-dom";
+import { HashRouter } from "react-router-dom"; // Use hash-based routing to handle deep links without server fallback
 import AuthProvider from "@/contexts/AuthContext";
 import { toast } from 'sonner';
 import { ensureSingleOwner, releaseLock } from '@/lib/lock';


### PR DESCRIPTION
## Summary
- document hash-based routing to ensure deep links render correctly without server fallback
- record build steps in PR-037 report

## Testing
- `npm run build`
- `npx tauri build` *(fails: couldn't recognize current folder as a Tauri project)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9bcaac08832dbaa1b00fc99b7efb