### PR TITLE
chore: désactiver DevTools après correction de l’écran bleu

### DIFF
--- a/docs/reports/PR-038-WIN_report.json
+++ b/docs/reports/PR-038-WIN_report.json
@@ -1,0 +1,12 @@
+{
+  "files_modified": [
+    "src-tauri/tauri.conf.json",
+    "src/main.jsx"
+  ],
+  "reason": "Disable Tauri DevTools and retain commented global error handlers for future debugging.",
+  "tests": [
+    "npm run build",
+    "npx tauri build (fails: \"identifier\" is a required property)",
+    "./src-tauri/target/release/mamastock (binary missing)"
+  ]
+}

--- a/docs/reports/PR-038-WIN_report.md
+++ b/docs/reports/PR-038-WIN_report.md
@@ -1,0 +1,13 @@
+# PR-038-WIN Report
+
+## Files Modified
+- src-tauri/tauri.conf.json
+- src/main.jsx
+
+## Rationale
+- Disable Tauri DevTools and retain commented global error handlers for future debugging.
+
+## Tests
+- `npm run build`
+- `npx tauri build` (fails: "identifier" is a required property)
+- `./src-tauri/target/release/mamastock` (binary missing)

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,0 +1,12 @@
+{
+  "app": {
+    "windows": [
+      {
+        "title": "Mamastock",
+        "width": 800,
+        "height": 600,
+        "devtools": false
+      }
+    ]
+  }
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -40,6 +40,14 @@ window.addEventListener('beforeunload', () => {
   releaseLock();
 });
 
+// Global error handlers for future debugging
+// window.addEventListener('error', (event) => {
+//   console.error('Global error:', event.error);
+// });
+// window.addEventListener('unhandledrejection', (event) => {
+//   console.error('Unhandled promise rejection:', event.reason);
+// });
+
 // Option sentry/reporting
 // import * as Sentry from "@sentry/react";
 // Sentry.init({ dsn: "https://xxx.ingest.sentry.io/xxx" });


### PR DESCRIPTION
## Summary
- Disable Tauri DevTools in configuration
- Retain global error handlers in main entry file for future debugging
- Add PR-038 report files

## Testing
- `npm run build`
- `npx tauri build` *(fails: `identifier` is a required property)*
- `./src-tauri/target/release/mamastock` *(binary missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9de62a5c832da9390e776cd54e64